### PR TITLE
AV-412 Fixing ie11 sticky footer issues

### DIFF
--- a/modules/avoindata-drupal-theme/less/overrides.less
+++ b/modules/avoindata-drupal-theme/less/overrides.less
@@ -53,8 +53,6 @@ body, html {
   .flex-display(flex);
   .flex-direction(column);
   min-height: 100vh;
-  // https://github.com/philipwalton/flexbugs#workaround-2
-  height: 100vh;
 
   .region.region-footer {
     margin: auto 0 0 0;

--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -28,7 +28,6 @@ body {
   .flex-display(flex);
   .flex-direction(column);
   min-height: 100vh;
-  height: 100vh;
 }
 
 [role="main"] {


### PR DESCRIPTION
- Sticky footer was overlapping on content with IE11. Removal of height
value fixes this overlapping issue, but removes sticky footer
functionality on IE11. On other browsers sticky footer should work just
fine still.