### PR TITLE
AV-194: Populate title from title_translated when available

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/commands.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/commands.py
@@ -292,6 +292,8 @@ def migrate_orgs(ctx, config, dryrun):
                     value = old_org_dict.get('%s_%s' % (field, language))
                     if value is not None and value != "":
                         patch[translated_field][language] = value
+            else:
+                patch[field] = old_org_dict[translated_field].get(default_lang)
 
         if 'features' not in old_org_dict:
             # 'adminstration' is used in previous data model

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -659,6 +659,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
             'only_default_lang_required': validators.only_default_lang_required,
             'keep_old_value_if_missing': validators.keep_old_value_if_missing,
             'override_field': validators.override_field,
+            'override_field_with_default_translation': validators.override_field_with_default_translation,
             'ignore_if_invalid_isodatetime': validators.ignore_if_invalid_isodatetime
         }
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/schemas/presets.json
+++ b/modules/ckanext-ytp_main/ckanext/ytp/schemas/presets.json
@@ -129,7 +129,7 @@
         "form_snippet": "fluent_title.html",
         "display_snippet": "fluent_text.html",
         "error_snippet": "fluent_text.html",
-        "validators": "fluent_text only_default_lang_required ",
+        "validators": "fluent_text only_default_lang_required override_field_with_default_translation(title)",
         "output_validators": "fluent_core_translated_output",
         "form_attrs": {
           "data-module": "slug-preview-target"


### PR DESCRIPTION
- Modify organization migration tool to perform translated->non_translated field patching
- Added new validator: `override_field_with_default_translation` that picks the default_locale translation from the current field and overrides another field's value with it
- Utilize `override_field_with_default_translation` in `fluent_core_title_translated` preset to apply it to relevant schemas