### PR TITLE
Language and image fields made visible on basic page form

### DIFF
--- a/modules/avoindata-drupal-theme/config/install/core.entity_form_display.node.page.default.yml
+++ b/modules/avoindata-drupal-theme/config/install/core.entity_form_display.node.page.default.yml
@@ -1,0 +1,101 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.node.page.body
+    - field.field.node.page.field_basic_page_comments
+    - field.field.node.page.field_image
+    - image.style.thumbnail
+    - node.type.page
+  module:
+    - image
+    - path
+    - text
+_core:
+  default_config_hash: sb0qCkzU_8mNq29NehYAU8jCBXWPLeX0UN8sYFVGVcw
+id: node.page.default
+targetEntityType: node
+bundle: page
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 8
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: image_image
+    weight: 10
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 5
+    region: content
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 9
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 6
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  translation:
+    weight: 4
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 2
+    region: content
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  field_basic_page_comments: true

--- a/modules/avoindata-drupal-theme/config/install/language.content_settings.node.page.yml
+++ b/modules/avoindata-drupal-theme/config/install/language.content_settings.node.page.yml
@@ -8,8 +8,10 @@ dependencies:
 third_party_settings:
   content_translation:
     enabled: true
+_core:
+  default_config_hash: 21RHPFh-gwdgk2GZV9Y-X9gF1IRPAAEFCL_XAU4Wfic
 id: node.page
 target_entity_type_id: node
 target_bundle: page
 default_langcode: site_default
-language_alterable: false
+language_alterable: true


### PR DESCRIPTION
Previously, basic page was translatable and it had an image field, but these fields were not visible on the create/edit form. This was fixed by adding editing the configuration files. 