### PR TITLE
AV-108: Add smtp port to drupal configuration

### DIFF
--- a/ansible/roles/drupal/templates/drupal_site_config/smtp.settings.yml.j2
+++ b/ansible/roles/drupal/templates/drupal_site_config/smtp.settings.yml.j2
@@ -4,3 +4,9 @@ smtp_protocol: tls
 smtp_username: {{ secret.smtp_user }}
 smtp_password: {{ secret.smtp_password }}
 smtp_from: {{ email_from }}
+{% if AWS.enabled -%}
+smtp_port: 587
+{%- else -%}
+smtp_port: 25
+{%- endif %}
+


### PR DESCRIPTION
Uses port 587 on aws instances and port 25 in local vagrant.