### PR TITLE
Added style for defined license title

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/license.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/license.html
@@ -1,6 +1,6 @@
 {% macro license_string(pkg_dict) %}
     {% if 'license_url' in pkg_dict %}
-        <a href="{{ _(pkg_dict.license_url) }}" rel="dc:rights">{{ _(pkg_dict.license_title) }}</a>
+        <a class="license-title-text" href="{{ _(pkg_dict.license_url) }}" rel="dc:rights">{{ _(pkg_dict.license_title) }}</a>
     {% else %}
         <span class="license-title-text" property="dc:rights">{{ _(pkg_dict.license_title) }}</span>
     {% endif %}


### PR DESCRIPTION
Added "license-title-text" class also for licenses that were defined. Previously, it was only used for undefined licenses. 