### PR TITLE
AV-381 http header fixes

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -52,6 +52,7 @@
   with_items:
     - { 'template':'server.config.j2', 'destination':'ytp.conf', 'root_redirect': "{{ hostname_language }}" }
     - { 'template':'server.config.j2', 'destination':'ytp-secondary.conf', 'root_redirect': "{{ secondary_hostname_language }}" }
+    - { 'template':'nginx_security_headers.conf.j2', 'destination':'nginx_security_headers.conf', 'root_redirect': "{{ secondary_hostname_language }}" }
   notify: Restart Nginx
 
 - name: Enable Nginx site

--- a/ansible/roles/nginx/templates/nginx_security_headers.conf.j2
+++ b/ansible/roles/nginx/templates/nginx_security_headers.conf.j2
@@ -1,0 +1,11 @@
+# XSS-Protection - Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.
+add_header X-XSS-Protection "1; mode=block";
+
+# Content security policies allowing content to be loaded from specified addresses
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' platform.twitter.com syndication.twitter.com cdn.syndication.twimg.com *.disqus.com https://disqus.com *.disquscdn.com www.google-analytics.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; img-src 'self' *.avoindata.fi *.opendata.fi *.disqus.com *.disquscdn.com *.disquscdn.com www.google-analytics.com data: *.twitter.com *.twimg.com *.disqus.com www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://platform.twitter.com https://ton.twimg.com *.disquscdn.com https://www.google.com https://ajax.googleapis.com; font-src 'self' https://themes.googleusercontent.com; frame-src syndication.twitter.com https://platform.twitter.com https://disqus.com *.disqus.com https://www.google.com/recaptcha/; object-src 'none'; connect-src 'self' https://links.services.disqus.com wss://realtime.services.disqus.com";
+
+# Strict Transport Security (use only https)
+add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+
+# Referer Policy "Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP)."
+add_header Referrer-Policy "strict-origin-when-cross-origin";

--- a/ansible/roles/nginx/templates/server.config.j2
+++ b/ansible/roles/nginx/templates/server.config.j2
@@ -120,8 +120,6 @@ location /resources {
     log_not_found off;
 }
 
-# Always enforce same origin policy
-add_header X-Frame-Options SAMEORIGIN;
 # XSS-Protection - Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.
 add_header X-XSS-Protection "1; mode=block";
 # Content security policies allowing content to be loaded from specified addresses
@@ -129,10 +127,24 @@ add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsaf
 # Strict Transport Security (use only https)
 add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
 # Referer Policy "Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP)."
