### PR TITLE
AV 137 disable servicemessage promote to front page

### DIFF
--- a/modules/avoindata-drupal-theme/config/install/core.base_field_override.node.avoindata_servicemessage.promote.yml
+++ b/modules/avoindata-drupal-theme/config/install/core.base_field_override.node.avoindata_servicemessage.promote.yml
@@ -1,0 +1,21 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - node.type.avoindata_servicemessage
+id: node.avoindata_servicemessage.promote
+field_name: promote
+entity_type: node
+bundle: avoindata_servicemessage
+label: 'Promoted to front page'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean


### PR DESCRIPTION
- Service message is no longer promoted to frontpage by default (message
is still displayed on the frontpage).