### PR TITLE
AV-183: Merge usernames in userlists and add auth checks

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/auth.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/auth.py
@@ -155,3 +155,9 @@ def package_update(context, data_dict):
                     }
 
     return result
+
+
+def user_list(context, data_dict):
+    if not context.userobj or not context.userobj.sysadmin:
+        return {'success': False, 'msg': _('Only system administrators are allowed to view user list.')}
+    return {'success': True}

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -1,15 +1,15 @@
 # Translations template for ckanext-ytp_main.
-# Copyright (C) 2018 ORGANIZATION
+# Copyright (C) 2019 ORGANIZATION
 # This file is distributed under the same license as the ckanext-ytp_main
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-11-13 09:56+0200\n"
+"POT-Creation-Date: 2019-01-04 09:07+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -65,6 +65,11 @@ msgstr ""
 
 #: ckanext/ytp/auth.py:154
 msgid "Cannot modify dataset because of organization policy"
+msgstr ""
+
+#: ckanext/ytp/auth.py:162 ckanext/ytp/controller.py:644
+#: ckanext/ytp/controller.py:689
+msgid "Only system administrators are allowed to view user list."
 msgstr ""
 
 #: ckanext/ytp/controller.py:85
@@ -175,7 +180,7 @@ msgstr ""
 msgid "Related item was successfully updated"
 msgstr ""
 
-#: ckanext/ytp/controller.py:420 ckanext/ytp/controller.py:860
+#: ckanext/ytp/controller.py:420 ckanext/ytp/controller.py:892
 msgid "Integrity Error"
 msgstr ""
 
@@ -219,35 +224,35 @@ msgstr ""
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:599 ckanext/ytp/controller.py:670
-#: ckanext/ytp/controller.py:697
+#: ckanext/ytp/controller.py:599 ckanext/ytp/controller.py:702
+#: ckanext/ytp/controller.py:729
 msgid "Group not found"
 msgstr ""
 
-#: ckanext/ytp/controller.py:763
+#: ckanext/ytp/controller.py:795
 msgid "No user specified"
 msgstr ""
 
-#: ckanext/ytp/controller.py:769
+#: ckanext/ytp/controller.py:801
 msgid "Unauthorized to edit a user."
 msgstr ""
 
-#: ckanext/ytp/controller.py:788 ckanext/ytp/controller.py:856
+#: ckanext/ytp/controller.py:820 ckanext/ytp/controller.py:888
 #, python-format
 msgid "Unauthorized to edit user %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:790 ckanext/ytp/controller.py:858
+#: ckanext/ytp/controller.py:822 ckanext/ytp/controller.py:890
 #: ckanext/ytp/logic.py:184
 msgid "User not found"
 msgstr ""
 
-#: ckanext/ytp/controller.py:796
+#: ckanext/ytp/controller.py:828
 #, python-format
 msgid "User %s not authorized to edit %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:853
+#: ckanext/ytp/controller.py:885
 msgid "Profile updated"
 msgstr ""
 
@@ -296,7 +301,7 @@ msgstr ""
 
 #: ckanext/ytp/menu.py:70
 #: ckanext/ytp/templates/user/dashboard_organizations.html:12
-#: ckanext/ytp/templates/user/dashboard_organizations.html:25
+#: ckanext/ytp/templates/user/dashboard_organizations.html:27
 msgid "My Organizations"
 msgstr ""
 
@@ -419,43 +424,43 @@ msgstr ""
 msgid "Additional Info"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:923
+#: ckanext/ytp/plugin.py:924
 msgid "Group title already exists in database"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1101
+#: ckanext/ytp/plugin.py:1102
 msgid "Service charge must be supplied"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1111
+#: ckanext/ytp/plugin.py:1112
 msgid ""
 "If there is a service charge, you must supply either the pricing information "
 "web address for this service or a description of the service pricing or both"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1124
+#: ckanext/ytp/plugin.py:1125
 msgid "At least one of the main target groups must to be selected"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1261
+#: ckanext/ytp/plugin.py:1262
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1263
+#: ckanext/ytp/plugin.py:1264
 msgid "Invalid organization type"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1285
+#: ckanext/ytp/plugin.py:1286
 msgid "Harvested datasets are read-only"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1292
+#: ckanext/ytp/plugin.py:1293
 msgid "Login required"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1298 ckanext/ytp/plugin.py:1306
+#: ckanext/ytp/plugin.py:1299 ckanext/ytp/plugin.py:1307
 #, python-format
 msgid "User %s is not part of any public organization"
 msgstr ""
@@ -989,11 +994,11 @@ msgstr ""
 msgid "Required language \"%s\" missing"
 msgstr ""
 
-#: ckanext/ytp/validators.py:354
+#: ckanext/ytp/validators.py:355
 msgid "Start date is after end date"
 msgstr ""
 
-#: ckanext/ytp/validators.py:358
+#: ckanext/ytp/validators.py:360
 msgid "End date is before start date"
 msgstr ""
 
@@ -1059,7 +1064,7 @@ msgstr ""
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:167
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:174
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:181
-#: ckanext/ytp/templates/snippets/search_form.html:69
+#: ckanext/ytp/templates/snippets/search_form.html:74
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr ""
@@ -1073,25 +1078,20 @@ msgstr ""
 msgid "Deleted"
 msgstr ""
 
-#: ckanext/ytp/templates/group/snippets/info.html:25
-#: ckanext/ytp/templates/snippets/organization.html:39
-msgid "read more"
-msgstr ""
-
-#: ckanext/ytp/templates/group/snippets/info.html:33
+#: ckanext/ytp/templates/group/snippets/info.html:32
 #: ckanext/ytp/templates/package/snippets/info.html:23
-#: ckanext/ytp/templates/snippets/organization.html:49
+#: ckanext/ytp/templates/snippets/organization.html:48
 msgid "Followers"
 msgstr ""
 
