### PR TITLE
Fix ckan groups about page translation display

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
@@ -1,0 +1,50 @@
+{% block info %}
+<div class="module context-info">
+  <section class="module-content">
+    {% block inner %}
+    {% block image %}
+    <div class="image">
+      <a href="{{ group.url }}">
+        <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" width="190" height="118" alt="{{ group.name }}" />
+      </a>
+    </div>
+    {% endblock %}
+    {% block heading %}
+    <h1 class="heading">
+      {{ h.scheming_language_text(group.title) }}
+      {% if group.state == 'deleted' %}
+        [{{ _('Deleted') }}]
+      {% endif %}
+    </h1>
+    {% endblock %}
+    {% block description %}
+    {% if group.description %}
+      <p>
+        {{ h.markdown_extract(group.description, 180) }}
+        {% link_for _('read more'), named_route='group.about', id=group.name %}
+      </p>
+    {% endif %}
+    {% endblock %}
+    {% if show_nums %}
+      {% block nums %}
+      <div class="nums">
+        <dl>
+          <dt>{{ _('Followers') }}</dt>
+          <dd data-module="followers-counter" data-module-id="{{ group.id }}" data-module-num_followers="{{ group.num_followers }}">{{ h.SI_number_span(group.num_followers) }}</dd>
+        </dl>
+        <dl>
+          <dt>{{ _('Datasets') }}</dt>
+          <dd>{{ h.SI_number_span(group.package_count) }}</dd>
+        </dl>
+      </div>
+      {% endblock %}
+      {% block follow %}
+      <div class="follow_button">
+        {{ h.follow_button('group', group.id) }}
+      </div>
+      {% endblock %}
+    {% endif %}
+    {% endblock %}
+  </section>
+</div>
+{% endblock %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/group/about.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/group/about.html
@@ -1,0 +1,10 @@
+{% extends "group/about.html" %}
+
+{% block primary_content_inner %}
+<dl>
+{% for f in c.scheming_fields %}
+<dt>{{ h.scheming_language_text(f.label) }}:</dt>
+<dd>{{ h.scheming_language_text(c.group_dict[f.field_name]) or ("&nbsp;"|safe) }}</dd>
+{% endfor %}
+</dl>
+{% endblock %}


### PR DESCRIPTION
- Ckan groups about page was showing python dict of translations. Now it
should display only the value for current user language.