### PR TITLE
AV-185: Fix data rendering issues in organization/about

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-09-07 08:02+0300\n"
+"POT-Creation-Date: 2018-09-27 13:47+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -261,7 +261,7 @@ msgstr ""
 msgid "Date format incorrect"
 msgstr ""
 
-#: ckanext/ytp/helpers.py:67 ckanext/ytp/plugin.py:532
+#: ckanext/ytp/helpers.py:81 ckanext/ytp/plugin.py:532
 msgid "Unnamed resource"
 msgstr ""
 
@@ -317,7 +317,7 @@ msgid "Delete Account"
 msgstr ""
 
 #: ckanext/ytp/menu.py:135 ckanext/ytp/templates/organization/admin_list.html:4
-#: ckanext/ytp/templates/organization/index.html:18
+#: ckanext/ytp/templates/organization/index.html:20
 #: ckanext/ytp/templates/organization/user_list.html:4
 #: ckanext/ytp/templates/user/dashboard_datasets.html:4
 #: ckanext/ytp/templates/user/dashboard_organizations.html:4
@@ -337,19 +337,19 @@ msgstr ""
 msgid "Postit"
 msgstr ""
 
-#: ckanext/ytp/menu.py:185
+#: ckanext/ytp/menu.py:191
 msgid "Publish Public Service"
 msgstr ""
 
-#: ckanext/ytp/menu.py:193 ckanext/ytp/templates/package/ytp/new_select.html:17
+#: ckanext/ytp/menu.py:199 ckanext/ytp/templates/package/ytp/new_select.html:17
 msgid "Publish Interoperability Tools"
 msgstr ""
 
-#: ckanext/ytp/menu.py:198 ckanext/ytp/templates/package/ytp/new_select.html:16
+#: ckanext/ytp/menu.py:204 ckanext/ytp/templates/package/ytp/new_select.html:16
 msgid "Publish Open Data"
 msgstr ""
 
-#: ckanext/ytp/menu.py:203
+#: ckanext/ytp/menu.py:209
 msgid "Publish Data"
 msgstr ""
 
@@ -419,43 +419,43 @@ msgstr ""
 msgid "Additional Info"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:912
+#: ckanext/ytp/plugin.py:923
 msgid "Group title already exists in database"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1078
+#: ckanext/ytp/plugin.py:1089
 msgid "Service charge must be supplied"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1088
+#: ckanext/ytp/plugin.py:1099
 msgid ""
 "If there is a service charge, you must supply either the pricing information "
 "web address for this service or a description of the service pricing or both"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1101
+#: ckanext/ytp/plugin.py:1112
 msgid "At least one of the main target groups must to be selected"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1238
+#: ckanext/ytp/plugin.py:1249
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1240
+#: ckanext/ytp/plugin.py:1251
 msgid "Invalid organization type"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1262
+#: ckanext/ytp/plugin.py:1273
 msgid "Harvested datasets are read-only"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1269
+#: ckanext/ytp/plugin.py:1280
 msgid "Login required"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1275 ckanext/ytp/plugin.py:1283
+#: ckanext/ytp/plugin.py:1286 ckanext/ytp/plugin.py:1294
 #, python-format
 msgid "User %s is not part of any public organization"
 msgstr ""
@@ -644,152 +644,192 @@ msgstr ""
 msgid "Members can only edit their own datasets"
 msgstr ""
 
-#: ckanext/ytp/translations.py:66
-msgid "Log in"
+#: ckanext/ytp/translations.py:64
+msgid "Home page"
 msgstr ""
 
 #: ckanext/ytp/translations.py:67
-msgid "Log out"
+msgid "public_administration_organization"
 msgstr ""
 
 #: ckanext/ytp/translations.py:68
-msgid "Publish Datasets"
+msgid "personal_datasets"
 msgstr ""
 
 #: ckanext/ytp/translations.py:69
-msgid "News"
+msgid "civil-service"
 msgstr ""
 
 #: ckanext/ytp/translations.py:70
-msgid "About us"
+msgid "municipality"
 msgstr ""
 
 #: ckanext/ytp/translations.py:71
-msgid "Files"
+msgid "other-public-service"
 msgstr ""
 
 #: ckanext/ytp/translations.py:72
-msgid "Guide to Open Data"
+msgid "educational-research-institute"
 msgstr ""
 
 #: ckanext/ytp/translations.py:73
-msgid "User Info"
+msgid "company"
 msgstr ""
 
 #: ckanext/ytp/translations.py:74
-msgid "Training"
+msgid "individual"
 msgstr ""
 
 #: ckanext/ytp/translations.py:75
-msgid "Dataset is available at http://www.syke.fi/avointieto"
+msgid "association"
 msgstr ""
 
-#: ckanext/ytp/translations.py:76
-msgid "Apps"
+#: ckanext/ytp/translations.py:78
+msgid "Log in"
 msgstr ""
 
 #: ckanext/ytp/translations.py:79
-msgid "Add to group"
+msgid "Log out"
 msgstr ""
 
 #: ckanext/ytp/translations.py:80
+msgid "Publish Datasets"
+msgstr ""
+
+#: ckanext/ytp/translations.py:81
+msgid "News"
+msgstr ""
+
+#: ckanext/ytp/translations.py:82
+msgid "About us"
+msgstr ""
+
+#: ckanext/ytp/translations.py:83
+msgid "Files"
+msgstr ""
+
+#: ckanext/ytp/translations.py:84
+msgid "Guide to Open Data"
+msgstr ""
+
+#: ckanext/ytp/translations.py:85
+msgid "User Info"
+msgstr ""
+
+#: ckanext/ytp/translations.py:86
+msgid "Training"
+msgstr ""
+
+#: ckanext/ytp/translations.py:87
+msgid "Dataset is available at http://www.syke.fi/avointieto"
+msgstr ""
+
+#: ckanext/ytp/translations.py:88
+msgid "Apps"
+msgstr ""
+
+#: ckanext/ytp/translations.py:91
+msgid "Add to group"
+msgstr ""
+
+#: ckanext/ytp/translations.py:92
 msgid "There are no groups associated with this dataset"
 msgstr ""
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:44
-#: ckanext/ytp/translations.py:81
+#: ckanext/ytp/translations.py:93
 msgid "Remove dataset from this group"
 msgstr ""
 
-#: ckanext/ytp/translations.py:82
+#: ckanext/ytp/translations.py:94
 msgid "Associate this group with this dataset"
 msgstr ""
 
-#: ckanext/ytp/translations.py:83
+#: ckanext/ytp/translations.py:95
 msgid "Add Group"
 msgstr ""
 
-#: ckanext/ytp/translations.py:84
+#: ckanext/ytp/translations.py:96
 msgid "There are currently no groups for this site"
 msgstr ""
 
-#: ckanext/ytp/translations.py:85
+#: ckanext/ytp/translations.py:97
 msgid "Search groups..."
 msgstr ""
 
-#: ckanext/ytp/templates/package/read.html:14 ckanext/ytp/translations.py:86
+#: ckanext/ytp/templates/package/read.html:14 ckanext/ytp/translations.py:98
 msgid "Groups"
 msgstr ""
 
-#: ckanext/ytp/translations.py:87
+#: ckanext/ytp/translations.py:99
 msgid "A little information about my group..."
 msgstr ""
 
-#: ckanext/ytp/translations.py:88
+#: ckanext/ytp/translations.py:100
 msgid "Create a Group"
 msgstr ""
 
-#: ckanext/ytp/translations.py:89
+#: ckanext/ytp/translations.py:101
 msgid "Create Group"
 msgstr ""
 
-#: ckanext/ytp/translations.py:90
+#: ckanext/ytp/translations.py:102
 msgid "My Group"
 msgstr ""
 
-#: ckanext/ytp/translations.py:93
+#: ckanext/ytp/translations.py:105
 msgid "Liikenne- ja viestintäministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:94
+#: ckanext/ytp/translations.py:106
 msgid "Maa- ja metsätalousministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:95
+#: ckanext/ytp/translations.py:107
 msgid "Oikeusministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:96
+#: ckanext/ytp/translations.py:108
 msgid "Opetus- ja kulttuuriministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:97
+#: ckanext/ytp/translations.py:109
 msgid "Puolustusministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:98
+#: ckanext/ytp/translations.py:110
 msgid "Sisäministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:99
+#: ckanext/ytp/translations.py:111
 msgid "Sosiaali- ja terveysministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:100
+#: ckanext/ytp/translations.py:112
 msgid "Työ- ja elinkeinoministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:101
+#: ckanext/ytp/translations.py:113
 msgid "Valtioneuvoston kanslia's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:102
+#: ckanext/ytp/translations.py:114
 msgid "Valtiovarainministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:103
+#: ckanext/ytp/translations.py:115
 msgid "Ympäristöministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:104