-#: ckanext/ytp/templates/group/snippets/info.html:37
+#: ckanext/ytp/templates/group/snippets/info.html:36
 #: ckanext/ytp/templates/organization/read_base.html:11
 #: ckanext/ytp/templates/package/base.html:12
 #: ckanext/ytp/templates/package/base.html:16
 #: ckanext/ytp/templates/package/search.html:9
 #: ckanext/ytp/templates/package/search.html:12
 #: ckanext/ytp/templates/related/base_form_page.html:4
-#: ckanext/ytp/templates/snippets/organization.html:53
+#: ckanext/ytp/templates/snippets/organization.html:52
 #: ckanext/ytp/templates/user/dashboard_datasets.html:6
 #: ckanext/ytp/templates/user/read.html:5
 msgid "Datasets"
@@ -1355,7 +1355,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:8
 #: ckanext/ytp/templates/organization/members.html:7
-#: ckanext/ytp/templates/user/dashboard_organizations.html:19
+#: ckanext/ytp/templates/user/dashboard_organizations.html:20
 msgid "Membership Requests"
 msgstr ""
 
@@ -1742,22 +1742,19 @@ msgid "Downloads"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:27
-#: ckanext/ytp/templates/user/dashboard_datasets.html:13
+#: ckanext/ytp/templates/user/dashboard_datasets.html:14
 msgid "Add Dataset"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:34
-#: ckanext/ytp/templates/user/dashboard_datasets.html:20
 msgid "Add open data"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:37
-#: ckanext/ytp/templates/user/dashboard_datasets.html:23
 msgid "Add interoperability tools"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:41
-#: ckanext/ytp/templates/user/dashboard_datasets.html:27
 msgid "Add public service"
 msgstr ""
 
@@ -1766,13 +1763,13 @@ msgid "Relevance"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:62
-#: ckanext/ytp/templates/snippets/search_form.html:31
+#: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:63
-#: ckanext/ytp/templates/snippets/search_form.html:31
+#: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
 msgstr ""
@@ -2924,7 +2921,7 @@ msgid "Submitter email"
 msgstr ""
 
 #: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
-#: ckanext/ytp/templates/snippets/search_form.html:14
+#: ckanext/ytp/templates/snippets/search_form.html:19
 #: ckanext/ytp/templates/snippets/search_input.html:17
 msgid "Submit"
 msgstr ""
@@ -2973,7 +2970,7 @@ msgstr ""
 msgid "This dataset satisfies the Open Definition."
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/organization.html:42
+#: ckanext/ytp/templates/snippets/organization.html:41
 msgid "There is no description for this organization"
 msgstr ""
 
@@ -2982,22 +2979,22 @@ msgstr ""
 msgid "Search datasets..."
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:37
+#: ckanext/ytp/templates/snippets/search_form.html:42
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:36
 msgid "Order by"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:45
+#: ckanext/ytp/templates/snippets/search_form.html:50
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:80
+#: ckanext/ytp/templates/snippets/search_form.html:85
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid " <p class=\"extra\">Please try another search or change search facets.</p> "
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:86
+#: ckanext/ytp/templates/snippets/search_form.html:91
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "
@@ -3080,11 +3077,11 @@ msgstr ""
 msgid "Activity from items that I'm following"
 msgstr ""
 
-#: ckanext/ytp/templates/user/dashboard_organizations.html:34
+#: ckanext/ytp/templates/user/dashboard_organizations.html:36
 msgid "You are not a member of any organizations."
 msgstr ""
 
-#: ckanext/ytp/templates/user/dashboard_organizations.html:36
+#: ckanext/ytp/templates/user/dashboard_organizations.html:38
 #: ckanext/ytp/templates/user/read.html:16
 msgid "Create one now?"
 msgstr ""

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
@@ -1,8 +1,8 @@
 # Translations template for ckanext-ytp_main.
-# Copyright (C) 2018 ORGANIZATION
+# Copyright (C) 2019 ORGANIZATION
 # This file is distributed under the same license as the ckanext-ytp_main
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 # 
 # Translators:
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2018
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-11-13 09:56+0200\n"
+"POT-Creation-Date: 2019-01-04 09:07+0200\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2018\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -70,6 +70,11 @@ msgstr ""
 
 #: ckanext/ytp/auth.py:154
 msgid "Cannot modify dataset because of organization policy"
+msgstr ""
+
+#: ckanext/ytp/auth.py:162 ckanext/ytp/controller.py:644
+#: ckanext/ytp/controller.py:689
+msgid "Only system administrators are allowed to view user list."
 msgstr ""
 
 #: ckanext/ytp/controller.py:85
@@ -180,7 +185,7 @@ msgstr ""
 msgid "Related item was successfully updated"
 msgstr ""
 
-#: ckanext/ytp/controller.py:420 ckanext/ytp/controller.py:860
+#: ckanext/ytp/controller.py:420 ckanext/ytp/controller.py:892
 msgid "Integrity Error"
 msgstr ""
 
@@ -224,35 +229,35 @@ msgstr ""
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:599 ckanext/ytp/controller.py:670
-#: ckanext/ytp/controller.py:697
+#: ckanext/ytp/controller.py:599 ckanext/ytp/controller.py:702
+#: ckanext/ytp/controller.py:729
 msgid "Group not found"
 msgstr "Category not found"
 
-#: ckanext/ytp/controller.py:763
+#: ckanext/ytp/controller.py:795
 msgid "No user specified"
 msgstr ""
 
-#: ckanext/ytp/controller.py:769
+#: ckanext/ytp/controller.py:801
 msgid "Unauthorized to edit a user."
 msgstr ""
 
-#: ckanext/ytp/controller.py:788 ckanext/ytp/controller.py:856
+#: ckanext/ytp/controller.py:820 ckanext/ytp/controller.py:888
 #, python-format
 msgid "Unauthorized to edit user %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:790 ckanext/ytp/controller.py:858
