### PR TITLE
AV-284 Single showcase page styling

### DIFF
--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/read.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/read.html
@@ -33,10 +33,10 @@
 {% endblock %}
 
 {% block primary_content %}
-  <div class="">
+  <div class="showcase-content">
     <div class="page-heading-container">
       {% if pkg.icon_display_url %}
-        <div class="heading-icon">
+        <div class="showcase-heading-icon">
           <img src="{{ pkg.icon_display_url }}">
         </div>
       {% endif %}
@@ -147,17 +147,27 @@
 
   {% block application_website_link %}
     <section class="module module-narrow">
-      <a class="btn btn-block btn-transparent--inverse btn-list-item" href="{{pkg.application_website}}">
-        {{ _('Application website') }}
-        <i class="fa fa-angle-right"></i>
-      </a>
-
-      {% if pkg.author_website %}
-        <a class="btn btn-block btn-transparent--inverse btn-list-item" href="{{pkg.author_website}}">
-          {{ _('Author website') }}
-          <i class="fa fa-angle-right"></i>
-        </a>
+      <h3 class="module-heading">
+        {% trans %}
+        Links
+        {% endtrans %}
+      </h3>
+      <ul class="nav nav-simple">
+        <li class="nav-item">
+          <a class="application-website-link" href="{{pkg.application_website}}">
+            {{ _('Application website') }}
+            <i class="fas fa-external-link"></i>
+          </a>
+        </li>
+        {% if pkg.author_website %}
+        <li class="nav-item">
+          <a class="application-website-link" href="{{pkg.author_website}}">
+            {{ _('Author website') }}
+            <i class="fas fa-external-link"></i>
+          </a>
+        </li>
       {% endif %}
+      </ul>
     </section>
   {% endblock %}
 
@@ -171,9 +181,9 @@
           Categories
           {% endtrans %}
         </h3>
-        <ul class="list-unstyled">
+        <ul class="nav nav-simple">
           {% for category in showcase_categories %}
-            <li>
+            <li class="nav-item">
             {{ category }}
             </li>
           {% endfor %}
@@ -188,10 +198,6 @@
       <section class="module module-narrow">
         <h2 class="module-heading">{{ _('More from the author') }}</h2>
         {{ h.snippet('sixodp_showcase/snippets/related_list.html', packages=author_showcases, current=pkg.id) }}
-        <a href="{{ h.url_for(controller='ckanext.sixodp_showcase.controller:Sixodp_ShowcaseController', action='search', author=pkg.author) }}"
-        class="btn btn-block btn-transparent--inverse btn-list-item">
-          {{ _('Show all from this author') }}
-        </a>
       </section>
     {% endif %}
   {% endblock %}

--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/related_item.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/related_item.html
@@ -18,39 +18,15 @@ Example:
 {% set title = package.title or package.name %}
 
 {% block package_item %}
-<li class="dataset-item dataset-item-borderless">
-  <div class="row">
-    {% block content %}
-    <div class="{% if show_rating %}col-md-8 {% endif %} col-sm-12 dataset-col-left">
-      <div class="secondary-heading-container">
-        {% block heading %}
-          <a href="{{ h.url_for(controller='ckanext.sixodp_showcase.controller:Sixodp_ShowcaseController', action='read', id=package.name) }}">
-
-            {% set pkg_icon = h.url_for_static('uploads/showcase/' + package.get('icon')) %}
-            {% if pkg_icon %}
-              <div class="heading-icon">
-                <img src="{{ pkg_icon }}">
-              </div>
-            {% endif %}
-
-            <div class="headings-wrapper">
-              <h3 class="heading">
-                <span>{{title}}</span>
-              </h3>
-            </div>
-          </a>
-        {% endblock %}
-      </div>
-    </div>
-    {#
-    {% if show_rating %}
-      <div class="col-md-4 col-sm-12 dataset-col-right">
-        {% snippet "rating/snippets/rating_single.html", package=package %}
-      </div>
-      {% endif %}
-    #}
+<li class="nav-item">
+  {% block content %}
+  <div class="secondary-heading-container">
+    {% block heading %}
+      <a href="{{ h.url_for(controller='ckanext.sixodp_showcase.controller:Sixodp_ShowcaseController', action='read', id=package.name) }}">
+        {{ title }}
+      </a>
     {% endblock %}
-
   </div>
+  {% endblock %}
 </li>
 {% endblock %}

--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/related_list.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/related_list.html
@@ -16,7 +16,7 @@ Example:
 #}
 {% block package_list %}
   {% if packages %}
-  <ul class="{{ list_class or 'dataset-list unstyled' }}">
+  <ul class="{{ list_class or 'nav nav-simple' }}">
     {% block package_list_inner %}
       {% for package in packages %}
         {% snippet 'sixodp_showcase/snippets/related_item.html', package=package, item_class=item_class, hide_resources=hide_resources, banner=banner, truncate=truncate, truncate_title=truncate_title, show_rating=show_rating %}

--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -175,6 +175,7 @@
     background-color: @sidebar-block-color-background;
     color: @sidebar-block-color-text;
     margin-bottom: 15px;
+    overflow: hidden;
 
     .module-content {
       padding-left: 15px;
@@ -318,9 +319,9 @@
 
 .module-narrow > .btn,
 .module-narrow > a {
-  color: transparent;
+  background-color: transparent;
   &:hover {
-    color: transparent;
+    background-color: transparent;
   }
 }
 
@@ -373,6 +374,20 @@
   }
 }
 
+.showcase-content {
+  margin-top: 35px;
+  margin-left: 10px;
+}
+
+.showcase-heading-icon {
+  max-width: 160px;
+  max-height: 160px;
+  img {
+    max-height: 100%;
+    max-width: 100%;
+  }
+}
+
 .appstore-links {
   margin: 2em 0;
 }
@@ -390,7 +405,7 @@
 
 .page-subheading {
   font-size: 1em;
-  font-family: roboto;
+  font-family: Open Sans;
   color: #333;
 }
 
@@ -497,21 +512,12 @@
 
 .page-heading-container {
   margin-top: 10px;
-  .flex-display(flex);
-
-  .heading-icon {
-    .flex(initial);
-    margin-right: 1em;
-    img {
-      max-width: 10em;
-      max-height: 10em;
-    }
-  }
-  .headings-wrapper {
-    .flex(auto);
-  }
 }
 
+.application-website-link, .application-website-link:hover, .application-website-link:active {
+  color: @link-color;
+  font-size: 14px;
+}
 
 .no-right-padding {
   padding-right: 0px;

--- a/modules/ytp-assets-common/src/less/variables.less
+++ b/modules/ytp-assets-common/src/less/variables.less
@@ -35,6 +35,10 @@
 @btn-dark-text-color:    #FFF;
 @btn-black-color: #000;
 
+// Link colors
+@link-default-color: @opendata-brand-primary;
+@link-dark-color: #000000;
+
 // For very 'extra' information, meant for small text on white/light backgrounds
 @nonimportant-text-color: lighten(@opendata-brand-gray, 0%);
 


### PR DESCRIPTION
- Showcase page had some issues with the pictures in the sidebar. These
were logos of other applications by the same user. These logos did not
fit well to our gray sidebar as the logos have no predefined size or
format specified (they can differ from the sites styling by quite a
lot). I decided to remove the imgaes from the sidebar altogether.
- The page had also some other issues with the applications logo in the
header that caused the title and other text to flow in very different
ways based on the logo size. Now the logo is on its own row and the
title and subheadings follow the logo after that.
- Other sidebar styling fixes.