+#: ckanext/ytp/translations.py:116
 msgid "Ulkoministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:107
+#: ckanext/ytp/translations.py:119
 msgid "Administrative Branch Summary"
 msgstr ""
 
-#: ckanext/ytp/translations.py:108
+#: ckanext/ytp/translations.py:120
 msgid "Dataset statistics by administrative branch summary"
 msgstr ""
 
@@ -807,15 +847,15 @@ msgstr ""
 msgid "invalid encoding for \"%s\" value"
 msgstr ""
 
-#: ckanext/ytp/validators.py:237
+#: ckanext/ytp/validators.py:237 ckanext/ytp/validators.py:293
 msgid "Failed to decode JSON string"
 msgstr ""
 
-#: ckanext/ytp/validators.py:240
+#: ckanext/ytp/validators.py:240 ckanext/ytp/validators.py:296
 msgid "Invalid encoding for JSON string"
 msgstr ""
 
-#: ckanext/ytp/validators.py:243
+#: ckanext/ytp/validators.py:243 ckanext/ytp/validators.py:299
 msgid "expecting JSON object"
 msgstr ""
 
@@ -970,155 +1010,6 @@ msgstr ""
 msgid " Maximum file size is limited to %(size)s MB. "
 msgstr ""
 
-#: ckanext/ytp/templates/organization/about.html:13
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:99
-msgid "Civil Service"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:14
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:100
-msgid "Municipality / City"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:15
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:101
-msgid "Other Public Service"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:16
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:102
-msgid "Educational / Research Institute"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:17
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:103
-msgid "Company"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:18
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:104
-msgid "Individual"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:19
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:105
-msgid "Association"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:42
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:94
-msgid "Producer type"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:43
-msgid "Business ID"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:44
-msgid "OID"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:45
-#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:20
-#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:91
-msgid "Alternative name"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:46
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:129
-#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:190
-#: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:12
-msgid "Period of validity"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:58
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:142
-msgid "Contact info"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Street"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "House number"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Staircase"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Apartment number"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:63
-msgid "P.O. box"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:64
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:149
-msgid "Zip code"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:65
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:152
-msgid "Place of Business"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:66
-msgid "Country"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:67
-msgid "Unofficial name of the building"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:68
-msgid "Building ID"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:69
-msgid "Getting there"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:70
-msgid "Parking"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:71
-msgid "Arrival by public transport"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:72
-msgid "Web address for public transport"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:73
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:169
-msgid "Homepage"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:83
-msgid "Embed link"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:121
-msgid "Plain language translation available"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:124
-msgid "Plain language translation not available"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:133
-msgid "Organization hierarchy"
-msgstr ""
-
 #: ckanext/ytp/templates/organization/admin_list.html:5
 #: ckanext/ytp/templates/organization/user_list.html:5
 msgid "All Users"
@@ -1188,6 +1079,10 @@ msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:13
 msgid "My membership requests"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/index.html:29
+msgid "Add Organization"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/member_new.html:7
@@ -1378,8 +1273,46 @@ msgstr ""
 msgid "No"
 msgstr ""
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:94
+msgid "Producer type"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:99
+msgid "Civil Service"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:100
+msgid "Municipality / City"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:101
+msgid "Other Public Service"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:102
+msgid "Educational / Research Institute"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:103
+msgid "Company"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:104
+msgid "Individual"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:105
+msgid "Association"
+msgstr ""
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:110
 msgid "Select a producer type..."
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:129
+#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:190
+#: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:12
+msgid "Period of validity"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:132
@@ -1391,6 +1324,10 @@ msgstr ""
 msgid "YYYY-MM-DD"
 msgstr ""
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:142
+msgid "Contact info"
+msgstr ""
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:144
 msgid "Address"
 msgstr ""
@@ -1399,12 +1336,40 @@ msgstr ""
 msgid "Example street 1 apartment 5"
 msgstr ""
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Street"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "House number"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Staircase"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Apartment number"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:149
+msgid "Zip code"
+msgstr ""
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:149
 msgid "12345"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:152
+msgid "Place of Business"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:152
 msgid "Example City"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:169
+msgid "Homepage"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:169
@@ -2263,6 +2228,11 @@ msgstr ""
 msgid "Telephone number"
 msgstr ""
 
+#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:20
+#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:91
+msgid "Alternative name"
+msgstr ""
+
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:25
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:99
 msgid "Opening hours"
@@ -2613,11 +2583,19 @@ msgstr ""
 msgid "No organization"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:27
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:4
+msgid "Showcases"
+msgstr ""
+
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:5
+msgid "Showcase submit"
+msgstr ""
+
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:16
 msgid "New application"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:33
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:22
 msgid ""
 " Inform us about an application, web page or vizualization that you'be "
 "created with the form bellow and we will add it to application gallery. "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-09-07 08:02+0300\n"
+"POT-Creation-Date: 2018-09-27 13:47+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2018\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -263,7 +263,7 @@ msgstr ""
 msgid "Date format incorrect"
 msgstr ""
 
-#: ckanext/ytp/helpers.py:67 ckanext/ytp/plugin.py:532
+#: ckanext/ytp/helpers.py:81 ckanext/ytp/plugin.py:532
 msgid "Unnamed resource"
 msgstr ""
 
@@ -320,7 +320,7 @@ msgstr ""
 
 #: ckanext/ytp/menu.py:135
 #: ckanext/ytp/templates/organization/admin_list.html:4
-#: ckanext/ytp/templates/organization/index.html:18
+#: ckanext/ytp/templates/organization/index.html:20
 #: ckanext/ytp/templates/organization/user_list.html:4
 #: ckanext/ytp/templates/user/dashboard_datasets.html:4
 #: ckanext/ytp/templates/user/dashboard_organizations.html:4
@@ -341,21 +341,21 @@ msgstr ""
 msgid "Postit"
 msgstr ""
 
-#: ckanext/ytp/menu.py:185
+#: ckanext/ytp/menu.py:191
 msgid "Publish Public Service"
 msgstr ""
 
-#: ckanext/ytp/menu.py:193
+#: ckanext/ytp/menu.py:199
 #: ckanext/ytp/templates/package/ytp/new_select.html:17
 msgid "Publish Interoperability Tools"
 msgstr ""
 
-#: ckanext/ytp/menu.py:198
+#: ckanext/ytp/menu.py:204
 #: ckanext/ytp/templates/package/ytp/new_select.html:16
 msgid "Publish Open Data"
 msgstr ""
 
-#: ckanext/ytp/menu.py:203
+#: ckanext/ytp/menu.py:209
 msgid "Publish Data"
 msgstr ""
 
@@ -426,44 +426,44 @@ msgstr ""
 msgid "Additional Info"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:912
+#: ckanext/ytp/plugin.py:923
 msgid "Group title already exists in database"
 msgstr "Category title already exists in database"
 
-#: ckanext/ytp/plugin.py:1078
+#: ckanext/ytp/plugin.py:1089
 msgid "Service charge must be supplied"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1088
+#: ckanext/ytp/plugin.py:1099
 msgid ""
 "If there is a service charge, you must supply either the pricing information"
 " web address for this service or a description of the service pricing or "
 "both"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1101
+#: ckanext/ytp/plugin.py:1112
 msgid "At least one of the main target groups must to be selected"
 msgstr "At least one of the main target categories must to be selected"
 
-#: ckanext/ytp/plugin.py:1238
+#: ckanext/ytp/plugin.py:1249
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1240
+#: ckanext/ytp/plugin.py:1251
 msgid "Invalid organization type"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1262
+#: ckanext/ytp/plugin.py:1273
 msgid "Harvested datasets are read-only"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1269
+#: ckanext/ytp/plugin.py:1280
 msgid "Login required"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1275 ckanext/ytp/plugin.py:1283
+#: ckanext/ytp/plugin.py:1286 ckanext/ytp/plugin.py:1294
 #, python-format
 msgid "User %s is not part of any public organization"
 msgstr ""
@@ -653,152 +653,192 @@ msgstr ""
 msgid "Members can only edit their own datasets"
 msgstr ""
 
-#: ckanext/ytp/translations.py:66
-msgid "Log in"
+#: ckanext/ytp/translations.py:64
+msgid "Home page"
 msgstr ""
 
 #: ckanext/ytp/translations.py:67
-msgid "Log out"
-msgstr ""
+msgid "public_administration_organization"
+msgstr "public administration organization"
 
 #: ckanext/ytp/translations.py:68
-msgid "Publish Datasets"
-msgstr ""
+msgid "personal_datasets"
+msgstr "personal datasets"
 
 #: ckanext/ytp/translations.py:69
-msgid "News"
-msgstr ""
+msgid "civil-service"
+msgstr "Civil Service"
 
 #: ckanext/ytp/translations.py:70
-msgid "About us"
-msgstr ""
+msgid "municipality"
+msgstr "Municipality / City"
 
 #: ckanext/ytp/translations.py:71