+#: ckanext/ytp/controller.py:822 ckanext/ytp/controller.py:890
 #: ckanext/ytp/logic.py:184
 msgid "User not found"
 msgstr ""
 
-#: ckanext/ytp/controller.py:796
+#: ckanext/ytp/controller.py:828
 #, python-format
 msgid "User %s not authorized to edit %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:853
+#: ckanext/ytp/controller.py:885
 msgid "Profile updated"
 msgstr ""
 
@@ -301,7 +306,7 @@ msgstr ""
 
 #: ckanext/ytp/menu.py:70
 #: ckanext/ytp/templates/user/dashboard_organizations.html:12
-#: ckanext/ytp/templates/user/dashboard_organizations.html:25
+#: ckanext/ytp/templates/user/dashboard_organizations.html:27
 msgid "My Organizations"
 msgstr ""
 
@@ -429,44 +434,44 @@ msgstr ""
 msgid "Additional Info"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:923
+#: ckanext/ytp/plugin.py:924
 msgid "Group title already exists in database"
 msgstr "Category title already exists in database"
 
-#: ckanext/ytp/plugin.py:1101
+#: ckanext/ytp/plugin.py:1102
 msgid "Service charge must be supplied"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1111
+#: ckanext/ytp/plugin.py:1112
 msgid ""
 "If there is a service charge, you must supply either the pricing information"
 " web address for this service or a description of the service pricing or "
 "both"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1124
+#: ckanext/ytp/plugin.py:1125
 msgid "At least one of the main target groups must to be selected"
 msgstr "At least one of the main target categories must to be selected"
 
-#: ckanext/ytp/plugin.py:1261
+#: ckanext/ytp/plugin.py:1262
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1263
+#: ckanext/ytp/plugin.py:1264
 msgid "Invalid organization type"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1285
+#: ckanext/ytp/plugin.py:1286
 msgid "Harvested datasets are read-only"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1292
+#: ckanext/ytp/plugin.py:1293
 msgid "Login required"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:1298 ckanext/ytp/plugin.py:1306
+#: ckanext/ytp/plugin.py:1299 ckanext/ytp/plugin.py:1307
 #, python-format
 msgid "User %s is not part of any public organization"
 msgstr ""
@@ -1004,11 +1009,11 @@ msgstr ""
 msgid "Required language \"%s\" missing"
 msgstr ""
 
-#: ckanext/ytp/validators.py:354
+#: ckanext/ytp/validators.py:355
 msgid "Start date is after end date"
 msgstr ""
 
-#: ckanext/ytp/validators.py:358
+#: ckanext/ytp/validators.py:360
 msgid "End date is before start date"
 msgstr ""
 
@@ -1074,7 +1079,7 @@ msgstr ""
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:167
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:174
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:181
-#: ckanext/ytp/templates/snippets/search_form.html:69
+#: ckanext/ytp/templates/snippets/search_form.html:74
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr ""
@@ -1088,25 +1093,20 @@ msgstr ""
 msgid "Deleted"
 msgstr ""
 
-#: ckanext/ytp/templates/group/snippets/info.html:25
-#: ckanext/ytp/templates/snippets/organization.html:39
-msgid "read more"
-msgstr ""
-
-#: ckanext/ytp/templates/group/snippets/info.html:33
+#: ckanext/ytp/templates/group/snippets/info.html:32
 #: ckanext/ytp/templates/package/snippets/info.html:23
-#: ckanext/ytp/templates/snippets/organization.html:49
+#: ckanext/ytp/templates/snippets/organization.html:48
 msgid "Followers"
 msgstr ""
 
-#: ckanext/ytp/templates/group/snippets/info.html:37
+#: ckanext/ytp/templates/group/snippets/info.html:36
 #: ckanext/ytp/templates/organization/read_base.html:11
 #: ckanext/ytp/templates/package/base.html:12
 #: ckanext/ytp/templates/package/base.html:16
 #: ckanext/ytp/templates/package/search.html:9
 #: ckanext/ytp/templates/package/search.html:12
 #: ckanext/ytp/templates/related/base_form_page.html:4
-#: ckanext/ytp/templates/snippets/organization.html:53
+#: ckanext/ytp/templates/snippets/organization.html:52
 #: ckanext/ytp/templates/user/dashboard_datasets.html:6
 #: ckanext/ytp/templates/user/read.html:5
 msgid "Datasets"
@@ -1370,7 +1370,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:8
 #: ckanext/ytp/templates/organization/members.html:7
-#: ckanext/ytp/templates/user/dashboard_organizations.html:19
+#: ckanext/ytp/templates/user/dashboard_organizations.html:20
 msgid "Membership Requests"
 msgstr ""
 
@@ -1757,22 +1757,19 @@ msgid "Downloads"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:27
-#: ckanext/ytp/templates/user/dashboard_datasets.html:13
+#: ckanext/ytp/templates/user/dashboard_datasets.html:14
 msgid "Add Dataset"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:34
-#: ckanext/ytp/templates/user/dashboard_datasets.html:20
 msgid "Add open data"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:37
-#: ckanext/ytp/templates/user/dashboard_datasets.html:23
 msgid "Add interoperability tools"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:41
-#: ckanext/ytp/templates/user/dashboard_datasets.html:27
 msgid "Add public service"
 msgstr ""
 
@@ -1781,13 +1778,13 @@ msgid "Relevance"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:62
-#: ckanext/ytp/templates/snippets/search_form.html:31
+#: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:63
-#: ckanext/ytp/templates/snippets/search_form.html:31
+#: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
 msgstr ""
@@ -2939,7 +2936,7 @@ msgid "Submitter email"
 msgstr ""
 
 #: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
-#: ckanext/ytp/templates/snippets/search_form.html:14
+#: ckanext/ytp/templates/snippets/search_form.html:19
 #: ckanext/ytp/templates/snippets/search_input.html:17
 msgid "Submit"
 msgstr ""
