### PR TITLE
Translatable basic page and ansible configuration removal fix

### DIFF
--- a/ansible/roles/drupal/tasks/main.yml
+++ b/ansible/roles/drupal/tasks/main.yml
@@ -297,11 +297,20 @@
     chdir: "{{ drupal8_root }}/web"
   with_items: "{{ custom_modules }}"
 
-#TODO: This should be fixed so that it's not necessary to delete configs like this
-- name: Delete breadcrumb settings
-  command: ../vendor/drush/drush/drush config-delete easy_breadcrumb.settings
+# Some configurations need to be removed to avoid conflicts at the next step
+# To avoid failure with clean installs, error about trying to remove a non-existing
+# configuration is ignored. As a result, it is important to carefully check the
+# spelling of configurations. 
+- name: Delete existing configurations
+  command: ../vendor/drush/drush/drush config-delete {{ item }}
+  register: result
+  failed_when:
+    - result.rc == 1 and 'Config {{ item }} does not exist' not in result.stderr 
   args:
     chdir: "{{ drupal8_root }}/web"
+  with_items:
+    - easy_breadcrumb.settings
+    - node.type.page
 
 - name: Enable custom theme
   command: ../vendor/drush/drush/drush then -y avoindata

--- a/modules/avoindata-drupal-theme/config/install/field.field.node.page.field_basic_page_comments.yml
+++ b/modules/avoindata-drupal-theme/config/install/field.field.node.page.field_basic_page_comments.yml
@@ -1,0 +1,23 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_basic_page_comments
+    - node.type.page
+  module:
+    - disqus
+id: node.page.field_basic_page_comments
+field_name: field_basic_page_comments
+entity_type: node
+bundle: page
+label: 'Basic page comments'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    status: 1
+    identifier: ''
+default_value_callback: ''
+settings: {  }
+field_type: disqus_comment

--- a/modules/avoindata-drupal-theme/config/install/field.storage.node.field_basic_page_comments.yml
+++ b/modules/avoindata-drupal-theme/config/install/field.storage.node.field_basic_page_comments.yml
@@ -1,0 +1,18 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - disqus
+    - node
+id: node.field_basic_page_comments
+field_name: field_basic_page_comments
+entity_type: node
+type: disqus_comment
+settings: {  }
+module: disqus
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/avoindata-drupal-theme/config/install/language.content_settings.node.page.yml
+++ b/modules/avoindata-drupal-theme/config/install/language.content_settings.node.page.yml
@@ -1,0 +1,15 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: node.page
+target_entity_type_id: node
+target_bundle: page
+default_langcode: site_default
+language_alterable: false

--- a/modules/avoindata-drupal-theme/config/install/node.type.page.yml
+++ b/modules/avoindata-drupal-theme/config/install/node.type.page.yml
@@ -1,0 +1,20 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+_core:
+  default_config_hash: KuyA4NHPXcmKAjRtwa0vQc2ZcyrUJy6IlS2TAyMNRbc
+name: 'Basic page'
+type: page
+description: 'Use <em>basic pages</em> for your static content, such as an ''About us'' page, which doesn''t fall under any other content type'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false
+translatable: true

--- a/modules/avoindata-drupal-theme/templates/node/node--page.html.twig
+++ b/modules/avoindata-drupal-theme/templates/node/node--page.html.twig
@@ -1,0 +1,106 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a node.
+ *
+ * Available variables:
+ * - node: The node entity with limited access to object properties and methods.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - node.getCreatedTime() will return the node creation timestamp.
+ *   - node.hasField('field_example') returns TRUE if the node bundle includes
+ *     field_example. (This does not indicate the presence of a value in this
+ *     field.)
+ *   - node.isPublished() will return whether the node is published or not.
+ *   Calling other methods, such as node.delete(), will result in an exception.
+ *   See \Drupal\node\Entity\Node for a full list of public properties and
+ *   methods for the node object.
+ * - label: The title of the node.
+ * - content: All node items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - author_picture: The node author user entity, rendered using the "compact"
+ *   view mode.
+ * - metadata: Metadata for this node.
+ * - date: Themed creation date field.
+ * - author_name: Themed author name field.
+ * - url: Direct URL of the current node.
+ * - display_submitted: Whether submission information should be displayed.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - node: The current template type (also known as a "theming hook").
+ *   - node--type-[type]: The current node type. For example, if the node is an
+ *     "Article" it would result in "node--type-article". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
+ *     teaser would result in: "node--view-mode-teaser", and
+ *     full: "node--view-mode-full".
+ *   The following are controlled through the node publishing options.
+ *   - node--promoted: Appears on nodes promoted to the front page.
+ *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
+ *     teaser listings.
+ *   - node--unpublished: Appears on unpublished nodes visible only to site
+ *     admins.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - content_attributes: Same as attributes, except applied to the main
+ *   content tag that appears in the template.
+ * - author_attributes: Same as attributes, except applied to the author of
+ *   the node tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - view_mode: View mode; for example, "teaser" or "full".
+ * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
+ * - page: Flag for the full page state. Will be true if view_mode is 'full'.
+ * - readmore: Flag for more state. Will be true if the teaser content of the
+ *   node cannot hold the main body content.
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_node()
+ *
+ * @todo Remove the id attribute (or make it a class), because if that gets
+ *   rendered twice on a page this is invalid CSS for example: two lists
+ *   in different view modes.
+ *
+ * @ingroup themeable
+ */
+#}
+<article{{ attributes }}>
+
+  {{ title_prefix }}
+  {% if not page %}
+    <h2{{ title_attributes }}>
+      <a href="{{ url }}" rel="bookmark">{{ label }}</a>
+    </h2>
+  {% endif %}
+  {{ title_suffix }}
+
+  <div{{ content_attributes }}>
+  <div class="container-fluid">
+    <div class="avoindata-article-container avoindata-card-container">
+        <div class="col-md-12">
+            <h3 class="article-header">
+              {{label}}
+            </h3>
+            <div class="row">
+                {{ content.field_image|field_value }}
+            </div>
+            <div class="spacer"></div>
+            <div class="row">
+                {{ content.body|field_value }}
+            </div>
+            <div class="row">
+                {{ content.field_basic_page_comments|field_value }}
+            </div>
+        </div>
+    </div>
+  </div>
+
+</article>


### PR DESCRIPTION
-Made basic page content type translatable
-Added images and Disqus comments to the basic page
-Template changes for basic page
-Trying to delete configurations in Ansible doesn't result in an error anymore with a clean install