### PR TITLE
AV-480: Fix showcase dataset edit page breadcrumb link

### DIFF
--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/showcase/manage_datasets.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/showcase/manage_datasets.html
@@ -1,4 +1,4 @@
-{% extends 'showcase/edit_base.html' %}
+{% extends 'sixodp_showcase/edit_base.html' %}
 
 {% block subtitle %}{{ _('Showcases - Manage datasets') }}{% endblock %}
 


### PR DESCRIPTION
- Use `sixodp_showcase` base template that uses correct plugin for breadcrumb link target