### PR TITLE
Fix avoindata events module install in ansible

### DIFF
--- a/ansible/roles/drupal/tasks/main.yml
+++ b/ansible/roles/drupal/tasks/main.yml
@@ -204,9 +204,6 @@
   args: 
     chdir: "{{ drupal8_root }}/web"
 
-
-
-
 ### Custom modules ###
 # Contrib modules should be installed with Composer, not here #
 

--- a/ansible/roles/drupal/vars/main.yml
+++ b/ansible/roles/drupal/vars/main.yml
@@ -2,14 +2,15 @@
 
 custom_modules:
   - { src_name: avoindata-drupal-header, module_name: avoindata-header, machine_name: avoindata_header }
-  - { src_name: avoindata-drupal-hero, module_name: avoindata-hero, machine_name: avoindata_hero}
-  - { src_name: avoindata-drupal-categories, module_name: avoindata-categories, machine_name: avoindata_categories}
-  - { src_name: avoindata-drupal-infobox, module_name: avoindata-infobox, machine_name: avoindata_infobox}
-  - { src_name: avoindata-drupal-datasetlist, module_name: avoindata-datasetlist, machine_name: avoindata_datasetlist}
-  - { src_name: avoindata-drupal-newsfeed, module_name: avoindata-newsfeed, machine_name: avoindata_newsfeed}
-  - { src_name: avoindata-drupal-appfeed, module_name: avoindata-appfeed, machine_name: avoindata_appfeed}
-  - { src_name: avoindata-drupal-footer, module_name: avoindata-footer, machine_name: avoindata_footer}
-  - { src_name: avoindata-drupal-articles, module_name: avoindata-articles, machine_name: avoindata_articles}
+  - { src_name: avoindata-drupal-hero, module_name: avoindata-hero, machine_name: avoindata_hero }
+  - { src_name: avoindata-drupal-categories, module_name: avoindata-categories, machine_name: avoindata_categories }
+  - { src_name: avoindata-drupal-infobox, module_name: avoindata-infobox, machine_name: avoindata_infobox }
+  - { src_name: avoindata-drupal-datasetlist, module_name: avoindata-datasetlist, machine_name: avoindata_datasetlist }
+  - { src_name: avoindata-drupal-newsfeed, module_name: avoindata-newsfeed, machine_name: avoindata_newsfeed }
+  - { src_name: avoindata-drupal-appfeed, module_name: avoindata-appfeed, machine_name: avoindata_appfeed }
+  - { src_name: avoindata-drupal-footer, module_name: avoindata-footer, machine_name: avoindata_footer }
+  - { src_name: avoindata-drupal-articles, module_name: avoindata-articles, machine_name: avoindata_articles }
+  - { src_name: avoindata-drupal-events, module_name: avoindata-events, machine_name: avoindata_events }
 
 
 # drupal_theme_path: "{{ drupal_root }}/sites/all/themes"


### PR DESCRIPTION
- Avoindata events module installation had been deleted. This now adds
the installation back to ansible files.