### PR TITLE
AV 68 Category view translation

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/group_item.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/group_item.html
@@ -1,0 +1,50 @@
+{#
+Renders a media item for a group. This should be used in a list.
+
+group - A group dict.
+
+Example:
+
+    <ul class="media-grid">
+      {% for group in groups %}
+        {% snippet "group/snippets/group_item.html", group=group %}
+      {% endfor %}
+    </ul>
+#}
+{% set type = group.type or 'group' %}
+{% set url = h.url_for(type ~ '_read', action='read', id=group.name) %}
+{% block item %}
+<li class="media-item">
+  {% block item_inner %}
+  {% block image %}
+    <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image img-responsive">
+  {% endblock %}
+  {% block title %}
+    <h3 class="media-heading">{{ h.get_translated(group, 'title') or group.title }}</h3>
+  {% endblock %}
+  {% block description %}
+    {% if group.description %}
+      <p>{{ h.get_translated(group, 'description')|truncate(80) or h.markdown_extract(group.description, 80)}}</p>
+    {% endif %}
+  {% endblock %}
+  {% block datasets %}
+    {% if group.package_count %}
+      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', group.package_count).format(num=group.package_count) }}</strong>
+    {% elif group.package_count == 0 %}
+      <span class="count">{{ _('0 Datasets') }}</span>
+    {% endif %}
+  {% endblock %}
+  {% block link %}
+  <a href="{{ url }}" title="{{ _('View {name}').format(name=group.display_name) }}" class="media-view">
+    <span>{{ _('View {name}').format(name=group.display_name) }}</span>
+  </a>
+  {% endblock %}
+  {% if group.user_member %}
+    <input name="group_remove.{{ group.id }}" value="{{ _('Remove') }}" type="submit" class="btn btn-danger btn-sm media-edit" title="{{ _('Remove dataset from this group') }}"/>
+  {% endif %}
+  {% endblock %}
+</li>
+{% endblock %}
+{% if position is divisibleby 3 %}
+  <li class="clearfix js-hide"></li>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/group_item.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/group_item.html
@@ -23,7 +23,7 @@ Example:
     <h3 class="media-heading">{{ h.get_translated(group, 'title') or group.title }}</h3>
   {% endblock %}
   {% block description %}
-    {% set description = h.extra_translation(group, 'description', markdown=True) %}
+    {% set description =  h.render_markdown(h.get_translated(group, 'description')) %}
     {% if description %}
       <p>{{ description|truncate(80) }}</p>
     {% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/group_item.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/group_item.html
@@ -23,8 +23,9 @@ Example:
     <h3 class="media-heading">{{ h.get_translated(group, 'title') or group.title }}</h3>
   {% endblock %}
   {% block description %}
-    {% if group.description %}
-      <p>{{ h.get_translated(group, 'description')|truncate(80) or h.markdown_extract(group.description, 80)}}</p>
+    {% set description = h.extra_translation(group, 'description', markdown=True) %}
+    {% if description %}
+      <p>{{ description|truncate(80) }}</p>
     {% endif %}
   {% endblock %}
   {% block datasets %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
@@ -18,7 +18,7 @@
     </h1>
     {% endblock %}
     {% block description %}
-    {% set description = h.extra_translation(group, 'description', markdown=True) %}
+    {% set description =  h.render_markdown(h.get_translated(group, 'description')) %}
     {% if description %}
       <p>
         {{ description|truncate(180) }}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
@@ -11,7 +11,7 @@
     {% endblock %}
     {% block heading %}
     <h1 class="heading">
-      {{ h.scheming_language_text(group.title) }}
+      {{ h.get_translated(group, 'title') or group.title }}
       {% if group.state == 'deleted' %}
         [{{ _('Deleted') }}]
       {% endif %}
@@ -20,7 +20,7 @@
     {% block description %}
     {% if group.description %}
       <p>
-        {{ h.markdown_extract(group.description, 180) }}
+        {{ h.get_translated(group, 'description')|truncate(180) or h.markdown_extract(group.description, 180)}}
         {% link_for _('read more'), named_route='group.about', id=group.name %}
       </p>
     {% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
@@ -18,9 +18,10 @@
     </h1>
     {% endblock %}
     {% block description %}
-    {% if group.description %}
+    {% set description = h.extra_translation(group, 'description', markdown=True) %}
+    {% if description %}
       <p>
-        {{ h.get_translated(group, 'description')|truncate(180) or h.markdown_extract(group.description, 180)}}
+        {{ description|truncate(180) }}
         {% link_for _('read more'), named_route='group.about', id=group.name %}
       </p>
     {% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/info.html
@@ -10,8 +10,8 @@ Example:
 #}
 {% block package_info %}
  {% if pkg %}
-    <section class="module module-narrow">
-      <div class="module context-info opendata-card">
+    <section class="module-narrow">
+      <div class="module context-info">
         <div class="module-content">
           {% block package_info_inner %}
             {% block heading %}


### PR DESCRIPTION
- Category view didn't fetch the name and description translations to
the info bar. Now these should work when user changes the language.
- Also fixed view issue with package info bar that caused two "card
views" to be displayed on top of each other