@@ -2988,7 +2985,7 @@ msgstr ""
 msgid "This dataset satisfies the Open Definition."
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/organization.html:42
+#: ckanext/ytp/templates/snippets/organization.html:41
 msgid "There is no description for this organization"
 msgstr ""
 
@@ -2997,23 +2994,23 @@ msgstr ""
 msgid "Search datasets..."
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:37
+#: ckanext/ytp/templates/snippets/search_form.html:42
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:36
 msgid "Order by"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:45
+#: ckanext/ytp/templates/snippets/search_form.html:50
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:80
+#: ckanext/ytp/templates/snippets/search_form.html:85
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid ""
 " <p class=\"extra\">Please try another search or change search facets.</p> "
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:86
+#: ckanext/ytp/templates/snippets/search_form.html:91
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "
@@ -3096,11 +3093,11 @@ msgstr ""
 msgid "Activity from items that I'm following"
 msgstr ""
 
-#: ckanext/ytp/templates/user/dashboard_organizations.html:34
+#: ckanext/ytp/templates/user/dashboard_organizations.html:36
 msgid "You are not a member of any organizations."
 msgstr ""
 
-#: ckanext/ytp/templates/user/dashboard_organizations.html:36
+#: ckanext/ytp/templates/user/dashboard_organizations.html:38
 #: ckanext/ytp/templates/user/read.html:16
 msgid "Create one now?"
 msgstr ""

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -1,22 +1,22 @@
 # Translations template for ckanext-ytp_main.
-# Copyright (C) 2018 ORGANIZATION
+# Copyright (C) 2019 ORGANIZATION
 # This file is distributed under the same license as the ckanext-ytp_main
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 # 
 # Translators:
 # Pentti Laitinen, 2018
-# Zharktas <jari-pekka.voutilainen@gofore.com>, 2018
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2018
+# Zharktas <jari-pekka.voutilainen@gofore.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-11-13 09:56+0200\n"
+"POT-Creation-Date: 2019-01-04 09:07+0200\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2018\n"
+"Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2019\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -73,6 +73,11 @@ msgstr "Käyttäjällä %s ei ole oikeuksia muokata organisaatiota %s"
 #: ckanext/ytp/auth.py:154
 msgid "Cannot modify dataset because of organization policy"
 msgstr "Tietoaineiston muokkaaminen on vastoin organisaation käytäntöjä"
+
+#: ckanext/ytp/auth.py:162 ckanext/ytp/controller.py:644
+#: ckanext/ytp/controller.py:689
+msgid "Only system administrators are allowed to view user list."
+msgstr "Vain järjestelmän ylläpitäjä saa katsella käyttäjälistaa."
 
 #: ckanext/ytp/controller.py:85
 msgid "Dataset was saved successfully."
@@ -182,7 +187,7 @@ msgstr "Tähän liittyvä kohde luotiin onnistuneesti"
 msgid "Related item was successfully updated"
 msgstr "Tähän liittyvä kohde päivitettiin onnistuneesti"
 
-#: ckanext/ytp/controller.py:420 ckanext/ytp/controller.py:860
+#: ckanext/ytp/controller.py:420 ckanext/ytp/controller.py:892
 msgid "Integrity Error"
 msgstr "Eheysvirhe"
 
@@ -226,35 +231,35 @@ msgstr "Visualisointi"
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:599 ckanext/ytp/controller.py:670
-#: ckanext/ytp/controller.py:697
+#: ckanext/ytp/controller.py:599 ckanext/ytp/controller.py:702
+#: ckanext/ytp/controller.py:729
 msgid "Group not found"
 msgstr "Kategoriaa ei löydy"
 
-#: ckanext/ytp/controller.py:763
+#: ckanext/ytp/controller.py:795
 msgid "No user specified"
 msgstr ""
 
-#: ckanext/ytp/controller.py:769
+#: ckanext/ytp/controller.py:801
 msgid "Unauthorized to edit a user."
 msgstr ""
 
-#: ckanext/ytp/controller.py:788 ckanext/ytp/controller.py:856
+#: ckanext/ytp/controller.py:820 ckanext/ytp/controller.py:888
 #, python-format
 msgid "Unauthorized to edit user %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:790 ckanext/ytp/controller.py:858
+#: ckanext/ytp/controller.py:822 ckanext/ytp/controller.py:890
 #: ckanext/ytp/logic.py:184
 msgid "User not found"
 msgstr "Käyttäjää ei löytynyt"
 
-#: ckanext/ytp/controller.py:796
+#: ckanext/ytp/controller.py:828
 #, python-format
 msgid "User %s not authorized to edit %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:853
+#: ckanext/ytp/controller.py:885
 msgid "Profile updated"
 msgstr ""
 
@@ -305,7 +310,7 @@ msgstr "Minun tietoaineistoni"
 
 #: ckanext/ytp/menu.py:70
 #: ckanext/ytp/templates/user/dashboard_organizations.html:12
-#: ckanext/ytp/templates/user/dashboard_organizations.html:25
+#: ckanext/ytp/templates/user/dashboard_organizations.html:27
 msgid "My Organizations"
 msgstr "Minun organisaationi"
 
@@ -433,15 +438,15 @@ msgstr "Muu"
 msgid "Additional Info"
 msgstr "Lisätiedot"
 
-#: ckanext/ytp/plugin.py:923
+#: ckanext/ytp/plugin.py:924
 msgid "Group title already exists in database"
 msgstr "Kategorian otsikko löytyy jo tietokannasta"
 
-#: ckanext/ytp/plugin.py:1101
+#: ckanext/ytp/plugin.py:1102
 msgid "Service charge must be supplied"
 msgstr "Palvelun maksullisuus pitää antaa"
 
-#: ckanext/ytp/plugin.py:1111
+#: ckanext/ytp/plugin.py:1112
 msgid ""
 "If there is a service charge, you must supply either the pricing information"
 " web address for this service or a description of the service pricing or "
