### PR TITLE
AV-98 service messages

### DIFF
--- a/ansible/roles/drupal/vars/main.yml
+++ b/ansible/roles/drupal/vars/main.yml
@@ -2,6 +2,7 @@
 
 custom_modules:
   - { src_name: avoindata-drupal-header, module_name: avoindata-header, machine_name: avoindata_header }
+  - { src_name: avoindata-drupal-servicemessage, module_name: avoindata-servicemessage, machine_name: avoindata_servicemessage }
   - { src_name: avoindata-drupal-hero, module_name: avoindata-hero, machine_name: avoindata_hero }
   - { src_name: avoindata-drupal-categories, module_name: avoindata-categories, machine_name: avoindata_categories }
   - { src_name: avoindata-drupal-infobox, module_name: avoindata-infobox, machine_name: avoindata_infobox }

--- a/modules/avoindata-drupal-header/templates/avoindata_header.html.twig
+++ b/modules/avoindata-drupal-header/templates/avoindata_header.html.twig
@@ -1,3 +1,8 @@
+{# Service Message #}
+{% block service_message %}
+  {{ drupal_region('service_message') }}
+{% endblock %}
+
 {# Header #}
 <nav id="first-navbar" class="navbar first-navbar navbar-default">
 {% block header %}

--- a/modules/avoindata-drupal-servicemessage/README.md
+++ b/modules/avoindata-drupal-servicemessage/README.md
@@ -1,0 +1,3 @@
+# Avoindata servicemessage module #
+
+Avoindata servicemessage module.

--- a/modules/avoindata-drupal-servicemessage/avoindata_servicemessage.info.yml
+++ b/modules/avoindata-drupal-servicemessage/avoindata_servicemessage.info.yml
@@ -1,0 +1,5 @@
+name: Avoindata Servicemessage
+type: module
+description: Creates servicemessage component
+package: Custom
+core: 8.x

--- a/modules/avoindata-drupal-servicemessage/avoindata_servicemessage.module
+++ b/modules/avoindata-drupal-servicemessage/avoindata_servicemessage.module
@@ -1,0 +1,29 @@
+<?php
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function avoindata_servicemessage_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    case 'help.page.avoindata_servicemessage':
+      return t('
+        Creates servicemessage module.
+      ');
+  }
+}
+
+/**
+ * Implements hook_theme().
+ */
+function avoindata_servicemessage_theme($existing, $type, $theme, $path) {
+  return array(
+    'avoindata_servicemessage' => array(
+      'template' => 'avoindata_servicemessage_block',
+      'variables' => array(
+        'messages' => []
+      )
+    ),
+  );
+}

--- a/modules/avoindata-drupal-servicemessage/src/Plugin/Block/ServicemessageBlock.php
+++ b/modules/avoindata-drupal-servicemessage/src/Plugin/Block/ServicemessageBlock.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\avoindata_servicemessage\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Component\Serialization\Json;
+
+/**
+ * Provides a 'Avoindata Servicemessage' Block.
+ *
+ * @Block(
+ *   id = "avoindata_servicemessage",
+ *   admin_label = @Translation("Avoindata Servicemessage"),
+ *   category = @Translation("Avoindata Servicemessage"),
+ * )
+ */
+class ServicemessageBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $lang = \Drupal::languageManager()->getCurrentLanguage()->getId();
+
+    $messageNodeIdsQuery = \Drupal::entityQuery('node')
+    ->condition('type', 'avoindata_servicemessage')
+    ->condition('langcode', $lang);
+
+    $messageNodeIds = $messageNodeIdsQuery
+      ->execute();
+
+    $messageNodes = \Drupal::entityTypeManager()
+    ->getStorage('node')
+    ->loadMultiple($messageNodeIds);
+
+    $messages = [];
+
+    foreach ($messageNodes as $key => $node) {
+      array_push($messages, (object) array(
+        'id' => $node->id(),
+        'createdtime' => $node->getCreatedTime(),
+        'body' => $node->body->getValue()[0]['value'],
+        'severity' => $node->field_severity->getValue()[0]['value']
+      ));
+    }
+    return array(
+      '#theme' => 'avoindata_servicemessage',
+      '#messages' => $messages
+    );
+  }
+}

--- a/modules/avoindata-drupal-servicemessage/templates/avoindata_servicemessage_block.html.twig
+++ b/modules/avoindata-drupal-servicemessage/templates/avoindata_servicemessage_block.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Avoindata Servicemessage Block
+ *
+ * @ingroup themeable
+ */
+#}
+<ul class="service-messages">
+{% for message in messages %}
+  {% set alert_type = "secondary" %}
+  {% if message.severity == "critical" %}
+    {% set alert_type = "danger" %}
+  {% elseif message.severity == "warning" %}
+    {% set alert_type = "warning" %}
+  {% elseif message.severity == "info" %}
+    {% set alert_type = "info" %}
+  {% endif %}
+
+  <li class="alert alert-{{ alert_type }} alert-dismissible">
+    <span>{{ message.body|raw }}</span>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </li>
+{% endfor %}
+</ul>

--- a/modules/avoindata-drupal-theme/avoindata.info.yml
+++ b/modules/avoindata-drupal-theme/avoindata.info.yml
@@ -21,6 +21,7 @@ regions:
   page_top: 'Page top'
   page_bottom: 'Page bottom'
   guide_menu: 'Guide menu'
