### PR TITLE
AV-158: Hide RSS subscription link on front page

### DIFF
--- a/modules/avoindata-drupal-theme/less/overrides.less
+++ b/modules/avoindata-drupal-theme/less/overrides.less
@@ -835,3 +835,11 @@ p:last-child,
     margin-bottom: 20px;
   }    
 }
+
+.views-element-container {
+  margin-bottom: 0;
+
+  .feed-icons {
+    display: none;
+  }
+}


### PR DESCRIPTION
`views-element-container` seems to be a container for stuff produced by the `views`-plugin. I didn't want to remove it entirely as based on my research it might break other things. Also I wanted to keep the RSS feed link in the page markup to maintain support.

- Hide RSS feed icon from front page
- Remove margin from `views-element-container` to make it visually disappear if there's no content