### PR TITLE
AV-379 Deny specific dirs to be downloaded

### DIFF
--- a/ansible/roles/nginx/templates/server.config.j2
+++ b/ansible/roles/nginx/templates/server.config.j2
@@ -94,6 +94,22 @@ location ~ ^/sites/.*/private/ {
     return 403;
 }
 
+location ~ ^/sites/[^/]+/files/.*\.php$ {
+    deny all;
+}
+
+# Deny settings.php and services.yml files
+location ~ /sites/default/.*\.(php|yml|conf|config|cfg)$ {
+    deny all;
+    return 404;
+}
+
+# Config files should not be serverd (web.cofig for example)
+location ~ /.*\.(conf|config|cfg)$ {
+    deny all;
+    return 404;
+}
+
 location ~ (^|/)\. {
     return 403;
 }


### PR DESCRIPTION
- It was possible to download web.config from the root and empty
settings php file. Served files didn't have any secrets in them but it
is cleaner to just deny the access altogether. 

This change might have side-effects as some drupal files are served under sites/default. I did
however test most of the pages but this changed needs some more eyes on it.