### PR TITLE
Av 8 organization page styles

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -1011,20 +1011,20 @@ class YtpOrganizationsPlugin(plugins.SingletonPlugin, DefaultOrganizationForm, Y
             m.connect('/user_list', action='user_list', ckan_icon='user')
             m.connect('/admin_list', action='admin_list', ckan_icon='user')
 
-        map.connect('/organization/new', 
-                    action='new', 
+        map.connect('/organization/new',
+                    action='new',
                     controller='organization')
-        
-        map.connect('organization_read_extended', 
+
+        map.connect('organization_read_extended',
                     '/organization/{id}',
-                    controller=organization_controller, 
-                    action='read', 
+                    controller=organization_controller,
+                    action='read',
                     ckan_icon='group')
-        
-        map.connect('organization_embed', 
-                    '/organization/{id}/embed', 
-                    controller=organization_controller, 
-                    action='embed', 
+
+        map.connect('organization_embed',
+                    '/organization/{id}/embed',
+                    controller=organization_controller,
+                    action='embed',
                     ckan_icon='group')
         return map
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -1011,9 +1011,21 @@ class YtpOrganizationsPlugin(plugins.SingletonPlugin, DefaultOrganizationForm, Y
             m.connect('/user_list', action='user_list', ckan_icon='user')
             m.connect('/admin_list', action='admin_list', ckan_icon='user')
 
-        map.connect('/organization/new', action='new', controller='organization')
-        map.connect('organization_read_extended', '/organization/{id}', controller=organization_controller, action='read', ckan_icon='group')
-        map.connect('organization_embed', '/organization/{id}/embed', controller=organization_controller, action='embed', ckan_icon='group')
+        map.connect('/organization/new', 
+                    action='new', 
+                    controller='organization')
+        
+        map.connect('organization_read_extended', 
+                    '/organization/{id}',
+                    controller=organization_controller, 
+                    action='read', 
+                    ckan_icon='group')
+        
+        map.connect('organization_embed', 
+                    '/organization/{id}/embed', 
+                    controller=organization_controller, 
+                    action='embed', 
+                    ckan_icon='group')
         return map
 
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -1012,7 +1012,7 @@ class YtpOrganizationsPlugin(plugins.SingletonPlugin, DefaultOrganizationForm, Y
             m.connect('/admin_list', action='admin_list', ckan_icon='user')
 
         map.connect('/organization/new', action='new', controller='organization')
-        map.connect('organization_read', '/organization/{id}', controller=organization_controller, action='read', ckan_icon='group')
+        map.connect('organization_read_extended', '/organization/{id}', controller=organization_controller, action='read', ckan_icon='group')
         map.connect('organization_embed', '/organization/{id}/embed', controller=organization_controller, action='embed', ckan_icon='group')
         return map
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/read_base.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/read_base.html
@@ -8,7 +8,7 @@
 {% endblock %}
 
 {% block content_primary_nav %}
-  {{ h.build_nav_icon('organization_read', _('Datasets'), id=c.group_dict.name) }}
+  {{ h.build_nav_icon('organization_read_extended', _('Datasets'), id=c.group_dict.name) }}
   {% if h.check_access('organization_update', {'id': c.group_dict.id})%}
     {{ h.build_nav_icon('organization_activity', _('Activity Stream'), id=c.group_dict.name, offset=0) }}
   {% endif %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/facet_list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/facet_list.html
@@ -67,7 +67,9 @@ within_tertiary
                     {% set count = count_label(item['count']) if count_label else ('(%d)' % item['count']) %}
                       <li class="{{ nav_item_class or 'nav-item' }}{% if item.active %} active{% endif %}">
                         <a href="{{ href }}" title="{{ label if label != label_truncated else '' }}" rel="nofollow">
-                          <span>{{ _(label_truncated) }} {{ count }}</span>
+                          <span>{{ _(label_truncated) }} {{ count }} </span>
+                          <i class="fas fa-plus-circle"></i>
+                          <i class="fas fa-times-circle"></i>
                         </a>
                       </li>
                   {% endfor %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -66,7 +66,7 @@
               {%- else -%}
                 {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
               {%- endif %}
-              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="icon-remove"></i></a>
+              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fas fa-times-circle"></i></a>
             </span>
           {% endfor %}
         {% endfor %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form_without_input.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form_without_input.html
@@ -73,7 +73,7 @@
                 {%- else -%}
                   {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
                 {%- endif %}
-                <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="icon-remove"></i></a>
+                <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><<i class="fas fa-times-circle"></i></a>
               </span>
             {% endfor %}
           </div>

--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -127,7 +127,7 @@
 .nav-aside > li,
 .nav-simple > li {
   a {
-    color: #020202;
+    color: @facet-link-text-color;
     text-decoration: none;
     margin: 0;
 
@@ -154,10 +154,10 @@
   &.active {
     a {
       background-color: transparent;
-      color: inherit;
+      color: @facet-link-text-color;
       &:hover {
         background-color: transparent;
-        color: inherit;
+        color: @facet-link-text-color;
       }
     }
     color: #219ad3;

--- a/modules/ytp-assets-common/src/less/ckan/upstream_ckan/nav.less
+++ b/modules/ytp-assets-common/src/less/ckan/upstream_ckan/nav.less
@@ -84,6 +84,10 @@
 }
 
 .nav-facet li.nav-item{
+  // The purpose of the display definitions is that
+  // the cross (fa-times-circle) is only visible on active elements
+  // whereas the plus-circle is visible only on non-active elements
+  // and only on hover
   &.active{
     .fa-plus-circle {
       display: none;
@@ -119,6 +123,12 @@
       display: none;
     }
   }
+}
+
+.filter-list .fa-times-circle {
+  color: @btn-black-color;
+  font-size: 15px;
+  padding-left: 5px;  
 }
 
 .user-list {

--- a/modules/ytp-assets-common/src/less/ckan/upstream_ckan/nav.less
+++ b/modules/ytp-assets-common/src/less/ckan/upstream_ckan/nav.less
@@ -83,13 +83,42 @@
   margin-top: -8px;
 }
 
-.nav-facet .nav-item > a:hover:after {
-  .ckan-icon-circle-add;
-}
-
-.nav-facet .nav-item.active > a:after {
-  .ckan-icon-circle-cross;
-  right: 3px;
+.nav-facet li.nav-item{
+  &.active{
+    .fa-plus-circle {
+      display: none;
+    }
+    .fa-times-circle {
+      display: inline;
+    }
+    &:hover {
+      .fa-plus-circle {
+        display: none;
+      }
+    }
+  }
+  &:hover {
+    .fa-plus-circle {
+      display: inline;
+    }
+  }
+  a {
+    display: flex;
+    justify-content: space-between;
+    .fas {
+      align-self: center;
+    }
+    .fa-plus-circle {
+      color: @btn-dark-bg;
+      font-size: 18px;
+      display:none;
+    }
+    .fa-times-circle {
+      color: @btn-black-color;
+      font-size: 18px;
+      display: none;
+    }
+  }
 }
 
 .user-list {

--- a/modules/ytp-assets-common/src/less/variables.less
+++ b/modules/ytp-assets-common/src/less/variables.less
@@ -33,6 +33,7 @@
 @btn-default-border:   #e8e7e6;
 @btn-dark-bg:          #2a6ebb;
 @btn-dark-text-color:    #FFF;
+@btn-black-color: #000;
 
 // For very 'extra' information, meant for small text on white/light backgrounds
 @nonimportant-text-color: lighten(@opendata-brand-gray, 0%);
@@ -102,6 +103,7 @@
 @menu-hover-color: @opendata-brand-decorative;
 
 @body-color-background: white;
+
 
 // Footer colors
 @footer-background: @opendata-brand-dark;
@@ -179,3 +181,5 @@
 
 @dataset-count-text-color: #C6C6C6;
 @organization-count-header-color: #C6C6C6; 
+
+@facet-link-text-color: #020202;


### PR DESCRIPTION
-Changed name of action to fix an issue that the "Datasets" tab, didn't have the 'active' class, because actions using custom controllers could not have a same name with default pylons actions. 

-Changed icons to use fontawesome and changed their styles

-Changed active facet link color to black so it's the same as non-active link color. The activeness is still visible to the user by the cross icon