@@ -450,29 +455,29 @@ msgstr ""
 "Jos palvelu on maksullinen, pitää sinun antaa hintatiedot verkossa tai "
 "kuvaus hinnoista tai molemmat"
 
-#: ckanext/ytp/plugin.py:1124
+#: ckanext/ytp/plugin.py:1125
 msgid "At least one of the main target groups must to be selected"
 msgstr "Vähintään yksi päätason kohdekategoria on valittava"
 
-#: ckanext/ytp/plugin.py:1261
+#: ckanext/ytp/plugin.py:1262
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
 msgstr "Organisaatiota ei ole"
 
-#: ckanext/ytp/plugin.py:1263
+#: ckanext/ytp/plugin.py:1264
 msgid "Invalid organization type"
 msgstr "Väärä organisaatiotyyppi"
 
-#: ckanext/ytp/plugin.py:1285
+#: ckanext/ytp/plugin.py:1286
 msgid "Harvested datasets are read-only"
 msgstr "Harvestoituja tietoaineistoja voi vain lukea"
 
-#: ckanext/ytp/plugin.py:1292
+#: ckanext/ytp/plugin.py:1293
 msgid "Login required"
 msgstr "Kirjautuminen vaaditaan"
 
-#: ckanext/ytp/plugin.py:1298 ckanext/ytp/plugin.py:1306
+#: ckanext/ytp/plugin.py:1299 ckanext/ytp/plugin.py:1307
 #, python-format
 msgid "User %s is not part of any public organization"
 msgstr "Käyttäjä %s ei ole osana mitään julkista organisaatiota"
@@ -1029,11 +1034,11 @@ msgstr ""
 msgid "Required language \"%s\" missing"
 msgstr "Vaadittu käännös \"%s\" puuttuu"
 
-#: ckanext/ytp/validators.py:354
+#: ckanext/ytp/validators.py:355
 msgid "Start date is after end date"
 msgstr "Alkupäivä on ennen loppupäivää"
 
-#: ckanext/ytp/validators.py:358
+#: ckanext/ytp/validators.py:360
 msgid "End date is before start date"
 msgstr "Loppupäivä on ennen alkupäivää"
 
@@ -1099,7 +1104,7 @@ msgstr ""
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:167
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:174
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:181
-#: ckanext/ytp/templates/snippets/search_form.html:69
+#: ckanext/ytp/templates/snippets/search_form.html:74
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr "Poista"
@@ -1113,25 +1118,20 @@ msgstr "Poista"
 msgid "Deleted"
 msgstr "Poistettu"
 
-#: ckanext/ytp/templates/group/snippets/info.html:25
-#: ckanext/ytp/templates/snippets/organization.html:39
-msgid "read more"
-msgstr "Lisätietoja"
-
-#: ckanext/ytp/templates/group/snippets/info.html:33
+#: ckanext/ytp/templates/group/snippets/info.html:32
 #: ckanext/ytp/templates/package/snippets/info.html:23
-#: ckanext/ytp/templates/snippets/organization.html:49
+#: ckanext/ytp/templates/snippets/organization.html:48
 msgid "Followers"
 msgstr "Seuraajat"
 
-#: ckanext/ytp/templates/group/snippets/info.html:37
+#: ckanext/ytp/templates/group/snippets/info.html:36
 #: ckanext/ytp/templates/organization/read_base.html:11
 #: ckanext/ytp/templates/package/base.html:12
 #: ckanext/ytp/templates/package/base.html:16
 #: ckanext/ytp/templates/package/search.html:9
 #: ckanext/ytp/templates/package/search.html:12
 #: ckanext/ytp/templates/related/base_form_page.html:4
-#: ckanext/ytp/templates/snippets/organization.html:53
+#: ckanext/ytp/templates/snippets/organization.html:52
 #: ckanext/ytp/templates/user/dashboard_datasets.html:6
 #: ckanext/ytp/templates/user/read.html:5
 msgid "Datasets"
@@ -1399,7 +1399,7 @@ msgstr "Sulje tallentamatta"
 
 #: ckanext/ytp/templates/organization/index.html:8
 #: ckanext/ytp/templates/organization/members.html:7
-#: ckanext/ytp/templates/user/dashboard_organizations.html:19
+#: ckanext/ytp/templates/user/dashboard_organizations.html:20
 msgid "Membership Requests"
 msgstr "Jäsenhakemukset"
 
@@ -1803,22 +1803,19 @@ msgid "Downloads"
 msgstr "Latauksia"
 
 #: ckanext/ytp/templates/package/search.html:27
-#: ckanext/ytp/templates/user/dashboard_datasets.html:13
+#: ckanext/ytp/templates/user/dashboard_datasets.html:14
 msgid "Add Dataset"
 msgstr "Lisää tietoaineisto"
 
 #: ckanext/ytp/templates/package/search.html:34
-#: ckanext/ytp/templates/user/dashboard_datasets.html:20
 msgid "Add open data"
 msgstr "Lisää avoin data"
 
 #: ckanext/ytp/templates/package/search.html:37
-#: ckanext/ytp/templates/user/dashboard_datasets.html:23
 msgid "Add interoperability tools"
 msgstr "Lisää yhteentoimivuuden kuvaus tai ohje"
 
 #: ckanext/ytp/templates/package/search.html:41
-#: ckanext/ytp/templates/user/dashboard_datasets.html:27
 msgid "Add public service"
 msgstr "Lisää julkinen palvelu"
 
@@ -1827,13 +1824,13 @@ msgid "Relevance"
 msgstr "Relevanssi"
 
 #: ckanext/ytp/templates/package/search.html:62
-#: ckanext/ytp/templates/snippets/search_form.html:31
+#: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
 msgstr "Nimen mukaan nousevasti"
 
 #: ckanext/ytp/templates/package/search.html:63
-#: ckanext/ytp/templates/snippets/search_form.html:31
+#: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
 msgstr "Nimen mukaan laskevasti"
