### PR TITLE
AV-171 Language aware newsfeed module

### DIFF
--- a/modules/avoindata-drupal-events/src/Controller/EventsController.php
+++ b/modules/avoindata-drupal-events/src/Controller/EventsController.php
@@ -13,7 +13,7 @@ use Drupal\Core\Datetime\DrupalDateTime;
 class EventsController extends ControllerBase {
   public function events(Request $request) {
     $lang = \Drupal::languageManager()->getCurrentLanguage()->getId();
-    $currentDateTime = new DrupalDateTime('now');
+    $currentDateTime = new DrupalDateTime('today');
     $currentDateTime->setTimezone(new \DateTimezone(DATETIME_STORAGE_TIMEZONE));
     $formattedcurrentDateTime = $currentDateTime->format(DATETIME_DATETIME_STORAGE_FORMAT);
 

--- a/modules/avoindata-drupal-newsfeed/src/Plugin/Block/NewsFeedBlock.php
+++ b/modules/avoindata-drupal-newsfeed/src/Plugin/Block/NewsFeedBlock.php
@@ -5,6 +5,7 @@ namespace Drupal\avoindata_newsfeed\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Entity\Query\QueryFactory;
+use Drupal\Core\Datetime\DrupalDateTime;
 
 /**
  * Provides a 'Avoindata News Feed' Block.
@@ -21,8 +22,14 @@ class NewsFeedBlock extends BlockBase {
    * {@inheritdoc}
    */
   public function build() {
+    $lang = \Drupal::languageManager()->getCurrentLanguage()->getId();
+    $currentDateTime = new DrupalDateTime('today');
+    $currentDateTime->setTimezone(new \DateTimezone(DATETIME_STORAGE_TIMEZONE));
+    $formattedcurrentDateTime = $currentDateTime->format(DATETIME_DATETIME_STORAGE_FORMAT);
+
     $articleNodeIds = \Drupal::entityQuery('node')
     ->condition('type', 'avoindata_article')
+    ->condition('langcode', $lang)
     ->sort('created' , 'DESC')
     ->range(0, 5)
     ->execute();
@@ -30,10 +37,11 @@ class NewsFeedBlock extends BlockBase {
     ->getStorage('node')
     ->loadMultiple($articleNodeIds);
 
-    // TODO: How will we sort the upcoming events?
     $eventNodeIds = \Drupal::entityQuery('node')
     ->condition('type', 'avoindata_event')
-    ->sort('created' , 'DESC')
+    ->condition('langcode', $lang)
+    ->condition('field_start_date', $formattedcurrentDateTime, '>=')
+    ->sort('field_start_date' , 'ASC')
     ->range(0, 5)
     ->execute();
     $eventNodes = \Drupal::entityTypeManager()


### PR DESCRIPTION
- Newsfeed now shows only events and articles from selected language
(fi/en/sv).
- Events in newsfeed are now filtered to show only future events.
- Fixed past filter in Events page to use "today" instead of "now" which
filtered events based on hours and minutes. We probably want filtering
only based on the date.