### PR TITLE
AV-608: customized main search pages to have similar styles

### DIFF
--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
@@ -10,6 +10,13 @@
 
 {% block pre_primary %}
   {% set featured_showcases = h.get_featured_showcases() %}
+  {#
+  {% if featured_showcases %}
+    <div class="page-highlight">
+      {{ h.snippet('snippets/horizontal_accordion.html', items=featured_showcases, image_identifier="featured_image_display_url", meta_identifier="category", controller='ckanext.sixodp_showcase.controller:Sixodp_ShowcaseController') }}
+    </div>
+  {% endif %}
+  #}
 {% endblock %}
 
 {% block page_primary_action %}

--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
@@ -7,15 +7,9 @@
   <li class="active">{{ h.nav_link(_('Showcases'), controller='ckanext.sixodp_showcase.controller:Sixodp_ShowcaseController', action='search', highlight_actions = 'new index') }}</li>
 {% endblock %}
 
+
 {% block pre_primary %}
   {% set featured_showcases = h.get_featured_showcases() %}
-  {#
-  {% if featured_showcases %}
-    <div class="page-highlight">
-      {{ h.snippet('snippets/horizontal_accordion.html', items=featured_showcases, image_identifier="featured_image_display_url", meta_identifier="category", controller='ckanext.sixodp_showcase.controller:Sixodp_ShowcaseController') }}
-    </div>
-  {% endif %}
-  #}
 {% endblock %}
 
 {% block page_primary_action %}
@@ -26,47 +20,17 @@
   </div>
 
   <div class="search-form-container search-form-container-borderless row">
-    <div class="col-lg-12 col-md-12 col-sm-12">
+    <div>
       {{ h.snippet('sixodp_showcase/snippets/showcase_search_input.html', query=c.q, placeholder=_('Search applications...'), query_params=c.fields_grouped, sorting=c.sort_by_selected) }}
     </div>
   </div>
-
-  {% if h.check_access('ckanext_showcase_create') %}
-    <div class="row">
-      <div class="col-lg-12 col-md-12 col-sm-12">
-          <div class="page_primary_action pull-right">
-              {% link_for _('Add Showcase'), controller='ckanext.sixodp_showcase.controller:Sixodp_ShowcaseController', action='new', class_='btn btn-primary btn-add-application', icon='plus-sign-alt' %}
-          </div>
-      </div>
-    </div>
-  {% endif %}
 {% endblock %}
 
 {% block form %}
-  {% set facets = {
-    'fields': c.fields_grouped,
-    'search': c.search_facets,
-    'titles': c.facet_titles,
-    'translated_fields': c.translated_fields,
-    'remove_field': c.remove_field }
-  %}
-  {% set sorting = [
-    (_('Newest first'), 'metadata_created desc'),
-    (_('Oldest first'), 'metadata_created asc'),
-    (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false)
-    (_('Relevance'), 'score desc, metadata_modified desc'),
-    (_('Name Ascending'), 'title_string asc'),
-    (_('Name Descending'), 'title_string desc'),
-    (_('Last Modified'), 'metadata_modified desc'),
-    (_('Top rating'), 'rating desc') ]
-  %}
-  <div class="search-options">
-    {% snippet 'sixodp_showcase/snippets/showcase_search_form.html', type='showcase', placeholder=_('Search showcases...'), query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields, no_bottom_border=true %}
-  </div>
 {% endblock %}
 
 {% block package_search_results_list %}
-  <div class="col-lg-12 col-md-12 col-sm-12">
+  <div>
     {{ h.snippet('sixodp_showcase/snippets/showcase_list.html', packages=c.page.items) }}
   </div>
 {% endblock %}

--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_greeting.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_greeting.html
@@ -10,22 +10,31 @@ Example:
     <section class="module module-narrow">
       <div class="module context-info">
         <div class="module-content">
-          <h1>
-            {% trans %}
-            Applications
-            {% endtrans %}
-          </h1>
-          <p>
-            {% trans %}Datasets provided by this service come alive with the help of applications (visualizations, research, webservices and data journalism).{% endtrans %}
-          </p>
-          <p>
-            {% trans %}Commonly the creators of opendata applications are researchers, freelanchers and software developers, but with the help of improved development and visualization tools anyone is able to utilize these datasets. You can find additional information from our guide to open data.{% endtrans %}
-          </p>
-          <p>
-            {% set current_language = h.lang() %}
-            {% trans %}Have you created application that utilizes open data?{% endtrans %}
-            <a href="/data/{{current_language}}/submit-showcase">{% trans %}Inform us about your application by using this form and it will be added to the list below.{% endtrans %}</a>
-          </p>
+          <div class="row">
+            <h1 class="pull-left">
+              {% trans %}
+              Applications
+              {% endtrans %}
+            </h1>
+            {% if h.check_access('ckanext_showcase_create') %}
+              <div class="pull-right">
+                  {% link_for _('Add Showcase'), controller='ckanext.sixodp_showcase.controller:Sixodp_ShowcaseController', action='new', class_='btn btn-avoindata-header no-right-padding', icon='plus-sign' %}
+              </div>
+            {% endif %}
+          </div>
+          <div class="row">
+            <p>
+              {% trans %}Datasets provided by this service come alive with the help of applications (visualizations, research, webservices and data journalism).{% endtrans %}
+            </p>
+            <p>
+              {% trans %}Commonly the creators of opendata applications are researchers, freelanchers and software developers, but with the help of improved development and visualization tools anyone is able to utilize these datasets. You can find additional information from our guide to open data.{% endtrans %}
+            </p>
+            <p>
+              {% set current_language = h.lang() %}
+              {% trans %}Have you created application that utilizes open data?{% endtrans %}
+              <a href="/data/{{current_language}}/submit-showcase">{% trans %}Inform us about your application by using this form and it will be added to the list below.{% endtrans %}</a>
+            </p>
+          </div>
         </div>
       </div>
     </section>

--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_form.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_form.html
@@ -1,29 +1,29 @@
 {% extends "snippets/search_form_without_input.html" %}
 
 {% block search_title %}
-{% if not no_title %}
-  <h4>{% snippet 'sixodp_showcase/snippets/showcase_search_result_text.html', query=query, count=count, type=type %}</h4>
-{% endif %}
+  {% if not no_title %}
+    <h2>{% snippet 'sixodp_showcase/snippets/showcase_search_result_text.html', query=query, count=count, type=type %}</h2>
+  {% endif %}
 {% endblock %}
 
 
 {% block search_facets %}
-{% if facets %}
-  <p class="filter-list">
-    {% for field in facets.fields %}
-      {% set search_facets_items = facets.search.get(field)['items'] %}
-      <span class="facet">{{ facets.titles.get(field) }}:</span>
-      {% for value in facets.fields[field] %}
-        <span class="filtered pill">
-          {%- if facets.translated_fields and facets.translated_fields.has_key((field,value)) -%}
-            {{ facets.translated_fields[(field,value)] }}
-          {%- else -%}
-            {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
-          {%- endif %}
-          <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fas fa-times-circle"></i></a>
-        </span>
+  {% if facets %}
+    <p class="filter-list">
+      {% for field in facets.fields %}
+        {% set search_facets_items = facets.search.get(field)['items'] %}
+        <span class="facet">{{ facets.titles.get(field) }}:</span>
+        {% for value in facets.fields[field] %}
+          <span class="filtered pill">
+            {%- if facets.translated_fields and facets.translated_fields.has_key((field,value)) -%}
+              {{ facets.translated_fields[(field,value)] }}
+            {%- else -%}
+              {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+            {%- endif %}
+            <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fas fa-times-circle"></i></a>
+          </span>
+        {% endfor %}
       {% endfor %}
-    {% endfor %}
-  </p>
-{% endif %}
+    </p>
+  {% endif %}
 {% endblock %}

--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html
@@ -1,9 +1,13 @@
+{% import 'macros/form.html' as form %}
 {% set search_class = search_class if search_class else 'search-giant' %}
 
-<form class="opendata-search-form{% if no_bottom_border %} no-bottom-border{% endif %} form_{{ search_class }}" method="get" data-module="select-switch">
-    <div class="search-wrapper {{ search_class }}">
-        <input class="search-input" type="text" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
-
+<form class="search-form{% if no_bottom_border %} no-bottom-border{% endif %} form_{{ search_class }}" method="get" data-module="select-switch">
+    <div class="search-input control-group search-giant">
+        <input class="search form-control" type="text" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
+        <button type="submit" value="search">
+            <i class="fa fa-search"></i>
+            <span>{{ _('Submit') }}</span>
+        </button>
         {% for param in query_params %}
             {% for value in query_params[param] %}
                 <input class="search-input" type="hidden" name="{{ param }}" value="{{value}}">
@@ -11,9 +15,28 @@
         {% endfor %}
 
         <input class="search-input" type="hidden" name="sort" value="{{ sorting }}">
-        <button type="submit" value="search" class="btn btn-primary search-submit">
-            <i class="fa fa-search"></i>
-            <span>{{ _('Search with keyword') }}</span>
-        </button>
     </div>
+
+    {% block form %}
+        {% set facets = {
+            'fields': c.fields_grouped,
+            'search': c.search_facets,
+            'titles': c.facet_titles,
+            'translated_fields': c.translated_fields,
+            'remove_field': c.remove_field }
+        %}
+        {% set sorting = [
+            (_('Newest first'), 'metadata_created desc'),
+            (_('Oldest first'), 'metadata_created asc'),
+            (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false)
+            (_('Relevance'), 'score desc, metadata_modified desc'),
+            (_('Name Ascending'), 'title_string asc'),
+            (_('Name Descending'), 'title_string desc'),
+            (_('Last Modified'), 'metadata_modified desc'),
+            (_('Top rating'), 'rating desc') ]
+        %}
+        <div class="search-options">
+            {% snippet 'sixodp_showcase/snippets/showcase_search_form.html', type='showcase', placeholder=_('Search showcases...'), query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields, no_bottom_border=true %}
+        </div>
+    {% endblock %}
 </form>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/index.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/index.html
@@ -1,33 +1,47 @@
 {% ckan_extends %}
 
 {% block page_primary_action %}
+{% endblock %}
 
-    {% set orgs =  h.organizations_available() %}
-    {% if orgs | count != 0 %}
-        <div class="btn-group">
-            <a href="/data/{{ h.lang() }}/member-request/list" class="btn btn-primary">{{ _('Membership Requests') }}</a>
-        </div>
-    {% endif %}
-    {% if not h.is_sysadmin() and h.is_loggedinuser() %}
-        <div class="btn-group">
-           <a href="/data/{{ h.lang() }}/member-request/mylist" class="btn btn-primary">{{ _('My membership requests') }}</a>
-        </div>
-    {% endif %}
-    {% if h.is_sysadmin() %}
-        <div class="btn-group">
-            <a href="/data/{{ h.lang() }}/user_list" class="btn btn-primary">
-                <i class="fas fa-user-circle"></i>
-                {{ _('Users') }}
-            </a>
-        </div>
-    {% endif %}
+{% block primary_content_inner %}
+  <div class="row">
+    <h1 class="pull-left">{% block page_heading %}{{ _('Organizations') }}{% endblock %}</h1>
+    {% snippet 'organization/snippets/organization_primary_actions.html' %}
+  </div>
+  <div class="row">
+    {% block organizations_search_form %}
+        <form class="search-form" method="get" data-module="select-switch">
+          <div class="search-input control-group search-giant">
+            <input data-organization-filter type="text" class="search form-control" name="q" value="{{ c.q }}" autocomplete="off" placeholder="{{ _('Search organizations...') }}">
+            <button type="submit">
+              <i class="fa fa-search"></i>
+              <span>{{ _('Submit') }}</span>
+            </button>
+          </div>
+            {% block search_title %}
+              <h2>{% snippet 'snippets/search_result_text.html', query=c.q, count=c.page.item_count, type='organization',from='organizations' %}</h2>
+            {% endblock %}
+        </form>
+    {% endblock %}
+  </div>
 
-    {% if h.check_access('organization_create') %}
-        <div class="btn-group">
-            <a href="/data/{{ h.lang() }}/organization/new" class="btn btn-primary">
-                <i class="fas fa-plus"></i>
-                {{ _('Add Organization') }}
-            </a>
-        </div>
+  {# Show a hierarchical tree of organizations if no search parameters are given. Otherwise show a flat list of results. #}
+  {% block organizations_list %}
+    {% if c.q and c.page.items %}
+      {# Organizations found with query params, we should show a flatlist #}
+      <ul class="no-bullet">
+       {% for organization in c.page.items %}
+         {% snippet "organization/snippets/organization_item.html", organization=organization, position=loop.index %}
+       {% endfor %}
+      </ul>
+      {% block page_pagination %}
+        {{ c.page.pager(q=c.q) }}
+      {% endblock %}
+    {% elif not c.q and c.page.items %}
+      {# Organizations found but no query params were given, we should show a tree #}
+      <div id="publisher-tree">
+        {% snippet 'organization/snippets/organization_tree.html', top_nodes=h.group_tree(), show_dataset_count=true%}
+      </div>
     {% endif %}
+  {% endblock %}
 {% endblock %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/snippets/organization_primary_actions.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/snippets/organization_primary_actions.html
@@ -1,0 +1,30 @@
+<div class="pull-right">
+  {% set orgs =  h.organizations_available() %}
+  {% if orgs | count != 0 %}
+    <div class="btn-group">
+      <a href="/data/{{ h.lang() }}/member-request/list" class="btn btn-avoindata-header">{{ _('Membership Requests') }}</a>
+    </div>
+  {% endif %}
+  {% if not h.is_sysadmin() and h.is_loggedinuser() %}
+    <div class="btn-group">
+      <a href="/data/{{ h.lang() }}/member-request/mylist" class="btn btn-avoindata-header">{{ _('My membership requests') }}</a>
+    </div>
+  {% endif %}
+  {% if h.is_sysadmin() %}
+    <div class="btn-group">
+      <a href="/data/{{ h.lang() }}/user_list" class="btn btn-avoindata-header">
+        <i class="fas fa-user-circle"></i>
+        {{ _('Users') }}
+      </a>
+    </div>
+  {% endif %}
+
+  {% if h.check_access('organization_create') %}
+    <div class="btn-group">
+      <a href="/data/{{ h.lang() }}/organization/new" class="btn btn-avoindata-header">
+        <i class="fas fa-plus"></i>
+        {{ _('Add Organization') }}
+      </a>
+    </div>
+  {% endif %}
+</div>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
@@ -18,12 +18,16 @@
       {% block page_primary_action %}
         {% if h.check_access('package_create') %}
         <div class="row">
-          <div class="page_primary_action pull-right">
-            {% link_for _('My Datasets'), named_route='dashboard.datasets', class_='btn btn-avoindata-header', icon='star-empty' %}
-
+          <h1 class="pull-left">
+            {% trans %}
+            Datasets
+            {% endtrans %}
+          </h1>
+          <div class="pull-right">
             <!-- Begin Add Dataset split button -->
             {% resource 'ytp_common_js/ytp_form.js' %}
             <div class="btn-group">
+              {% link_for _('My Datasets'), named_route='dashboard.datasets', class_='btn btn-avoindata-header', icon='star-empty' %}
               {% link_for _('Add Dataset'), controller='package', action='new', class_='btn btn-avoindata-header no-right-padding', icon='plus-sign' %}
               <a class="btn btn-avoindata-header dropdown-toggle" data-toggle="dropdown">
                 <span class="fas fa-plus"></span>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -54,7 +54,7 @@
 
   {% block search_title %}
     {% if not no_title %}
-      <h1>{% snippet 'snippets/search_result_text.html', query=query, count=count, type=type, from='organization' %}</h1>
+      <h2>{% snippet 'snippets/search_result_text.html', query=query, count=count, type=type, from='organization' %}</h2>
     {% endif %}
   {% endblock %}
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form_without_input.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form_without_input.html
@@ -34,7 +34,7 @@
     {% if disableable_sorting %}
       <div class="form-select control-group control-order-by">
         <label for="field-order-by">{{ _('Order by') }}</label>
-        <select id="field-order-by" class="opendata-select" name="sort">
+        <select id="field-order-by" class="form-control" name="sort">
           {% for label, value in disableable_sorting %}
             {% if label and value %}
               <option value="{{ value }}"{% if sorting_selected == value %} selected="selected"{% endif %}>{{ label }}</option>

--- a/modules/ytp-assets-common/src/less/ckan/upstream_ckan/search.less
+++ b/modules/ytp-assets-common/src/less/ckan/upstream_ckan/search.less
@@ -61,17 +61,11 @@
             width: auto;
         }
     }
-    // h2 {
-    //     font-size: 24px;
-    //     line-height: 1.3;
-    //     color: @layoutBoldColor;
-    //     margin-bottom: 0;
-    //     margin-top: 20px;
-    // }
+
     .filter-list {
         color: @layoutTextColor;
         line-height: 32px;
-        margin: 10px 0 0 0;
+        margin: 10px 0 10px 0;
         .pill {
             line-height: 21px;
         }


### PR DESCRIPTION
## Changes
- Added title to each page
- moved primary action buttons to right of title
- synced action button styles between pages
- made search bar the same on all pages
- changed found amount text to h2
- synced sorting style between pages
- synced horizontal ruler style between pages
- added margin to active filters

![Screenshot 2019-03-14 at 15 35 21](https://user-images.githubusercontent.com/9134893/54365268-d4ad8800-466e-11e9-8618-c39f7a7dc5e8.png)
