### PR TITLE
AV-18 category listing layout

### DIFF
--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
@@ -66,7 +66,9 @@
 {% endblock %}
 
 {% block package_search_results_list %}
-  {{ h.snippet('sixodp_showcase/snippets/showcase_list.html', packages=c.page.items) }}
+  <div class="col-lg-12 col-md-12 col-sm-12">
+    {{ h.snippet('sixodp_showcase/snippets/showcase_list.html', packages=c.page.items) }}
+  </div>
 {% endblock %}
 
 {% block package_search_results_api %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -1073,12 +1073,12 @@ msgstr "Peruuta kommenttien tilaus"
 #: ckanext/ytp/templates/group/snippets/group_item.html:33
 msgid "{num} Dataset"
 msgid_plural "{num} Datasets"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "{num} tietoaineisto"
+msgstr[1] "{num} tietoaineistoa"
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:35
 msgid "0 Datasets"
-msgstr ""
+msgstr "0 tietoaineistoa"
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:39
 #: ckanext/ytp/templates/group/snippets/group_item.html:40

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/group_item.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/group_item.html
@@ -19,6 +19,7 @@ Example:
   {% block image %}
     <img src="{{ group.image_display_url or h.url_for_static('/base/images/placeholder-group.png') }}" alt="{{ group.name }}" class="media-image img-responsive">
   {% endblock %}
+  <div class="item-content item-content-slide-up">
   {% block title %}
     <h3 class="media-heading">{{ h.get_translated(group, 'title') or group.title }}</h3>
   {% endblock %}
@@ -43,6 +44,7 @@ Example:
   {% if group.user_member %}
     <input name="group_remove.{{ group.id }}" value="{{ _('Remove') }}" type="submit" class="btn btn-danger btn-sm media-edit" title="{{ _('Remove dataset from this group') }}"/>
   {% endif %}
+  </div>
   {% endblock %}
 </li>
 {% endblock %}

--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -559,6 +559,7 @@
     border-top: 1px solid rgba(0, 0, 0, 0.16);
     border-radius: 3px;
     padding: 0px;
+    margin: 0px 25px 25px 0px;
     .media-image {
       padding: 0px;
       border-radius: 0px;
@@ -750,4 +751,8 @@ li.organization {
   color: @opendata-brand-danger;
   vertical-align: middle;
   height: 1.3em;
+}
+
+.context-info .module-content {
+  padding: 0;
 }

--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -756,3 +756,7 @@ li.organization {
 .context-info .module-content {
   padding: 0;
 }
+
+#content > .wrapper > .primary:first-child > .module > .module-content {
+  padding-left: 0;
+}


### PR DESCRIPTION
- Replace left-margins with right-margins in media-grid items
- Remove extra padding where it misaligns leftmost content
  - Fix fallout of the point above
- Unify category and application grid item layouts
- Translations