### PR TITLE
AV-450 Showcase text overflow fix

### DIFF
--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -406,9 +406,12 @@ body {
 .showcase-heading-icon {
   max-width: 160px;
   max-height: 160px;
+  overflow: hidden;
+
   img {
-    max-height: 100%;
-    max-width: 100%;
+    max-width: 160px;
+    max-height: 160px;
+    object-fit: cover;
   }
 }
 
@@ -594,37 +597,65 @@ body {
     border-radius: 3px;
     padding: 0px;
     margin: 0px 25px 25px 0px;
+    overflow: hidden;
+    text-overflow: ellipsis;
     .media-image {
       padding: 0px;
       border-radius: 0px;
       width: 247px;
-      height: 165px;
+      height: 155px;
       overflow: hidden;
       object-fit: cover;
       border-top-left-radius: 2px;
       border-top-right-radius: 1px;
     }
+
     .item-content {
-      margin-right: 16px;
-      margin-left: 16px;
-      margin-top: 12px;
-      margin-bottom: 12px;
+      .flex-display(flex);
+      .flex-direction(column);
+      margin-right: 15px;
+      margin-left: 15px;
+      margin-top: 5px;
+      margin-bottom: 10px;
+      max-height: 160px;
+      width: 217px;
+      overflow: hidden;
+      object-fit: cover;
+      text-overflow: ellipsis;
+
       .media-heading {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-height: 25px;
         a {
           color: @mediagrid-header-text-color;
         }
       }
-    }
-    .item-description {
-      display: block;
-      display: -webkit-box;
-      height: 80px;
-      -webkit-line-clamp: 4;
-      -webkit-box-orient: vertical;
-      overflow: hidden;
-      text-overflow: ellipsis;
+
+      .item-platform {
+        p {
+          display: block;
+          white-space: nowrap;        
+          overflow: hidden;
+          text-overflow: ellipsis;
+          margin-bottom: 10px;
+        }
+      }
+
+      .item-description {
+        display: block;
+        display: -webkit-box;
+        -webkit-line-clamp: 4;
+        max-lines: 4;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-height: 80px;
+      }
     }
   }
+
   .opendata-category-icon {
     color: @mediagrid-category-icon-color;
   }


### PR DESCRIPTION
- Text were overflowing from the containers in showcase listing view.
Styling for the containers have been now fixed for Chrome, Firefox and
IE.

Old view:
![showcase_chrome_old](https://user-images.githubusercontent.com/2406748/50837207-c50a7e00-1363-11e9-83a7-d86f0dd50d37.png)


Fixed views:
![showcase_new](https://user-images.githubusercontent.com/2406748/50837221-ca67c880-1363-11e9-8775-8d149b2e7a08.gif)
