### PR TITLE
AV-322: Lazy Load dynamic content to hero

### DIFF
--- a/modules/avoindata-drupal-hero/avoindata_hero.module
+++ b/modules/avoindata-drupal-hero/avoindata_hero.module
@@ -1,6 +1,7 @@
 <?php
 
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Component\Serialization\Json;
 
 /**
  * Implements hook_help().
@@ -24,4 +25,54 @@ function avoindata_hero_theme($existing, $type, $theme, $path) {
       'template' => 'avoindata_hero_form',
     ),
   );
+}
+
+function avoindata_hero_datasetCount() {
+  $client = \Drupal::httpClient();
+
+  try {
+    $datasetResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/package_search');
+    $datasetResult = Json::decode($datasetResponse->getBody());
+    $datasetCount = $datasetResult['result']['count'];
+  } catch (\Exception $e) {
+    $datasetCount = 0;
+  }
+
+  return [
+    '#markup' => $datasetCount,
+    '#cache' => ['max-age' => 0],
+  ];
+}
+
+function avoindata_hero_organizationCount(){
+  $client = \Drupal::httpClient();
+  try {
+    $organizationResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/organization_list');
+    $organizationResult = Json::decode($organizationResponse->getBody());
+    $organizationCount = count($organizationResult['result']);
+  } catch (\Exception $e) {
+    $organizationCount = 0;
+  }
+
+  return [
+    '#markup' => $organizationCount,
+    '#cache' => ['max-age' => 0],
+  ];
+}
+
+function avoindata_hero_applicationCount(){
+  $client = \Drupal::httpClient();
+
+  try {
+    $applicationResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/ckanext_showcase_list');
+    $applicationResult = Json::decode($applicationResponse->getBody());
+    $applicationCount = count($applicationResult['result']);
+  } catch (\Exception $e) {
+    $applicationCount = 0;
+  }
+
+  return [
+    '#markup' => $applicationCount,
+    '#cache' => ['max-age' => 0],
+  ];
 }

--- a/modules/avoindata-drupal-hero/src/Plugin/Block/HeroBlock.php
+++ b/modules/avoindata-drupal-hero/src/Plugin/Block/HeroBlock.php
@@ -21,6 +21,22 @@ class HeroBlock extends BlockBase {
    */
   public function build() {
     $form = \Drupal::formBuilder()->getForm('Drupal\avoindata_hero\Plugin\Form\HeroForm');
+
+    $form['datasetcount'] = [
+      '#lazy_builder' => ['avoindata_hero_datasetCount', []],
+      '#create_placeholder' => TRUE,
+    ];
+
+    $form['organizationcount'] = [
+      '#lazy_builder' => ['avoindata_hero_organizationCount', []],
+      '#create_placeholder' => TRUE,
+    ];
+
+    $form['applicationcount'] = [
+      '#lazy_builder' => ['avoindata_hero_applicationCount', []],
+      '#create_placeholder' => TRUE,
+    ];
+
     return $form;
   }
 

--- a/modules/avoindata-drupal-hero/src/Plugin/Form/HeroForm.php
+++ b/modules/avoindata-drupal-hero/src/Plugin/Form/HeroForm.php
@@ -21,43 +21,6 @@ class HeroForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $client = \Drupal::httpClient();
-
-    try {
-      $datasetResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/package_search');
-      $datasetResult = Json::decode($datasetResponse->getBody());
-      $datasetCount = $datasetResult['result']['count'];
-    } catch (\Exception $e) {
-      $datasetCount = 0;
-    }
-
-    try {
-      $organizationResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/organization_list');
-      $organizationResult = Json::decode($organizationResponse->getBody());
-      $organizationCount = count($organizationResult['result']);
-    } catch (\Exception $e) {
-      $organizationCount = 0;
-    }
-
-    try {
-      $applicationResponse = $client->request('GET', 'http://localhost:8080/data/api/3/action/ckanext_showcase_list');
-      $applicationResult = Json::decode($applicationResponse->getBody());
-      $applicationCount = count($applicationResult['result']);
-    } catch (\Exception $e) {
-      $applicationCount = 0;
-    }
-
-    $form['datasetcount'] = array(
-      '#markup' => $datasetCount,
-    );
-
-    $form['organizationcount'] = array(
-      '#markup' => $organizationCount,
-    );
-
-    $form['applicationcount'] = array(
-      '#markup' => $applicationCount,
-    );
 
     $form['searchfilter'] = array(
       '#type' => 'textfield',


### PR DESCRIPTION
Uses lazy builder for dynamic ckan parts of the hero. This way template can cached but the values will still update if new datasets are added.

Integration queries do not supply session cookie so the data itself is only public. 

Similar thing probably needs to be done to new datasets list component.