-msgid "Files"
-msgstr ""
+msgid "other-public-service"
+msgstr "Other Public Service"
 
 #: ckanext/ytp/translations.py:72
-msgid "Guide to Open Data"
-msgstr ""
+msgid "educational-research-institute"
+msgstr "Educational research institute"
 
 #: ckanext/ytp/translations.py:73
-msgid "User Info"
-msgstr ""
+msgid "company"
+msgstr "Company"
 
 #: ckanext/ytp/translations.py:74
-msgid "Training"
-msgstr ""
+msgid "individual"
+msgstr "Individual"
 
 #: ckanext/ytp/translations.py:75
-msgid "Dataset is available at http://www.syke.fi/avointieto"
-msgstr ""
+msgid "association"
+msgstr "Association"
 
-#: ckanext/ytp/translations.py:76
-msgid "Apps"
+#: ckanext/ytp/translations.py:78
+msgid "Log in"
 msgstr ""
 
 #: ckanext/ytp/translations.py:79
+msgid "Log out"
+msgstr ""
+
+#: ckanext/ytp/translations.py:80
+msgid "Publish Datasets"
+msgstr ""
+
+#: ckanext/ytp/translations.py:81
+msgid "News"
+msgstr ""
+
+#: ckanext/ytp/translations.py:82
+msgid "About us"
+msgstr ""
+
+#: ckanext/ytp/translations.py:83
+msgid "Files"
+msgstr ""
+
+#: ckanext/ytp/translations.py:84
+msgid "Guide to Open Data"
+msgstr ""
+
+#: ckanext/ytp/translations.py:85
+msgid "User Info"
+msgstr ""
+
+#: ckanext/ytp/translations.py:86
+msgid "Training"
+msgstr ""
+
+#: ckanext/ytp/translations.py:87
+msgid "Dataset is available at http://www.syke.fi/avointieto"
+msgstr ""
+
+#: ckanext/ytp/translations.py:88
+msgid "Apps"
+msgstr ""
+
+#: ckanext/ytp/translations.py:91
 msgid "Add to group"
 msgstr "Add to category"
 
-#: ckanext/ytp/translations.py:80
+#: ckanext/ytp/translations.py:92
 msgid "There are no groups associated with this dataset"
 msgstr "There are no categories associated with this dataset"
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:44
-#: ckanext/ytp/translations.py:81
+#: ckanext/ytp/translations.py:93
 msgid "Remove dataset from this group"
 msgstr "Remove dataset from this category"
 
-#: ckanext/ytp/translations.py:82
+#: ckanext/ytp/translations.py:94
 msgid "Associate this group with this dataset"
 msgstr "Associate this category with this dataset"
 
-#: ckanext/ytp/translations.py:83
+#: ckanext/ytp/translations.py:95
 msgid "Add Group"
 msgstr "Add Category"
 
-#: ckanext/ytp/translations.py:84
+#: ckanext/ytp/translations.py:96
 msgid "There are currently no groups for this site"
 msgstr "There are currently no categories for this site"
 
-#: ckanext/ytp/translations.py:85
+#: ckanext/ytp/translations.py:97
 msgid "Search groups..."
 msgstr "Search categories..."
 
-#: ckanext/ytp/templates/package/read.html:14 ckanext/ytp/translations.py:86
+#: ckanext/ytp/templates/package/read.html:14 ckanext/ytp/translations.py:98
 msgid "Groups"
 msgstr "Categories"
 
-#: ckanext/ytp/translations.py:87
+#: ckanext/ytp/translations.py:99
 msgid "A little information about my group..."
 msgstr "A little information about my category..."
 
-#: ckanext/ytp/translations.py:88
+#: ckanext/ytp/translations.py:100
 msgid "Create a Group"
 msgstr "Create a Category"
 
-#: ckanext/ytp/translations.py:89
+#: ckanext/ytp/translations.py:101
 msgid "Create Group"
 msgstr "Create Category"
 
-#: ckanext/ytp/translations.py:90
+#: ckanext/ytp/translations.py:102
 msgid "My Group"
 msgstr "My Category"
 
-#: ckanext/ytp/translations.py:93
+#: ckanext/ytp/translations.py:105
 msgid "Liikenne- ja viestintäministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:94
+#: ckanext/ytp/translations.py:106
 msgid "Maa- ja metsätalousministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:95
+#: ckanext/ytp/translations.py:107
 msgid "Oikeusministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:96
+#: ckanext/ytp/translations.py:108
 msgid "Opetus- ja kulttuuriministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:97
+#: ckanext/ytp/translations.py:109
 msgid "Puolustusministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:98
+#: ckanext/ytp/translations.py:110
 msgid "Sisäministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:99
+#: ckanext/ytp/translations.py:111
 msgid "Sosiaali- ja terveysministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:100
+#: ckanext/ytp/translations.py:112
 msgid "Työ- ja elinkeinoministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:101
+#: ckanext/ytp/translations.py:113
 msgid "Valtioneuvoston kanslia's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:102
+#: ckanext/ytp/translations.py:114
 msgid "Valtiovarainministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:103
+#: ckanext/ytp/translations.py:115
 msgid "Ympäristöministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:104
+#: ckanext/ytp/translations.py:116
 msgid "Ulkoministeriö's administrative branch"
 msgstr ""
 
-#: ckanext/ytp/translations.py:107
+#: ckanext/ytp/translations.py:119
 msgid "Administrative Branch Summary"
 msgstr ""
 
-#: ckanext/ytp/translations.py:108
+#: ckanext/ytp/translations.py:120
 msgid "Dataset statistics by administrative branch summary"
 msgstr ""
 
@@ -816,15 +856,15 @@ msgstr ""
 msgid "invalid encoding for \"%s\" value"
 msgstr ""
 
-#: ckanext/ytp/validators.py:237
+#: ckanext/ytp/validators.py:237 ckanext/ytp/validators.py:293
 msgid "Failed to decode JSON string"
 msgstr ""
 
-#: ckanext/ytp/validators.py:240
+#: ckanext/ytp/validators.py:240 ckanext/ytp/validators.py:296
 msgid "Invalid encoding for JSON string"
 msgstr ""
 
-#: ckanext/ytp/validators.py:243
+#: ckanext/ytp/validators.py:243 ckanext/ytp/validators.py:299
 msgid "expecting JSON object"
 msgstr ""
 
@@ -979,155 +1019,6 @@ msgstr ""
 msgid " Maximum file size is limited to %(size)s MB. "
 msgstr ""
 
-#: ckanext/ytp/templates/organization/about.html:13
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:99
-msgid "Civil Service"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:14
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:100
-msgid "Municipality / City"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:15
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:101
-msgid "Other Public Service"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:16
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:102
-msgid "Educational / Research Institute"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:17
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:103
-msgid "Company"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:18
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:104
-msgid "Individual"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:19
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:105
-msgid "Association"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:42
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:94
-msgid "Producer type"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:43
-msgid "Business ID"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:44
-msgid "OID"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:45
-#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:20
-#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:91
-msgid "Alternative name"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:46
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:129
-#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:190
-#: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:12
-msgid "Period of validity"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:58
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:142
-msgid "Contact info"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Street"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "House number"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Staircase"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Apartment number"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:63
-msgid "P.O. box"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:64
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:149
-msgid "Zip code"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:65
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:152
-msgid "Place of Business"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:66
-msgid "Country"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:67
-msgid "Unofficial name of the building"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:68
-msgid "Building ID"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:69
-msgid "Getting there"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:70
-msgid "Parking"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:71
-msgid "Arrival by public transport"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:72
-msgid "Web address for public transport"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:73
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:169
-msgid "Homepage"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:83
-msgid "Embed link"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:121
-msgid "Plain language translation available"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:124
-msgid "Plain language translation not available"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:133
-msgid "Organization hierarchy"
-msgstr ""
-
 #: ckanext/ytp/templates/organization/admin_list.html:5
 #: ckanext/ytp/templates/organization/user_list.html:5
 msgid "All Users"
@@ -1197,6 +1088,10 @@ msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:13
 msgid "My membership requests"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/index.html:29
+msgid "Add Organization"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/member_new.html:7
@@ -1387,8 +1282,46 @@ msgstr ""
 msgid "No"
 msgstr ""
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:94
+msgid "Producer type"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:99
+msgid "Civil Service"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:100
+msgid "Municipality / City"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:101
+msgid "Other Public Service"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:102
+msgid "Educational / Research Institute"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:103
+msgid "Company"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:104
+msgid "Individual"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:105
+msgid "Association"
+msgstr ""
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:110
 msgid "Select a producer type..."
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:129
+#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:190
+#: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:12
+msgid "Period of validity"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:132
@@ -1400,6 +1333,10 @@ msgstr ""
 msgid "YYYY-MM-DD"
 msgstr ""
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:142
+msgid "Contact info"
+msgstr ""
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:144
 msgid "Address"
 msgstr ""
