### PR TITLE
AV 96 Custom module cache fix

### DIFF
--- a/modules/avoindata-drupal-articles/src/Controller/ArticlesController.php
+++ b/modules/avoindata-drupal-articles/src/Controller/ArticlesController.php
@@ -82,6 +82,9 @@ class ArticlesController extends ControllerBase {
       '#tags' => $taxonomyTerms,
       '#language' => $lang,
       '#theme' => 'avoindata_articles',
+      '#cache' => array(
+        'max-age' => 0,
+      )
     );
   }
 }

--- a/modules/avoindata-drupal-articles/src/Controller/ArticlesController.php
+++ b/modules/avoindata-drupal-articles/src/Controller/ArticlesController.php
@@ -83,7 +83,7 @@ class ArticlesController extends ControllerBase {
       '#language' => $lang,
       '#theme' => 'avoindata_articles',
       '#cache' => array(
-        'max-age' => 0,
+        'tags' => ['node_list']
       )
     );
   }

--- a/modules/avoindata-drupal-events/src/Controller/EventsController.php
+++ b/modules/avoindata-drupal-events/src/Controller/EventsController.php
@@ -64,6 +64,9 @@ class EventsController extends ControllerBase {
       '#events' => $eventNodes,
       '#language' => $lang,
       '#theme' => 'avoindata_events',
+      '#cache' => array(
+        'tags' => ['node_list']
+      )
     );
   }
 }

--- a/modules/avoindata-drupal-newsfeed/src/Plugin/Block/NewsFeedBlock.php
+++ b/modules/avoindata-drupal-newsfeed/src/Plugin/Block/NewsFeedBlock.php
@@ -45,6 +45,9 @@ class NewsFeedBlock extends BlockBase {
       '#eventfeed' => $eventNodes,
       '#language' => \Drupal::languageManager()->getCurrentLanguage()->getId(),
       '#theme' => 'avoindata_newsfeed',
+      '#cache' => array(
+        'tags' => ['node_list']
+      )
     );
   }
 }

--- a/modules/avoindata-drupal-newsfeed/templates/avoindata_newsfeed_block.html.twig
+++ b/modules/avoindata-drupal-newsfeed/templates/avoindata_newsfeed_block.html.twig
@@ -59,7 +59,7 @@
         </div>
       {% endfor %}
       <div>
-        <a href="" class="btn avoindata-newsfeed-button">
+        <a href="/{{language}}/events" class="btn avoindata-newsfeed-button">
           {% trans %}
           All Events
           {% endtrans %}


### PR DESCRIPTION
- Custom modules should now properly load new node data when nodes are
created/update/deleted. This is done via cache node_list definition
within the modules. There might be room for improvementby creating own
custom cache tags which are invalidated when specific node types are
changed.
- Also fixed the front page "all events" link