### PR TITLE
AV-184 Request error handling fixes

### DIFF
--- a/modules/avoindata-drupal-appfeed/src/Plugin/Block/AppFeedBlock.php
+++ b/modules/avoindata-drupal-appfeed/src/Plugin/Block/AppFeedBlock.php
@@ -23,9 +23,13 @@ class AppFeedBlock extends BlockBase {
     $client = \Drupal::httpClient();
     $currentLang = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
-    $recentApplicationsResponse = $client->request('GET', 'http://localhost:8080/data/api/action/package_search?fq=dataset_type:showcase&sort=metadata_modified%20desc&rows=3');
-    $recentApplicationsResult = Json::decode($recentApplicationsResponse->getBody());
-    $recentApplications = $recentApplicationsResult['result']['results'];
+    try {
+      $recentApplicationsResponse = $client->request('GET', 'http://localhost:8080/data/api/action/package_search?fq=dataset_type:showcase&sort=metadata_modified%20desc&rows=3');
+      $recentApplicationsResult = Json::decode($recentApplicationsResponse->getBody());
+      $recentApplications = $recentApplicationsResult['result']['results'];
+    } catch (\Exception $e) {
+      $recentApplications = NULL;
+    }
 
     return array(
       '#applications' => $recentApplications,

--- a/modules/avoindata-drupal-categories/src/Plugin/Block/CategoriesBlock.php
+++ b/modules/avoindata-drupal-categories/src/Plugin/Block/CategoriesBlock.php
@@ -21,9 +21,15 @@ class CategoriesBlock extends BlockBase {
    */
   public function build() {
     $client = \Drupal::httpClient();
-    $response = $client->request('GET', 'http://localhost:8080/data/api/3/action/group_list?all_fields=true&include_extras=true');
-    $result = Json::decode($response->getBody());
-    $categories = $result['result'];
+
+    try {
+      $response = $client->request('GET', 'http://localhost:8080/data/api/3/action/group_list?all_fields=true&include_extras=true');
+      $result = Json::decode($response->getBody());
+      $categories = $result['result'];
+    } catch (\Exception $e) {
+      $categories = NULL;
+    }
+    
     return array(
       '#theme' => 'avoindata_categories',
       '#categories' => $categories,

--- a/modules/avoindata-drupal-datasetlist/src/Plugin/Block/DatasetlistBlock.php
+++ b/modules/avoindata-drupal-datasetlist/src/Plugin/Block/DatasetlistBlock.php
@@ -21,18 +21,33 @@ class DatasetlistBlock extends BlockBase {
    */
   public function build() {
     $client = \Drupal::httpClient();
+    
     // recently modified datasets
-    $recentDatasetsResponse = $client->request('GET', 'http://localhost:8080/data/api/action/package_search?sort=metadata_modified%20desc&facet.limit=1&rows=5');
-    $recentDatasetsResult = Json::decode($recentDatasetsResponse->getBody());
-    $recentDatasets = $recentDatasetsResult['result']['results'];
+    try {
+      $recentDatasetsResponse = $client->request('GET', 'http://localhost:8080/data/api/action/package_search?sort=metadata_modified%20desc&facet.limit=1&rows=5');
+      $recentDatasetsResult = Json::decode($recentDatasetsResponse->getBody());
+      $recentDatasets = $recentDatasetsResult['result']['results'];
+    } catch (\Exception $e) {
+      $recentDatasets = NULL;
+    }
+
     // new datasets
-    $newDatasetsResponse = $client->request('GET', 'http://localhost:8080/data/api/action/package_search?sort=metadata_created%20desc&facet.limit=1&rows=5');
-    $newDatasetsResult = Json::decode($newDatasetsResponse->getBody());
-    $newDatasets = $newDatasetsResult['result']['results'];
-    // // popular datasets
-    $popularDatasetsResponse = $client->request('GET', 'http://localhost:8080/data/api/action/package_search?sort=views_recent%20desc&facet.limit=1&rows=5');
-    $popularDatasetsResult = Json::decode($popularDatasetsResponse->getBody());
-    $popularDatasets = $popularDatasetsResult['result']['results'];
+    try {
+      $newDatasetsResponse = $client->request('GET', 'http://localhost:8080/data/api/action/package_search?sort=metadata_created%20desc&facet.limit=1&rows=5');
+      $newDatasetsResult = Json::decode($newDatasetsResponse->getBody());
+      $newDatasets = $newDatasetsResult['result']['results'];
+    } catch (\Exception $e) {
+      $newDatasets = NULL;
+    }
+    
+    // popular datasets
+    try {
+      $popularDatasetsResponse = $client->request('GET', 'http://localhost:8080/data/api/action/package_search?sort=views_recent%20desc&facet.limit=1&rows=5');
+      $popularDatasetsResult = Json::decode($popularDatasetsResponse->getBody());
+      $popularDatasets = $popularDatasetsResult['result']['results'];
+    } catch (\Exception $e) {
+      $popularDatasets = NULL;
+    }
     
     return array(
       '#recentdatasets' => $recentDatasets,

--- a/modules/avoindata-drupal-hero/src/Plugin/Form/HeroForm.php
+++ b/modules/avoindata-drupal-hero/src/Plugin/Form/HeroForm.php
@@ -23,17 +23,29 @@ class HeroForm extends FormBase {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $client = \Drupal::httpClient();
 
-    $datasetResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/package_list');
-    $datasetResult = Json::decode($datasetResponse->getBody());
-    $datasetCount = count($datasetResult['result']);
+    try {
+      $datasetResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/package_list');
+      $datasetResult = Json::decode($datasetResponse->getBody());
+      $datasetCount = count($datasetResult['result']);
+    } catch (\Exception $e) {
+      $datasetCount = 0;
+    }
 
-    $organizationResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/organization_list');
-    $organizationResult = Json::decode($organizationResponse->getBody());
-    $organizationCount = count($datasetResult['result']);
+    try {
+      $organizationResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/organization_list');
+      $organizationResult = Json::decode($organizationResponse->getBody());
+      $organizationCount = count($datasetResult['result']);
+    } catch (\Exception $e) {
+      $organizationCount = 0;
+    }
 
-    $applicationResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/ckanext_showcase_list');
-    $applicationResult = Json::decode($applicationResponse->getBody());
-    $applicationCount = count($datasetResult['result']);
+    try {
+      $applicationResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/ckanext_showcase_list');
+      $applicationResult = Json::decode($applicationResponse->getBody());
+      $applicationCount = count($datasetResult['result']);
+    } catch (\Exception $e) {
+      $applicationCount = 0;
+    }
 
     $form['datasetcount'] = array(
       '#markup' => $datasetCount,


### PR DESCRIPTION
- Added basic error handling to Appfeed, Categories, Datasetlist and
Hero modules. Error handling response values to null or zero based the
data that module expects. Before this change the front page would hang
if ckan encountered exceptions during the request.