@@ -1408,12 +1345,40 @@ msgstr ""
 msgid "Example street 1 apartment 5"
 msgstr ""
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Street"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "House number"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Staircase"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Apartment number"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:149
+msgid "Zip code"
+msgstr ""
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:149
 msgid "12345"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:152
+msgid "Place of Business"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:152
 msgid "Example City"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:169
+msgid "Homepage"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:169
@@ -2272,6 +2237,11 @@ msgstr ""
 msgid "Telephone number"
 msgstr ""
 
+#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:20
+#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:91
+msgid "Alternative name"
+msgstr ""
+
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:25
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:99
 msgid "Opening hours"
@@ -2622,11 +2592,19 @@ msgstr ""
 msgid "No organization"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:27
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:4
+msgid "Showcases"
+msgstr ""
+
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:5
+msgid "Showcase submit"
+msgstr ""
+
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:16
 msgid "New application"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:33
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:22
 msgid ""
 " Inform us about an application, web page or vizualization that you'be "
 "created with the form bellow and we will add it to application gallery. "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-09-07 08:02+0300\n"
+"POT-Creation-Date: 2018-09-27 13:47+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Pentti Laitinen, 2018\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Date format incorrect"
 msgstr "Päivämäärän muoto väärä"
 
-#: ckanext/ytp/helpers.py:67 ckanext/ytp/plugin.py:532
+#: ckanext/ytp/helpers.py:81 ckanext/ytp/plugin.py:532
 msgid "Unnamed resource"
 msgstr "Nimetön resurssi"
 
@@ -322,7 +322,7 @@ msgstr "Poista käyttäjätili"
 
 #: ckanext/ytp/menu.py:135
 #: ckanext/ytp/templates/organization/admin_list.html:4
-#: ckanext/ytp/templates/organization/index.html:18
+#: ckanext/ytp/templates/organization/index.html:20
 #: ckanext/ytp/templates/organization/user_list.html:4
 #: ckanext/ytp/templates/user/dashboard_datasets.html:4
 #: ckanext/ytp/templates/user/dashboard_organizations.html:4
@@ -343,21 +343,21 @@ msgstr "Organisaatiot"
 msgid "Postit"
 msgstr ""
 
-#: ckanext/ytp/menu.py:185
+#: ckanext/ytp/menu.py:191
 msgid "Publish Public Service"
 msgstr "Julkaise julkinen palvelu"
 
-#: ckanext/ytp/menu.py:193
+#: ckanext/ytp/menu.py:199
 #: ckanext/ytp/templates/package/ytp/new_select.html:17
 msgid "Publish Interoperability Tools"
 msgstr "Julkaise yhteentoimivuuden kuvauksia ja ohjeita"
 
-#: ckanext/ytp/menu.py:198
+#: ckanext/ytp/menu.py:204
 #: ckanext/ytp/templates/package/ytp/new_select.html:16
 msgid "Publish Open Data"
 msgstr "Julkaise avointa dataa"
 
-#: ckanext/ytp/menu.py:203
+#: ckanext/ytp/menu.py:209
 msgid "Publish Data"
 msgstr "Julkaise dataa"
 
@@ -428,15 +428,15 @@ msgstr "Muu"
 msgid "Additional Info"
 msgstr "Lisätiedot"
 
-#: ckanext/ytp/plugin.py:912
+#: ckanext/ytp/plugin.py:923
 msgid "Group title already exists in database"
 msgstr "Kategorian otsikko löytyy jo tietokannasta"
 
-#: ckanext/ytp/plugin.py:1078
+#: ckanext/ytp/plugin.py:1089
 msgid "Service charge must be supplied"
 msgstr "Palvelun maksullisuus pitää antaa"
 
-#: ckanext/ytp/plugin.py:1088
+#: ckanext/ytp/plugin.py:1099
 msgid ""
 "If there is a service charge, you must supply either the pricing information"
 " web address for this service or a description of the service pricing or "
@@ -445,29 +445,29 @@ msgstr ""
 "Jos palvelu on maksullinen, pitää sinun antaa hintatiedot verkossa tai "
 "kuvaus hinnoista tai molemmat"
 
-#: ckanext/ytp/plugin.py:1101
+#: ckanext/ytp/plugin.py:1112
 msgid "At least one of the main target groups must to be selected"
 msgstr "Vähintään yksi päätason kohdekategoria on valittava"
 
-#: ckanext/ytp/plugin.py:1238
+#: ckanext/ytp/plugin.py:1249
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
 msgstr "Organisaatiota ei ole"
 
-#: ckanext/ytp/plugin.py:1240
+#: ckanext/ytp/plugin.py:1251
 msgid "Invalid organization type"
 msgstr "Väärä organisaatiotyyppi"
 
-#: ckanext/ytp/plugin.py:1262
+#: ckanext/ytp/plugin.py:1273
 msgid "Harvested datasets are read-only"
 msgstr "Harvestoituja tietoaineistoja voi vain lukea"
 
-#: ckanext/ytp/plugin.py:1269
+#: ckanext/ytp/plugin.py:1280
 msgid "Login required"
 msgstr "Kirjautuminen vaaditaan"
 
-#: ckanext/ytp/plugin.py:1275 ckanext/ytp/plugin.py:1283
+#: ckanext/ytp/plugin.py:1286 ckanext/ytp/plugin.py:1294
 #, python-format
 msgid "User %s is not part of any public organization"
 msgstr "Käyttäjä %s ei ole osana mitään julkista organisaatiota"
@@ -664,152 +664,192 @@ msgstr "Ominaisuudet"
 msgid "Members can only edit their own datasets"
 msgstr "Jäsenet voivat muokata vain omia tietoaineistojaan"
 
-#: ckanext/ytp/translations.py:66
+#: ckanext/ytp/translations.py:64
+msgid "Home page"
+msgstr "Kotisivu"
+
+#: ckanext/ytp/translations.py:67
+msgid "public_administration_organization"
+msgstr "Julkisen hallinnon organisaatio"
+
+#: ckanext/ytp/translations.py:68
+msgid "personal_datasets"
+msgstr "henkilökohtaiset tietoaineistot"
+
+#: ckanext/ytp/translations.py:69
+msgid "civil-service"
+msgstr "Valtionhallinto"
+
+#: ckanext/ytp/translations.py:70
+msgid "municipality"
+msgstr "Kunta / Kaupunki"
+
+#: ckanext/ytp/translations.py:71
+msgid "other-public-service"
+msgstr "Muu julkinen palvelu"
+
+#: ckanext/ytp/translations.py:72
+msgid "educational-research-institute"
+msgstr "Oppilaitos / tutkimuslaitos"
+
+#: ckanext/ytp/translations.py:73
+msgid "company"
+msgstr "Yritys"
+
+#: ckanext/ytp/translations.py:74
+msgid "individual"
+msgstr "Yksityishenkilö"
+
+#: ckanext/ytp/translations.py:75
+msgid "association"
+msgstr ""
+
+#: ckanext/ytp/translations.py:78
 msgid "Log in"
 msgstr "Kirjaudu"
 
-#: ckanext/ytp/translations.py:67
+#: ckanext/ytp/translations.py:79
 msgid "Log out"
 msgstr "Kirjaudu ulos"
 
-#: ckanext/ytp/translations.py:68
+#: ckanext/ytp/translations.py:80
 msgid "Publish Datasets"
 msgstr "Julkaise aineistoja"
 
-#: ckanext/ytp/translations.py:69
+#: ckanext/ytp/translations.py:81
 msgid "News"
 msgstr "Ajankohtaista"
 
-#: ckanext/ytp/translations.py:70
+#: ckanext/ytp/translations.py:82
 msgid "About us"
 msgstr "Tietoa palvelusta"
 
-#: ckanext/ytp/translations.py:71
+#: ckanext/ytp/translations.py:83
 msgid "Files"
 msgstr "Tiedostot"
 
-#: ckanext/ytp/translations.py:72
+#: ckanext/ytp/translations.py:84
 msgid "Guide to Open Data"
 msgstr "Avoimen datan opas"
 
-#: ckanext/ytp/translations.py:73
+#: ckanext/ytp/translations.py:85
 msgid "User Info"
 msgstr "Omat tietoni"
 
-#: ckanext/ytp/translations.py:74
+#: ckanext/ytp/translations.py:86
 msgid "Training"
 msgstr "Koulutukset"
 
-#: ckanext/ytp/translations.py:75
+#: ckanext/ytp/translations.py:87
 msgid "Dataset is available at http://www.syke.fi/avointieto"
 msgstr "Tietoaineisto on saatavilla osoitteessa http://www.syke.fi/avointieto"
 
-#: ckanext/ytp/translations.py:76
+#: ckanext/ytp/translations.py:88
 msgid "Apps"
 msgstr "Sovellukset"
 
