### PR TITLE
Fixed ansible issue with clean installs

### DIFF
--- a/ansible/roles/drupal/tasks/main.yml
+++ b/ansible/roles/drupal/tasks/main.yml
@@ -6,15 +6,6 @@
     state: absent
     path: "/root/.drush"
 
-# Disable removed modules, modules must be removed from removed_extensions after they are removed from composer.json
-
-- name: Disable removed drupal extra modules
-  shell: ./vendor/bin/drush pm:uninstall -y {{ item }}
-  args:
-    chdir: "{{ drupal8_root }}"
-  with_items: "{{ removed_extensions }}"
-  when: "removed_extensions is defined"
-
 ### Get PHP ###
 
 - name: Get PHP and required extensions
@@ -269,6 +260,15 @@
   when: deployment_environment_id == "vagrant"
 
 ### Install external modules ###
+
+# Disable removed modules, modules must be removed from removed_extensions 
+# after they are removed from composer.json
+- name: Disable removed drupal extra modules
+  shell: ./vendor/bin/drush pm:uninstall -y {{ item }}
+  args:
+    chdir: "{{ drupal8_root }}"
+  with_items: "{{ removed_extensions }}"
+  when: "removed_extensions is defined"
 
 - name: Enable Drupal extra modules
   shell: ./vendor/bin/drush en -y {{ item }}


### PR DESCRIPTION
 - Provisioning failed with clean installs, because the "Disable removed drupal extra modules"
   task didn't work if Drupal was not installed. The task is now moved to later phase, when Drupal
   is installed