### PR TITLE
AV-494: Fix drupal mobile menu margins

### DIFF
--- a/modules/ytp-assets-common/src/less/drupal/overrides.less
+++ b/modules/ytp-assets-common/src/less/drupal/overrides.less
@@ -964,9 +964,11 @@ p:last-child,
 }
 
 //Overrides navbar-collapse padding
-.opendata-menu-container {
-  padding-left: 0px;
-  padding-right: 0px;
+@media(min-width:768px) {
+  .opendata-menu-container {
+    padding-left: 0px;
+    padding-right: 0px;
+  }
 }
 
 .views-element-container {


### PR DESCRIPTION
- Made a margin fix previously introduced in AV-371 only apply to wide screen layouts, because it breaks mobile menus