-#: ckanext/ytp/translations.py:79
+#: ckanext/ytp/translations.py:91
 msgid "Add to group"
 msgstr "Lisää kategoriaan"
 
-#: ckanext/ytp/translations.py:80
+#: ckanext/ytp/translations.py:92
 msgid "There are no groups associated with this dataset"
 msgstr "Tietoaineistoon ei ole liitetty kategorioita"
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:44
-#: ckanext/ytp/translations.py:81
+#: ckanext/ytp/translations.py:93
 msgid "Remove dataset from this group"
 msgstr "Poista tietoaineisto tästä kategoriasta"
 
-#: ckanext/ytp/translations.py:82
+#: ckanext/ytp/translations.py:94
 msgid "Associate this group with this dataset"
 msgstr "Liitä kategoria tähän tietoaineistoon"
 
-#: ckanext/ytp/translations.py:83
+#: ckanext/ytp/translations.py:95
 msgid "Add Group"
 msgstr "Lisää kategoria"
 
-#: ckanext/ytp/translations.py:84
+#: ckanext/ytp/translations.py:96
 msgid "There are currently no groups for this site"
 msgstr "Sivulla ei ole tällä hetkellä kategorioita."
 
-#: ckanext/ytp/translations.py:85
+#: ckanext/ytp/translations.py:97
 msgid "Search groups..."
 msgstr "Etsi kategorioita..."
 
-#: ckanext/ytp/templates/package/read.html:14 ckanext/ytp/translations.py:86
+#: ckanext/ytp/templates/package/read.html:14 ckanext/ytp/translations.py:98
 msgid "Groups"
 msgstr "Kategoriat"
 
-#: ckanext/ytp/translations.py:87
+#: ckanext/ytp/translations.py:99
 msgid "A little information about my group..."
 msgstr "Lyhyt kuvaus kategoriasta"
 
-#: ckanext/ytp/translations.py:88
+#: ckanext/ytp/translations.py:100
 msgid "Create a Group"
 msgstr "Luo kategoria"
 
-#: ckanext/ytp/translations.py:89
+#: ckanext/ytp/translations.py:101
 msgid "Create Group"
 msgstr "Luo kategoria"
 
-#: ckanext/ytp/translations.py:90
+#: ckanext/ytp/translations.py:102
 msgid "My Group"
 msgstr "Kategoriani"
 
-#: ckanext/ytp/translations.py:93
+#: ckanext/ytp/translations.py:105
 msgid "Liikenne- ja viestintäministeriö's administrative branch"
 msgstr "Liikenne- ja viestintäministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:94
+#: ckanext/ytp/translations.py:106
 msgid "Maa- ja metsätalousministeriö's administrative branch"
 msgstr "Maa- ja metsätalousministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:95
+#: ckanext/ytp/translations.py:107
 msgid "Oikeusministeriö's administrative branch"
 msgstr "Oikeusministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:96
+#: ckanext/ytp/translations.py:108
 msgid "Opetus- ja kulttuuriministeriö's administrative branch"
 msgstr "Opetus- ja kulttuuriministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:97
+#: ckanext/ytp/translations.py:109
 msgid "Puolustusministeriö's administrative branch"
 msgstr "Puolustusministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:98
+#: ckanext/ytp/translations.py:110
 msgid "Sisäministeriö's administrative branch"
 msgstr "Sisäministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:99
+#: ckanext/ytp/translations.py:111
 msgid "Sosiaali- ja terveysministeriö's administrative branch"
 msgstr "Sosiaali- ja terveysministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:100
+#: ckanext/ytp/translations.py:112
 msgid "Työ- ja elinkeinoministeriö's administrative branch"
 msgstr "Työ- ja elinkeinoministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:101
+#: ckanext/ytp/translations.py:113
 msgid "Valtioneuvoston kanslia's administrative branch"
 msgstr "Valtioneuvoston kanslian hallinnonala"
 
-#: ckanext/ytp/translations.py:102
+#: ckanext/ytp/translations.py:114
 msgid "Valtiovarainministeriö's administrative branch"
 msgstr "Valtiovarainministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:103
+#: ckanext/ytp/translations.py:115
 msgid "Ympäristöministeriö's administrative branch"
 msgstr "Ympäristöministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:104
+#: ckanext/ytp/translations.py:116
 msgid "Ulkoministeriö's administrative branch"
 msgstr "Ulkoministeriön hallinnonala"
 
-#: ckanext/ytp/translations.py:107
+#: ckanext/ytp/translations.py:119
 msgid "Administrative Branch Summary"
 msgstr "Hallinnonalakooste"
 
-#: ckanext/ytp/translations.py:108
+#: ckanext/ytp/translations.py:120
 msgid "Dataset statistics by administrative branch summary"
 msgstr "Tietoaineistotilastoja hallinnonaloittain"
 
@@ -827,15 +867,15 @@ msgstr ""
 msgid "invalid encoding for \"%s\" value"
 msgstr ""
 
-#: ckanext/ytp/validators.py:237
+#: ckanext/ytp/validators.py:237 ckanext/ytp/validators.py:293
 msgid "Failed to decode JSON string"
 msgstr ""
 
-#: ckanext/ytp/validators.py:240
+#: ckanext/ytp/validators.py:240 ckanext/ytp/validators.py:296
 msgid "Invalid encoding for JSON string"
 msgstr ""
 
-#: ckanext/ytp/validators.py:243
+#: ckanext/ytp/validators.py:243 ckanext/ytp/validators.py:299
 msgid "expecting JSON object"
 msgstr ""
 
@@ -994,155 +1034,6 @@ msgstr "Tyhjennä lataus"
 msgid " Maximum file size is limited to %(size)s MB. "
 msgstr "Tiedoston enimmäiskoko on rajoitettu %(size)s megatavuun."
 
-#: ckanext/ytp/templates/organization/about.html:13
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:99
-msgid "Civil Service"
-msgstr "Valtionhallinto"
-
-#: ckanext/ytp/templates/organization/about.html:14
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:100
-msgid "Municipality / City"
-msgstr "Kunta / Kaupunki"
-
-#: ckanext/ytp/templates/organization/about.html:15
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:101
-msgid "Other Public Service"
-msgstr "Muu julkinen palvelu"
-
-#: ckanext/ytp/templates/organization/about.html:16
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:102
-msgid "Educational / Research Institute"
-msgstr "Oppilaitos / tutkimuslaitos"
-
-#: ckanext/ytp/templates/organization/about.html:17
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:103
-msgid "Company"
-msgstr "Yritys"
-
-#: ckanext/ytp/templates/organization/about.html:18
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:104
-msgid "Individual"
-msgstr "Yksityishenkilö"
-
-#: ckanext/ytp/templates/organization/about.html:19
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:105
-msgid "Association"
-msgstr "Yhdistys"
-
-#: ckanext/ytp/templates/organization/about.html:42
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:94
-msgid "Producer type"
-msgstr "Tuottajatyyppi"
-
-#: ckanext/ytp/templates/organization/about.html:43
-msgid "Business ID"
-msgstr "Y-tunnus"
-
-#: ckanext/ytp/templates/organization/about.html:44
-msgid "OID"
-msgstr "OID"
-
-#: ckanext/ytp/templates/organization/about.html:45
-#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:20
-#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:91
-msgid "Alternative name"
-msgstr "Vaihtoehtoinen nimi"
-
-#: ckanext/ytp/templates/organization/about.html:46
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:129
-#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:190
-#: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:12
-msgid "Period of validity"
-msgstr "Voimassaolo"
-
-#: ckanext/ytp/templates/organization/about.html:58
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:142
-msgid "Contact info"
-msgstr "Yhteystiedot"
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Street"
-msgstr "Katu/tie"
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "House number"
-msgstr "Talon numero"
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Staircase"
-msgstr "Porras"
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Apartment number"
-msgstr "Huoneisto"
-
-#: ckanext/ytp/templates/organization/about.html:63
-msgid "P.O. box"
-msgstr "Postilokero"
-
-#: ckanext/ytp/templates/organization/about.html:64
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:149
-msgid "Zip code"
-msgstr "Postinumero"
-
-#: ckanext/ytp/templates/organization/about.html:65
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:152
-msgid "Place of Business"
-msgstr "Toimipaikka"
-
-#: ckanext/ytp/templates/organization/about.html:66
-msgid "Country"
-msgstr "Maa"
-
-#: ckanext/ytp/templates/organization/about.html:67
-msgid "Unofficial name of the building"
-msgstr "Rakennuksen epävirallinen nimi"
-
-#: ckanext/ytp/templates/organization/about.html:68
-msgid "Building ID"
-msgstr "Rakennustunnus"
-
-#: ckanext/ytp/templates/organization/about.html:69
-msgid "Getting there"
-msgstr "Kulkuohje"
-
-#: ckanext/ytp/templates/organization/about.html:70
-msgid "Parking"
-msgstr "Pysäköinti"
-
-#: ckanext/ytp/templates/organization/about.html:71
-msgid "Arrival by public transport"
-msgstr "Saapuminen julkisilla kulkuvälineillä"
-
-#: ckanext/ytp/templates/organization/about.html:72
-msgid "Web address for public transport"
-msgstr "Verkko-osoite julkiselle liikenteelle"
-
-#: ckanext/ytp/templates/organization/about.html:73
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:169
-msgid "Homepage"
-msgstr "Kotisivu"
-
-#: ckanext/ytp/templates/organization/about.html:83
-msgid "Embed link"
-msgstr "Upotuslinkki"
-
-#: ckanext/ytp/templates/organization/about.html:121
-msgid "Plain language translation available"
-msgstr "Selkokielinen versio saatavilla"
-
-#: ckanext/ytp/templates/organization/about.html:124
-msgid "Plain language translation not available"
-msgstr "Ei selkokielistä versiota saatavilla"
-
-#: ckanext/ytp/templates/organization/about.html:133
-msgid "Organization hierarchy"
-msgstr "Organisaatiohierarkia"
-
 #: ckanext/ytp/templates/organization/admin_list.html:5
 #: ckanext/ytp/templates/organization/user_list.html:5
 msgid "All Users"
