### PR TITLE
AV-302: Remove 'contextual' module from drupal

### DIFF
--- a/ansible/roles/drupal/vars/main.yml
+++ b/ansible/roles/drupal/vars/main.yml
@@ -17,6 +17,7 @@ custom_modules:
 
 removed_extensions:
   - search
+  - contextual
 
 # drupal_theme_path: "{{ drupal_root }}/sites/all/themes"
 # features_module_path: "{{ drupal_root }}/sites/all/modules/ytp_features"


### PR DESCRIPTION
- Added contextual to `removed_extensions` in ansible, also removes quickedit