### PR TITLE
Changed button colors with different states

### DIFF
--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -130,7 +130,11 @@
 .btn-success {
   background-color: @btn-dark-bg;
   border-color: @btn-dark-bg;
-  &:hover, &:focus, &:active, &.disabled:focus, &.disabled:hover {
+  &.disabled, &.disabled:focus, &.disabled:hover{
+    background-color: tint(@btn-dark-bg, 50%);
+    border-color: tint(@btn-dark-bg, 50%);
+  }
+  &:hover, &:focus, &:active {
     background-color: @btn-dark-bg;
     border-color: @btn-dark-bg;
   }

--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -130,9 +130,13 @@
 .btn-success {
   background-color: @btn-dark-bg;
   border-color: @btn-dark-bg;
-  &:hover, &:focus, &:active, &:active:focus, &.disabled:focus, &.disabled:hover {
+  &:hover, &:focus, &:active, &.disabled:focus, &.disabled:hover {
     background-color: @btn-dark-bg;
     border-color: @btn-dark-bg;
+  }
+  &:focus:hover, &:active:hover, &:active:focus {
+    background-color: darken(@btn-dark-bg, 10%);
+    border-color: darken(@btn-dark-bg, 10%);
   }
 }
 

--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -130,7 +130,7 @@
 .btn-success {
   background-color: @btn-dark-bg;
   border-color: @btn-dark-bg;
-  &:hover {
+  &:hover, &:focus, &:active, &:active:focus, &.disabled:focus, &.disabled:hover {
     background-color: @btn-dark-bg;
     border-color: @btn-dark-bg;
   }


### PR DESCRIPTION
Previously bootstrap default colors caused the follow button and probably some other buttons as well to have weird colors with certain states like :hover and :active. The colors were some shades of green or yellow and stayed there for a short time. I don't think this kind of behaviour would be wanted anywhere on the application so I didn't limit the fix for only the follow button. 