@@ -1213,6 +1104,10 @@ msgstr "Jäsenhakemukset"
 #: ckanext/ytp/templates/organization/index.html:13
 msgid "My membership requests"
 msgstr "Omat jäsenhakemukset"
+
+#: ckanext/ytp/templates/organization/index.html:29
+msgid "Add Organization"
+msgstr ""
 
 #: ckanext/ytp/templates/organization/member_new.html:7
 msgid "If you wish to add an existing user, search for their username below."
@@ -1417,9 +1312,47 @@ msgstr "Kyllä"
 msgid "No"
 msgstr "Ei"
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:94
+msgid "Producer type"
+msgstr "Tuottajatyyppi"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:99
+msgid "Civil Service"
+msgstr "Valtionhallinto"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:100
+msgid "Municipality / City"
+msgstr "Kunta / Kaupunki"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:101
+msgid "Other Public Service"
+msgstr "Muu julkinen palvelu"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:102
+msgid "Educational / Research Institute"
+msgstr "Oppilaitos / tutkimuslaitos"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:103
+msgid "Company"
+msgstr "Yritys"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:104
+msgid "Individual"
+msgstr "Yksityishenkilö"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:105
+msgid "Association"
+msgstr "Yhdistys"
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:110
 msgid "Select a producer type..."
 msgstr "Valitse tuottajatyyppi..."
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:129
+#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:190
+#: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:12
+msgid "Period of validity"
+msgstr "Voimassaolo"
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:132
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:136
@@ -1430,6 +1363,10 @@ msgstr "Valitse tuottajatyyppi..."
 msgid "YYYY-MM-DD"
 msgstr "VVVV-KK-PP"
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:142
+msgid "Contact info"
+msgstr "Yhteystiedot"
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:144
 msgid "Address"
 msgstr "Osoite"
@@ -1438,13 +1375,41 @@ msgstr "Osoite"
 msgid "Example street 1 apartment 5"
 msgstr "Esimerkkikatu 1 as. 5"
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Street"
+msgstr "Katu/tie"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "House number"
+msgstr "Talon numero"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Staircase"
+msgstr "Porras"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Apartment number"
+msgstr "Huoneisto"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:149
+msgid "Zip code"
+msgstr "Postinumero"
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:149
 msgid "12345"
 msgstr "12345"
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:152
+msgid "Place of Business"
+msgstr "Toimipaikka"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:152
 msgid "Example City"
 msgstr "Esimerkkikaupunki"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:169
+msgid "Homepage"
+msgstr "Kotisivu"
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:169
 msgid "http://example.com"
@@ -2340,6 +2305,11 @@ msgstr "Sähköpostiosoite"
 msgid "Telephone number"
 msgstr "Puhelinnumero"
 
+#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:20
+#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:91
+msgid "Alternative name"
+msgstr "Vaihtoehtoinen nimi"
+
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:25
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:99
 msgid "Opening hours"
@@ -2700,11 +2670,19 @@ msgstr ""
 msgid "No organization"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:27
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:4
+msgid "Showcases"
+msgstr ""
+
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:5
+msgid "Showcase submit"
+msgstr ""
+
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:16
 msgid "New application"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:33
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:22
 msgid ""
 " Inform us about an application, web page or vizualization that you'be "
 "created with the form bellow and we will add it to application gallery. "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-09-07 08:02+0300\n"
+"POT-Creation-Date: 2018-09-27 13:47+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2018\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
@@ -273,7 +273,7 @@ msgstr ""
 msgid "Date format incorrect"
 msgstr "Datumets format är felaktigt"
 
-#: ckanext/ytp/helpers.py:67 ckanext/ytp/plugin.py:532
+#: ckanext/ytp/helpers.py:81 ckanext/ytp/plugin.py:532
 msgid "Unnamed resource"
 msgstr "Namnlös resurs"
 
@@ -330,7 +330,7 @@ msgstr "Radera användarkonto"
 
 #: ckanext/ytp/menu.py:135
 #: ckanext/ytp/templates/organization/admin_list.html:4
-#: ckanext/ytp/templates/organization/index.html:18
+#: ckanext/ytp/templates/organization/index.html:20
 #: ckanext/ytp/templates/organization/user_list.html:4
 #: ckanext/ytp/templates/user/dashboard_datasets.html:4
 #: ckanext/ytp/templates/user/dashboard_organizations.html:4
@@ -351,21 +351,21 @@ msgstr "Organisationer"
 msgid "Postit"
 msgstr ""
 
-#: ckanext/ytp/menu.py:185
+#: ckanext/ytp/menu.py:191
 msgid "Publish Public Service"
 msgstr "Publicera offentlig tjänst"
 
-#: ckanext/ytp/menu.py:193
+#: ckanext/ytp/menu.py:199
 #: ckanext/ytp/templates/package/ytp/new_select.html:17
 msgid "Publish Interoperability Tools"
 msgstr "Publicera interoperabilitetsverktyg"
 
-#: ckanext/ytp/menu.py:198
+#: ckanext/ytp/menu.py:204
 #: ckanext/ytp/templates/package/ytp/new_select.html:16
 msgid "Publish Open Data"
 msgstr "Publicera öppen data"
 
-#: ckanext/ytp/menu.py:203
+#: ckanext/ytp/menu.py:209
 msgid "Publish Data"
 msgstr "Publicera data"
 
@@ -436,15 +436,15 @@ msgstr "Annan"
 msgid "Additional Info"
 msgstr "Tilläggsinformation"
 
-#: ckanext/ytp/plugin.py:912
+#: ckanext/ytp/plugin.py:923
 msgid "Group title already exists in database"
 msgstr "Titeln för kategorien finns redan i databasen"
 
-#: ckanext/ytp/plugin.py:1078
+#: ckanext/ytp/plugin.py:1089
 msgid "Service charge must be supplied"
 msgstr "Tjänstens avgiftsbelagdhet måste anges"
 
-#: ckanext/ytp/plugin.py:1088
+#: ckanext/ytp/plugin.py:1099
 msgid ""
 "If there is a service charge, you must supply either the pricing information"
 " web address for this service or a description of the service pricing or "
@@ -453,29 +453,29 @@ msgstr ""
 "Om tjänsten är avgiftsbelagd, måste du ange prisinformationen på webben "
 "eller en beskrivning om priserna eller båda"
 
-#: ckanext/ytp/plugin.py:1101
+#: ckanext/ytp/plugin.py:1112
 msgid "At least one of the main target groups must to be selected"
 msgstr "Åtminstone en målkategori från huvudnivån måste väljas"
 
-#: ckanext/ytp/plugin.py:1238
+#: ckanext/ytp/plugin.py:1249
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
 msgstr "Organisationen finns inte"
 
-#: ckanext/ytp/plugin.py:1240
+#: ckanext/ytp/plugin.py:1251
 msgid "Invalid organization type"
 msgstr "Felaktig organisationstyp"
 
-#: ckanext/ytp/plugin.py:1262
+#: ckanext/ytp/plugin.py:1273
 msgid "Harvested datasets are read-only"
 msgstr "Skrapade dataset kan endast läsas"
 
-#: ckanext/ytp/plugin.py:1269
+#: ckanext/ytp/plugin.py:1280
 msgid "Login required"
 msgstr "Inloggning krävs"
 
-#: ckanext/ytp/plugin.py:1275 ckanext/ytp/plugin.py:1283
+#: ckanext/ytp/plugin.py:1286 ckanext/ytp/plugin.py:1294
 #, python-format
 msgid "User %s is not part of any public organization"
 msgstr "Användare %s är inte medlem av någon offentlig organisation"
