### PR TITLE
AV-461: Remove inviting users by email address

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/member_new.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/member_new.html
@@ -1,6 +1,7 @@
 {% ckan_extends %}
+
 {% block form %}
-<form class="dataset-form add-member-form" method='post'>
+<form class="dataset-form add-member-form" method='post' id="add-member-form">
   <div class="row">
     <div class="col-md-5">
       <div class="form-group control-medium">
@@ -16,16 +17,15 @@
           {% if user %}
           <input type="hidden" name="username" value="{{ user.name }}" />
           <input id="username" name="username" type="text" value="{{ user.name }}"
-                 disabled="True" class="form-control">
+                 disabled="True" class="form-control control-medium">
           {% else %}
-          <input id="username" type="text" name="username" placeholder="{{ _('Username') }}"
+          <input id="username" type="text" name="username" placeholder="Username"
                  value="" class="control-medium" data-module="autocomplete"
                  data-module-source="/api/2/util/user/autocomplete?q=?">
           {% endif %}
         </div>
       </div>
     </div>
-
   </div>
 
   {% set format_attrs = {'data-module': 'autocomplete'} %}
@@ -34,7 +34,7 @@
     {% if user %}
     <a href="{{ h.url_for(group_type + '.member_delete', id=group_dict.id, user=user_id) }}" class="btn btn-danger pull-left" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this member?') }}">{{ _('Delete') }}</a>
     <button class="btn btn-primary" type="submit" name="submit" >
-      {{ _('Update Member') }}
+      {{ _('Save') }}
     </button>
     {% else %}
     <button class="btn btn-primary" type="submit" name="submit" >
@@ -44,5 +44,3 @@
   </div>
 </form>
 {% endblock %}
-
-


### PR DESCRIPTION
In CKAN, it's possible to invite users to organization and groups by email. This in turn creates user accounts, but our account handling is in drupal so we probably don't want to support this. Inviting users is already prohibited in ckan configuration.