### PR TITLE
Added max_width: 100% for img tags in articles and events

### DIFF
--- a/modules/avoindata-drupal-theme/less/overrides.less
+++ b/modules/avoindata-drupal-theme/less/overrides.less
@@ -721,6 +721,9 @@ p:last-child,
     margin-bottom: 10px;
   }
   .article-body {
+    img {
+      max-width: 100%;
+    }
     margin-top: 15px;
     margin-bottom: 40px;
   }
@@ -847,6 +850,9 @@ p:last-child,
   }
   .content {
     margin-bottom: 50px;
+  }
+  img {
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
This applies to images that are within the HTML content of the item content. Guide pages had a similar max-width rule implemented already earlier. 