### PR TITLE
AV-155: Fix fluent field error rendering for non language-specific er…

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -842,7 +842,7 @@ msgstr ""
 #: ckanext/ytp/validators.py:247 ckanext/ytp/validators.py:254
 #, python-format
 msgid "Required language \"%s\" missing"
-msgstr ""
+msgstr "Vaadittu käännös \"%s\" puuttuu"
 
 #: ckanext/ytp/public/javascript/translations.js:4
 #: ckanext/ytp/templates/organization/member_new.html:27

--- a/modules/ckanext-ytp_main/ckanext/ytp/schemas/presets.json
+++ b/modules/ckanext-ytp_main/ckanext/ytp/schemas/presets.json
@@ -109,7 +109,7 @@
         "form_snippet": "fluent_markdown_ex.html",
         "display_snippet": "fluent_markdown.html",
         "error_snippet": "fluent_text.html",
-        "validators": "only_default_lang_required fluent_text",
+        "validators": "fluent_text only_default_lang_required ",
         "output_validators": "fluent_core_translated_output"
       }
     },
@@ -129,7 +129,7 @@
         "form_snippet": "fluent_title.html",
         "display_snippet": "fluent_text.html",
         "error_snippet": "fluent_text.html",
-        "validators": "only_default_lang_required fluent_text",
+        "validators": "fluent_text only_default_lang_required ",
         "output_validators": "fluent_core_translated_output",
         "form_attrs": {
           "data-module": "slug-preview-target"

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_markdown_ex.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_markdown_ex.html
@@ -1,5 +1,4 @@
 {% import 'macros/form.html' as form %}
-
 <div class="form-group-fluent control-group">
   <label class="control-label group-label">{{_(field.label)}}</label>
   {%- for lang in h.fluent_form_languages(field, entity_type, object_type, schema) -%}
@@ -10,7 +9,9 @@
       placeholder=h.scheming_language_text(field.form_placeholder, lang),
       value=data[field.field_name + '-' + lang]
           or data.get(field.field_name, {})[lang],
-      error=errors[field.field_name + '-' + lang],
+      error=errors[field.field_name + '-' + lang]
+          or errors.get(field.field_name, {})[lang]
+          or errors[field.field_name],
       attrs=field.form_attrs or {},
       is_required=h.scheming_field_only_default_required(field, lang)
       ) %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_text_ex.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_text_ex.html
@@ -10,7 +10,9 @@
       placeholder=h.scheming_language_text(field.form_placeholder, lang),
       value=data[field.field_name + '-' + lang]
           or data.get(field.field_name, {})[lang],
-      error=errors[field.field_name + '-' + lang],
+      error=errors[field.field_name + '-' + lang]
+          or errors.get(field.field_name, {})[lang]
+          or errors[field.field_name],
       classes=['control-full'],
       attrs=field.form_attrs if 'form_attrs' in field else {},
       is_required=h.scheming_field_only_default_required(field, lang)

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_title.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_title.html
@@ -12,7 +12,9 @@
     placeholder=h.scheming_language_text(field.form_placeholder, lang),
     value=data[field.field_name + '-' + lang]
     or data.get(field.field_name, {})[lang],
-    error=errors[field.field_name + '-' + lang],
+    error=errors[field.field_name + '-' + lang]
+          or errors.get(field.field_name, {})[lang]
+          or errors[field.field_name],
     classes=['control-full'],
     attrs=field.form_attrs if 'form_attrs' in field else {},
     is_required=h.scheming_field_only_default_required(field, lang)

--- a/modules/ckanext-ytp_main/ckanext/ytp/validators.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/validators.py
@@ -243,14 +243,14 @@ def only_default_lang_required(field, schema):
                 errors[key].append(_('expecting JSON object'))
                 return
 
-            if field.get('only_default_lang_required') is not None and value.get(default_lang) is None:
+            if field.get('only_default_lang_required') is True and value.get(default_lang, '') == '':
                 errors[key].append(_('Required language "%s" missing') % default_lang)
             return
 
         prefix = key[-1] + '-'
         extras = data.get(key[:-1] + ('__extras',), {})
 
-        if extras.get(prefix + default_lang) == '' or extras.get(prefix + default_lang) is None:
+        if extras.get(prefix + default_lang, '') == '':
             errors[key].append(_('Required language "%s" missing') % default_lang)
 
     return validator


### PR DESCRIPTION
- Fix edge cases in `only_default_lang_required` validator
- Render non-language specific errors into all fields
- Execute `fluent_text` validator before `only_default_lang_required`