### PR TITLE
Added missing configuration file defining, which fields are shown

### DIFF
--- a/modules/avoindata-drupal-theme/config/install/core.entity_view_display.node.page.default.yml
+++ b/modules/avoindata-drupal-theme/config/install/core.entity_view_display.node.page.default.yml
@@ -1,0 +1,50 @@
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.field.node.page.body
+    - field.field.node.page.field_basic_page_comments
+    - field.field.node.page.field_image
+    - node.type.page
+  module:
+    - disqus
+    - image
+    - text
+    - user
+_core:
+  default_config_hash: g1S3_GLaxq4l3I9RIca5Mlz02MxI2KmOquZpHw59akM
+id: node.page.default
+targetEntityType: node
+bundle: page
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_basic_page_comments:
+    type: disqus_comment
+    weight: 3
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: image
+    weight: 2
+    region: content
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+  links:
+    weight: 1
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  langcode: true

--- a/modules/avoindata-drupal-theme/config/install/core.entity_view_display.node.page.default.yml
+++ b/modules/avoindata-drupal-theme/config/install/core.entity_view_display.node.page.default.yml
@@ -11,7 +11,6 @@ dependencies:
     - image
     - text
     - user
-_core:
 id: node.page.default
 targetEntityType: node
 bundle: page

--- a/modules/avoindata-drupal-theme/config/install/core.entity_view_display.node.page.default.yml
+++ b/modules/avoindata-drupal-theme/config/install/core.entity_view_display.node.page.default.yml
@@ -12,7 +12,6 @@ dependencies:
     - text
     - user
 _core:
-  default_config_hash: g1S3_GLaxq4l3I9RIca5Mlz02MxI2KmOquZpHw59akM
 id: node.page.default
 targetEntityType: node
 bundle: page


### PR DESCRIPTION
Previously, the basic page content type had fields for image and comments and the image field was shown on the content creation page. However, the comments and image fields were not configured to be shown on the actual page itself. I fixed the issue by adding this new configuration file. 