### PR TITLE
Av 716 supervisor harvester fix

### DIFF
--- a/ansible/roles/ckan/defaults/main.yml
+++ b/ansible/roles/ckan/defaults/main.yml
@@ -204,7 +204,7 @@ ckan_patches:
   - fix-flask-root-path  # CKAN issue #4452
   - enforce-url-decoding  # CKAN issue #4619
   - add_error_email_logger_to_flask  # https://github.com/ckan/ckan/pull/4623
-  - add_credentials_to_email_logger # https://github.com/ckan/ckan/pull/4711
+  - add_credentials_to_email_logger  # https://github.com/ckan/ckan/pull/4711
   - fix-popped-wrong-app-context  # CKAN issue #4431
   - remove_deprecated_resource_preview_call  # https://github.com/ckan/ckan/pull/4669
 

--- a/ansible/roles/ckan/tasks/configure.yml
+++ b/ansible/roles/ckan/tasks/configure.yml
@@ -96,4 +96,11 @@
   with_flattened:
     - "{{ ckan_supervisor_services }}"
 
+- name: Start supervisor services
+  supervisorctl:
+    name: "{{ item }}"
+    state: started
+  with_flattened:
+    - "{{ ckan_supervisor_services }}"
+
 - include: cron.yml

--- a/ansible/roles/ckan/tasks/database.yml
+++ b/ansible/roles/ckan/tasks/database.yml
@@ -5,7 +5,7 @@
     {{ ckan_virtual_environment }}/bin/paster
     --plugin=ckan db init
     --config='{{ item.file }}'
-    chdir='{{ virtual_environment }}'
+    chdir='{{ ckan_virtual_environment }}'
   with_items: "{{ ckan_config_files }}"
   tags:
     - skip_ansible_lint
@@ -24,7 +24,7 @@
   shell: >-
     {{ ckan_virtual_environment }}/bin/paster --plugin=ckan user list
     --config={{ ckan_ini }}
-    chdir={{ virtual_environment }}
+    chdir={{ ckan_virtual_environment }}
   register: ckan_current_users
   environment:
     PYTHONIOENCODING: 'utf_8'
@@ -47,7 +47,7 @@
   shell: >-
     {{ ckan_virtual_environment }}/bin/paster --plugin=ckan sysadmin list
     --config={{ ckan_ini }}
-    chdir={{ virtual_environment }}
+    chdir={{ ckan_virtual_environment }}
   register: ckan_current_sysadmins
   environment:
     PYTHONIOENCODING: 'utf_8'


### PR DESCRIPTION
AV-716: Add explicit start to Supervisor services
- Supervisor services were only started via a handler triggered on Supervisor configuration file changes, but as a part of the play the services were also stopped if running. If configuration would not change and playbook was re-executed the services would stay stopped. 