@@ -3033,7 +3030,7 @@ msgid "Submitter email"
 msgstr "Ilmoittajan sähköpostiosoite"
 
 #: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
-#: ckanext/ytp/templates/snippets/search_form.html:14
+#: ckanext/ytp/templates/snippets/search_form.html:19
 #: ckanext/ytp/templates/snippets/search_input.html:17
 msgid "Submit"
 msgstr "Lähetä"
@@ -3082,7 +3079,7 @@ msgstr "Lisenssiä ei annettu"
 msgid "This dataset satisfies the Open Definition."
 msgstr "Tämä tietoaineisto täyttää Open Definition määrittelyn"
 
-#: ckanext/ytp/templates/snippets/organization.html:42
+#: ckanext/ytp/templates/snippets/organization.html:41
 msgid "There is no description for this organization"
 msgstr "Tällä organisaatiolla ei ole kuvausta"
 
@@ -3091,17 +3088,17 @@ msgstr "Tällä organisaatiolla ei ole kuvausta"
 msgid "Search datasets..."
 msgstr "Etsi tietoaineistoista..."
 
-#: ckanext/ytp/templates/snippets/search_form.html:37
+#: ckanext/ytp/templates/snippets/search_form.html:42
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:36
 msgid "Order by"
 msgstr "Järjestäminen"
 
-#: ckanext/ytp/templates/snippets/search_form.html:45
+#: ckanext/ytp/templates/snippets/search_form.html:50
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr "Siirry"
 
-#: ckanext/ytp/templates/snippets/search_form.html:80
+#: ckanext/ytp/templates/snippets/search_form.html:85
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid ""
 " <p class=\"extra\">Please try another search or change search facets.</p> "
@@ -3109,7 +3106,7 @@ msgstr ""
 "<p class=\"extra\">Kokeile syöttämällä eri hakusanat tai muuta valitsemiasi "
 "hakuehtoja.</p>"
 
-#: ckanext/ytp/templates/snippets/search_form.html:86
+#: ckanext/ytp/templates/snippets/search_form.html:91
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "
@@ -3192,11 +3189,11 @@ msgstr "Uutisvirta"
 msgid "Activity from items that I'm following"
 msgstr "Seuraamieni asioiden toiminta"
 
-#: ckanext/ytp/templates/user/dashboard_organizations.html:34
+#: ckanext/ytp/templates/user/dashboard_organizations.html:36
 msgid "You are not a member of any organizations."
 msgstr "Et ole minkään organisaation jäsen."
 
-#: ckanext/ytp/templates/user/dashboard_organizations.html:36
+#: ckanext/ytp/templates/user/dashboard_organizations.html:38
 #: ckanext/ytp/templates/user/read.html:16
 msgid "Create one now?"
 msgstr "Luo uusi nyt?"

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
@@ -1,8 +1,8 @@
 # Translations template for ckanext-ytp_main.
-# Copyright (C) 2018 ORGANIZATION
+# Copyright (C) 2019 ORGANIZATION
 # This file is distributed under the same license as the ckanext-ytp_main
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2018.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2019.
 # 
 # Translators:
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2018
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2018-11-13 09:56+0200\n"
+"POT-Creation-Date: 2019-01-04 09:07+0200\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2018\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
@@ -78,6 +78,11 @@ msgstr "Användare %s är inte behörig att redigera organisationen %s"
 
 #: ckanext/ytp/auth.py:154
 msgid "Cannot modify dataset because of organization policy"
+msgstr ""
+
+#: ckanext/ytp/auth.py:162 ckanext/ytp/controller.py:644
+#: ckanext/ytp/controller.py:689
+msgid "Only system administrators are allowed to view user list."
 msgstr ""
 
 #: ckanext/ytp/controller.py:85
@@ -190,7 +195,7 @@ msgstr "Relaterade objektet skapades"
 msgid "Related item was successfully updated"
 msgstr "Relaterade objektet redigerades"
 
-#: ckanext/ytp/controller.py:420 ckanext/ytp/controller.py:860
+#: ckanext/ytp/controller.py:420 ckanext/ytp/controller.py:892
 msgid "Integrity Error"
 msgstr "Integritetsfel"
 
@@ -234,35 +239,35 @@ msgstr "Visualisering"
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/controller.py:599 ckanext/ytp/controller.py:670
-#: ckanext/ytp/controller.py:697
+#: ckanext/ytp/controller.py:599 ckanext/ytp/controller.py:702
+#: ckanext/ytp/controller.py:729
 msgid "Group not found"
 msgstr "Kategorin hittades inte"
 
-#: ckanext/ytp/controller.py:763
+#: ckanext/ytp/controller.py:795
 msgid "No user specified"
 msgstr "Ingen användare angiven"
 
-#: ckanext/ytp/controller.py:769
+#: ckanext/ytp/controller.py:801
 msgid "Unauthorized to edit a user."
 msgstr "Du saknar behörighet för att redigera en användare."
 
-#: ckanext/ytp/controller.py:788 ckanext/ytp/controller.py:856
+#: ckanext/ytp/controller.py:820 ckanext/ytp/controller.py:888
 #, python-format
 msgid "Unauthorized to edit user %s"
 msgstr "Obehörig att redigera användare %s"
 
-#: ckanext/ytp/controller.py:790 ckanext/ytp/controller.py:858
+#: ckanext/ytp/controller.py:822 ckanext/ytp/controller.py:890
 #: ckanext/ytp/logic.py:184
 msgid "User not found"
 msgstr "Användaren hittades inte"
 
-#: ckanext/ytp/controller.py:796
+#: ckanext/ytp/controller.py:828
 #, python-format
 msgid "User %s not authorized to edit %s"
 msgstr "Användare %s har inte rättigheter redigera %s"
 
-#: ckanext/ytp/controller.py:853
+#: ckanext/ytp/controller.py:885
 msgid "Profile updated"
 msgstr "Profil uppdaterad"
 
