### PR TITLE
Use title in breadcrumb if possible

### DIFF
--- a/modules/avoindata-drupal-theme/config/install/easy_breadcrumb.settings.yml
+++ b/modules/avoindata-drupal-theme/config/install/easy_breadcrumb.settings.yml
@@ -15,4 +15,4 @@ excluded_paths: ''
 replaced_titles: ''
 segments_separator: null
 title_segment_as_link: false
-title_from_page_when_available: false
+title_from_page_when_available: true


### PR DESCRIPTION
In some cases, there might be a need to have the breadcrumb title be different from the page title. However, Easy Breadcrumb offers a possibility to write lists of exceptions in the configuration. No such exceptions are configured now, but that can be done later if a need is noticed. 