### PR TITLE
AV-398 Frontpage tweaks

### DIFF
--- a/modules/avoindata-drupal-appfeed/templates/avoindata_appfeed_block.html.twig
+++ b/modules/avoindata-drupal-appfeed/templates/avoindata_appfeed_block.html.twig
@@ -21,7 +21,9 @@
           <div class="avoindata-appfeed-application-box row">
             <div class="application-item-logo col-sm-3 col-xs-12">
               <a href="/data/{{ language }}/showcase/{{ app['name'] }}">
-                <img class="application-item-img" src="/data/uploads/showcase/{{ app['icon'] }}" alt="">
+                {% if app['icon']|length %}
+                  <img class="application-item-img" src="/data/uploads/showcase/{{ app['icon'] }}" alt="">
+                {% endif %}
               </a>
             </div>
             <div class="application-item-content col-sm-9 col-xs-12">

--- a/modules/avoindata-drupal-categories/templates/avoindata_categories_block.html.twig
+++ b/modules/avoindata-drupal-categories/templates/avoindata_categories_block.html.twig
@@ -20,7 +20,7 @@
     </div>
     <div class="row avoindata-categories-row">
       {% for category in categories %}
-        <div class="avoindata-category-box col-md-2 col-sm-3 col-xs-12">
+        <div class="avoindata-category-box col-md-2 col-sm-3 col-xs-6">
           <div class="row avoindata-category-image-wrapper">
             <a href="../data/{{ language }}/group/{{ category['name'] }}">
               <img class="avoindata-category-img" src={{ category['image_display_url'] }} alt={{ category['title'] }}>

--- a/modules/avoindata-drupal-theme/less/overrides.less
+++ b/modules/avoindata-drupal-theme/less/overrides.less
@@ -222,6 +222,7 @@ p:last-child,
   padding-left: 50px;
   padding-top: 10px;
   padding-bottom: 25px;
+  
   .avoindata-categories-container {
     max-width: @opendata-container-max-width;
     float: none;
@@ -230,12 +231,15 @@ p:last-child,
   }
 
   .avoindata-category-box {
+    height: 11em;
     text-align: center;
     justify-content: center;
     padding-top: 10px;
+
     a {
       color: black;
     }
+    
     .avoindata-category-image-wrapper {
       padding: 10px;
       margin-bottom: 10px;
@@ -244,6 +248,7 @@ p:last-child,
           transform: scale(1.1);
       }
     }
+
     .avoindata-category-img {
       height: 60px;
     }


### PR DESCRIPTION
- Categories listing had some issues with long texts. Made a quick fix
for this with defined height for category item box.
- Empty logos for showcases were not handled properly in app feed
tempalte. Now the listing will not attempt to load any images if logo is
not defined.