### PR TITLE
Disable internal page cache

### DIFF
--- a/ansible/roles/drupal/vars/main.yml
+++ b/ansible/roles/drupal/vars/main.yml
@@ -18,3 +18,4 @@ custom_modules:
 removed_extensions:
   - search
   - contextual
+  - page_cache


### PR DESCRIPTION
 Drupal internal page cache is over aggressive and will be replaced by cloudfront. Frontpage stats will be cached in internal cache but not in dynamic cache.