### PR TITLE
Av 501 procstat monitoring

### DIFF
--- a/ansible/roles/cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
+++ b/ansible/roles/cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
@@ -15,7 +15,7 @@
     },
     "metrics_collected": {
       {% if cloudwatch_agent_procstat_metrics_config is defined -%}
-      "procstat": {{ cloudwatch_agent_procstat_metrics_config | to_nice_json(indent=2) | indent(6) }}
+      "procstat": {{ cloudwatch_agent_procstat_metrics_config | to_nice_json(indent=2) | indent(6) }},
       {% endif -%}
       "mem": {
         "measurement": [

--- a/ansible/roles/cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
+++ b/ansible/roles/cloudwatch_agent/templates/amazon-cloudwatch-agent.json.j2
@@ -14,6 +14,9 @@
       "InstanceType": "${aws:InstanceType}"
     },
     "metrics_collected": {
+      {% if cloudwatch_agent_procstat_metrics_config is defined -%}
+      "procstat": {{ cloudwatch_agent_procstat_metrics_config | to_nice_json(indent=2) | indent(6) }}
+      {% endif -%}
       "mem": {
         "measurement": [
           "mem_used_percent"

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -275,3 +275,11 @@ cloudwatch_agent_logs_config:
     log_group_name: nginx-error
     log_stream_name: '{local_hostname}'
     timestamp_format: '%Y/%m/%d %H:%M:%S %z'
+
+cloudwatch_agent_procstat_metrics_config:
+  - pattern: "ckan_default"
+    measurement:
+      - cpu_usage
+  - pattern: "php-fpm"
+    measurement:
+      - cpu_usage


### PR DESCRIPTION
Add option to conditionally include cloudwatch agent procstat plugin configuration if they have been defined, and add cpu usage metrics to configuration for ckan and php-fpm