### PR TITLE
AV-205 Request certificate verification changes

### DIFF
--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -121,6 +121,9 @@ ckanext.drupal8.domain = {{ hostname }},{{ secondary_hostname }}
 ckanext.drupal8.sysadmin_role = {{ drupal_ckan_admin_rolename }}
 ckanext.drupal8.connection = postgres://{{ postgres.users.drupal8.username }}:{{ postgres.users.drupal8.password }}@{{ postgres.server.host }}/{{ postgres.databases.drupal8.name }}
 ckanext.drupal8.allow_edit = true
+{% if AWS.enabled -%}
+ckanext.drupal8.development_cert = /etc/ssl/opendata/server.crt
+{%- endif %}
 
 licenses_group_url = file://{{ ckan_files_path }}/license.json
 service_classes_options_url = file://{{ ckan_files_path }}/service_classes.json

--- a/modules/ckanext-ytp_drupal/ckanext/ytp_drupal/plugin.py
+++ b/modules/ckanext-ytp_drupal/ckanext/ytp_drupal/plugin.py
@@ -7,6 +7,7 @@ from ckan.logic import NotFound
 from ckan.lib import helpers
 from ckan.lib.plugins import DefaultTranslation
 
+import pylons.config as config
 from pylons import request
 
 import requests

--- a/modules/ckanext-ytp_drupal/ckanext/ytp_drupal/plugin.py
+++ b/modules/ckanext-ytp_drupal/ckanext/ytp_drupal/plugin.py
@@ -118,7 +118,8 @@ class YtpDrupalPlugin(plugins.SingletonPlugin, DefaultTranslation):
     def get_drupal_session_token(self, domain, service, cookie_header=''):
         '''return text of X-CSRF-Token)'''
         token_url = 'https://' + domain + '/' + service + '/?q=services/session/token'
-        token_request = requests.get(token_url, headers={"Cookie": cookie_header}, verify=False)
+        verify_cert = config.get('ckanext.drupal8.development_cert', '') or True
+        token_request = requests.get(token_url, headers={"Cookie": cookie_header}, verify=verify_cert)
         token = token_request.text
         return token
 

--- a/modules/ckanext-ytp_drupal/ckanext/ytp_drupal/plugin.py
+++ b/modules/ckanext-ytp_drupal/ckanext/ytp_drupal/plugin.py
@@ -6,8 +6,8 @@ from ckan.common import c
 from ckan.logic import NotFound
 from ckan.lib import helpers
 from ckan.lib.plugins import DefaultTranslation
+from ckan.plugins.toolkit import config
 
-import pylons.config as config
 from pylons import request
 
 import requests

--- a/modules/ckanext-ytp_main/ckanext/ytp/logic.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/logic.py
@@ -9,6 +9,7 @@ from ckan.lib import uploader, munge, helpers
 from ckan.common import c
 from ckan.plugins.core import get_plugin
 
+import pylons.config as config
 import requests
 import json
 import logging

--- a/modules/ckanext-ytp_main/ckanext/ytp/logic.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/logic.py
@@ -82,7 +82,8 @@ def _update_drupal_user(context, data_dict):
         payload = {"field_fullname": {"und": [{"value":  fullname, "format": None, "safe_value":  fullname}]},
                    'field_ckan_api_key': {'und': [{'value': apikey, "format": None, "safe_value": apikey}]}}
         headers = {"Content-type": "application/json", "X-CSRF-Token": token, "Cookie": cookie_header}
-        r = requests.put(update_url, data=json.dumps(payload), headers=headers, verify=False)
+        verify_cert = config.get('ckanext.drupal8.development_cert', '') or True
+        r = requests.put(update_url, data=json.dumps(payload), headers=headers, verify=verify_cert)
         if r.status_code == requests.codes.ok:
             return True
         else:

--- a/modules/ckanext-ytp_main/ckanext/ytp/logic.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/logic.py
@@ -8,8 +8,8 @@ from ckan.lib.dictization.model_dictize import user_dictize
 from ckan.lib import uploader, munge, helpers
 from ckan.common import c
 from ckan.plugins.core import get_plugin
+from ckan.plugins.toolkit import config
 
-import pylons.config as config
 import requests
 import json
 import logging

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -2,12 +2,10 @@ import ast
 import json
 import logging
 import pylons
-import pylons.config as config
 import re
 import types
 import urlparse
 import validators
-
 
 import ckan.lib.base as base
 import logic as plugin_logic
@@ -27,6 +25,7 @@ from ckan.lib.plugins import DefaultOrganizationForm, DefaultTranslation
 from ckan.logic import NotFound, NotAuthorized, auth as ckan_auth, get_action
 from ckan.model import Session
 from ckan.plugins import toolkit
+from ckan.plugins.toolkit import config
 from ckanext.harvest.model import HarvestObject
 from ckanext.report.interfaces import IReport
 from ckanext.spatial.interfaces import ISpatialHarvester

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -1483,7 +1483,7 @@ class YtpThemePlugin(plugins.SingletonPlugin, YtpMainTranslation):
         try:
             # Call our custom Drupal API to get drupal block content
             hostname = config.get('ckan.site_url', '')
-            domains = config.get('ckanext.drupal8.domain').split(",") 
+            domains = config.get('ckanext.drupal8.domain').split(",")
             verify_cert = config.get('ckanext.drupal8.development_cert', '') or True
             cookies = {}
             for domain in domains:

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -1483,7 +1483,8 @@ class YtpThemePlugin(plugins.SingletonPlugin, YtpMainTranslation):
         try:
             # Call our custom Drupal API to get drupal block content
             hostname = config.get('ckan.site_url', '')
-            domains = config.get('ckanext.drupal8.domain').split(",")
+            domains = config.get('ckanext.drupal8.domain').split(",") 
+            verify_cert = config.get('ckanext.drupal8.development_cert', '') or True
             cookies = {}
             for domain in domains:
                 domain_hash = hashlib.sha256(domain).hexdigest()[:32]
@@ -1492,7 +1493,7 @@ class YtpThemePlugin(plugins.SingletonPlugin, YtpMainTranslation):
                 if cookie is not None:
                     cookies.update({cookiename: cookie})
 
-            response = requests.get('%s/%s/%s' % (hostname, lang, path), cookies=cookies, verify=False)
+            response = requests.get('%s/%s/%s' % (hostname, lang, path), cookies=cookies, verify=verify_cert)
             return response.text
         except requests.exceptions.RequestException, e:
             log.error('%s' % e)


### PR DESCRIPTION
- Enabled certificate verification in ckan requests that use "requests" library. Local development verification is done by importing local cert.

This is branched of AV-207