### PR TITLE
User roles creation tasks ignores errors

### DIFF
--- a/ansible/roles/drupal/tasks/main.yml
+++ b/ansible/roles/drupal/tasks/main.yml
@@ -308,6 +308,7 @@
   - "{{ drupal_editor_rolename }}"
   - "{{ drupal_ckan_admin_rolename }}"
   - "{{ drupal_publisher_rolename }}"
+  ignore_errors: True
   tags:
   - drupal
 


### PR DESCRIPTION
Fixed user roles creation task so that it ignores errors. Previously, this caused build process to fail if the roles existed already