### PR TITLE
AV-162 Member request fix

### DIFF
--- a/modules/ckanext-ytp_request/ckanext/ytp_request/logic/action/create.py
+++ b/modules/ckanext-ytp_request/ckanext/ytp_request/logic/action/create.py
@@ -57,7 +57,7 @@ def _create_member_request(context, data_dict):
             raise logic.ValidationError({"organization": _(
                 "Duplicate organization request")}, {_("Organization"): message})
     else:
-        member = model.Member(table_name="user", table_id=userobj.id,
+        member = model.Member(table_name="user", table_id=userobj.id, group=group,
                               group_id=group.id, capacity=role, state='pending')
 
     # TODO: Is there a way to get language associated to all admins. User table there is nothing as such stored

--- a/modules/ckanext-ytp_request/ckanext/ytp_request/logic/action/get.py
+++ b/modules/ckanext-ytp_request/ckanext/ytp_request/logic/action/get.py
@@ -151,7 +151,8 @@ def _member_list_dictize(obj_list, context, sort_key=lambda x: x['group_id'], re
         member_dict = model_dictize.member_dictize(obj, context)
         user = model.Session.query(model.User).get(obj.table_id)
 
-        member_dict['group_name'] = obj.group.name
+        if obj.group is not None:
+            member_dict['group_name'] = obj.group.name
         member_dict['role'] = obj.capacity
         # Member request must always exist since state is pending. Fetch just
         # the latest
@@ -165,7 +166,8 @@ def _member_list_dictize(obj_list, context, sort_key=lambda x: x['group_id'], re
         member_dict['request_date'] = my_date
         member_dict['mid'] = obj.id
 
-        member_dict['user_name'] = user.name
+        if user.email is not None:
+            member_dict['user_name'] = user.name
         member_dict['user_email'] = user.email
         result_list.append(member_dict)
     return sorted(result_list, key=sort_key, reverse=reverse)


### PR DESCRIPTION
- Member requests were failing becasue the sqlalchemy didnt save the
group relationship to member request correctly. Apparently the group id
was not enough for the relation ship.
- Also added some "none" checking to member_list_dictize to avoid
rendering errors incase email or group was missing from member request.