### PR TITLE
Remove redundant additional information links

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/snippets/info.html
@@ -22,7 +22,6 @@
     {% if description %}
       <p>
         {{ description|truncate(180) }}
-        {% link_for _('read more'), named_route='group.about', id=group.name %}
       </p>
     {% endif %}
     {% endblock %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/organization.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/organization.html
@@ -36,7 +36,6 @@ Example:
       {% if organization.description %}
         <p>
           {{ h.markdown_extract(h.extra_translation(organization, 'description'), 180) }}
-          {% link_for _('read more'), controller='organization', action='about', id=organization.name %}
         </p>
       {% else %}
         <p class="empty">{{ _('There is no description for this organization') }}</p>


### PR DESCRIPTION
The links are not necessary, because there is already the additional information tab