### PR TITLE
Fix for broken dataset and organization listings (AV-717)

### DIFF
--- a/modules/ytp-assets-common/src/less/offcanvas.less
+++ b/modules/ytp-assets-common/src/less/offcanvas.less
@@ -47,8 +47,6 @@ body {
   }
 
   .sidebar-offcanvas {
-    position: absolute;
-    top: 0;
     width: 90%; /* 6 columns */
   }
 }


### PR DESCRIPTION
Position: absolute caused the info boxes to be positioned on top of the listings on mobile views. The changed css rule affects only screens with resolution of max 768px so the change doesn't affect the desktop view. 