@@ -665,152 +665,192 @@ msgstr ""
 msgid "Members can only edit their own datasets"
 msgstr "Medlemmar kan bara redigera egna dataset"
 
-#: ckanext/ytp/translations.py:66
+#: ckanext/ytp/translations.py:64
+msgid "Home page"
+msgstr "Hemsidan"
+
+#: ckanext/ytp/translations.py:67
+msgid "public_administration_organization"
+msgstr "offentlig förvaltningsorganisation"
+
+#: ckanext/ytp/translations.py:68
+msgid "personal_datasets"
+msgstr "personliga dataset"
+
+#: ckanext/ytp/translations.py:69
+msgid "civil-service"
+msgstr "Statsförvaltningen"
+
+#: ckanext/ytp/translations.py:70
+msgid "municipality"
+msgstr "Kommun / Stad"
+
+#: ckanext/ytp/translations.py:71
+msgid "other-public-service"
+msgstr "Andra offentliga organ"
+
+#: ckanext/ytp/translations.py:72
+msgid "educational-research-institute"
+msgstr "Läroanstalt / Forskningsinstitut"
+
+#: ckanext/ytp/translations.py:73
+msgid "company"
+msgstr "Företag"
+
+#: ckanext/ytp/translations.py:74
+msgid "individual"
+msgstr "En individ"
+
+#: ckanext/ytp/translations.py:75
+msgid "association"
+msgstr "Förening"
+
+#: ckanext/ytp/translations.py:78
 msgid "Log in"
 msgstr "Logga in"
 
-#: ckanext/ytp/translations.py:67
+#: ckanext/ytp/translations.py:79
 msgid "Log out"
 msgstr "Logga ut"
 
-#: ckanext/ytp/translations.py:68
+#: ckanext/ytp/translations.py:80
 msgid "Publish Datasets"
 msgstr "Publicera dataseten"
 
-#: ckanext/ytp/translations.py:69
+#: ckanext/ytp/translations.py:81
 msgid "News"
 msgstr "Aktuellt"
 
-#: ckanext/ytp/translations.py:70
+#: ckanext/ytp/translations.py:82
 msgid "About us"
 msgstr "Om oss"
 
-#: ckanext/ytp/translations.py:71
+#: ckanext/ytp/translations.py:83
 msgid "Files"
 msgstr "Filer"
 
-#: ckanext/ytp/translations.py:72
+#: ckanext/ytp/translations.py:84
 msgid "Guide to Open Data"
 msgstr "Guide till Öppna Data"
 
-#: ckanext/ytp/translations.py:73
+#: ckanext/ytp/translations.py:85
 msgid "User Info"
 msgstr "Mina uppgifter"
 
-#: ckanext/ytp/translations.py:74
+#: ckanext/ytp/translations.py:86
 msgid "Training"
 msgstr "Träning"
 
-#: ckanext/ytp/translations.py:75
+#: ckanext/ytp/translations.py:87
 msgid "Dataset is available at http://www.syke.fi/avointieto"
 msgstr "Dataseten kommas åt på http://www.syke.fi/avointieto"
 
-#: ckanext/ytp/translations.py:76
+#: ckanext/ytp/translations.py:88
 msgid "Apps"
 msgstr "Apps"
 
-#: ckanext/ytp/translations.py:79
+#: ckanext/ytp/translations.py:91
 msgid "Add to group"
 msgstr "Lägg till kategorin"
 
-#: ckanext/ytp/translations.py:80
+#: ckanext/ytp/translations.py:92
 msgid "There are no groups associated with this dataset"
 msgstr "Det finns inga kategorier kopplade till detta dataset"
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:44
-#: ckanext/ytp/translations.py:81
+#: ckanext/ytp/translations.py:93
 msgid "Remove dataset from this group"
 msgstr "Ta bort dataset från denna kategori"
 
-#: ckanext/ytp/translations.py:82
+#: ckanext/ytp/translations.py:94
 msgid "Associate this group with this dataset"
 msgstr "Koppla denna kategori till detta dataset"
 
-#: ckanext/ytp/translations.py:83
+#: ckanext/ytp/translations.py:95
 msgid "Add Group"
 msgstr "Lägg till kategori"
 
-#: ckanext/ytp/translations.py:84
+#: ckanext/ytp/translations.py:96
 msgid "There are currently no groups for this site"
 msgstr "Det finns för närvarande inga kategorier för denna site"
 
-#: ckanext/ytp/translations.py:85
+#: ckanext/ytp/translations.py:97
 msgid "Search groups..."
 msgstr "Sök kategorier..."
 
-#: ckanext/ytp/templates/package/read.html:14 ckanext/ytp/translations.py:86
+#: ckanext/ytp/templates/package/read.html:14 ckanext/ytp/translations.py:98
 msgid "Groups"
 msgstr "Kategorier"
 
-#: ckanext/ytp/translations.py:87
+#: ckanext/ytp/translations.py:99
 msgid "A little information about my group..."
 msgstr "En kort beskrivning om min kategorien"
 
-#: ckanext/ytp/translations.py:88
+#: ckanext/ytp/translations.py:100
 msgid "Create a Group"
 msgstr "Skapa kategori"
 
-#: ckanext/ytp/translations.py:89
+#: ckanext/ytp/translations.py:101
 msgid "Create Group"
 msgstr "Skapa kategori"
 
-#: ckanext/ytp/translations.py:90
+#: ckanext/ytp/translations.py:102
 msgid "My Group"
 msgstr "Min kategori"
 
-#: ckanext/ytp/translations.py:93
+#: ckanext/ytp/translations.py:105
 msgid "Liikenne- ja viestintäministeriö's administrative branch"
 msgstr "Kommunikationsministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:94
+#: ckanext/ytp/translations.py:106
 msgid "Maa- ja metsätalousministeriö's administrative branch"
 msgstr "Jord- och skogsbruksministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:95
+#: ckanext/ytp/translations.py:107
 msgid "Oikeusministeriö's administrative branch"
 msgstr "Justitieministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:96
+#: ckanext/ytp/translations.py:108
 msgid "Opetus- ja kulttuuriministeriö's administrative branch"
 msgstr "Undervisnings- och kulturministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:97
+#: ckanext/ytp/translations.py:109
 msgid "Puolustusministeriö's administrative branch"
 msgstr "Försvarsministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:98
+#: ckanext/ytp/translations.py:110
 msgid "Sisäministeriö's administrative branch"
 msgstr "Inrikesministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:99
+#: ckanext/ytp/translations.py:111
 msgid "Sosiaali- ja terveysministeriö's administrative branch"
 msgstr "Social- och hälsovårdsministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:100
+#: ckanext/ytp/translations.py:112
 msgid "Työ- ja elinkeinoministeriö's administrative branch"
 msgstr "Arbets- och näringsministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:101
+#: ckanext/ytp/translations.py:113
 msgid "Valtioneuvoston kanslia's administrative branch"
 msgstr "Statsrådets kanslis förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:102
+#: ckanext/ytp/translations.py:114
 msgid "Valtiovarainministeriö's administrative branch"
 msgstr "Finansministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:103
+#: ckanext/ytp/translations.py:115
 msgid "Ympäristöministeriö's administrative branch"
 msgstr "Miljöministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:104
+#: ckanext/ytp/translations.py:116
 msgid "Ulkoministeriö's administrative branch"
 msgstr "Utrikesministeriets förvaltningsområdet"
 
-#: ckanext/ytp/translations.py:107
+#: ckanext/ytp/translations.py:119
 msgid "Administrative Branch Summary"
 msgstr ""
 
-#: ckanext/ytp/translations.py:108
+#: ckanext/ytp/translations.py:120
 msgid "Dataset statistics by administrative branch summary"
 msgstr ""
 
@@ -828,15 +868,15 @@ msgstr ""
 msgid "invalid encoding for \"%s\" value"
 msgstr ""
 
-#: ckanext/ytp/validators.py:237
+#: ckanext/ytp/validators.py:237 ckanext/ytp/validators.py:293
 msgid "Failed to decode JSON string"
 msgstr ""
 
-#: ckanext/ytp/validators.py:240
+#: ckanext/ytp/validators.py:240 ckanext/ytp/validators.py:296
 msgid "Invalid encoding for JSON string"
 msgstr ""
 
-#: ckanext/ytp/validators.py:243
+#: ckanext/ytp/validators.py:243 ckanext/ytp/validators.py:299
 msgid "expecting JSON object"
 msgstr ""
 
@@ -993,155 +1033,6 @@ msgstr "Töm uppladdningen"
 msgid " Maximum file size is limited to %(size)s MB. "
 msgstr "Maximala filstorleken är begränsad till %(size)s MB"
 
