### PR TITLE
AV-160: improve form help text styles

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
+++ b/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
@@ -20,8 +20,7 @@
       "form_placeholder": "eg. my-dataset",
       "form_attrs": {
         "class": "form-control"
-      },
-      "description": "An URL-address which refers to the dataset. The automatically filled option derived from the title is the best option in most cases."
+      }
     },
     {
       "field_name": "notes_translated",

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/date.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/date.html
@@ -14,6 +14,8 @@
 %}
     {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
 {% endcall %}
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
     {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_markdown_ex.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_markdown_ex.html
@@ -20,7 +20,10 @@
         lang=lang -%}
     {% endcall %}
   {%- endfor -%}
+
+  {% if field.description and field.description.strip() %}
   <div class="field-assistive-text">
-    {{ _(field.description) }}
+      {{ _(field.description) }}
   </div>
+  {% endif %}
 </div>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_tags_with_autocomplete.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_tags_with_autocomplete.html
@@ -28,6 +28,8 @@
     {% endcall %}
   {%- endfor -%}
 </div>
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
-  {{ _(field.description) }}
+    {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_text_ex.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_text_ex.html
@@ -23,6 +23,8 @@
     {% endcall %}
   {%- endfor -%}
 </div>
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
-  {{ _(field.description) }}
+    {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_title.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/fluent_title.html
@@ -43,7 +43,9 @@
         {% endcall %}
     {% endif %}
   {%- endfor -%}
+  {% if field.description and field.description.strip() %}
   <div class="field-assistive-text">
-    {{ _(field.description) }}
+      {{ _(field.description) }}
   </div>
+  {% endif %}
 </div>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/license.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/license.html
@@ -33,6 +33,8 @@
 %}
     {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
 {% endcall %}
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
     {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/organization_ex.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/organization_ex.html
@@ -55,6 +55,8 @@
   {% endif %}
 </div>
 
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
-  {{ _(field.description) }}
+    {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/private.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/private.html
@@ -8,6 +8,8 @@
     </select>
     </div>
 </div>
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
     {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/repeating.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/repeating.html
@@ -10,6 +10,8 @@
     attrs=field.form_attrs if 'form_attrs' in field else {},
     is_required=h.scheming_field_required(field),
     classes=['control-full']) }}
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
     {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/slug_ex.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/slug_ex.html
@@ -57,7 +57,8 @@
     attrs=attrs,
     is_required=h.scheming_field_required(field)
     ) }}
-
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
-  {{ _(field.description) }}
+    {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/tag_list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/tag_list.html
@@ -19,6 +19,8 @@ is_required=h.scheming_field_required(field)
 %}
 {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
 {% endcall %}
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
     {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/text.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/text.html
@@ -14,6 +14,8 @@
 %}
     {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
 {% endcall %}
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
     {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/text_ex.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/text_ex.html
@@ -23,6 +23,8 @@
 %}
     {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
 {% endcall %}
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
-  {{ _(field.description) }}
+    {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/textarea.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/textarea.html
@@ -14,6 +14,8 @@
 %}
 {%- snippet 'scheming/form_snippets/help_text.html', field=field -%}
 {% endcall %}
+{% if field.description and field.description.strip() %}
 <div class="field-assistive-text">
     {{ _(field.description) }}
 </div>
+{% endif %}

--- a/modules/ytp-assets-common/src/less/forms.less
+++ b/modules/ytp-assets-common/src/less/forms.less
@@ -1,1 +1,6 @@
 @import "variables";
+
+.field-assistive-text {
+    font-style: italic;
+    margin-bottom: 2em;
+}


### PR DESCRIPTION
- Made `field-assistive-text` class elements conditional and styled them a bit
- Removed URL field help text since it renders into the wrong place and would be complicated to fix