### PR TITLE
Added momentum scrolling for iOS devices

### DIFF
--- a/modules/ytp-assets-common/src/less/drupal/overrides.less
+++ b/modules/ytp-assets-common/src/less/drupal/overrides.less
@@ -45,7 +45,8 @@ body, html {
   height: 100%;
   margin: 0px;
   padding: 0px;
-  overflow-x: hidden; 
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch; 
 }
 
 // Footer to the bottom of the screen if there is not enough content on the page (not sticky).


### PR DESCRIPTION
This should be the default behavious nowadays and it is somewhat unclear why it needed to be added specifically. This also only affects the Drupal pages, but the momentum scrolling already works on Ckan sites. 