### PR TITLE
AV-389: Fix spatial harvesting and modify sixodp harvester

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/harvesters/sixodp_harvester.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/harvesters/sixodp_harvester.py
@@ -87,6 +87,16 @@ def sixodp_to_opendata_postprocess(package_dict):
         package_dict['date_released'] = date_released_isoformat
         package_dict['metadata_created'] = date_released_isoformat
 
+    for resource in package_dict['resources']:
+        time_series_start = resource.get('time_series_start')
+        if time_series_start is not None and parse_datetime(time_series_start) is None:
+            resource.pop('time_series_start')
+
+        time_series_end = resource.get('time_series_end')
+        if time_series_end is not None and parse_datetime(time_series_end) is None:
+            resource.pop('time_series_end')
+
+
 
 class SixodpHarvester(HarvesterBase):
     '''

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -82,7 +82,7 @@ class YtpMainTranslation(DefaultTranslation):
         return "ckanext-ytp_main"
 
 
-def create_vocabulary(name):
+def create_vocabulary(name, defer=False):
     user = toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
     context = {'user': user['name']}
 
@@ -95,13 +95,14 @@ def create_vocabulary(name):
     log.info("Creating vocab '" + name + "'")
     data = {'name': name}
     try:
-        # context['defer_commit'] = True
+        if defer:
+            context['defer_commit'] = True
         return toolkit.get_action('vocabulary_create')(context, data)
     except Exception, e:
         log.error('%s' % e)
 
 
-def create_tag_to_vocabulary(tag, vocab):
+def create_tag_to_vocabulary(tag, vocab, defer=False):
     user = toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
     context = {'user': user['name']}
 
@@ -112,7 +113,8 @@ def create_tag_to_vocabulary(tag, vocab):
         "name": tag,
         "vocabulary_id": v['id']}
 
-    # context['defer_commit'] = True
+    if defer:
+        context['defer_commit'] = True
     try:
         toolkit.get_action('tag_create')(context, data)
     except ValidationError:
@@ -672,6 +674,7 @@ class YTPSpatialHarvester(plugins.SingletonPlugin):
 
     def get_package_dict(self, context, data_dict):
 
+        context['defer'] = True
         package_dict = data_dict['package_dict']
 
         list_map = {'access_constraints': 'copyright_notice'}

--- a/modules/ckanext-ytp_main/ckanext/ytp/validators.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/validators.py
@@ -104,10 +104,15 @@ def create_fluent_tags(vocab):
 
 
 def add_to_vocab(context, tags, vocab):
+
+    defer = context.get('defer', False)
     try:
         v = get_action('vocabulary_show')(context, {'id': vocab})
     except ObjectNotFound:
-        v = plugin.create_vocabulary(vocab)
+        log.info("creating vocab")
+        v = plugin.create_vocabulary(vocab, defer)
+
+
 
     context['vocabulary'] = model.Vocabulary.get(v.get('id'))
     if isinstance(tags, basestring):
@@ -120,7 +125,7 @@ def add_to_vocab(context, tags, vocab):
         try:
             validators.tag_in_vocabulary_validator(tag, context)
         except Invalid:
-            plugin.create_tag_to_vocabulary(tag, vocab)
+            plugin.create_tag_to_vocabulary(tag, vocab, defer)
 
 
 def tag_list_output(value):


### PR DESCRIPTION
In spatial harvester, commits are deferred as spatial itself defers them before hand.

Sixodp harvester removes timeseries timestamps if they aren't datetimes, since HRI requested the change.