### PR TITLE
AV-722: Remove user activity from group activity list

### DIFF
--- a/ansible/roles/ckan/defaults/main.yml
+++ b/ansible/roles/ckan/defaults/main.yml
@@ -208,6 +208,7 @@ ckan_patches:
   - fix-popped-wrong-app-context  # CKAN issue #4431
   - remove_deprecated_resource_preview_call  # https://github.com/ckan/ckan/pull/4669
   - remove_members_from_group_read # https://github.com/ckan/ckan/pull/4717
+  - remove_user_activity_from_group_activity_list # modification from ckan master, can be removed once 2.9 is released
 
 ckan_config_files:
   - file: /etc/ckan/default/production.ini

--- a/ansible/roles/ckan/files/patches/remove_user_activity_from_group_activity_list.patch
+++ b/ansible/roles/ckan/files/patches/remove_user_activity_from_group_activity_list.patch
@@ -1,0 +1,42 @@
+diff --git a/ckan/model/activity.py b/ckan/model/activity.py
+index b56d91e..6f3377f 100644
+--- a/ckan/model/activity.py
++++ b/ckan/model/activity.py
+@@ -198,14 +198,12 @@ def _group_activity_query(group_id):
+         model.Member,
+         and_(
+             model.Activity.object_id == model.Member.table_id,
+-            model.Member.state == 'active'
+         )
+     ).outerjoin(
+         model.Package,
+         and_(
+             model.Package.id == model.Member.table_id,
+             model.Package.private == False,
+-            model.Package.state == 'active'
+         )
+     ).filter(
+         # We only care about activity either on the the group itself or on
+@@ -214,9 +212,19 @@ def _group_activity_query(group_id):
+         # to a group but was then removed will not show up. This may not be
+         # desired but is consistent with legacy behaviour.
+         or_(
+-            model.Member.group_id == group_id,
+-            model.Activity.object_id == group_id
+-        ),
++            # active dataset in the group
++            and_(model.Member.group_id == group_id,
++                 model.Member.state == 'active',
++                 model.Package.state == 'active'),
++            # deleted dataset in the group
++            and_(model.Member.group_id == group_id,
++                 model.Member.state == 'deleted',
++                 model.Package.state == 'deleted'),
++                 # (we want to avoid showing changes to an active dataset that
++                 # was once in this group)
++            # activity the the group itself
++            model.Activity.object_id == group_id,
++        )
+     )
+ 
+     return q


### PR DESCRIPTION
SQL query was already changed in CKAN master, with the new query groups do not show user activity in group activity lists.