### PR TITLE
AV-263: keywords to facet filters

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -16,7 +16,7 @@ from ckan import plugins, model, logic
 from ckan.common import _, c, request, is_flask_request
 
 from ckan.config.routing import SubMapper
-from ckan.lib import helpers, i18n
+from ckan.lib import helpers
 from ckan.lib.dictization import model_dictize
 from ckan.lib.munge import munge_title_to_name
 from ckan.lib.navl import dictization_functions
@@ -431,14 +431,10 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
                 raise
 
     # IFacets #
-    _LOCALE_ALIASES = {'en_GB': 'en'}
 
     def dataset_facets(self, facets_dict, package_type):
+        lang = helpers.get_lang_prefix()
         facets_dict = OrderedDict()
-        lang = i18n.get_lang()
-        if lang in self._LOCALE_ALIASES:
-            lang = self._LOCALE_ALIASES[lang]
-
         facets_dict.update({'vocab_international_benchmarks': _('International benchmarks')})
         facets_dict.update({'collection_type': _('Collection Type')})
         facets_dict['vocab_keywords_' + lang] = _('Tags')
@@ -455,7 +451,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
         return facets_dict
 
     def organization_facets(self, facets_dict, organization_type, package_type):
-
+        lang = helpers.get_lang_prefix()
         facets_dict = OrderedDict()
         facets_dict.update({'collection_type': _('Collection Type')})
         facets_dict['vocab_keywords_' + lang] = _('Tags')

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -433,7 +433,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
     # IFacets #
 
     def dataset_facets(self, facets_dict, package_type):
-        lang = helpers.get_lang_prefix()
+        lang = get_lang_prefix()
         facets_dict = OrderedDict()
         facets_dict.update({'vocab_international_benchmarks': _('International benchmarks')})
         facets_dict.update({'collection_type': _('Collection Type')})
@@ -451,7 +451,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
         return facets_dict
 
     def organization_facets(self, facets_dict, organization_type, package_type):
-        lang = helpers.get_lang_prefix()
+        lang = get_lang_prefix()
         facets_dict = OrderedDict()
         facets_dict.update({'collection_type': _('Collection Type')})
         facets_dict['vocab_keywords_' + lang] = _('Tags')

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -16,13 +16,12 @@ from ckan import plugins, model, logic
 from ckan.common import _, c, request, is_flask_request
 
 from ckan.config.routing import SubMapper
-from ckan.lib import helpers
+from ckan.lib import helpers, i18n
 from ckan.lib.dictization import model_dictize
 from ckan.lib.munge import munge_title_to_name
 from ckan.lib.navl import dictization_functions
 from ckan.lib.navl.dictization_functions import Missing, StopOnError, missing, flatten_dict, unflatten, Invalid
 from ckan.lib.plugins import DefaultOrganizationForm, DefaultTranslation
-from ckan.lib import i18n
 from ckan.logic import NotFound, NotAuthorized, auth as ckan_auth, get_action
 from ckan.model import Session
 from ckan.plugins import toolkit
@@ -442,14 +441,13 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
 
         facets_dict.update({'vocab_international_benchmarks': _('International benchmarks')})
         facets_dict.update({'collection_type': _('Collection Type')})
-        facets_dict.update({'tags': _('Tags')})
+        facets_dict['vocab_keywords_' + lang] = _('Tags')
         facets_dict.update({'vocab_content_type': _('Content Type')})
         facets_dict.update({'organization': _('Organization')})
         facets_dict.update({'res_format': _('Formats')})
         # BFW: source is not part of the schema. created artificially at before_index function
         facets_dict.update({'source': _('Source')})
         facets_dict.update({'license_id': _('License')})
-        facets_dict['vocab_keywords_' + lang] = _('Tags')
         # add more dataset facets here
         return facets_dict
 
@@ -460,7 +458,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
 
         facets_dict = OrderedDict()
         facets_dict.update({'collection_type': _('Collection Type')})
-        facets_dict.update({'tags': _('Tags')})
+        facets_dict['vocab_keywords_' + lang] = _('Tags')
         facets_dict.update({'vocab_content_type': _('Content Type')})
         facets_dict.update({'res_format': _('Formats')})
 
@@ -647,9 +645,11 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
         languages = ['fi', 'sv', 'en']
         for prop_key in translated_vocabs:
             prop_json = pkg_dict.get(prop_key)
+            # Add only if not already there
             if not prop_json:
                 continue
             prop_value = json.loads(prop_json)
+            # Add for each language
             for lang in languages:
                 if prop_value.get(lang):
                     pkg_dict['vocab_%s_%s' % (prop_key, lang)] = [tag for tag in prop_value[lang]] 


### PR DESCRIPTION
- Added translated keywords to facets in dataset and organizations pages

Requires search-index rebuild: `/usr/lib/ckan/default/bin/paster --plugin=ckan search-index rebuild -c /etc/ckan/default/production.ini` and maybe apache restart.

related to this pr: https://github.com/vrk-kpa/opendata/pull/415. Might overlap a bit.

PS: the logic might be in the wrong place, comment if so. First change to plugins functionality 😄 