### PR TITLE
Guide front page automatically created for all languages and small guide menu changes

### DIFF
--- a/modules/avoindata-drupal-guide/avoindata_guide.install
+++ b/modules/avoindata-drupal-guide/avoindata_guide.install
@@ -1,0 +1,34 @@
+<?php
+
+use Drupal\node\Entity\Node;
+
+function avoindata_guide_install() {
+    // Ensure the translation fields are created in the database.
+    \Drupal::service('entity.definition_update_manager')->applyUpdates();
+    $node = Node::create([
+         'type' => 'avoindata_guide_page',
+         'langcode' => 'fi',
+         'created' => REQUEST_TIME,
+         'changed' => REQUEST_TIME,
+         'uid' => 1,
+         'title' => 'Oppaan etusivu. ',
+         'field_content' => 'Oppaan etusivun sisältö'
+         ]
+       );
+    $node->save();
+    \Drupal::service('path.alias_storage')->save("/node/" . $node->id(), "/opas", "fi");
+
+    //English translation
+    $node_en = $node->addTranslation('en');
+    $node_en->title = 'Guide frontpage';
+    $node_en->field_content = 'Guide frontpage content';
+    $node_en->save();
+    \Drupal::service('path.alias_storage')->save("/node/" . $node->id(), "/guide", "en");
+
+    //Swedish translation
+    $node_sv = $node->addTranslation('sv');
+    $node_sv->title = 'Guide startsidan';
+    $node_sv->field_content = 'Guide innehåll';
+    $node_sv->save();
+    \Drupal::service('path.alias_storage')->save("/node/" . $node->id(), "/guide", "sv");
+    }

--- a/modules/avoindata-drupal-guide/avoindata_guide.links.menu.yml
+++ b/modules/avoindata-drupal-guide/avoindata_guide.links.menu.yml
@@ -24,3 +24,30 @@ avoindata_guide.beginners_guide_en:
   url: 'internal:#'
   expanded: true
   weight: 0
+
+avoindata_guide.data_user_guide_en:
+  title: "Data user's guide"
+  description: "Data user's guide"
+  parent: guide-menu-en
+  menu_name: guide-menu-en
+  url: 'internal:#'
+  expanded: true
+  weight: 1
+
+avoindata_guide.beginners_guide_sv:
+  title: "Nybörjares guide"
+  description: "Nybörjares guide"
+  parent: guide-menu-sv
+  menu_name: guide-menu-sv
+  url: 'internal:#'
+  expanded: true
+  weight: 0
+
+avoindata_guide.data_user_guide_sv:
+  title: "Data användares guide"
+  description: "Data användares guide"
+  parent: guide-menu-sv
+  menu_name: guide-menu-sv
+  url: 'internal:#'
+  expanded: true
+  weight: 1

--- a/modules/avoindata-drupal-header/avoindata_header.links.menu.yml
+++ b/modules/avoindata-drupal-header/avoindata_header.links.menu.yml
@@ -153,8 +153,8 @@ avoindata_header.news_sv:
   weight: 5
 
 avoindata_header.guide_sv:
-  title: 'Anvisningar'
-  description: 'Anvisningar'
+  title: 'Guide'
+  description: 'Guide'
   parent: main-sv
   menu_name: main-sv
   url: 'internal:/sv/guide'

--- a/modules/avoindata-drupal-header/avoindata_header.links.menu.yml
+++ b/modules/avoindata-drupal-header/avoindata_header.links.menu.yml
@@ -43,7 +43,7 @@ avoindata_header.guide_fi:
   description: 'Opas'
   parent: main-fi
   menu_name: main-fi
-  url: 'internal:/fi/guide'
+  url: 'internal:/fi/opas'
   weight: 6
 
 avoindata_header.moreoptions_fi:
@@ -95,7 +95,7 @@ avoindata_header.news_en:
   url: 'internal:/en/articles'
   weight: 5
 
-  avoindata_header.guide_en:
+avoindata_header.guide_en:
   title: 'Guide'
   description: 'Guide'
   parent: main-en
@@ -152,7 +152,7 @@ avoindata_header.news_sv:
   url: 'internal:/sv/articles'
   weight: 5
 
-  avoindata_header.guide_sv:
+avoindata_header.guide_sv:
   title: 'Anvisningar'
   description: 'Anvisningar'
   parent: main-sv


### PR DESCRIPTION
Front pages of the open data guide are automatically created for Finnish, Swedish and English guide. The header has a link to this guide front page. The page doesn't have real content, but the content creator can add it later. 

All language versions of the guide page menu now have two top level submenus. These menus can be changed later, when actual content is created. 

Small translation changes