### PR TITLE
AV-453: Fix job translation errors

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -26,8 +26,10 @@ def get_field(obj_or_dict, field, default=None):
         return obj_or_dict.get(field, default)
     elif hasattr(obj_or_dict, field):
         return getattr(obj_or_dict, field)
-    else:
+    elif hasattr(obj_or_dict, 'extras'):
         return obj_or_dict.extras.get(field, default)
+    else:
+        return default
 
 
 def get_translation(translated):

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/user/list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/user/list.html
@@ -21,9 +21,10 @@
                 {{ h.linked_user(user['name'], maxlength=20, avatar=60) }}
                 <p>
                 {% set main_organization = h.main_organization(user[0]).display_name %}
-                {%- if user[0].extras -%}
-                  {# Translate the job_title field #}
-                  {{ h.extra_translation(user[0].extras, 'job_title') }}
+                {# Translate the job_title field #}
+                {% set job_title = h.extra_translation(user[0], 'job_title') %}
+                {%- if job_title -%}
+                  {{ job_title }}
                   {%- if main_organization -%}
                   ,
                   {%- endif %}


### PR DESCRIPTION
- Make translation system more robust by handling cases where the given object is not a dict, doesn't have the field nor an extras-field by returning the given default value
- Only render job title if a translation for it exists