### PR TITLE
Switch bootstrap table to using npm

### DIFF
--- a/ansible/roles/common_webserver/files/package.json
+++ b/ansible/roles/common_webserver/files/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.4.1",
     "bootstrap": "^3.3.7",
+    "bootstrap-table": "^1.12.1",
     "eonasdan-bootstrap-datetimepicker": "^4.17.47",
     "jstree": "^3.3.6",
     "moment": "^2.22.2",

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/admin_list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/admin_list.html
@@ -12,8 +12,8 @@
 {% endblock %}
 
 {% block primary_content_inner %}
-    {% resource "ytp_resources/vendor/bootstrap-table.css" %}
-    {% resource "ytp_resources/vendor/bootstrap-table.js" %}
+    {% resource "ytp_resources/vendor/bootstrap-table/dist/bootstrap-table.css" %}
+    {% resource "ytp_resources/vendor/bootstrap-table/dist/bootstrap-table.js" %}
     {% resource "ytp_common_js/table.js" %}
     <h3 class="page-heading">{{ _('{0} admins'.format(c.users|length)) }}</h3>
     <div><a href="user_list">{{ _('Show all users') }}</a></div>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/user_list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/user_list.html
@@ -12,8 +12,8 @@
 {% endblock %}
 
 {% block primary_content_inner %}
-    {% resource "ytp_resources/vendor/bootstrap-table.css" %}
-    {% resource "ytp_resources/vendor/bootstrap-table.js" %}
+    {% resource "ytp_resources/vendor/bootstrap-table/dist/bootstrap-table.css" %}
+    {% resource "ytp_resources/vendor/bootstrap-table/dist/bootstrap-table.js" %}
     {% resource "ytp_common_js/table.js" %}
     <h3 class="page-heading">{{ _('{0} users'.format(c.users|length)) }}</h3>
     <div><a href="admin_list">{{ _('Show admins only') }}</a></div>

--- a/modules/ytp-assets-common/package.json
+++ b/modules/ytp-assets-common/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-pro": "^5.5.0",
     "bootstrap": "^3.3.7",
+    "bootstrap-table": "^1.12.1",
     "eonasdan-bootstrap-datetimepicker": "^4.17.47",
     "jstree": "^3.3.6",
     "moment": "^2.22.2",


### PR DESCRIPTION
The userlist page failed, because the path to bootstrap-table was wrong, because the vendor folder was earlier removed. Now it was switched to using npm and the path was updated. 