@@ -313,7 +318,7 @@ msgstr "Mina dataset"
 
 #: ckanext/ytp/menu.py:70
 #: ckanext/ytp/templates/user/dashboard_organizations.html:12
-#: ckanext/ytp/templates/user/dashboard_organizations.html:25
+#: ckanext/ytp/templates/user/dashboard_organizations.html:27
 msgid "My Organizations"
 msgstr "Mina organisationer"
 
@@ -441,15 +446,15 @@ msgstr "Annan"
 msgid "Additional Info"
 msgstr "Tilläggsinformation"
 
-#: ckanext/ytp/plugin.py:923
+#: ckanext/ytp/plugin.py:924
 msgid "Group title already exists in database"
 msgstr "Titeln för kategorien finns redan i databasen"
 
-#: ckanext/ytp/plugin.py:1101
+#: ckanext/ytp/plugin.py:1102
 msgid "Service charge must be supplied"
 msgstr "Tjänstens avgiftsbelagdhet måste anges"
 
-#: ckanext/ytp/plugin.py:1111
+#: ckanext/ytp/plugin.py:1112
 msgid ""
 "If there is a service charge, you must supply either the pricing information"
 " web address for this service or a description of the service pricing or "
@@ -458,29 +463,29 @@ msgstr ""
 "Om tjänsten är avgiftsbelagd, måste du ange prisinformationen på webben "
 "eller en beskrivning om priserna eller båda"
 
-#: ckanext/ytp/plugin.py:1124
+#: ckanext/ytp/plugin.py:1125
 msgid "At least one of the main target groups must to be selected"
 msgstr "Åtminstone en målkategori från huvudnivån måste väljas"
 
-#: ckanext/ytp/plugin.py:1261
+#: ckanext/ytp/plugin.py:1262
 #: ckanext/ytp/templates/organization/organization_not_found.html:3
 #: ckanext/ytp/templates/organization/organization_not_found.html:9
 msgid "Organization does not exist"
 msgstr "Organisationen finns inte"
 
-#: ckanext/ytp/plugin.py:1263
+#: ckanext/ytp/plugin.py:1264
 msgid "Invalid organization type"
 msgstr "Felaktig organisationstyp"
 
-#: ckanext/ytp/plugin.py:1285
+#: ckanext/ytp/plugin.py:1286
 msgid "Harvested datasets are read-only"
 msgstr "Skrapade dataset kan endast läsas"
 
-#: ckanext/ytp/plugin.py:1292
+#: ckanext/ytp/plugin.py:1293
 msgid "Login required"
 msgstr "Inloggning krävs"
 
-#: ckanext/ytp/plugin.py:1298 ckanext/ytp/plugin.py:1306
+#: ckanext/ytp/plugin.py:1299 ckanext/ytp/plugin.py:1307
 #, python-format
 msgid "User %s is not part of any public organization"
 msgstr "Användare %s är inte medlem av någon offentlig organisation"
@@ -1018,11 +1023,11 @@ msgstr ""
 msgid "Required language \"%s\" missing"
 msgstr ""
 
-#: ckanext/ytp/validators.py:354
+#: ckanext/ytp/validators.py:355
 msgid "Start date is after end date"
 msgstr ""
 
-#: ckanext/ytp/validators.py:358
+#: ckanext/ytp/validators.py:360
 msgid "End date is before start date"
 msgstr ""
 
@@ -1088,7 +1093,7 @@ msgstr ""
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:167
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:174
 #: ckanext/ytp/templates/package/ytp/service/package_service_channels_fields.html:181
-#: ckanext/ytp/templates/snippets/search_form.html:69
+#: ckanext/ytp/templates/snippets/search_form.html:74
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr "Ta bort"
@@ -1102,25 +1107,20 @@ msgstr "Ta bort"
 msgid "Deleted"
 msgstr "Raderad"
 
-#: ckanext/ytp/templates/group/snippets/info.html:25
-#: ckanext/ytp/templates/snippets/organization.html:39
-msgid "read more"
-msgstr "läs mera"
-
-#: ckanext/ytp/templates/group/snippets/info.html:33
+#: ckanext/ytp/templates/group/snippets/info.html:32
 #: ckanext/ytp/templates/package/snippets/info.html:23
-#: ckanext/ytp/templates/snippets/organization.html:49
+#: ckanext/ytp/templates/snippets/organization.html:48
 msgid "Followers"
 msgstr "Följare"
 
-#: ckanext/ytp/templates/group/snippets/info.html:37
+#: ckanext/ytp/templates/group/snippets/info.html:36
 #: ckanext/ytp/templates/organization/read_base.html:11
 #: ckanext/ytp/templates/package/base.html:12
 #: ckanext/ytp/templates/package/base.html:16
 #: ckanext/ytp/templates/package/search.html:9
 #: ckanext/ytp/templates/package/search.html:12
 #: ckanext/ytp/templates/related/base_form_page.html:4
-#: ckanext/ytp/templates/snippets/organization.html:53
+#: ckanext/ytp/templates/snippets/organization.html:52
 #: ckanext/ytp/templates/user/dashboard_datasets.html:6
 #: ckanext/ytp/templates/user/read.html:5
 msgid "Datasets"
@@ -1386,7 +1386,7 @@ msgstr "Stäng utan att spara"
 
 #: ckanext/ytp/templates/organization/index.html:8
 #: ckanext/ytp/templates/organization/members.html:7
-#: ckanext/ytp/templates/user/dashboard_organizations.html:19
+#: ckanext/ytp/templates/user/dashboard_organizations.html:20
 msgid "Membership Requests"
 msgstr "Medlemsansökan"
 
@@ -1789,22 +1789,19 @@ msgid "Downloads"
 msgstr "Nedladdningar"
 
 #: ckanext/ytp/templates/package/search.html:27
-#: ckanext/ytp/templates/user/dashboard_datasets.html:13
+#: ckanext/ytp/templates/user/dashboard_datasets.html:14
 msgid "Add Dataset"
 msgstr "Lägg till dataset"
 
 #: ckanext/ytp/templates/package/search.html:34
