### PR TITLE
Added ckan email validators to email fields

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
+++ b/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
@@ -98,6 +98,7 @@
       },
       "display_property": "dc:contributor",
       "display_snippet": "email.html",
+      "validators": "email_validator",
       "display_email_name_field": "maintainer",
       "required": true
     },

--- a/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
+++ b/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
@@ -218,6 +218,7 @@
       },
       "display_property": "dc:creator",
       "display_snippet": "email.html",
+      "validators": "email_validator",
       "display_email_name_field": "author"
     },
     {


### PR DESCRIPTION
The "email_validator" is one of the core validators so it doesn't need to imported specifically. 