### PR TITLE
Av 167 URL structure implementation

### DIFF
--- a/ansible/roles/drupal/tasks/main.yml
+++ b/ansible/roles/drupal/tasks/main.yml
@@ -283,6 +283,7 @@
     - twig_field_value
     - disqus
     - recaptcha
+    - redirect
 
 # Not symlinked because nested symlinks don't work on windows
 - name: Synchronize fonts
@@ -312,6 +313,8 @@
   with_items:
     - easy_breadcrumb.settings
     - node.type.page
+    - core.entity_form_display.node.page.default
+    - pathauto.settings
 
 - name: Enable custom theme
   command: ../vendor/drush/drush/drush then -y avoindata

--- a/drupal8/composer.json
+++ b/drupal8/composer.json
@@ -39,7 +39,8 @@
         "drush/drush": "^9.0.0",
         "vlucas/phpdotenv": "^2.4",
         "webflo/drupal-finder": "^1.0.0",
-        "webmozart/path-util": "^2.3"
+        "webmozart/path-util": "^2.3",
+        "drupal/redirect": "^1.2"
     },
     "require-dev": {
         "webflo/drupal-core-require-dev": "~8.5.3"

--- a/modules/avoindata-drupal-articles/avoindata_articles.install
+++ b/modules/avoindata-drupal-articles/avoindata_articles.install
@@ -1,0 +1,6 @@
+<?php
+
+function avoindata_articles_install() {
+    \Drupal::service('path.alias_storage')->save("/articles", "/artikkelit", "fi");
+    \Drupal::service('path.alias_storage')->save("/articles", "/artiklar", "sv");
+}

--- a/modules/avoindata-drupal-articles/avoindata_articles.routing.yml
+++ b/modules/avoindata-drupal-articles/avoindata_articles.routing.yml
@@ -2,6 +2,6 @@ avoindata_articles.articles:
   path: '/articles'
   defaults:
     _controller: '\Drupal\avoindata_articles\Controller\ArticlesController::articles'
-    _title: 'Articles'
+    _title: 'News and articles'
   requirements:
     _permission: 'access content'

--- a/modules/avoindata-drupal-articles/config/install/pathauto.pattern.article_pattern_english.yml
+++ b/modules/avoindata-drupal-articles/config/install/pathauto.pattern.article_pattern_english.yml
@@ -1,0 +1,32 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: article_pattern_english
+label: 'Article pattern (English)'
+type: 'canonical_entities:node'
+pattern: 'article/[node:title]'
+selection_criteria:
+  69ada610-24f7-4b8d-9764-d4a3ea24c25a:
+    id: node_type
+    bundles:
+      avoindata_article: avoindata_article
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 69ada610-24f7-4b8d-9764-d4a3ea24c25a
+  10d948bb-602d-41f7-bf7f-f2dbd3d19290:
+    id: language
+    langcodes:
+      en: en
+    negate: false
+    context_mapping:
+      language: 'node:langcode:language'
+    uuid: 10d948bb-602d-41f7-bf7f-f2dbd3d19290
+selection_logic: and
+weight: -10
+relationships:
+  'node:langcode:language':
+    label: Language

--- a/modules/avoindata-drupal-articles/config/install/pathauto.pattern.article_pattern_finnish.yml
+++ b/modules/avoindata-drupal-articles/config/install/pathauto.pattern.article_pattern_finnish.yml
@@ -1,0 +1,32 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: article_pattern_finnish
+label: 'Article pattern (Finnish)'
+type: 'canonical_entities:node'
+pattern: 'artikkeli/[node:title]'
+selection_criteria:
+  de114023-5b31-46e6-a889-f8a3452b6c03:
+    id: node_type
+    bundles:
+      avoindata_article: avoindata_article
+    negate: false
+    context_mapping:
+      node: node
+    uuid: de114023-5b31-46e6-a889-f8a3452b6c03
+  96e400af-23c6-48f4-83a6-42f0294159f4:
+    id: language
+    langcodes:
+      fi: fi
+    negate: false
+    context_mapping:
+      language: 'node:langcode:language'
+    uuid: 96e400af-23c6-48f4-83a6-42f0294159f4
+selection_logic: and
+weight: -10
+relationships:
+  'node:langcode:language':
+    label: Language

--- a/modules/avoindata-drupal-articles/config/install/pathauto.pattern.article_pattern_swedish.yml
+++ b/modules/avoindata-drupal-articles/config/install/pathauto.pattern.article_pattern_swedish.yml
@@ -1,0 +1,32 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: article_pattern_swedish
+label: 'Article pattern (Swedish)'
+type: 'canonical_entities:node'
+pattern: 'artikel/[node:title]'
+selection_criteria:
+  32f5bd53-fc19-47a2-a05b-bf01e60bbcd2:
+    id: node_type
+    bundles:
+      avoindata_article: avoindata_article
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 32f5bd53-fc19-47a2-a05b-bf01e60bbcd2
+  f4cccaa7-0deb-4d2f-8717-0496c973edb9:
+    id: language
+    langcodes:
+      sv: sv
+    negate: false
+    context_mapping:
+      language: 'node:langcode:language'
+    uuid: f4cccaa7-0deb-4d2f-8717-0496c973edb9
+selection_logic: and
+weight: -10
+relationships:
+  'node:langcode:language':
+    label: Language

--- a/modules/avoindata-drupal-articles/templates/avoindata_articles_block.html.twig
+++ b/modules/avoindata-drupal-articles/templates/avoindata_articles_block.html.twig
@@ -12,7 +12,7 @@
     <div class="row">
       <h1>
         {% trans %}
-        News
+        News and articles
         {% endtrans %}
       </h1>
     </div>

--- a/modules/avoindata-drupal-events/avoindata_events.install
+++ b/modules/avoindata-drupal-events/avoindata_events.install
@@ -1,0 +1,6 @@
+<?php
+
+function avoindata_events_install() {
+    \Drupal::service('path.alias_storage')->save("/events", "/tapahtumat", "fi");
+    \Drupal::service('path.alias_storage')->save("/events", "/evenemanger", "sv");
+}

--- a/modules/avoindata-drupal-events/config/install/pathauto.pattern.event_pattern_english.yml
+++ b/modules/avoindata-drupal-events/config/install/pathauto.pattern.event_pattern_english.yml
@@ -1,0 +1,32 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: event_pattern_english
+label: 'Event pattern (English)'
+type: 'canonical_entities:node'
+pattern: '/event/[node:title]'
+selection_criteria:
+  2d641ba9-f386-4f0d-aac3-336cde628d34:
+    id: node_type
+    bundles:
+      avoindata_event: avoindata_event
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 2d641ba9-f386-4f0d-aac3-336cde628d34
+  bf08cb84-1412-4df5-8386-bb3700a18564:
+    id: language
+    langcodes:
+      en: en
+    negate: false
+    context_mapping:
+      language: 'node:langcode:language'
+    uuid: bf08cb84-1412-4df5-8386-bb3700a18564
+selection_logic: and
+weight: -10
+relationships:
+  'node:langcode:language':
+    label: Language

--- a/modules/avoindata-drupal-events/config/install/pathauto.pattern.event_pattern_finnish.yml
+++ b/modules/avoindata-drupal-events/config/install/pathauto.pattern.event_pattern_finnish.yml
@@ -1,0 +1,32 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: event_pattern_finnish
+label: 'Event pattern (Finnish)'
+type: 'canonical_entities:node'
+pattern: '/tapahtuma/[node:title]'
+selection_criteria:
+  3cfff855-7127-48cb-beb8-5963dd8ffeae:
+    id: node_type
+    bundles:
+      avoindata_event: avoindata_event
+    negate: false
+    context_mapping:
+      node: node
+    uuid: 3cfff855-7127-48cb-beb8-5963dd8ffeae
+  c9fbc11c-e12e-4782-8640-28c0fed2b4a1:
+    id: language
+    langcodes:
+      fi: fi
+    negate: false
+    context_mapping:
+      language: 'node:langcode:language'
+    uuid: c9fbc11c-e12e-4782-8640-28c0fed2b4a1
+selection_logic: and
+weight: -10
+relationships:
+  'node:langcode:language':
+    label: Language

--- a/modules/avoindata-drupal-events/config/install/pathauto.pattern.event_pattern_swedish.yml
+++ b/modules/avoindata-drupal-events/config/install/pathauto.pattern.event_pattern_swedish.yml
@@ -1,0 +1,32 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - language
+    - node
+id: event_pattern_swedish
+label: 'Event pattern (Swedish)'
+type: 'canonical_entities:node'
+pattern: '/evenemang/[node:title]'
+selection_criteria:
+  c73287f3-0bed-4737-8bfe-9c625c3b2751:
+    id: node_type
+    bundles:
+      avoindata_event: avoindata_event
+    negate: false
+    context_mapping:
+      node: node
+    uuid: c73287f3-0bed-4737-8bfe-9c625c3b2751
+  c09c1820-cced-4af3-ab29-d20bf5b5af2d:
+    id: language
+    langcodes:
+      sv: sv
+    negate: false
+    context_mapping:
+      language: 'node:langcode:language'
+    uuid: c09c1820-cced-4af3-ab29-d20bf5b5af2d
+selection_logic: and
+weight: -10
+relationships:
+  'node:langcode:language':
+    label: Language

--- a/modules/avoindata-drupal-header/avoindata_header.links.menu.yml
+++ b/modules/avoindata-drupal-header/avoindata_header.links.menu.yml
@@ -31,8 +31,8 @@ avoindata_header.apps_fi:
   weight: 4
 
 avoindata_header.news_fi:
-  title: 'Uutiset'
-  description: 'Uutiset'
+  title: 'Ajankohtaista'
+  description: 'Ajankohtaista'
   parent: main-fi
   menu_name: main-fi
   url: 'internal:/fi/articles'
@@ -88,8 +88,8 @@ avoindata_header.apps_en:
   weight: 4
 
 avoindata_header.news_en:
-  title: 'News'
-  description: 'News'
+  title: 'News and articles'
+  description: 'News and articles'
   parent: main-en
   menu_name: main-en
   url: 'internal:/en/articles'
@@ -145,8 +145,8 @@ avoindata_header.apps_sv:
   weight: 4
 
 avoindata_header.news_sv:
-  title: 'Nyhet'
-  description: 'Nyhet'
+  title: 'Aktuell'
+  description: 'Aktuell'
   parent: main-sv
   menu_name: main-sv
   url: 'internal:/sv/articles'

--- a/modules/avoindata-drupal-theme/config/install/pathauto.settings.yml
+++ b/modules/avoindata-drupal-theme/config/install/pathauto.settings.yml
@@ -1,0 +1,54 @@
+enabled_entity_types:
+  - user
+punctuation:
+  double_quotes: 0
+  quotes: 0
+  backtick: 0
+  comma: 0
+  period: 0
+  hyphen: 1
+  underscore: 0
+  colon: 0
+  semicolon: 0
+  pipe: 0
+  left_curly: 0
+  left_square: 0
+  right_curly: 0
+  right_square: 0
+  plus: 0
+  equal: 0
+  asterisk: 0
+  ampersand: 0
+  percent: 0
+  caret: 0
+  dollar: 0
+  hash: 0
+  at: 0
+  exclamation: 0
+  tilde: 0
+  left_parenthesis: 0
+  right_parenthesis: 0
+  question_mark: 0
+  less_than: 0
+  greater_than: 0
+  slash: 0
+  back_slash: 0
+verbose: false
+separator: '-'
+max_length: 100
+max_component_length: 100
+transliterate: true
+reduce_ascii: false
+case: true
+ignore_words: ''
+update_action: 2
+safe_tokens:
+  - alias
+  - path
+  - join-path
+  - login-url
+  - url
+  - url-brief
+_core:
+  default_config_hash: SwvLp8snyPEExF41CaJJYdPUVomofLqtXvwciHc4cPg
+langcode: fi


### PR DESCRIPTION
- Added Redirect module (https://www.drupal.org/project/redirect). The default settings are used, which automatically redirect to the URL alias of the page if one exists

- Articles and Events have a install hook that adds URL aliases for their listing pages.

- URL alias patterns added for single articles and events

- Added pathauto.settings file. It doesn't show in the file, but the most important change is that words such as and, or, with, by etc. are not removed from URLs anymore. 

- Changed terminology of News (Uutiset) to correspond to the demo implementation. So it's now "News and articles" in English, "Ajankohtaista" in Finnish and "Aktuell" in Swedish. 

- Some of the new configuration files need to be removed as part of the provisioning and this was changed to main.yml.
    