-#: ckanext/ytp/templates/user/dashboard_datasets.html:20
 msgid "Add open data"
 msgstr "Lägg till öppen data"
 
 #: ckanext/ytp/templates/package/search.html:37
-#: ckanext/ytp/templates/user/dashboard_datasets.html:23
 msgid "Add interoperability tools"
 msgstr "Lägg till interoperabilitetsverktyg"
 
 #: ckanext/ytp/templates/package/search.html:41
-#: ckanext/ytp/templates/user/dashboard_datasets.html:27
 msgid "Add public service"
 msgstr "Lägg till offentlig tjänst"
 
@@ -1813,13 +1810,13 @@ msgid "Relevance"
 msgstr "Relevans"
 
 #: ckanext/ytp/templates/package/search.html:62
-#: ckanext/ytp/templates/snippets/search_form.html:31
+#: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
 msgstr "Namn i stigande ordning"
 
 #: ckanext/ytp/templates/package/search.html:63
-#: ckanext/ytp/templates/snippets/search_form.html:31
+#: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
 msgstr "Namn i nedstigande ordning"
@@ -3004,7 +3001,7 @@ msgid "Submitter email"
 msgstr ""
 
 #: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
-#: ckanext/ytp/templates/snippets/search_form.html:14
+#: ckanext/ytp/templates/snippets/search_form.html:19
 #: ckanext/ytp/templates/snippets/search_input.html:17
 msgid "Submit"
 msgstr "Skicka"
@@ -3053,7 +3050,7 @@ msgstr "Ingen licens angiven"
 msgid "This dataset satisfies the Open Definition."
 msgstr "Det här datasetet uppfyller \"The Open Definition\""
 
-#: ckanext/ytp/templates/snippets/organization.html:42
+#: ckanext/ytp/templates/snippets/organization.html:41
 msgid "There is no description for this organization"
 msgstr "Det finns ingen beskriving för organisationen"
 
@@ -3062,17 +3059,17 @@ msgstr "Det finns ingen beskriving för organisationen"
 msgid "Search datasets..."
 msgstr "Sök i dataseten..."
 
-#: ckanext/ytp/templates/snippets/search_form.html:37
+#: ckanext/ytp/templates/snippets/search_form.html:42
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:36
 msgid "Order by"
 msgstr "Sortera enligt"
 
-#: ckanext/ytp/templates/snippets/search_form.html:45
+#: ckanext/ytp/templates/snippets/search_form.html:50
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr "Kör"
 
-#: ckanext/ytp/templates/snippets/search_form.html:80
+#: ckanext/ytp/templates/snippets/search_form.html:85
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid ""
 " <p class=\"extra\">Please try another search or change search facets.</p> "
@@ -3080,7 +3077,7 @@ msgstr ""
 "<p class=\"extra\">Försök en annan sökning eller ändra på dina "
 "sökkriterier.</p>"
 
-#: ckanext/ytp/templates/snippets/search_form.html:86
+#: ckanext/ytp/templates/snippets/search_form.html:91
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "
@@ -3165,11 +3162,11 @@ msgstr "Nyhetsflöde"
 msgid "Activity from items that I'm following"
 msgstr "Aktivitet från ämnen som jag följer"
 
-#: ckanext/ytp/templates/user/dashboard_organizations.html:34
+#: ckanext/ytp/templates/user/dashboard_organizations.html:36
 msgid "You are not a member of any organizations."
 msgstr "Du är inte medlem av någon organisation."
 
-#: ckanext/ytp/templates/user/dashboard_organizations.html:36
+#: ckanext/ytp/templates/user/dashboard_organizations.html:38
 #: ckanext/ytp/templates/user/read.html:16
 msgid "Create one now?"
 msgstr "Lägg till en nu?"

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -589,7 +589,8 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
     def get_auth_functions(self):
         return {'related_update': auth.related_update,
                 'related_create': auth.related_create,
-                'package_update': auth.package_update}
+                'package_update': auth.package_update,
+                'allowed_to_view_user_list': auth.user_list}
 
         # IPackageController #
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/admin_list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/admin_list.html
@@ -35,14 +35,14 @@
         </tr>
         </thead>
         <tbody>
-        {% for user in c.users %}
+        {% for username, user in c.users.iteritems()  %}
             <tr>
                 <td class="media">
                     {{ h.linked_user(user['user_id'], maxlength=20) }}
                 </td>
-                <td>{{ user['username'] }}</td>
-                <td>{{ user['organization'] }}</td>
-                <td>{{ user['role'] }}</td>
+                <td>{{ username }}</td>
+                <td>{{ user['organizations'] | join(', ') }}</td>
+                <td>{{ user['roles'] | join(', ') }}</td>
                 <td>{{ user['email'] }}</td>
                 <td>
                     {% set locale = h.dump_json({'content': _('Are you sure you want to delete this User?')}) %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/user_list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/user_list.html
@@ -35,14 +35,14 @@
         </tr>
         </thead>
         <tbody>
-        {% for user in c.users %}
+        {% for username, user in c.users.iteritems() %}
             <tr>
                 <td class="media">
                     {{ h.linked_user(user['user_id'], maxlength=20) }}
                 </td>
-                <td>{{ user['username'] }}</td>
-                <td>{{ user['organization'] }}</td>
-                <td>{{ user['role'] }}</td>
+                <td>{{ username }}</td>
+                <td>{{ user['organizations'] | join(', ') }}</td>
+                <td>{{ user['roles']| join(', ') }}</td>
                 <td>{{ user['email'] }}</td>
                 <td>
                     {% set locale = h.dump_json({'content': _('Are you sure you want to delete this User?')}) %}


### PR DESCRIPTION
User lists are now limited to sysadmins with authentication.

Duplicate usernames are now merged in lists with organizations and roles appended to single user object.