### PR TITLE
AV-218 Fix CKAN development cert config

### DIFF
--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -121,7 +121,7 @@ ckanext.drupal8.domain = {{ hostname }},{{ secondary_hostname }}
 ckanext.drupal8.sysadmin_role = {{ drupal_ckan_admin_rolename }}
 ckanext.drupal8.connection = postgres://{{ postgres.users.drupal8.username }}:{{ postgres.users.drupal8.password }}@{{ postgres.server.host }}/{{ postgres.databases.drupal8.name }}
 ckanext.drupal8.allow_edit = true
-{% if AWS.enabled -%}
+{% if not AWS.enabled -%}
 ckanext.drupal8.development_cert = /etc/ssl/opendata/server.crt
 {%- endif %}
 


### PR DESCRIPTION
- CKAN config had wrong conditional check for AWS enviroments regarding
the drupal8 development cert.