### PR TITLE
Fix gulp for ansible

### DIFF
--- a/ansible/roles/common_webserver/tasks/main.yml
+++ b/ansible/roles/common_webserver/tasks/main.yml
@@ -75,7 +75,7 @@
   - resources
 
 - name: Install gulp
-  npm: name=gulp global=yes
+  npm: name=gulp-cli global=yes
   when: modules_copy|changed
   tags:
   - resources


### PR DESCRIPTION
- Gulp 4 uses gulp-cli global npm not gulp