### PR TITLE
AV-110: Restrict allowed characters to match ckan

### DIFF
--- a/ansible/roles/drupal/vars/main.yml
+++ b/ansible/roles/drupal/vars/main.yml
@@ -13,7 +13,7 @@ custom_modules:
   - { src_name: avoindata-drupal-articles, module_name: avoindata-articles, machine_name: avoindata_articles }
   - { src_name: avoindata-drupal-events, module_name: avoindata-events, machine_name: avoindata_events }
   - { src_name: avoindata-drupal-guide, module_name: avoindata-guide, machine_name: avoindata_guide }
-
+  - { src_name: avoindata-drupal-user, module_name: avoindata-user, machine_name: avoindata_user }
 
 # drupal_theme_path: "{{ drupal_root }}/sites/all/themes"
 # features_module_path: "{{ drupal_root }}/sites/all/modules/ytp_features"

--- a/modules/avoindata-drupal-user/avoindata_user.info.yml
+++ b/modules/avoindata-drupal-user/avoindata_user.info.yml
@@ -1,0 +1,5 @@
+name: Avoindata User
+type: module
+description: Modifies user validation
+package: Custom
+core: 8.x

--- a/modules/avoindata-drupal-user/avoindata_user.module
+++ b/modules/avoindata-drupal-user/avoindata_user.module
@@ -1,0 +1,43 @@
+<?php
+
+use Drupal\Core\Form\FormStateInterface;
+
+
+function avoindata_user_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id){
+  $form['account']['name']['#description'] = t("Must be purely lowercase alphanumeric (ascii) characters and these symbols: -_");
+  avoindata_user_add_name_validator($form);
+}
+
+function avoindata_form_user_register_form_alter(&$form, FormStateInterface $form_state, $form_id){
+  $form['account']['name']['#description'] = t("Must be purely lowercase alphanumeric (ascii) characters and these symbols: -_");
+  avoindata_user_add_name_validator($form);
+}
+
+function avoindata_user_add_name_validator(array &$form){
+
+  $validate =& $form['#validate'];
+
+  # Since `validate_name()` clears out any errors for the "name" field, we
+  # want to put it right after the validator we want to partially override.
+  $acct_validate_index = array_search('user_account_form_validate', $validate);
+  array_splice($validate, ($acct_validate_index + 1), 0,
+    ['avoindata_user_validate_name']
+  );
+
+}
+
+function avoindata_user_validate_name(array $form, \Drupal\Core\Form\FormStateInterface &$form_state){
+
+  $name = $form_state->getValue('name', null);
+
+  if (!preg_match('/^[a-z0-9_\-]*$/', $name)){
+
+    $error = t('The username contains an illegal character.');
+  }
+
+  if (isset($error)){
+    $form_state->setErrorByName('name', $error);
+  }
+
+}
+


### PR DESCRIPTION
* Added a new drupal module, as admin forms can't be altered from themes.
* Does regex match in admin user edit and on register form. Users can't edit their usernames themselves. 