### PR TITLE
 Fixed organization tree filtering and buttons being on wrong row

### DIFF
--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -738,6 +738,9 @@ li.organization {
   &:focus {
     outline: none;
   }
+  &:active:focus {
+    background-color: @background-body-color;
+  }
   .fa-plus-circle, .fa-minus-circle {
     color: @btn-dark-bg;
     font-size: 17px;
@@ -805,4 +808,9 @@ li.organization {
   content: "\f057";
   font-family: "Font Awesome 5 Pro", "Font Awesome 5 Free";
   color: @black;
+}
+
+.highlight {
+  color: darken(@opendata-brand-primary, 10%);
+  font-weight: @font-weight-heavy;
 }


### PR DESCRIPTION
 - Matches are highlighted when using the filtering in the organization tree
 - Plus and minus buttons' css is changed manually instead of .show() to prevent wrong class
 - Filtering also shows parents of matches
 - Removed blue background when clicking and holding buttons