### PR TITLE
AV-40 Enable Showcase submit module

### DIFF
--- a/ansible/roles/ckan/vars/main.yml
+++ b/ansible/roles/ckan/vars/main.yml
@@ -7,7 +7,7 @@ celery_user: "{{ www_user }}"
 
 ckan_plugins_default: stats scheming_datasets scheming_groups scheming_organizations fluent
 # order matters, when templates call super()
-ckan_plugins: harvest ckan_harvester hri_harvester dcat dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query csw_harvester drupal8 datarequests report ytp_organizations ytp_request ytp_report hierarchy_display ytp_theme ytp_drupal ytp_tasks ytp_dataset ytp_spatial ytp_user ytp_service datastore sixodp_showcase datapusher recline_grid_view recline_graph_view recline_map_view text_view image_view pdf_view geo_view geojson_view sixodp_harvester disqus reminder ytp_restrict_category_creation_and_updating archiver qa
+ckan_plugins: harvest ckan_harvester hri_harvester dcat dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query csw_harvester drupal8 datarequests report ytp_organizations ytp_request ytp_report hierarchy_display ytp_theme ytp_drupal ytp_tasks ytp_dataset ytp_spatial ytp_user ytp_service datastore sixodp_showcase sixodp_showcasesubmit datapusher recline_grid_view recline_graph_view recline_map_view text_view image_view pdf_view geo_view geojson_view sixodp_harvester disqus reminder ytp_restrict_category_creation_and_updating archiver qa
 
 ckan_aws_plugins: cloudstorage
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html
@@ -1,23 +1,12 @@
 {% extends "sixodp_showcasesubmit/base.html" %}
 
+{% block breadcrumb_content %}
+  <li>{{ h.nav_link(_('Showcases'), named_route='ckanext_showcase_index') }}</li>
+  <li class="active">{{ h.nav_link(_('Showcase submit'), controller='ckanext.sixodp_showcasesubmit.controller:Sixodp_ShowcasesubmitController', action='index') }}</li>
+{% endblock %}
+
+
 {% block pre_primary %}
-  <div class="page-hero"></div>
-
-  {% block toolbar %}
-    <div class="toolbar">
-      <div class="container">
-        {% block breadcrumb %}
-          {% if self.breadcrumb_content() | trim %}
-            <ol class="breadcrumb">
-              {% snippet 'snippets/home_breadcrumb_item.html' %}
-              {% block breadcrumb_content %}{% endblock %}
-            </ol>
-          {% endif %}
-        {% endblock %}
-      </div>
-    </div>
-  {% endblock %}
-
   <div class="container">
     <div class="module-content main-content">
       {% block pre_primary_content %}


### PR DESCRIPTION
- Re-enabled the showcase submit module. Apparently it was disabled in
some merge or commit.
- Added proper breadcrumbs to the Showcase Submit view.