### PR TITLE
AV-306: Fix guide search form action URL

### DIFF
--- a/cypress/integration/front_page_spec.js
+++ b/cypress/integration/front_page_spec.js
@@ -21,7 +21,7 @@ describe('Basic tests', function() {
     cy.visit("/opas");
     cy.visit("/en/guide");
     cy.visit("/sv/guide");
-    cy.visit("fi/opas/guide-search?search_api_fulltext=test");
+    cy.visit("fi/guide-search?search_api_fulltext=test");
     cy.visit("/user/register");
     cy.visit("/contact");
     cy.visit("/tapahtumat")

--- a/modules/avoindata-drupal-theme/avoindata.theme
+++ b/modules/avoindata-drupal-theme/avoindata.theme
@@ -18,6 +18,10 @@ function avoindata_preprocess_block(&$variables) {
   }
 }
 
+function avoindata_preprocess_region(&$variables) {
+  $variables['language'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
+}
+
 // Implements hook_views_pre_render().
 function avoindata_views_pre_render(ViewExecutable $view) {
   if($view->id() == 'frontpage' && $view->current_display == 'page_1') {

--- a/modules/avoindata-drupal-theme/templates/node/region--guide_menu.html.twig
+++ b/modules/avoindata-drupal-theme/templates/node/region--guide_menu.html.twig
@@ -3,7 +3,7 @@
         {{ content }}
     </div>
 </div>
-<form action="guide-search" id="guide-search-form">
+<form action="/{{ language }}/guide-search" id="guide-search-form">
     <input type="search" id="guide-search-field" 
             maxlength="256" name="search_api_fulltext" 
             placeholder="{% trans %}Guide search{% endtrans %}" required="">


### PR DESCRIPTION
- Added 'language' variable available for Drupal Twig templates
- Fixed guide search form to use an absolute path