### PR TITLE
AV 92 - Added logout to header menu

### DIFF
--- a/ansible/roles/drupal/tasks/main.yml
+++ b/ansible/roles/drupal/tasks/main.yml
@@ -192,7 +192,7 @@
         - "d7_user"
     when: "'1' in drupal7_database_initialized.stdout"
 
-  when: drupal8_database_initialized is not defined
+  # when: drupal8_database_initialized is not defined
 
 ### Translations ###
 

--- a/ansible/roles/drupal/tasks/main.yml
+++ b/ansible/roles/drupal/tasks/main.yml
@@ -192,7 +192,7 @@
         - "d7_user"
     when: "'1' in drupal7_database_initialized.stdout"
 
-  # when: drupal8_database_initialized is not defined
+  when: drupal8_database_initialized is not defined
 
 ### Translations ###
 

--- a/modules/avoindata-drupal-header/avoindata_header.links.menu.yml
+++ b/modules/avoindata-drupal-header/avoindata_header.links.menu.yml
@@ -150,7 +150,7 @@ avoindata_header.login_fi:
   description: 'Kirjaudu sisään'
   parent: avoindata_header.moreoptions_fi
   menu_name: main-fi
-  url: 'internal:/fi/user/login'
+  route_name: user.login
   weight: 1
   options:
     fa_icon: 'fa-sign-in'
@@ -160,10 +160,30 @@ avoindata_header.register_fi:
   description: 'Rekisteröidy palveluun'
   parent: avoindata_header.moreoptions_fi
   menu_name: main-fi
-  url: 'internal:/fi/user/register'
+  route_name: user.register
   weight: 2
   options:
     fa_icon: 'fa-pencil'
+
+avoindata_header.profile_fi:
+  title: 'Profiili'
+  description: 'Profiili'
+  parent: avoindata_header.moreoptions_fi
+  menu_name: main-fi
+  route_name: user.page
+  weight: 3
+  options:
+    fa_icon: 'fa-user-alt'
+
+avoindata_header.signout_fi:
+  title: 'Kirjaudu ulos'
+  description: 'Kirjaudu ulos'
+  parent: avoindata_header.moreoptions_fi
+  menu_name: main-fi
+  route_name: user.logout
+  weight: 4
+  options:
+    fa_icon: 'fa-sign-out-alt'
     
 avoindata_header.events_fi:
   title: 'Tapahtumakalenteri'
@@ -171,7 +191,7 @@ avoindata_header.events_fi:
   parent: avoindata_header.moreoptions_fi
   menu_name: main-fi
   url: 'internal:/fi/events/'
-  weight: 3
+  weight: 5
 
 avoindata_header.login_en:
   title: 'Log in'
@@ -179,7 +199,7 @@ avoindata_header.login_en:
   description: 'Log in'
   parent: avoindata_header.moreoptions_en
   menu_name: main-en
-  url: 'internal:/en/user/login'
+  route_name: user.login
   weight: 1
   options:
     fa_icon: 'fa-sign-in'
@@ -189,10 +209,30 @@ avoindata_header.register_en:
   description: 'Register an account'
   parent: avoindata_header.moreoptions_en
   menu_name: main-en
-  url: 'internal:/en/user/register'
+  route_name: user.register
   weight: 2
   options:
     fa_icon: 'fa-pencil'
+
+avoindata_header.profile_en:
+  title: 'Profile'
+  description: 'Profile'
+  parent: avoindata_header.moreoptions_en
+  menu_name: main-en
+  route_name: user.page
+  weight: 3
+  options:
+    fa_icon: 'fa-user-alt'
+    
+avoindata_header.signout_en:
+  title: 'Sign out'
+  description: 'Sign out'
+  parent: avoindata_header.moreoptions_en
+  menu_name: main-en
+  route_name: user.logout
+  weight: 4
+  options:
+    fa_icon: 'fa-sign-out-alt'
 
 avoindata_header.events_en:
   title: 'Calendar of events'
@@ -200,7 +240,7 @@ avoindata_header.events_en:
   parent: avoindata_header.moreoptions_en
   menu_name: main-en
   url: 'internal:/en/events/'
-  weight: 3
+  weight: 5
 
 avoindata_header.login_sv:
   title: 'Logga in'
@@ -208,7 +248,7 @@ avoindata_header.login_sv:
   description: 'Logga in'
   parent: avoindata_header.moreoptions_sv
   menu_name: main-sv
-  url: 'internal:/sv/user/login'
+  route_name: user.login
   weight: 1
   options:
     fa_icon: 'fa-sign-in'
@@ -218,10 +258,30 @@ avoindata_header.register_sv:
   description: 'Registrera ett konto'
   parent: avoindata_header.moreoptions_sv
   menu_name: main-sv
-  url: 'internal:/sv/user/register'
+  route_name: user.register
   weight: 2
   options:
     fa_icon: 'fa-pencil'
+
+avoindata_header.profile_sv:
+  title: 'Profil'
+  description: 'Profil'
+  parent: avoindata_header.moreoptions_sv
+  menu_name: main-sv
+  route_name: user.page
+  weight: 3
+  options:
+    fa_icon: 'fa-user-alt'
+
+avoindata_header.signout_sv:
+  title: 'Logga ut'
+  description: 'Logga ut'
+  parent: avoindata_header.moreoptions_sv
+  menu_name: main-sv
+  route_name: user.logout
+  weight: 4
+  options:
+    fa_icon: 'fa-sign-out-alt'
 
 avoindata_header.events_sv:
   title: 'Kalendarium'
@@ -229,4 +289,4 @@ avoindata_header.events_sv:
   parent: avoindata_header.moreoptions_sv
   menu_name: main-sv
   url: 'internal:/sv/events/'
-  weight: 3
+  weight: 5

--- a/modules/avoindata-drupal-header/avoindata_header.routing.yml
+++ b/modules/avoindata-drupal-header/avoindata_header.routing.yml
@@ -5,4 +5,3 @@ avoindata_header.header:
     _title: 'Header'
   requirements:
     _permission: 'access content'
-

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -1576,9 +1576,8 @@ class YtpThemePlugin(plugins.SingletonPlugin, YtpMainTranslation):
             hostname = config.get('ckan.site_url', '')
             domains = config.get('ckanext.drupal8.domain').split(",")
             cookies = {}
-
+            
             for domain in domains:
-                log.error(domain)
                 domain_hash = hashlib.sha256(domain).hexdigest()[:32]
                 cookiename = 'SSESS%s' % domain_hash
                 cookie = p.toolkit.request.cookies.get(cookiename)

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -5,7 +5,6 @@ import pylons
 import pylons.config as config
 import re
 import types
-import urllib2
 import urlparse
 import validators
 
@@ -1576,12 +1575,11 @@ class YtpThemePlugin(plugins.SingletonPlugin, YtpMainTranslation):
             hostname = config.get('ckan.site_url', '')
             domains = config.get('ckanext.drupal8.domain').split(",")
             cookies = {}
-            
             for domain in domains:
                 domain_hash = hashlib.sha256(domain).hexdigest()[:32]
                 cookiename = 'SSESS%s' % domain_hash
                 cookie = p.toolkit.request.cookies.get(cookiename)
-                if cookie != None:
+                if cookie is not None:
                     cookies.update({cookiename: cookie})
 
             response = requests.get('%s/%s/%s' % (hostname, lang, path), cookies=cookies, verify=False)


### PR DESCRIPTION
- Header menu has now logout and profile links that should only be visible for users that are logged in.
- CKANnow sends the drupal cookies with the footer and header api requests. This allows these menus to know whether the user is logged in even when user is browsing the ckan site.