-#: ckanext/ytp/templates/organization/about.html:13
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:99
-msgid "Civil Service"
-msgstr "Statsförvaltningen"
-
-#: ckanext/ytp/templates/organization/about.html:14
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:100
-msgid "Municipality / City"
-msgstr "Kommun / Stad"
-
-#: ckanext/ytp/templates/organization/about.html:15
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:101
-msgid "Other Public Service"
-msgstr "Andra offentliga organ"
-
-#: ckanext/ytp/templates/organization/about.html:16
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:102
-msgid "Educational / Research Institute"
-msgstr "Läroanstalt / Forskningsinstitut"
-
-#: ckanext/ytp/templates/organization/about.html:17
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:103
-msgid "Company"
-msgstr "Företag"
-
-#: ckanext/ytp/templates/organization/about.html:18
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:104
-msgid "Individual"
-msgstr "En individ"
-
-#: ckanext/ytp/templates/organization/about.html:19
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:105
-msgid "Association"
-msgstr "Förening"
-
-#: ckanext/ytp/templates/organization/about.html:42
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:94
-msgid "Producer type"
-msgstr "Producenttyp"
-
-#: ckanext/ytp/templates/organization/about.html:43
-msgid "Business ID"
-msgstr "FO-nummer"
-
-#: ckanext/ytp/templates/organization/about.html:44
-msgid "OID"
-msgstr "OID"
-
-#: ckanext/ytp/templates/organization/about.html:45
-#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:20
-#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:91
-msgid "Alternative name"
-msgstr "Alternativt namn"
-
-#: ckanext/ytp/templates/organization/about.html:46
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:129
-#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:190
-#: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:12
-msgid "Period of validity"
-msgstr "Giltighetstid"
-
-#: ckanext/ytp/templates/organization/about.html:58
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:142
-msgid "Contact info"
-msgstr "Kontaktinfo"
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Street"
-msgstr "Gata/väg"
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "House number"
-msgstr "Husnummer"
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Staircase"
-msgstr "Trappa"
-
-#: ckanext/ytp/templates/organization/about.html:62
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
-msgid "Apartment number"
-msgstr "Lägenhet"
-
-#: ckanext/ytp/templates/organization/about.html:63
-msgid "P.O. box"
-msgstr "Postbox"
-
-#: ckanext/ytp/templates/organization/about.html:64
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:149
-msgid "Zip code"
-msgstr "Postnummer"
-
-#: ckanext/ytp/templates/organization/about.html:65
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:152
-msgid "Place of Business"
-msgstr "Driftställe"
-
-#: ckanext/ytp/templates/organization/about.html:66
-msgid "Country"
-msgstr "Land"
-
-#: ckanext/ytp/templates/organization/about.html:67
-msgid "Unofficial name of the building"
-msgstr "Byggnadens inofficiella namn"
-
-#: ckanext/ytp/templates/organization/about.html:68
-msgid "Building ID"
-msgstr "ID för byggnaden"
-
-#: ckanext/ytp/templates/organization/about.html:69
-msgid "Getting there"
-msgstr "Färdinstruktioner"
-
-#: ckanext/ytp/templates/organization/about.html:70
-msgid "Parking"
-msgstr "Parkering"
-
-#: ckanext/ytp/templates/organization/about.html:71
-msgid "Arrival by public transport"
-msgstr "Ankomst med kollektivtrafik"
-
-#: ckanext/ytp/templates/organization/about.html:72
-msgid "Web address for public transport"
-msgstr "Webbadressen för kollektivtrafiken"
-
-#: ckanext/ytp/templates/organization/about.html:73
-#: ckanext/ytp/templates/organization/snippets/organization_form.html:169
-msgid "Homepage"
-msgstr "Hemsida"
-
-#: ckanext/ytp/templates/organization/about.html:83
-msgid "Embed link"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/about.html:121
-msgid "Plain language translation available"
-msgstr "En lättläst översättning tillgänglig"
-
-#: ckanext/ytp/templates/organization/about.html:124
-msgid "Plain language translation not available"
-msgstr "En lättläst översättning finns inte tillgänglig"
-
-#: ckanext/ytp/templates/organization/about.html:133
-msgid "Organization hierarchy"
-msgstr "Organisationshierarki"
-
 #: ckanext/ytp/templates/organization/admin_list.html:5
 #: ckanext/ytp/templates/organization/user_list.html:5
 msgid "All Users"
@@ -1212,6 +1103,10 @@ msgstr "Medlemsansökan"
 #: ckanext/ytp/templates/organization/index.html:13
 msgid "My membership requests"
 msgstr "Medlemsansökan"
+
+#: ckanext/ytp/templates/organization/index.html:29
+msgid "Add Organization"
+msgstr ""
 
 #: ckanext/ytp/templates/organization/member_new.html:7
 msgid "If you wish to add an existing user, search for their username below."
@@ -1415,9 +1310,47 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nej"
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:94
+msgid "Producer type"
+msgstr "Producenttyp"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:99
+msgid "Civil Service"
+msgstr "Statsförvaltningen"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:100
+msgid "Municipality / City"
+msgstr "Kommun / Stad"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:101
+msgid "Other Public Service"
+msgstr "Andra offentliga organ"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:102
+msgid "Educational / Research Institute"
+msgstr "Läroanstalt / Forskningsinstitut"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:103
+msgid "Company"
+msgstr "Företag"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:104
+msgid "Individual"
+msgstr "En individ"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:105
+msgid "Association"
+msgstr "Förening"
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:110
 msgid "Select a producer type..."
 msgstr "Välj producenttyp.."
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:129
+#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:190
+#: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:12
+msgid "Period of validity"
+msgstr "Giltighetstid"
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:132
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:136
@@ -1428,6 +1361,10 @@ msgstr "Välj producenttyp.."
 msgid "YYYY-MM-DD"
 msgstr "ÅÅÅÅ-MM-DD"
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:142
+msgid "Contact info"
+msgstr "Kontaktinfo"
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:144
 msgid "Address"
 msgstr "Adress"
@@ -1436,13 +1373,41 @@ msgstr "Adress"
 msgid "Example street 1 apartment 5"
 msgstr "Exempelgata 1 lägenhet 5"
 
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Street"
+msgstr "Gata/väg"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "House number"
+msgstr "Husnummer"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Staircase"
+msgstr "Trappa"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:145
+msgid "Apartment number"
+msgstr "Lägenhet"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:149
+msgid "Zip code"
+msgstr "Postnummer"
+
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:149
 msgid "12345"
 msgstr "12345"
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:152
+msgid "Place of Business"
+msgstr "Driftställe"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:152
 msgid "Example City"
 msgstr "Exempelstad"
+
+#: ckanext/ytp/templates/organization/snippets/organization_form.html:169
+msgid "Homepage"
+msgstr "Hemsida"
 
 #: ckanext/ytp/templates/organization/snippets/organization_form.html:169
 msgid "http://example.com"
@@ -2333,6 +2298,11 @@ msgstr "E-postadress"
 msgid "Telephone number"
 msgstr "Telefonnummer"
 
+#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:20
+#: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:91
+msgid "Alternative name"
+msgstr "Alternativt namn"
+
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:25
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:99
 msgid "Opening hours"
@@ -2685,11 +2655,19 @@ msgstr ""
 msgid "No organization"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:27
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:4
+msgid "Showcases"
+msgstr ""
+
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:5
+msgid "Showcase submit"
+msgstr ""
+
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:16
 msgid "New application"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:33
+#: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:22
 msgid ""
 " Inform us about an application, web page or vizualization that you'be "
 "created with the form bellow and we will add it to application gallery. "

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/organization/about.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/organization/about.html
@@ -1,0 +1,12 @@
+{% extends "organization/about.html" %}
+
+{% block primary_content_inner %}
+<dl>
+{% for f in c.scheming_fields %}
+{% if f.field_name in c.group_dict and c.group_dict[f.field_name] %}
+<dt>{{ h.scheming_language_text(f.label) }}:</dt>
+<dd>{{ h.scheming_language_text(c.group_dict[f.field_name]) or ("&nbsp;"|safe) }}</dd>
+{% endif %}
+{% endfor %}
+</dl>
+{% endblock %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/translations.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/translations.py
@@ -61,6 +61,18 @@ def _translations():
     _('A short description of how frequently the dataset will get updated.')
     _('Features')
     _('Members can only edit their own datasets')
+    _('Home page')
+
+    # Values
+    _('public_administration_organization')
+    _('personal_datasets')
+    _('civil-service')
+    _('municipality')
+    _('other-public-service')
+    _('educational-research-institute')
+    _('company')
+    _('individual')
+    _('association')
 
     # Assets common terms
     _('Log in')


### PR DESCRIPTION
- Override ckanext-hierarchy's template with default scheming one
- Extend `scheming_language_text` to work with multiple_checkbox fields
- Add missing translations