### PR TITLE
AV-324 Footer link hover fix

### DIFF
--- a/modules/ytp-assets-common/src/less/navbars.less
+++ b/modules/ytp-assets-common/src/less/navbars.less
@@ -399,6 +399,13 @@ End of dropdown CSS
       padding: 0px;
     }
   }
+
+  .opendata-menu-container > ul > li > a {
+    &:hover, &:focus {
+      background-color: transparent;
+      text-decoration: underline;
+    }
+  }
 }
 
 .service-messages {


### PR DESCRIPTION
- Footer link hovers had incorrect styling. Now the style should follow
more closely the guidelines.

Old style:
![footer_hover_old](https://user-images.githubusercontent.com/2406748/50758702-98733b00-126b-11e9-8d7a-590f3cb37ceb.gif)


New style:
![footer_hover_new](https://user-images.githubusercontent.com/2406748/50758710-9d37ef00-126b-11e9-8902-bfaa7d5d7b46.gif)