-add_header Referer-Policy "strict-origin-when-cross-origin";
+add_header Referrer-Policy "strict-origin-when-cross-origin";
 
 # CKAN is mapped under data
 location /data {
+    # Same headers here as nginx removes any headers from parent if one additional is added in child definition
+    # Always enforce same origin policy
+    add_header X-Frame-Options SAMEORIGIN;
+    # XSS-Protection - Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.
+    add_header X-XSS-Protection "1; mode=block";
+    # Content security policies allowing content to be loaded from specified addresses
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' platform.twitter.com syndication.twitter.com cdn.syndication.twimg.com *.disqus.com https://disqus.com *.disquscdn.com www.google-analytics.com https://www.google.com/recaptcha/     https://www.gstatic.com/recaptcha/; img-src 'self' *.avoindata.fi *.disqus.com *.disquscdn.com *.disquscdn.com www.google-analytics.com data: *.twitter.com *.twimg.com *.disqus.com www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com    https://platform.twitter.com https://ton.twimg.com *.disquscdn.com https://www.google.com https://ajax.googleapis.com; font-src 'self' https://themes.googleusercontent.com; frame-src syndication.twitter.com https://platform.twitter.com https://disqus.com *.disqus.com   https://www.google.com/recaptcha/; object-src 'none'; connect-src 'self' https://links.services.disqus.com wss://realtime.services.disqus.com";
+    # Strict Transport Security (use only https)
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
+    # Referer Policy "Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP)."
+    add_header Referrer-Policy "strict-origin-when-cross-origin";
+    # Content type options https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+    add_header X-Content-Type-Options "nosniff" always;
+
     proxy_pass http://127.0.0.1:8080/data;
     proxy_set_header Host $host;
     proxy_cache cache;

--- a/ansible/roles/nginx/templates/server.config.j2
+++ b/ansible/roles/nginx/templates/server.config.j2
@@ -120,28 +120,15 @@ location /resources {
     log_not_found off;
 }
 
-# XSS-Protection - Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.
-add_header X-XSS-Protection "1; mode=block";
-# Content security policies allowing content to be loaded from specified addresses
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' platform.twitter.com syndication.twitter.com cdn.syndication.twimg.com *.disqus.com https://disqus.com *.disquscdn.com www.google-analytics.com https://www.google.com/recaptcha/ https://www.gstatic.com/recaptcha/; img-src 'self' *.avoindata.fi *.disqus.com *.disquscdn.com *.disquscdn.com www.google-analytics.com data: *.twitter.com *.twimg.com *.disqus.com www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://platform.twitter.com https://ton.twimg.com *.disquscdn.com https://www.google.com https://ajax.googleapis.com; font-src 'self' https://themes.googleusercontent.com; frame-src syndication.twitter.com https://platform.twitter.com https://disqus.com *.disqus.com https://www.google.com/recaptcha/; object-src 'none'; connect-src 'self' https://links.services.disqus.com wss://realtime.services.disqus.com";
-# Strict Transport Security (use only https)
-add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
-# Referer Policy "Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP)."
-add_header Referrer-Policy "strict-origin-when-cross-origin";
+include snippets/nginx_security_headers.conf;
 
 # CKAN is mapped under data
 location /data {
     # Same headers here as nginx removes any headers from parent if one additional is added in child definition
+    include snippets/nginx_security_headers.conf;
+
     # Always enforce same origin policy
     add_header X-Frame-Options SAMEORIGIN;
-    # XSS-Protection - Enables XSS filtering. Rather than sanitizing the page, the browser will prevent rendering of the page if an attack is detected.
-    add_header X-XSS-Protection "1; mode=block";
-    # Content security policies allowing content to be loaded from specified addresses
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' platform.twitter.com syndication.twitter.com cdn.syndication.twimg.com *.disqus.com https://disqus.com *.disquscdn.com www.google-analytics.com https://www.google.com/recaptcha/     https://www.gstatic.com/recaptcha/; img-src 'self' *.avoindata.fi *.disqus.com *.disquscdn.com *.disquscdn.com www.google-analytics.com data: *.twitter.com *.twimg.com *.disqus.com www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com    https://platform.twitter.com https://ton.twimg.com *.disquscdn.com https://www.google.com https://ajax.googleapis.com; font-src 'self' https://themes.googleusercontent.com; frame-src syndication.twitter.com https://platform.twitter.com https://disqus.com *.disqus.com   https://www.google.com/recaptcha/; object-src 'none'; connect-src 'self' https://links.services.disqus.com wss://realtime.services.disqus.com";
-    # Strict Transport Security (use only https)
-    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";
-    # Referer Policy "Send a full URL when performing a same-origin request, only send the origin when the protocol security level stays the same (HTTPS→HTTPS), and send no header to a less secure destination (HTTPS→HTTP)."
-    add_header Referrer-Policy "strict-origin-when-cross-origin";
     # Content type options https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
     add_header X-Content-Type-Options "nosniff" always;
 


### PR DESCRIPTION
- Fixed typo in Referrer-Policy header
- Removed dulicate headers from nginx root path (duplicates due to
drupal already inserting them).
- Added all headers to /data path as otherwise content type frame
options headers would be missing from ckan side.