### PR TITLE
AV-666: Fix styling of email field in user edit form

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/user/edit_user_form.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/user/edit_user_form.html
@@ -10,7 +10,7 @@
     {{ form.input('fullname', label=_('Full name'), id='field-fullname', value=data.fullname, error=errors.fullname, placeholder=_('eg. Joe Bloggs'), classes=['control-medium']) }}
 
     {# Email changed from Drupal user settings, but CKAN requires sending the field #}
-    {{ form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], is_required=true, attrs={'readonly': true}) }}
+    {{ form.input('email', label=_('Email'), id='field-email', type='email', value=data.email, error=errors.email, placeholder=_('eg. joe@example.com'), classes=['control-medium'], is_required=true, attrs={'readonly': '', 'class': 'form-control'}) }}
 
     {{ form.markdown('about', label=_('About'), id='field-about', value=data.about, error=errors.about, placeholder=_('A little information about yourself')) }}
 


### PR DESCRIPTION
The email field was readonly, but it did not look like it, due to missing class.