### PR TITLE
Fix ckan log files

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -241,6 +241,15 @@
   tags:
   - ckan
 
+- name: Setup Apache WSGI script
+  template:
+    src: "apache.wsgi.j2"
+    dest: /etc/ckan/default/apache.wsgi
+    mode: "0640"
+    owner: root
+    group: "{{ www_group }}"
+
+
 - name: Create debian cache path
   file:
     path: "{{ cache_path }}/debian"
@@ -302,7 +311,6 @@
     group: "{{ item.group }}"
   with_items:
     - { src: ckan.py, dest: /usr/bin/ckan, mode: "0755", owner: root, group: root }
-    - { src: apache.wsgi, dest: /etc/ckan/default/apache.wsgi, mode: "0640", owner: root, group: "{{ www_group }}" }
     - { src: who.ini, dest: "{{ ckan_who_ini }}", mode: "0644", owner: root, group: "{{ www_group }}"}
   tags:
     - ckan

--- a/ansible/roles/ckan/templates/apache.wsgi.j2
+++ b/ansible/roles/ckan/templates/apache.wsgi.j2
@@ -1,3 +1,6 @@
+import sys
+sys.stderr = sys.stdout = file('{{ ckan_log_path }}/ckan.log', 'a')
+
 import os
 activate_this = os.path.join('/usr/lib/ckan/default/bin/activate_this.py')
 execfile(activate_this, dict(__file__=activate_this))

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -219,7 +219,7 @@ ckan.datapusher.url = http://127.0.0.1:8800/
 keys = root, ckan, ckanext
 
 [handlers]
-keys = console, ckan
+keys = console
 
 [formatters]
 keys = generic
@@ -230,25 +230,19 @@ handlers = console
 
 [logger_ckan]
 level = {{ ckan_ckan_loglevel }}
-handlers = ckan
+handlers = console
 qualname = ckan
 propagate = 0
 
 [logger_ckanext]
 level = {{ ckan_ckanext_loglevel }}
-handlers = ckan
+handlers = console
 qualname = ckanext
 propagate = 0
 
 [handler_console]
 class = StreamHandler
 args = (sys.stderr,)
-level = NOTSET
-formatter = generic
-
-[handler_ckan]
-class = FileHandler
-args = ('{{ ckan_log_path }}/ckan.log','a')
 level = NOTSET
 formatter = generic
 


### PR DESCRIPTION
Previous #345 PR modified logfile paths, resulting all ckan logs to append into single log file, apache logs, harvester logs and other commands. This PR fixes that.