### PR TITLE
AV-542: Added CKAN profiling support for development environments

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -19,6 +19,15 @@
   - packages
   - ckan
 
+- name: Ensure CKAN profiling packages
+  apt:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - graphviz
+    - graphviz-dev
+  when: profiling_enabled
+
 - name: Ensure log file exists
   file:
     path: "{{ ckan_log_path }}/ckan.log"
@@ -77,6 +86,12 @@
     requirements: "{{ virtual_environment }}/src/ckan/dev-requirements.txt"
     virtualenv: "{{ virtual_environment }}"
   when: deployment_environment_id == "vagrant"
+
+- name: Install CKAN profiling tool
+  pip:
+    name: "git+http://github.com/vrk-kpa/linesman#egg=linesman"
+    virtualenv: "{{ virtual_environment }}"
+  when: profiling_enabled
 
 - name: Copy override requirements
   copy:

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -224,6 +224,10 @@ ckanext.ytp.theme.show_postit_demo = {{ show_postit_demo }}
 
 ckan.datapusher.url = http://127.0.0.1:8800/
 
+{% if profiling_enabled %}
+filter-with = linesman
+{% endif %}
+
 [loggers]
 keys = root, ckan, ckanext
 
@@ -268,3 +272,9 @@ BROKER_BACKEND =
 BROKER_HOST =
 CELERY_RESULT_DBURI =
 CELERYD_CONCURRENCY = 1
+
+{% if profiling_enabled %}
+[filter:linesman]
+use = egg:linesman#profiler
+filename = /tmp/linesman.sqlite
+{% endif %}

--- a/ansible/vars/common.yml
+++ b/ansible/vars/common.yml
@@ -183,6 +183,7 @@ AWS:
   smtp_server_domain: "email-smtp.eu-west-1.amazonaws.com"
 
 debug_enabled: false
+profiling_enabled: false
 
 cloudwatch_agent_logs_config:
   - file_path: '/var/log/ckan/ckan-worker-bulk.log*'

--- a/ansible/vars/environment-specific/beta.yml
+++ b/ansible/vars/environment-specific/beta.yml
@@ -4,3 +4,5 @@
 
 smtp:
   server_domain: email-smtp.eu-west-1.amazonaws.com
+
+profiling_enabled: true

--- a/ansible/vars/environment-specific/dev.yml
+++ b/ansible/vars/environment-specific/dev.yml
@@ -4,3 +4,5 @@
 
 smtp:
   server_domain: email-smtp.eu-west-1.amazonaws.com
+
+profiling_enabled: true

--- a/ansible/vars/environment-specific/vagrant.yml
+++ b/ansible/vars/environment-specific/vagrant.yml
@@ -3,6 +3,8 @@
 # THESE VARS ARE PUBLIC, DO NOT PUT SECRETS HERE
 
 debug_enabled: true
+profiling_enabled: true
+
 smtp:
   server_domain: localhost
 


### PR DESCRIPTION
- Added ansible variable `profiling_enabled: false` and per-environment overrides
  - Install graphviz and linesman if set
  - Include linesman config into production.ini if set
 