### PR TITLE
AV-358 Fix read more link

### DIFF
--- a/modules/avoindata-drupal-hero/templates/avoindata_hero_form.html.twig
+++ b/modules/avoindata-drupal-hero/templates/avoindata_hero_form.html.twig
@@ -29,7 +29,11 @@
           Finnish open data portal
           {% endtrans %}
         </p>
-        <a href="">
+        {% set guideurl = "/fi/opas" %}
+        {% if form.language in ['en', 'sv'] %}
+          {% set guideurl = "/%s/guide"|format(form.language) %}
+        {% endif %}
+        <a href="{{ guideurl }}">
           {% trans %}
           Read more >>
           {% endtrans %}


### PR DESCRIPTION
- Read more link in the hero had no path set. Seems like the link should
point to guide page so this functionality has now been added.