+  service_message: 'Service message'
 
 libraries:
   - 'avoindata/global-styling'

--- a/modules/avoindata-drupal-theme/config/install/block.block.avoindata_servicemessage.yml
+++ b/modules/avoindata-drupal-theme/config/install/block.block.avoindata_servicemessage.yml
@@ -1,0 +1,18 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - avoindata
+id: avoindata_servicemessage
+theme: avoindata
+region: service_message
+weight: 3
+provider: null
+plugin: avoindata_servicemessage
+settings:
+  id: avoindata_servicemessage
+  label: 'Avoindata Servicemessage'
+  provider: avoindata_servicemessage
+  label_display: '0'

--- a/modules/avoindata-drupal-theme/config/install/core.entity_form_display.node.avoindata_servicemessage.default.yml
+++ b/modules/avoindata-drupal-theme/config/install/core.entity_form_display.node.avoindata_servicemessage.default.yml
@@ -1,0 +1,60 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.node.avoindata_servicemessage.body
+    - field.field.node.avoindata_servicemessage.severity
+    - node.type.avoindata_servicemessage
+  module:
+    - datetime
+    - text
+    - options
+id: node.avoindata_servicemessage.default
+targetEntityType: node
+bundle: avoindata_servicemessage
+mode: default
+content:
+  body:
+    label: hidden
+    type: string_textfield
+    weight: 6
+    settings: { }
+    third_party_settings: {  }
+    region: content
+  field_severity:
+    type: options_select
+    settings: { }
+    third_party_settings: {  }
+    region: content
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 2
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    region: content
+    third_party_settings: {  }
+hidden:
+  promote: true

--- a/modules/avoindata-drupal-theme/config/install/field.field.node.avoindata_servicemessage.body.yml
+++ b/modules/avoindata-drupal-theme/config/install/field.field.node.avoindata_servicemessage.body.yml
@@ -1,0 +1,20 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.avoindata_servicemessage
+  module:
+    - text
+id: node.avoindata_servicemessage.body
+field_name: body
+entity_type: node
+bundle: avoindata_servicemessage
+label: "Message body"
+description: 'More specific information about the avoindata servicemessage.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: { }
+field_type: text

--- a/modules/avoindata-drupal-theme/config/install/field.field.node.avoindata_servicemessage.severity.yml
+++ b/modules/avoindata-drupal-theme/config/install/field.field.node.avoindata_servicemessage.severity.yml
@@ -1,0 +1,20 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_severity
+    - node.type.avoindata_servicemessage
+  module:
+    - options
+id: node.avoindata_event.severity
+field_name: field_severity
+entity_type: node
+bundle: avoindata_servicemessage
+label: Severity
+description: 'Severity of the service message'
+required: true
+translatable: false
+default_value: { }
+default_value_callback: ''
+settings: { }
+field_type: list_string

--- a/modules/avoindata-drupal-theme/config/install/field.storage.node.field_severity.yml
+++ b/modules/avoindata-drupal-theme/config/install/field.storage.node.field_severity.yml
@@ -1,0 +1,28 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_severity
+field_name: field_severity
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: critical
+      label: 'Critical'
+    -
+      value: warning
+      label: 'Warning'
+    -
+      value: info
+      label: 'Info'
+  allowed_values_function: {}
+module: options
+locked: false
+cardinality: 1
+translatable: true
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/avoindata-drupal-theme/config/install/language.content_settings.node.avoindata_servicemessage.yml
+++ b/modules/avoindata-drupal-theme/config/install/language.content_settings.node.avoindata_servicemessage.yml
@@ -1,0 +1,15 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - node.type.avoindata_servicemessage
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: false
+id: node.avoindata_servicemessage
+target_entity_type_id: node
+target_bundle: avoindata_servicemessage
+default_langcode: site_default
+language_alterable: true

--- a/modules/avoindata-drupal-theme/config/install/node.type.avoindata_servicemessage.yml
+++ b/modules/avoindata-drupal-theme/config/install/node.type.avoindata_servicemessage.yml
@@ -1,0 +1,16 @@
+langcode: fi
+status: true
+dependencies:
+  enforced:
+    module:
+      - avoindata_servicemessage
+  module:
+    - menu_ui
+third_party_settings: { }
+name: 'Avoindata Servicemessage'
+type: avoindata_servicemessage
+description: 'Content type that can be used to provide additional information on <em>Avoindata Servicemessages</em>'
+help: ''
+new_revision: false
+preview_mode: 0
+display_submitted: true

--- a/modules/ytp-assets-common/src/less/navbars.less
+++ b/modules/ytp-assets-common/src/less/navbars.less
@@ -294,3 +294,14 @@ End of dropdown CSS
   border-top: 1px solid #e5e5e5;
 }
 
+.service-messages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  li {
+    margin: 0;
+    padding: .5em 2em .5em 1em;
+    border-radius: 0 !important;
+  }
+}


### PR DESCRIPTION
- Added node type servicemessage to Drupal
- Added avoindata-drupal-servicemessage plugin for storing, adding and rendering a service messages
- Modified avoindata-drupal-header to include service messages
- Added a service_messages region to avoindata-drupal-theme

Messages can be viewed in Drupal and CKAN. A message instance must be added for every language to be visible on pages of all languages.