### PR TITLE
AV-720 dataset filter search button

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-18 13:58+0200\n"
+"POT-Creation-Date: 2019-04-29 12:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -172,7 +172,7 @@ msgstr ""
 msgid "Integrity Error"
 msgstr ""
 
-#: ckanext/ytp/controller.py:441 ckanext/ytp/templates/package/search.html:82
+#: ckanext/ytp/controller.py:441 ckanext/ytp/templates/package/search.html:86
 #: ckanext/ytp/templates/package/snippets/related_item.html:21
 msgid "API"
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Have to be logged in to list admins"
 msgstr ""
 
-#: ckanext/ytp/menu.py:60 ckanext/ytp/templates/package/search.html:22
+#: ckanext/ytp/menu.py:60 ckanext/ytp/templates/package/search.html:30
 msgid "My Datasets"
 msgstr ""
 
@@ -310,7 +310,7 @@ msgid "Delete Account"
 msgstr ""
 
 #: ckanext/ytp/menu.py:135 ckanext/ytp/templates/organization/admin_list.html:4
-#: ckanext/ytp/templates/organization/index.html:20
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:17
 #: ckanext/ytp/templates/organization/user_list.html:4
 #: ckanext/ytp/templates/user/dashboard_datasets.html:4
 #: ckanext/ytp/templates/user/dashboard_organizations.html:6
@@ -319,6 +319,7 @@ msgid "Users"
 msgstr ""
 
 #: ckanext/ytp/menu.py:145 ckanext/ytp/templates/organization/admin_list.html:31
+#: ckanext/ytp/templates/organization/index.html:8
 #: ckanext/ytp/templates/organization/organization_not_found.html:6
 #: ckanext/ytp/templates/organization/user_list.html:31
 #: ckanext/ytp/templates/package/base.html:8
@@ -362,10 +363,8 @@ msgstr ""
 msgid "Collection Type"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:442 ckanext/ytp/plugin.py:459
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:34
-#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:91
-msgid "Tags"
+#: ckanext/ytp/plugin.py:442
+msgid "Popular tags"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:443 ckanext/ytp/plugin.py:460
@@ -389,17 +388,23 @@ msgstr ""
 msgid "Formats"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:447 ckanext/ytp/templates/package/search.html:60
+#: ckanext/ytp/plugin.py:447 ckanext/ytp/templates/package/search.html:64
 #: ckanext/ytp/templates/package/snippets/additional_info.html:14
 msgid "Source"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:448 ckanext/ytp/templates/package/resource_read.html:156
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:78
+#: ckanext/ytp/plugin.py:448 ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:75
 #: ckanext/ytp/templates/package/snippets/package_basic_fields.html:63
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:37
 #: ckanext/ytp/templates/snippets/license.html:21
 msgid "License"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:459
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:34
+#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:91
+msgid "Tags"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:520
@@ -489,10 +494,10 @@ msgstr ""
 msgid "Internal"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:150
+#: ckanext/ytp/templates/package/resource_read.html:162
 #: ckanext/ytp/templates/package/snippets/additional_info.html:70
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:225
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:239
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:222
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:236
 #: ckanext/ytp/translations.py:28
 msgid "Created"
 msgstr ""
@@ -665,6 +670,7 @@ msgstr ""
 msgid "Home page"
 msgstr ""
 
+#: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/translations.py:75
 msgid "Maturity"
 msgstr ""
@@ -809,7 +815,7 @@ msgstr ""
 msgid "Add to group"
 msgstr ""
 
-#: ckanext/ytp/translations.py:117
+#: ckanext/ytp/templates/package/group_list.html:22 ckanext/ytp/translations.py:117
 msgid "There are no groups associated with this dataset"
 msgstr ""
 
@@ -818,7 +824,7 @@ msgstr ""
 msgid "Remove dataset from this group"
 msgstr ""
 
-#: ckanext/ytp/translations.py:119
+#: ckanext/ytp/templates/package/group_list.html:13 ckanext/ytp/translations.py:119
 msgid "Associate this group with this dataset"
 msgstr ""
 
@@ -834,6 +840,7 @@ msgstr ""
 msgid "Search groups..."
 msgstr ""
 
+#: ckanext/ytp/templates/package/group_list.html:3
 #: ckanext/ytp/templates/package/read.html:17 ckanext/ytp/translations.py:123
 msgid "Groups"
 msgstr ""
@@ -1022,6 +1029,11 @@ msgstr ""
 msgid "Unsubscribe from comments"
 msgstr ""
 
+#: ckanext/ytp/templates/page.html:8
+#: ckanext/ytp/templates/snippets/search_form.html:53
+msgid "Filter search"
+msgstr ""
+
 #: ckanext/ytp/templates/group/member_new.html:10
 #: ckanext/ytp/templates/organization/member_new.html:9
 msgid "Existing User"
@@ -1071,7 +1083,7 @@ msgid "View {name}"
 msgstr ""
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:45
-#: ckanext/ytp/templates/snippets/search_form.html:74
+#: ckanext/ytp/templates/snippets/search_form.html:78
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr ""
@@ -1203,22 +1215,25 @@ msgstr ""
 msgid "Close without saving"
 msgstr ""
 
-#: ckanext/ytp/templates/organization/index.html:8
-#: ckanext/ytp/templates/organization/members.html:7
-#: ckanext/ytp/templates/user/dashboard_organizations.html:20
-msgid "Membership Requests"
+#: ckanext/ytp/templates/organization/index.html:15
+msgid "Search organizations..."
 msgstr ""
 
-#: ckanext/ytp/templates/organization/index.html:13
-msgid "My membership requests"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/index.html:29
-msgid "Add Organization"
+#: ckanext/ytp/templates/organization/index.html:18
+#: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
+#: ckanext/ytp/templates/snippets/search_form.html:19
+#: ckanext/ytp/templates/snippets/search_input.html:17
+msgid "Submit"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/member_new.html:37
 msgid "Update Member"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/members.html:7
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:5
+#: ckanext/ytp/templates/user/dashboard_organizations.html:20
+msgid "Membership Requests"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/new_organization_form.html:17
@@ -1240,7 +1255,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/organization/read_base.html:6
 #: ckanext/ytp/templates/package/read.html:19
-#: ckanext/ytp/templates/package/resource_read.html:31
+#: ckanext/ytp/templates/package/resource_read.html:33
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:9
 msgid "Manage"
 msgstr ""
@@ -1452,6 +1467,22 @@ msgid ""
 "public and private datasets belonging to this organization."
 msgstr ""
 
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:10
+msgid "My membership requests"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:26
+msgid "Add Organization"
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:7
+msgid "Add category to dataset"
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:13
+msgid "Add to dataset"
+msgstr ""
+
 #: ckanext/ytp/templates/package/new_package_form.html:14
 msgid "Update"
 msgstr ""
@@ -1491,189 +1522,193 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:37
+#: ckanext/ytp/templates/package/resource_read.html:39
 msgid "View"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:39
+#: ckanext/ytp/templates/package/resource_read.html:41
 msgid "API Endpoint"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 #: ckanext/ytp/templates/package/snippets/related_item.html:65
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:11
 msgid "Open"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:43
+#: ckanext/ytp/templates/package/resource_read.html:45
 #: ckanext/ytp/templates/package/snippets/resource_item.html:52
 msgid "Download"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:61
+#: ckanext/ytp/templates/package/resource_read.html:72
 msgid "URL:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:71
+#: ckanext/ytp/templates/package/resource_read.html:82
 msgid "From the dataset abstract"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:73
+#: ckanext/ytp/templates/package/resource_read.html:84
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:114
+#: ckanext/ytp/templates/package/resource_read.html:125
 msgid "There are no views created for this resource yet."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:118
+#: ckanext/ytp/templates/package/resource_read.html:129
 msgid "Not seeing the views you were expecting?"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:120
+#: ckanext/ytp/templates/package/resource_read.html:131
 #: ckanext/ytp/templates/package/snippets/resource_view.html:26
 msgid "Click here for more information."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:123
+#: ckanext/ytp/templates/package/resource_read.html:134
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:125
+#: ckanext/ytp/templates/package/resource_read.html:136
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:126
+#: ckanext/ytp/templates/package/resource_read.html:137
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:127
+#: ckanext/ytp/templates/package/resource_read.html:138
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, or"
 " the data may not have been pushed to the DataStore, or the DataStore hasn't "
 "finished processing the data yet"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:143
+#: ckanext/ytp/templates/package/resource_read.html:155
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:4
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:67
 msgid "Extra information"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:147
+#: ckanext/ytp/templates/package/resource_read.html:159
 msgid "Last updated"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:148
-#: ckanext/ytp/templates/package/resource_read.html:151
-#: ckanext/ytp/templates/package/resource_read.html:154
+#: ckanext/ytp/templates/package/resource_read.html:160
+#: ckanext/ytp/templates/package/resource_read.html:163
+#: ckanext/ytp/templates/package/resource_read.html:166
 msgid "unknown"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:153
+#: ckanext/ytp/templates/package/resource_read.html:165
 msgid "Format"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:161
+#: ckanext/ytp/templates/package/resource_read.html:173
 msgid "Temporal Granularity"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:166
+#: ckanext/ytp/templates/package/resource_read.html:178
 msgid "Update Frequency"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:171
+#: ckanext/ytp/templates/package/resource_read.html:183
 msgid "Temporal Coverage"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:184
+#: ckanext/ytp/templates/package/resource_read.html:196
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:82
 msgid "Technical extra information"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:229
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:161
+#: ckanext/ytp/templates/package/resource_read.html:240
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:158
 msgid "Stats"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:230
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:162
+#: ckanext/ytp/templates/package/resource_read.html:241
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:159
 msgid "Last 30 days, updated daily"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:233
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:169
+#: ckanext/ytp/templates/package/resource_read.html:244
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:166
 msgid "All time downloads:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:249
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/resource_read.html:260
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Year"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:249
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/resource_read.html:260
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Downloads"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:27
+#: ckanext/ytp/templates/package/search.html:22
+msgid " Datasets "
+msgstr ""
+
+#: ckanext/ytp/templates/package/search.html:31
 #: ckanext/ytp/templates/user/dashboard_datasets.html:14
 msgid "Add Dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:34
+#: ckanext/ytp/templates/package/search.html:38
 msgid "Add open data"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:37
+#: ckanext/ytp/templates/package/search.html:41
 msgid "Add interoperability tools"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:56
+#: ckanext/ytp/templates/package/search.html:60
 msgid "Relevance"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:57
+#: ckanext/ytp/templates/package/search.html:61
 #: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:58
+#: ckanext/ytp/templates/package/search.html:62
 #: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:59
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:224
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:236
+#: ckanext/ytp/templates/package/search.html:63
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:221
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:233
 msgid "Last Modified"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:61
+#: ckanext/ytp/templates/package/search.html:65
 #: ckanext/ytp/templates/snippets/package_item.html:32
 #: ckanext/ytp/templates/snippets/popular.html:3
 msgid "Popular"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:83
+#: ckanext/ytp/templates/package/search.html:87
 msgid "API Docs"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:85
+#: ckanext/ytp/templates/package/search.html:89
 msgid "full {format} dump"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:86
+#: ckanext/ytp/templates/package/search.html:90
 #, python-format
 msgid ""
 " You can also access this registry using the %(api_link)s (see "
 "%(api_doc_link)s) or download a %(dump_link)s. "
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:90
+#: ckanext/ytp/templates/package/search.html:94
 #, python-format
 msgid ""
 " You can also access this registry using the %(api_link)s (see "
@@ -1713,27 +1748,27 @@ msgstr ""
 msgid "Last Updated"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:70
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:67
 msgid "Content Link"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:112
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:109
 msgid "License Not Specified"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:123
 msgid "Dataset Quality"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:129
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Resource Quality"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:138
 msgid "Metadata Quality"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:149
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:146
 msgid ""
 "Dataset's Resource Quality is the highest rating from the resources. It is "
 "automatically calculated and if it is zero, resources are unavailable or "
@@ -1741,31 +1776,31 @@ msgid ""
 "resource downloads, comments and translations into consideration."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:167
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:164
 msgid "Downloads during year"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:165
 msgid "All time visits:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Visits"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:221
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:218
 msgid "Change log"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:222
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:219
 msgid "Dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:232
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:229
 msgid "Resource"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:244
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:241
 msgid "Show change log"
 msgstr ""
 
@@ -2391,12 +2426,6 @@ msgstr ""
 msgid "Submitter email"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
-#: ckanext/ytp/templates/snippets/search_form.html:19
-#: ckanext/ytp/templates/snippets/search_input.html:17
-msgid "Submit"
-msgstr ""
-
 #: ckanext/ytp/templates/snippets/datapreview_embed_dialog.html:6
 msgid "Embed Data Viewer"
 msgstr ""
@@ -2450,22 +2479,22 @@ msgstr ""
 msgid "Search datasets..."
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:42
+#: ckanext/ytp/templates/snippets/search_form.html:44
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:36
 msgid "Order by"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:50
+#: ckanext/ytp/templates/snippets/search_form.html:54
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:85
+#: ckanext/ytp/templates/snippets/search_form.html:89
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid " <p class=\"extra\">Please try another search or change search facets.</p> "
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:91
+#: ckanext/ytp/templates/snippets/search_form.html:95
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-04-29 12:54+0000\n"
+"POT-Creation-Date: 2019-05-02 14:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1029,9 +1029,9 @@ msgstr ""
 msgid "Unsubscribe from comments"
 msgstr ""
 
-#: ckanext/ytp/templates/page.html:8
-#: ckanext/ytp/templates/snippets/search_form.html:53
-msgid "Filter search"
+#: ckanext/ytp/templates/page.html:13
+#: ckanext/ytp/templates/snippets/search_form.html:59
+msgid "Hide search filters"
 msgstr ""
 
 #: ckanext/ytp/templates/group/member_new.html:10
@@ -1083,7 +1083,7 @@ msgid "View {name}"
 msgstr ""
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:45
-#: ckanext/ytp/templates/snippets/search_form.html:78
+#: ckanext/ytp/templates/snippets/search_form.html:85
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr ""
@@ -2484,17 +2484,21 @@ msgstr ""
 msgid "Order by"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:54
+#: ckanext/ytp/templates/snippets/search_form.html:53
+msgid "Filter search"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/search_form.html:61
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:89
+#: ckanext/ytp/templates/snippets/search_form.html:96
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid " <p class=\"extra\">Please try another search or change search facets.</p> "
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:95
+#: ckanext/ytp/templates/snippets/search_form.html:102
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-18 13:58+0200\n"
+"POT-Creation-Date: 2019-04-29 12:54+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2019\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -178,7 +178,7 @@ msgstr ""
 msgid "Integrity Error"
 msgstr ""
 
-#: ckanext/ytp/controller.py:441 ckanext/ytp/templates/package/search.html:82
+#: ckanext/ytp/controller.py:441 ckanext/ytp/templates/package/search.html:86
 #: ckanext/ytp/templates/package/snippets/related_item.html:21
 msgid "API"
 msgstr ""
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Have to be logged in to list admins"
 msgstr ""
 
-#: ckanext/ytp/menu.py:60 ckanext/ytp/templates/package/search.html:22
+#: ckanext/ytp/menu.py:60 ckanext/ytp/templates/package/search.html:30
 msgid "My Datasets"
 msgstr ""
 
@@ -317,7 +317,7 @@ msgstr ""
 
 #: ckanext/ytp/menu.py:135
 #: ckanext/ytp/templates/organization/admin_list.html:4
-#: ckanext/ytp/templates/organization/index.html:20
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:17
 #: ckanext/ytp/templates/organization/user_list.html:4
 #: ckanext/ytp/templates/user/dashboard_datasets.html:4
 #: ckanext/ytp/templates/user/dashboard_organizations.html:6
@@ -327,6 +327,7 @@ msgstr ""
 
 #: ckanext/ytp/menu.py:145
 #: ckanext/ytp/templates/organization/admin_list.html:31
+#: ckanext/ytp/templates/organization/index.html:8
 #: ckanext/ytp/templates/organization/organization_not_found.html:6
 #: ckanext/ytp/templates/organization/user_list.html:31
 #: ckanext/ytp/templates/package/base.html:8
@@ -372,10 +373,8 @@ msgstr ""
 msgid "Collection Type"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:442 ckanext/ytp/plugin.py:459
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:34
-#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:91
-msgid "Tags"
+#: ckanext/ytp/plugin.py:442
+msgid "Popular tags"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:443 ckanext/ytp/plugin.py:460
@@ -399,18 +398,24 @@ msgstr ""
 msgid "Formats"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:447 ckanext/ytp/templates/package/search.html:60
+#: ckanext/ytp/plugin.py:447 ckanext/ytp/templates/package/search.html:64
 #: ckanext/ytp/templates/package/snippets/additional_info.html:14
 msgid "Source"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:448
-#: ckanext/ytp/templates/package/resource_read.html:156
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:78
+#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:75
 #: ckanext/ytp/templates/package/snippets/package_basic_fields.html:63
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:37
 #: ckanext/ytp/templates/snippets/license.html:21
 msgid "License"
+msgstr ""
+
+#: ckanext/ytp/plugin.py:459
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:34
+#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:91
+msgid "Tags"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:520
@@ -501,10 +506,10 @@ msgstr ""
 msgid "Internal"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:150
+#: ckanext/ytp/templates/package/resource_read.html:162
 #: ckanext/ytp/templates/package/snippets/additional_info.html:70
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:225
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:239
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:222
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:236
 #: ckanext/ytp/translations.py:28
 msgid "Created"
 msgstr ""
@@ -678,6 +683,7 @@ msgstr ""
 msgid "Home page"
 msgstr ""
 
+#: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/translations.py:75
 msgid "Maturity"
 msgstr ""
@@ -822,6 +828,7 @@ msgstr ""
 msgid "Add to group"
 msgstr "Add to category"
 
+#: ckanext/ytp/templates/package/group_list.html:22
 #: ckanext/ytp/translations.py:117
 msgid "There are no groups associated with this dataset"
 msgstr "There are no categories associated with this dataset"
@@ -831,6 +838,7 @@ msgstr "There are no categories associated with this dataset"
 msgid "Remove dataset from this group"
 msgstr "Remove dataset from this category"
 
+#: ckanext/ytp/templates/package/group_list.html:13
 #: ckanext/ytp/translations.py:119
 msgid "Associate this group with this dataset"
 msgstr "Associate this category with this dataset"
@@ -847,6 +855,7 @@ msgstr "There are currently no categories for this site"
 msgid "Search groups..."
 msgstr "Search categories..."
 
+#: ckanext/ytp/templates/package/group_list.html:3
 #: ckanext/ytp/templates/package/read.html:17 ckanext/ytp/translations.py:123
 msgid "Groups"
 msgstr "Categories"
@@ -1038,6 +1047,11 @@ msgstr ""
 msgid "Unsubscribe from comments"
 msgstr ""
 
+#: ckanext/ytp/templates/page.html:8
+#: ckanext/ytp/templates/snippets/search_form.html:53
+msgid "Filter search"
+msgstr ""
+
 #: ckanext/ytp/templates/group/member_new.html:10
 #: ckanext/ytp/templates/organization/member_new.html:9
 msgid "Existing User"
@@ -1087,7 +1101,7 @@ msgid "View {name}"
 msgstr ""
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:45
-#: ckanext/ytp/templates/snippets/search_form.html:74
+#: ckanext/ytp/templates/snippets/search_form.html:78
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr ""
@@ -1219,22 +1233,25 @@ msgstr ""
 msgid "Close without saving"
 msgstr ""
 
-#: ckanext/ytp/templates/organization/index.html:8
-#: ckanext/ytp/templates/organization/members.html:7
-#: ckanext/ytp/templates/user/dashboard_organizations.html:20
-msgid "Membership Requests"
+#: ckanext/ytp/templates/organization/index.html:15
+msgid "Search organizations..."
 msgstr ""
 
-#: ckanext/ytp/templates/organization/index.html:13
-msgid "My membership requests"
-msgstr ""
-
-#: ckanext/ytp/templates/organization/index.html:29
-msgid "Add Organization"
+#: ckanext/ytp/templates/organization/index.html:18
+#: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
+#: ckanext/ytp/templates/snippets/search_form.html:19
+#: ckanext/ytp/templates/snippets/search_input.html:17
+msgid "Submit"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/member_new.html:37
 msgid "Update Member"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/members.html:7
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:5
+#: ckanext/ytp/templates/user/dashboard_organizations.html:20
+msgid "Membership Requests"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/new_organization_form.html:17
@@ -1256,7 +1273,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/organization/read_base.html:6
 #: ckanext/ytp/templates/package/read.html:19
-#: ckanext/ytp/templates/package/resource_read.html:31
+#: ckanext/ytp/templates/package/resource_read.html:33
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:9
 msgid "Manage"
 msgstr ""
@@ -1468,6 +1485,22 @@ msgid ""
 "public and private datasets belonging to this organization."
 msgstr ""
 
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:10
+msgid "My membership requests"
+msgstr ""
+
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:26
+msgid "Add Organization"
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:7
+msgid "Add category to dataset"
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:13
+msgid "Add to dataset"
+msgstr ""
+
 #: ckanext/ytp/templates/package/new_package_form.html:14
 msgid "Update"
 msgstr ""
@@ -1507,189 +1540,193 @@ msgstr ""
 msgid "Views"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:37
+#: ckanext/ytp/templates/package/resource_read.html:39
 msgid "View"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:39
+#: ckanext/ytp/templates/package/resource_read.html:41
 msgid "API Endpoint"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 #: ckanext/ytp/templates/package/snippets/related_item.html:65
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:11
 msgid "Open"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:43
+#: ckanext/ytp/templates/package/resource_read.html:45
 #: ckanext/ytp/templates/package/snippets/resource_item.html:52
 msgid "Download"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:61
+#: ckanext/ytp/templates/package/resource_read.html:72
 msgid "URL:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:71
+#: ckanext/ytp/templates/package/resource_read.html:82
 msgid "From the dataset abstract"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:73
+#: ckanext/ytp/templates/package/resource_read.html:84
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:114
+#: ckanext/ytp/templates/package/resource_read.html:125
 msgid "There are no views created for this resource yet."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:118
+#: ckanext/ytp/templates/package/resource_read.html:129
 msgid "Not seeing the views you were expecting?"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:120
+#: ckanext/ytp/templates/package/resource_read.html:131
 #: ckanext/ytp/templates/package/snippets/resource_view.html:26
 msgid "Click here for more information."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:123
+#: ckanext/ytp/templates/package/resource_read.html:134
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:125
+#: ckanext/ytp/templates/package/resource_read.html:136
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:126
+#: ckanext/ytp/templates/package/resource_read.html:137
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:127
+#: ckanext/ytp/templates/package/resource_read.html:138
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, "
 "or the data may not have been pushed to the DataStore, or the DataStore "
 "hasn't finished processing the data yet"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:143
+#: ckanext/ytp/templates/package/resource_read.html:155
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:4
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:67
 msgid "Extra information"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:147
+#: ckanext/ytp/templates/package/resource_read.html:159
 msgid "Last updated"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:148
-#: ckanext/ytp/templates/package/resource_read.html:151
-#: ckanext/ytp/templates/package/resource_read.html:154
+#: ckanext/ytp/templates/package/resource_read.html:160
+#: ckanext/ytp/templates/package/resource_read.html:163
+#: ckanext/ytp/templates/package/resource_read.html:166
 msgid "unknown"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:153
+#: ckanext/ytp/templates/package/resource_read.html:165
 msgid "Format"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:161
+#: ckanext/ytp/templates/package/resource_read.html:173
 msgid "Temporal Granularity"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:166
+#: ckanext/ytp/templates/package/resource_read.html:178
 msgid "Update Frequency"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:171
+#: ckanext/ytp/templates/package/resource_read.html:183
 msgid "Temporal Coverage"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:184
+#: ckanext/ytp/templates/package/resource_read.html:196
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:82
 msgid "Technical extra information"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:229
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:161
+#: ckanext/ytp/templates/package/resource_read.html:240
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:158
 msgid "Stats"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:230
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:162
+#: ckanext/ytp/templates/package/resource_read.html:241
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:159
 msgid "Last 30 days, updated daily"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:233
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:169
+#: ckanext/ytp/templates/package/resource_read.html:244
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:166
 msgid "All time downloads:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:249
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/resource_read.html:260
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Year"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:249
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/resource_read.html:260
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Downloads"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:27
+#: ckanext/ytp/templates/package/search.html:22
+msgid " Datasets "
+msgstr ""
+
+#: ckanext/ytp/templates/package/search.html:31
 #: ckanext/ytp/templates/user/dashboard_datasets.html:14
 msgid "Add Dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:34
+#: ckanext/ytp/templates/package/search.html:38
 msgid "Add open data"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:37
+#: ckanext/ytp/templates/package/search.html:41
 msgid "Add interoperability tools"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:56
+#: ckanext/ytp/templates/package/search.html:60
 msgid "Relevance"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:57
+#: ckanext/ytp/templates/package/search.html:61
 #: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:58
+#: ckanext/ytp/templates/package/search.html:62
 #: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:59
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:224
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:236
+#: ckanext/ytp/templates/package/search.html:63
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:221
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:233
 msgid "Last Modified"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:61
+#: ckanext/ytp/templates/package/search.html:65
 #: ckanext/ytp/templates/snippets/package_item.html:32
 #: ckanext/ytp/templates/snippets/popular.html:3
 msgid "Popular"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:83
+#: ckanext/ytp/templates/package/search.html:87
 msgid "API Docs"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:85
+#: ckanext/ytp/templates/package/search.html:89
 msgid "full {format} dump"
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:86
+#: ckanext/ytp/templates/package/search.html:90
 #, python-format
 msgid ""
 " You can also access this registry using the %(api_link)s (see "
 "%(api_doc_link)s) or download a %(dump_link)s. "
 msgstr ""
 
-#: ckanext/ytp/templates/package/search.html:90
+#: ckanext/ytp/templates/package/search.html:94
 #, python-format
 msgid ""
 " You can also access this registry using the %(api_link)s (see "
@@ -1729,27 +1766,27 @@ msgstr ""
 msgid "Last Updated"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:70
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:67
 msgid "Content Link"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:112
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:109
 msgid "License Not Specified"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:123
 msgid "Dataset Quality"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:129
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Resource Quality"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:138
 msgid "Metadata Quality"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:149
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:146
 msgid ""
 "Dataset's Resource Quality is the highest rating from the resources. It is "
 "automatically calculated and if it is zero, resources are unavailable or "
@@ -1757,31 +1794,31 @@ msgid ""
 "resource downloads, comments and translations into consideration."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:167
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:164
 msgid "Downloads during year"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:165
 msgid "All time visits:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Visits"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:221
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:218
 msgid "Change log"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:222
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:219
 msgid "Dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:232
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:229
 msgid "Resource"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:244
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:241
 msgid "Show change log"
 msgstr ""
 
@@ -2407,12 +2444,6 @@ msgstr ""
 msgid "Submitter email"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
-#: ckanext/ytp/templates/snippets/search_form.html:19
-#: ckanext/ytp/templates/snippets/search_input.html:17
-msgid "Submit"
-msgstr ""
-
 #: ckanext/ytp/templates/snippets/datapreview_embed_dialog.html:6
 msgid "Embed Data Viewer"
 msgstr ""
@@ -2466,23 +2497,23 @@ msgstr ""
 msgid "Search datasets..."
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:42
+#: ckanext/ytp/templates/snippets/search_form.html:44
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:36
 msgid "Order by"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:50
+#: ckanext/ytp/templates/snippets/search_form.html:54
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:85
+#: ckanext/ytp/templates/snippets/search_form.html:89
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid ""
 " <p class=\"extra\">Please try another search or change search facets.</p> "
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:91
+#: ckanext/ytp/templates/snippets/search_form.html:95
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-04-29 12:54+0000\n"
+"POT-Creation-Date: 2019-05-02 14:27+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2019\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -1047,9 +1047,9 @@ msgstr ""
 msgid "Unsubscribe from comments"
 msgstr ""
 
-#: ckanext/ytp/templates/page.html:8
-#: ckanext/ytp/templates/snippets/search_form.html:53
-msgid "Filter search"
+#: ckanext/ytp/templates/page.html:13
+#: ckanext/ytp/templates/snippets/search_form.html:59
+msgid "Hide search filters"
 msgstr ""
 
 #: ckanext/ytp/templates/group/member_new.html:10
@@ -1101,7 +1101,7 @@ msgid "View {name}"
 msgstr ""
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:45
-#: ckanext/ytp/templates/snippets/search_form.html:78
+#: ckanext/ytp/templates/snippets/search_form.html:85
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr ""
@@ -2502,18 +2502,22 @@ msgstr ""
 msgid "Order by"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:54
+#: ckanext/ytp/templates/snippets/search_form.html:53
+msgid "Filter search"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/search_form.html:61
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:89
+#: ckanext/ytp/templates/snippets/search_form.html:96
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid ""
 " <p class=\"extra\">Please try another search or change search facets.</p> "
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:95
+#: ckanext/ytp/templates/snippets/search_form.html:102
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-04-29 12:54+0000\n"
+"POT-Creation-Date: 2019-05-02 14:27+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Teemu Leivo <teemu.leivo@gofore.com>, 2019\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
@@ -1071,10 +1071,10 @@ msgstr "Tilaa kommentit sähköpostiin"
 msgid "Unsubscribe from comments"
 msgstr "Peruuta kommenttien tilaus"
 
-#: ckanext/ytp/templates/page.html:8
-#: ckanext/ytp/templates/snippets/search_form.html:53
-msgid "Filter search"
-msgstr "Suodata hakua"
+#: ckanext/ytp/templates/page.html:13
+#: ckanext/ytp/templates/snippets/search_form.html:59
+msgid "Hide search filters"
+msgstr "Piilota suodattimet"
 
 #: ckanext/ytp/templates/group/member_new.html:10
 #: ckanext/ytp/templates/organization/member_new.html:9
@@ -1126,7 +1126,7 @@ msgid "View {name}"
 msgstr ""
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:45
-#: ckanext/ytp/templates/snippets/search_form.html:78
+#: ckanext/ytp/templates/snippets/search_form.html:85
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr "Poista"
@@ -2581,12 +2581,16 @@ msgstr "Etsi tietoaineistoista..."
 msgid "Order by"
 msgstr "Järjestäminen"
 
-#: ckanext/ytp/templates/snippets/search_form.html:54
+#: ckanext/ytp/templates/snippets/search_form.html:53
+msgid "Filter search"
+msgstr "Suodata hakua"
+
+#: ckanext/ytp/templates/snippets/search_form.html:61
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr "Siirry"
 
-#: ckanext/ytp/templates/snippets/search_form.html:89
+#: ckanext/ytp/templates/snippets/search_form.html:96
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid ""
 " <p class=\"extra\">Please try another search or change search facets.</p> "
@@ -2594,7 +2598,7 @@ msgstr ""
 "<p class=\"extra\">Kokeile syöttämällä eri hakusanat tai muuta valitsemiasi "
 "hakuehtoja.</p>"
 
-#: ckanext/ytp/templates/snippets/search_form.html:95
+#: ckanext/ytp/templates/snippets/search_form.html:102
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -1074,7 +1074,7 @@ msgstr "Peruuta kommenttien tilaus"
 #: ckanext/ytp/templates/page.html:8
 #: ckanext/ytp/templates/snippets/search_form.html:53
 msgid "Filter search"
-msgstr "Rajaa hakua"
+msgstr "Suodata hakua"
 
 #: ckanext/ytp/templates/group/member_new.html:10
 #: ckanext/ytp/templates/organization/member_new.html:9

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -9,15 +9,16 @@
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2018
 # Aaron Hakala <aaron.hakala@gofore.com>, 2019
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2019
+# Teemu Leivo <teemu.leivo@gofore.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-18 13:58+0200\n"
+"POT-Creation-Date: 2019-04-29 12:54+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2019\n"
+"Last-Translator: Teemu Leivo <teemu.leivo@gofore.com>, 2019\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -180,7 +181,7 @@ msgstr "Tähän liittyvä kohde päivitettiin onnistuneesti"
 msgid "Integrity Error"
 msgstr "Eheysvirhe"
 
-#: ckanext/ytp/controller.py:441 ckanext/ytp/templates/package/search.html:82
+#: ckanext/ytp/controller.py:441 ckanext/ytp/templates/package/search.html:86
 #: ckanext/ytp/templates/package/snippets/related_item.html:21
 msgid "API"
 msgstr "API"
@@ -293,7 +294,7 @@ msgstr "Pitää olla kirjautunut sisään nähdäkseen listan käyttäjistä"
 msgid "Have to be logged in to list admins"
 msgstr "PItää olla sisäänkirjautunut listataksesi ylläpitäjät"
 
-#: ckanext/ytp/menu.py:60 ckanext/ytp/templates/package/search.html:22
+#: ckanext/ytp/menu.py:60 ckanext/ytp/templates/package/search.html:30
 msgid "My Datasets"
 msgstr "Minun tietoaineistoni"
 
@@ -321,7 +322,7 @@ msgstr "Poista käyttäjätili"
 
 #: ckanext/ytp/menu.py:135
 #: ckanext/ytp/templates/organization/admin_list.html:4
-#: ckanext/ytp/templates/organization/index.html:20
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:17
 #: ckanext/ytp/templates/organization/user_list.html:4
 #: ckanext/ytp/templates/user/dashboard_datasets.html:4
 #: ckanext/ytp/templates/user/dashboard_organizations.html:6
@@ -331,6 +332,7 @@ msgstr "Käyttäjät"
 
 #: ckanext/ytp/menu.py:145
 #: ckanext/ytp/templates/organization/admin_list.html:31
+#: ckanext/ytp/templates/organization/index.html:8
 #: ckanext/ytp/templates/organization/organization_not_found.html:6
 #: ckanext/ytp/templates/organization/user_list.html:31
 #: ckanext/ytp/templates/package/base.html:8
@@ -376,11 +378,9 @@ msgstr "Kansainväliset vertailut"
 msgid "Collection Type"
 msgstr "Tietoaineisto"
 
-#: ckanext/ytp/plugin.py:442 ckanext/ytp/plugin.py:459
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:34
-#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:91
-msgid "Tags"
-msgstr "Aihe"
+#: ckanext/ytp/plugin.py:442
+msgid "Popular tags"
+msgstr ""
 
 #: ckanext/ytp/plugin.py:443 ckanext/ytp/plugin.py:460
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:51
@@ -403,19 +403,25 @@ msgstr "Organisaatio"
 msgid "Formats"
 msgstr "Tiedostomuoto"
 
-#: ckanext/ytp/plugin.py:447 ckanext/ytp/templates/package/search.html:60
+#: ckanext/ytp/plugin.py:447 ckanext/ytp/templates/package/search.html:64
 #: ckanext/ytp/templates/package/snippets/additional_info.html:14
 msgid "Source"
 msgstr "Lähde"
 
 #: ckanext/ytp/plugin.py:448
-#: ckanext/ytp/templates/package/resource_read.html:156
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:78
+#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:75
 #: ckanext/ytp/templates/package/snippets/package_basic_fields.html:63
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:37
 #: ckanext/ytp/templates/snippets/license.html:21
 msgid "License"
 msgstr "Lisenssi"
+
+#: ckanext/ytp/plugin.py:459
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:34
+#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:91
+msgid "Tags"
+msgstr "Aihe"
 
 #: ckanext/ytp/plugin.py:520
 msgid "Other"
@@ -507,10 +513,10 @@ msgstr "Ulkoinen"
 msgid "Internal"
 msgstr "Sisäinen"
 
-#: ckanext/ytp/templates/package/resource_read.html:150
+#: ckanext/ytp/templates/package/resource_read.html:162
 #: ckanext/ytp/templates/package/snippets/additional_info.html:70
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:225
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:239
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:222
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:236
 #: ckanext/ytp/translations.py:28
 msgid "Created"
 msgstr "Luotu"
@@ -694,6 +700,7 @@ msgstr "Jäsenet voivat muokata vain omia tietoaineistojaan"
 msgid "Home page"
 msgstr "Kotisivu"
 
+#: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/translations.py:75
 msgid "Maturity"
 msgstr "Kypsyysaste"
@@ -838,6 +845,7 @@ msgstr "Sovellukset"
 msgid "Add to group"
 msgstr "Lisää kategoriaan"
 
+#: ckanext/ytp/templates/package/group_list.html:22
 #: ckanext/ytp/translations.py:117
 msgid "There are no groups associated with this dataset"
 msgstr "Tietoaineistoon ei ole liitetty kategorioita"
@@ -847,6 +855,7 @@ msgstr "Tietoaineistoon ei ole liitetty kategorioita"
 msgid "Remove dataset from this group"
 msgstr "Poista tietoaineisto tästä kategoriasta"
 
+#: ckanext/ytp/templates/package/group_list.html:13
 #: ckanext/ytp/translations.py:119
 msgid "Associate this group with this dataset"
 msgstr "Liitä kategoria tähän tietoaineistoon"
@@ -863,6 +872,7 @@ msgstr "Sivulla ei ole tällä hetkellä kategorioita."
 msgid "Search groups..."
 msgstr "Etsi kategorioita..."
 
+#: ckanext/ytp/templates/package/group_list.html:3
 #: ckanext/ytp/templates/package/read.html:17 ckanext/ytp/translations.py:123
 msgid "Groups"
 msgstr "Kategoriat"
@@ -1061,6 +1071,11 @@ msgstr "Tilaa kommentit sähköpostiin"
 msgid "Unsubscribe from comments"
 msgstr "Peruuta kommenttien tilaus"
 
+#: ckanext/ytp/templates/page.html:8
+#: ckanext/ytp/templates/snippets/search_form.html:53
+msgid "Filter search"
+msgstr "Rajaa hakua"
+
 #: ckanext/ytp/templates/group/member_new.html:10
 #: ckanext/ytp/templates/organization/member_new.html:9
 msgid "Existing User"
@@ -1111,7 +1126,7 @@ msgid "View {name}"
 msgstr ""
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:45
-#: ckanext/ytp/templates/snippets/search_form.html:74
+#: ckanext/ytp/templates/snippets/search_form.html:78
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr "Poista"
@@ -1247,23 +1262,26 @@ msgstr "Muokkaa"
 msgid "Close without saving"
 msgstr "Sulje tallentamatta"
 
-#: ckanext/ytp/templates/organization/index.html:8
-#: ckanext/ytp/templates/organization/members.html:7
-#: ckanext/ytp/templates/user/dashboard_organizations.html:20
-msgid "Membership Requests"
-msgstr "Jäsenhakemukset"
+#: ckanext/ytp/templates/organization/index.html:15
+msgid "Search organizations..."
+msgstr ""
 
-#: ckanext/ytp/templates/organization/index.html:13
-msgid "My membership requests"
-msgstr "Omat jäsenhakemukset"
-
-#: ckanext/ytp/templates/organization/index.html:29
-msgid "Add Organization"
-msgstr "Lisää organisaatio"
+#: ckanext/ytp/templates/organization/index.html:18
+#: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
+#: ckanext/ytp/templates/snippets/search_form.html:19
+#: ckanext/ytp/templates/snippets/search_input.html:17
+msgid "Submit"
+msgstr "Lähetä"
 
 #: ckanext/ytp/templates/organization/member_new.html:37
 msgid "Update Member"
 msgstr "Päivitä jäsen"
+
+#: ckanext/ytp/templates/organization/members.html:7
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:5
+#: ckanext/ytp/templates/user/dashboard_organizations.html:20
+msgid "Membership Requests"
+msgstr "Jäsenhakemukset"
 
 #: ckanext/ytp/templates/organization/new_organization_form.html:17
 msgid "Update Organization"
@@ -1284,7 +1302,7 @@ msgstr "Jäsenet"
 
 #: ckanext/ytp/templates/organization/read_base.html:6
 #: ckanext/ytp/templates/package/read.html:19
-#: ckanext/ytp/templates/package/resource_read.html:31
+#: ckanext/ytp/templates/package/resource_read.html:33
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:9
 msgid "Manage"
 msgstr "Muokkaa"
@@ -1507,6 +1525,22 @@ msgstr ""
 "Haluatko varmasti poistaa tämän organisaation? Tämä poistaa kaikki julkiset "
 "ja yksityiset tietoaineistot, jotka kuuluvat tälle organisaatiolle."
 
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:10
+msgid "My membership requests"
+msgstr "Omat jäsenhakemukset"
+
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:26
+msgid "Add Organization"
+msgstr "Lisää organisaatio"
+
+#: ckanext/ytp/templates/package/group_list.html:7
+msgid "Add category to dataset"
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:13
+msgid "Add to dataset"
+msgstr ""
+
 #: ckanext/ytp/templates/package/new_package_form.html:14
 msgid "Update"
 msgstr "Päivitä"
@@ -1546,182 +1580,186 @@ msgstr "DataStore"
 msgid "Views"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:37
+#: ckanext/ytp/templates/package/resource_read.html:39
 msgid "View"
 msgstr "Katsele"
 
-#: ckanext/ytp/templates/package/resource_read.html:39
+#: ckanext/ytp/templates/package/resource_read.html:41
 msgid "API Endpoint"
 msgstr "API-päätepiste"
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 #: ckanext/ytp/templates/package/snippets/related_item.html:65
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:11
 msgid "Open"
 msgstr "Avaa"
 
-#: ckanext/ytp/templates/package/resource_read.html:43
+#: ckanext/ytp/templates/package/resource_read.html:45
 #: ckanext/ytp/templates/package/snippets/resource_item.html:52
 msgid "Download"
 msgstr "Lataa"
 
-#: ckanext/ytp/templates/package/resource_read.html:61
+#: ckanext/ytp/templates/package/resource_read.html:72
 msgid "URL:"
 msgstr "URL:"
 
-#: ckanext/ytp/templates/package/resource_read.html:71
+#: ckanext/ytp/templates/package/resource_read.html:82
 msgid "From the dataset abstract"
 msgstr "Tietoaineiston yhteenvedosta"
 
-#: ckanext/ytp/templates/package/resource_read.html:73
+#: ckanext/ytp/templates/package/resource_read.html:84
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr "Lähde: <a href=\"%(url)s\">%(dataset)s</a>"
 
-#: ckanext/ytp/templates/package/resource_read.html:114
+#: ckanext/ytp/templates/package/resource_read.html:125
 msgid "There are no views created for this resource yet."
 msgstr "Resurssille ei ole lisätty näkymiä"
 
-#: ckanext/ytp/templates/package/resource_read.html:118
+#: ckanext/ytp/templates/package/resource_read.html:129
 msgid "Not seeing the views you were expecting?"
 msgstr "Puuttuvatko odottamasi näkymät?"
 
-#: ckanext/ytp/templates/package/resource_read.html:120
+#: ckanext/ytp/templates/package/resource_read.html:131
 #: ckanext/ytp/templates/package/snippets/resource_view.html:26
 msgid "Click here for more information."
 msgstr "Klikkaa tästä saadaksesi lisätietoa."
 
-#: ckanext/ytp/templates/package/resource_read.html:123
+#: ckanext/ytp/templates/package/resource_read.html:134
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr "Tässä muutamia mahdollisia syitä puuttuville näkymille:"
 
-#: ckanext/ytp/templates/package/resource_read.html:125
+#: ckanext/ytp/templates/package/resource_read.html:136
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:126
+#: ckanext/ytp/templates/package/resource_read.html:137
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:127
+#: ckanext/ytp/templates/package/resource_read.html:138
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, "
 "or the data may not have been pushed to the DataStore, or the DataStore "
 "hasn't finished processing the data yet"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:143
+#: ckanext/ytp/templates/package/resource_read.html:155
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:4
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:67
 msgid "Extra information"
 msgstr "Lisätietoja"
 
-#: ckanext/ytp/templates/package/resource_read.html:147
+#: ckanext/ytp/templates/package/resource_read.html:159
 msgid "Last updated"
 msgstr "Viimeisin päivitys"
 
-#: ckanext/ytp/templates/package/resource_read.html:148
-#: ckanext/ytp/templates/package/resource_read.html:151
-#: ckanext/ytp/templates/package/resource_read.html:154
+#: ckanext/ytp/templates/package/resource_read.html:160
+#: ckanext/ytp/templates/package/resource_read.html:163
+#: ckanext/ytp/templates/package/resource_read.html:166
 msgid "unknown"
 msgstr "tuntematon"
 
-#: ckanext/ytp/templates/package/resource_read.html:153
+#: ckanext/ytp/templates/package/resource_read.html:165
 msgid "Format"
 msgstr "Muoto"
 
-#: ckanext/ytp/templates/package/resource_read.html:161
+#: ckanext/ytp/templates/package/resource_read.html:173
 msgid "Temporal Granularity"
 msgstr "Ajallinen mittausväli"
 
-#: ckanext/ytp/templates/package/resource_read.html:166
+#: ckanext/ytp/templates/package/resource_read.html:178
 msgid "Update Frequency"
 msgstr "Päivittymisväli"
 
-#: ckanext/ytp/templates/package/resource_read.html:171
+#: ckanext/ytp/templates/package/resource_read.html:183
 msgid "Temporal Coverage"
 msgstr "Katettu ajanjakso"
 
-#: ckanext/ytp/templates/package/resource_read.html:184
+#: ckanext/ytp/templates/package/resource_read.html:196
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:82
 msgid "Technical extra information"
 msgstr "Tekniset lisätiedot"
 
-#: ckanext/ytp/templates/package/resource_read.html:229
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:161
+#: ckanext/ytp/templates/package/resource_read.html:240
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:158
 msgid "Stats"
 msgstr "Tilastot"
 
-#: ckanext/ytp/templates/package/resource_read.html:230
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:162
+#: ckanext/ytp/templates/package/resource_read.html:241
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:159
 msgid "Last 30 days, updated daily"
 msgstr "Viimeiset 30 päivää, päivitetään päivittäin"
 
-#: ckanext/ytp/templates/package/resource_read.html:233
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:169
+#: ckanext/ytp/templates/package/resource_read.html:244
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:166
 msgid "All time downloads:"
 msgstr "Latauksia kaikkiaan:"
 
-#: ckanext/ytp/templates/package/resource_read.html:249
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/resource_read.html:260
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Year"
 msgstr "Vuosi"
 
-#: ckanext/ytp/templates/package/resource_read.html:249
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/resource_read.html:260
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Downloads"
 msgstr "Latauksia"
 
-#: ckanext/ytp/templates/package/search.html:27
+#: ckanext/ytp/templates/package/search.html:22
+msgid " Datasets "
+msgstr ""
+
+#: ckanext/ytp/templates/package/search.html:31
 #: ckanext/ytp/templates/user/dashboard_datasets.html:14
 msgid "Add Dataset"
 msgstr "Lisää tietoaineisto"
 
-#: ckanext/ytp/templates/package/search.html:34
+#: ckanext/ytp/templates/package/search.html:38
 msgid "Add open data"
 msgstr "Lisää avoin data"
 
-#: ckanext/ytp/templates/package/search.html:37
+#: ckanext/ytp/templates/package/search.html:41
 msgid "Add interoperability tools"
 msgstr "Lisää yhteentoimivuuden kuvaus tai ohje"
 
-#: ckanext/ytp/templates/package/search.html:56
+#: ckanext/ytp/templates/package/search.html:60
 msgid "Relevance"
 msgstr "Relevanssi"
 
-#: ckanext/ytp/templates/package/search.html:57
+#: ckanext/ytp/templates/package/search.html:61
 #: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
 msgstr "Nimen mukaan nousevasti"
 
-#: ckanext/ytp/templates/package/search.html:58
+#: ckanext/ytp/templates/package/search.html:62
 #: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
 msgstr "Nimen mukaan laskevasti"
 
-#: ckanext/ytp/templates/package/search.html:59
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:224
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:236
+#: ckanext/ytp/templates/package/search.html:63
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:221
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:233
 msgid "Last Modified"
 msgstr "Viimeksi muokattu"
 
-#: ckanext/ytp/templates/package/search.html:61
+#: ckanext/ytp/templates/package/search.html:65
 #: ckanext/ytp/templates/snippets/package_item.html:32
 #: ckanext/ytp/templates/snippets/popular.html:3
 msgid "Popular"
 msgstr "Suosittu"
 
-#: ckanext/ytp/templates/package/search.html:83
+#: ckanext/ytp/templates/package/search.html:87
 msgid "API Docs"
 msgstr "API-dokumentaatio"
 
-#: ckanext/ytp/templates/package/search.html:85
+#: ckanext/ytp/templates/package/search.html:89
 msgid "full {format} dump"
 msgstr "täysi {format} dumppi"
 
-#: ckanext/ytp/templates/package/search.html:86
+#: ckanext/ytp/templates/package/search.html:90
 #, python-format
 msgid ""
 " You can also access this registry using the %(api_link)s (see "
@@ -1730,7 +1768,7 @@ msgstr ""
 " Voit käyttää rekisteriä myös %(api_link)s avulla (katso myös "
 "%(api_doc_link)s) tai ladata tiedostoina %(dump_link)s. "
 
-#: ckanext/ytp/templates/package/search.html:90
+#: ckanext/ytp/templates/package/search.html:94
 #, python-format
 msgid ""
 " You can also access this registry using the %(api_link)s (see "
@@ -1772,27 +1810,27 @@ msgstr ""
 msgid "Last Updated"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:70
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:67
 msgid "Content Link"
 msgstr "Sisältölinkki"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:112
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:109
 msgid "License Not Specified"
 msgstr "Lisenssiä ei ole määritelty"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:123
 msgid "Dataset Quality"
 msgstr "Tietoaineiston laatu"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:129
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Resource Quality"
 msgstr "Aineistolinkin laatu"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:138
 msgid "Metadata Quality"
 msgstr "Metatietojen laatu"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:149
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:146
 msgid ""
 "Dataset's Resource Quality is the highest rating from the resources. It is "
 "automatically calculated and if it is zero, resources are unavailable or "
@@ -1805,31 +1843,31 @@ msgstr ""
 " ottaa huomioon täytettyjen tietokenttien määrän, sivukäynnit, "
 "tietoaineiston lataukset, kommentit ja käännökset."
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:167
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:164
 msgid "Downloads during year"
 msgstr "Latauksia vuonna"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:165
 msgid "All time visits:"
 msgstr "Sivunäyttöjä kaikkiaan:"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Visits"
 msgstr "Sivunäytöt"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:221
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:218
 msgid "Change log"
 msgstr "Muutoshistoria"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:222
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:219
 msgid "Dataset"
 msgstr "Tietoaineisto"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:232
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:229
 msgid "Resource"
 msgstr "Aineistolinkki"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:244
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:241
 msgid "Show change log"
 msgstr "Näytä muutoshistoria"
 
@@ -2485,12 +2523,6 @@ msgstr "Ilmoittajan nimi"
 msgid "Submitter email"
 msgstr "Ilmoittajan sähköpostiosoite"
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
-#: ckanext/ytp/templates/snippets/search_form.html:19
-#: ckanext/ytp/templates/snippets/search_input.html:17
-msgid "Submit"
-msgstr "Lähetä"
-
 #: ckanext/ytp/templates/snippets/datapreview_embed_dialog.html:6
 msgid "Embed Data Viewer"
 msgstr "Upota tietonäkymä"
@@ -2544,17 +2576,17 @@ msgstr "Tällä organisaatiolla ei ole kuvausta"
 msgid "Search datasets..."
 msgstr "Etsi tietoaineistoista..."
 
-#: ckanext/ytp/templates/snippets/search_form.html:42
+#: ckanext/ytp/templates/snippets/search_form.html:44
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:36
 msgid "Order by"
 msgstr "Järjestäminen"
 
-#: ckanext/ytp/templates/snippets/search_form.html:50
+#: ckanext/ytp/templates/snippets/search_form.html:54
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr "Siirry"
 
-#: ckanext/ytp/templates/snippets/search_form.html:85
+#: ckanext/ytp/templates/snippets/search_form.html:89
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid ""
 " <p class=\"extra\">Please try another search or change search facets.</p> "
@@ -2562,7 +2594,7 @@ msgstr ""
 "<p class=\"extra\">Kokeile syöttämällä eri hakusanat tai muuta valitsemiasi "
 "hakuehtoja.</p>"
 
-#: ckanext/ytp/templates/snippets/search_form.html:91
+#: ckanext/ytp/templates/snippets/search_form.html:95
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
@@ -15,7 +15,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-04-29 12:54+0000\n"
+"POT-Creation-Date: 2019-05-02 14:27+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Teemu Leivo <teemu.leivo@gofore.com>, 2019\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
@@ -1059,10 +1059,10 @@ msgstr "Prenumerera på kommentarer"
 msgid "Unsubscribe from comments"
 msgstr "Säg upp prenumeration"
 
-#: ckanext/ytp/templates/page.html:8
-#: ckanext/ytp/templates/snippets/search_form.html:53
-msgid "Filter search"
-msgstr "Filtrera sökningen"
+#: ckanext/ytp/templates/page.html:13
+#: ckanext/ytp/templates/snippets/search_form.html:59
+msgid "Hide search filters"
+msgstr "Gömma filtren"
 
 #: ckanext/ytp/templates/group/member_new.html:10
 #: ckanext/ytp/templates/organization/member_new.html:9
@@ -1115,7 +1115,7 @@ msgid "View {name}"
 msgstr ""
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:45
-#: ckanext/ytp/templates/snippets/search_form.html:78
+#: ckanext/ytp/templates/snippets/search_form.html:85
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr "Ta bort"
@@ -2555,12 +2555,16 @@ msgstr "Sök i dataseten..."
 msgid "Order by"
 msgstr "Sortera enligt"
 
-#: ckanext/ytp/templates/snippets/search_form.html:54
+#: ckanext/ytp/templates/snippets/search_form.html:53
+msgid "Filter search"
+msgstr "Filtrera sökningen"
+
+#: ckanext/ytp/templates/snippets/search_form.html:61
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr "Kör"
 
-#: ckanext/ytp/templates/snippets/search_form.html:89
+#: ckanext/ytp/templates/snippets/search_form.html:96
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid ""
 " <p class=\"extra\">Please try another search or change search facets.</p> "
@@ -2568,7 +2572,7 @@ msgstr ""
 "<p class=\"extra\">Försök en annan sökning eller ändra på dina "
 "sökkriterier.</p>"
 
-#: ckanext/ytp/templates/snippets/search_form.html:95
+#: ckanext/ytp/templates/snippets/search_form.html:102
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
@@ -8,15 +8,16 @@
 # Pentti Laitinen, 2018
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2018
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2019
+# Teemu Leivo <teemu.leivo@gofore.com>, 2019
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2019-03-18 13:58+0200\n"
+"POT-Creation-Date: 2019-04-29 12:54+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2019\n"
+"Last-Translator: Teemu Leivo <teemu.leivo@gofore.com>, 2019\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -185,7 +186,7 @@ msgstr "Relaterade objektet redigerades"
 msgid "Integrity Error"
 msgstr "Integritetsfel"
 
-#: ckanext/ytp/controller.py:441 ckanext/ytp/templates/package/search.html:82
+#: ckanext/ytp/controller.py:441 ckanext/ytp/templates/package/search.html:86
 #: ckanext/ytp/templates/package/snippets/related_item.html:21
 msgid "API"
 msgstr "API"
@@ -298,7 +299,7 @@ msgstr "Man måste vara inloggad för att se en lista på användare"
 msgid "Have to be logged in to list admins"
 msgstr ""
 
-#: ckanext/ytp/menu.py:60 ckanext/ytp/templates/package/search.html:22
+#: ckanext/ytp/menu.py:60 ckanext/ytp/templates/package/search.html:30
 msgid "My Datasets"
 msgstr "Mina dataset"
 
@@ -326,7 +327,7 @@ msgstr "Radera användarkonto"
 
 #: ckanext/ytp/menu.py:135
 #: ckanext/ytp/templates/organization/admin_list.html:4
-#: ckanext/ytp/templates/organization/index.html:20
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:17
 #: ckanext/ytp/templates/organization/user_list.html:4
 #: ckanext/ytp/templates/user/dashboard_datasets.html:4
 #: ckanext/ytp/templates/user/dashboard_organizations.html:6
@@ -336,6 +337,7 @@ msgstr "Användare"
 
 #: ckanext/ytp/menu.py:145
 #: ckanext/ytp/templates/organization/admin_list.html:31
+#: ckanext/ytp/templates/organization/index.html:8
 #: ckanext/ytp/templates/organization/organization_not_found.html:6
 #: ckanext/ytp/templates/organization/user_list.html:31
 #: ckanext/ytp/templates/package/base.html:8
@@ -381,11 +383,9 @@ msgstr ""
 msgid "Collection Type"
 msgstr "Typ av information"
 
-#: ckanext/ytp/plugin.py:442 ckanext/ytp/plugin.py:459
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:34
-#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:91
-msgid "Tags"
-msgstr "Taggar"
+#: ckanext/ytp/plugin.py:442
+msgid "Popular tags"
+msgstr ""
 
 #: ckanext/ytp/plugin.py:443 ckanext/ytp/plugin.py:460
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:51
@@ -408,19 +408,25 @@ msgstr "Organisation"
 msgid "Formats"
 msgstr "Filtyp"
 
-#: ckanext/ytp/plugin.py:447 ckanext/ytp/templates/package/search.html:60
+#: ckanext/ytp/plugin.py:447 ckanext/ytp/templates/package/search.html:64
 #: ckanext/ytp/templates/package/snippets/additional_info.html:14
 msgid "Source"
 msgstr "Källa"
 
 #: ckanext/ytp/plugin.py:448
-#: ckanext/ytp/templates/package/resource_read.html:156
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:78
+#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:75
 #: ckanext/ytp/templates/package/snippets/package_basic_fields.html:63
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:37
 #: ckanext/ytp/templates/snippets/license.html:21
 msgid "License"
 msgstr "Licens"
+
+#: ckanext/ytp/plugin.py:459
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:34
+#: ckanext/ytp/templates/package/snippets/package_basic_fields.html:91
+msgid "Tags"
+msgstr "Taggar"
 
 #: ckanext/ytp/plugin.py:520
 msgid "Other"
@@ -512,10 +518,10 @@ msgstr "Extern"
 msgid "Internal"
 msgstr "Intern"
 
-#: ckanext/ytp/templates/package/resource_read.html:150
+#: ckanext/ytp/templates/package/resource_read.html:162
 #: ckanext/ytp/templates/package/snippets/additional_info.html:70
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:225
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:239
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:222
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:236
 #: ckanext/ytp/translations.py:28
 msgid "Created"
 msgstr "Skapad"
@@ -689,6 +695,7 @@ msgstr "Medlemmar kan bara redigera egna dataset"
 msgid "Home page"
 msgstr "Hemsidan"
 
+#: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/translations.py:75
 msgid "Maturity"
 msgstr ""
@@ -833,6 +840,7 @@ msgstr "Apps"
 msgid "Add to group"
 msgstr "Lägg till kategorin"
 
+#: ckanext/ytp/templates/package/group_list.html:22
 #: ckanext/ytp/translations.py:117
 msgid "There are no groups associated with this dataset"
 msgstr "Det finns inga kategorier kopplade till detta dataset"
@@ -842,6 +850,7 @@ msgstr "Det finns inga kategorier kopplade till detta dataset"
 msgid "Remove dataset from this group"
 msgstr "Ta bort dataset från denna kategori"
 
+#: ckanext/ytp/templates/package/group_list.html:13
 #: ckanext/ytp/translations.py:119
 msgid "Associate this group with this dataset"
 msgstr "Koppla denna kategori till detta dataset"
@@ -858,6 +867,7 @@ msgstr "Det finns för närvarande inga kategorier för denna site"
 msgid "Search groups..."
 msgstr "Sök kategorier..."
 
+#: ckanext/ytp/templates/package/group_list.html:3
 #: ckanext/ytp/templates/package/read.html:17 ckanext/ytp/translations.py:123
 msgid "Groups"
 msgstr "Kategorier"
@@ -1049,6 +1059,11 @@ msgstr "Prenumerera på kommentarer"
 msgid "Unsubscribe from comments"
 msgstr "Säg upp prenumeration"
 
+#: ckanext/ytp/templates/page.html:8
+#: ckanext/ytp/templates/snippets/search_form.html:53
+msgid "Filter search"
+msgstr "Filtrera sökningen"
+
 #: ckanext/ytp/templates/group/member_new.html:10
 #: ckanext/ytp/templates/organization/member_new.html:9
 msgid "Existing User"
@@ -1100,7 +1115,7 @@ msgid "View {name}"
 msgstr ""
 
 #: ckanext/ytp/templates/group/snippets/group_item.html:45
-#: ckanext/ytp/templates/snippets/search_form.html:74
+#: ckanext/ytp/templates/snippets/search_form.html:78
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:76
 msgid "Remove"
 msgstr "Ta bort"
@@ -1234,23 +1249,26 @@ msgstr "Redigera"
 msgid "Close without saving"
 msgstr "Stäng utan att spara"
 
-#: ckanext/ytp/templates/organization/index.html:8
-#: ckanext/ytp/templates/organization/members.html:7
-#: ckanext/ytp/templates/user/dashboard_organizations.html:20
-msgid "Membership Requests"
-msgstr "Medlemsansökan"
-
-#: ckanext/ytp/templates/organization/index.html:13
-msgid "My membership requests"
-msgstr "Medlemsansökan"
-
-#: ckanext/ytp/templates/organization/index.html:29
-msgid "Add Organization"
+#: ckanext/ytp/templates/organization/index.html:15
+msgid "Search organizations..."
 msgstr ""
+
+#: ckanext/ytp/templates/organization/index.html:18
+#: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
+#: ckanext/ytp/templates/snippets/search_form.html:19
+#: ckanext/ytp/templates/snippets/search_input.html:17
+msgid "Submit"
+msgstr "Skicka"
 
 #: ckanext/ytp/templates/organization/member_new.html:37
 msgid "Update Member"
 msgstr "Uppdatera medlem"
+
+#: ckanext/ytp/templates/organization/members.html:7
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:5
+#: ckanext/ytp/templates/user/dashboard_organizations.html:20
+msgid "Membership Requests"
+msgstr "Medlemsansökan"
 
 #: ckanext/ytp/templates/organization/new_organization_form.html:17
 msgid "Update Organization"
@@ -1271,7 +1289,7 @@ msgstr "Medlemmar"
 
 #: ckanext/ytp/templates/organization/read_base.html:6
 #: ckanext/ytp/templates/package/read.html:19
-#: ckanext/ytp/templates/package/resource_read.html:31
+#: ckanext/ytp/templates/package/resource_read.html:33
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:9
 msgid "Manage"
 msgstr "Redigera"
@@ -1495,6 +1513,22 @@ msgstr ""
 "Vill du verkligen radera denna organisation? Detta kommer att radera alla "
 "publika och privata dataset som hör till denna organisation."
 
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:10
+msgid "My membership requests"
+msgstr "Medlemsansökan"
+
+#: ckanext/ytp/templates/organization/snippets/organization_primary_actions.html:26
+msgid "Add Organization"
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:7
+msgid "Add category to dataset"
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:13
+msgid "Add to dataset"
+msgstr ""
+
 #: ckanext/ytp/templates/package/new_package_form.html:14
 msgid "Update"
 msgstr "Uppdatera"
@@ -1534,182 +1568,186 @@ msgstr "Datalager"
 msgid "Views"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:37
+#: ckanext/ytp/templates/package/resource_read.html:39
 msgid "View"
 msgstr "Granska"
 
-#: ckanext/ytp/templates/package/resource_read.html:39
+#: ckanext/ytp/templates/package/resource_read.html:41
 msgid "API Endpoint"
 msgstr "API slutpunkt"
 
-#: ckanext/ytp/templates/package/resource_read.html:41
+#: ckanext/ytp/templates/package/resource_read.html:43
 #: ckanext/ytp/templates/package/snippets/related_item.html:65
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:11
 msgid "Open"
 msgstr "Öppen"
 
-#: ckanext/ytp/templates/package/resource_read.html:43
+#: ckanext/ytp/templates/package/resource_read.html:45
 #: ckanext/ytp/templates/package/snippets/resource_item.html:52
 msgid "Download"
 msgstr "Ladda ner"
 
-#: ckanext/ytp/templates/package/resource_read.html:61
+#: ckanext/ytp/templates/package/resource_read.html:72
 msgid "URL:"
 msgstr "URL:"
 
-#: ckanext/ytp/templates/package/resource_read.html:71
+#: ckanext/ytp/templates/package/resource_read.html:82
 msgid "From the dataset abstract"
 msgstr "Av datasetets sammandrag"
 
-#: ckanext/ytp/templates/package/resource_read.html:73
+#: ckanext/ytp/templates/package/resource_read.html:84
 #, python-format
 msgid "Source: <a href=\"%(url)s\">%(dataset)s</a>"
 msgstr "Källa: <a href=\"%(url)s\">%(dataset)s</a>"
 
-#: ckanext/ytp/templates/package/resource_read.html:114
+#: ckanext/ytp/templates/package/resource_read.html:125
 msgid "There are no views created for this resource yet."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:118
+#: ckanext/ytp/templates/package/resource_read.html:129
 msgid "Not seeing the views you were expecting?"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:120
+#: ckanext/ytp/templates/package/resource_read.html:131
 #: ckanext/ytp/templates/package/snippets/resource_view.html:26
 msgid "Click here for more information."
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:123
+#: ckanext/ytp/templates/package/resource_read.html:134
 msgid "Here are some reasons you may not be seeing expected views:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:125
+#: ckanext/ytp/templates/package/resource_read.html:136
 msgid "No view has been created that is suitable for this resource"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:126
+#: ckanext/ytp/templates/package/resource_read.html:137
 msgid "The site administrators may not have enabled the relevant view plugins"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:127
+#: ckanext/ytp/templates/package/resource_read.html:138
 msgid ""
 "If a view requires the DataStore, the DataStore plugin may not be enabled, "
 "or the data may not have been pushed to the DataStore, or the DataStore "
 "hasn't finished processing the data yet"
 msgstr ""
 
-#: ckanext/ytp/templates/package/resource_read.html:143
+#: ckanext/ytp/templates/package/resource_read.html:155
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:4
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:67
 msgid "Extra information"
 msgstr "Tilläggsinformation"
 
-#: ckanext/ytp/templates/package/resource_read.html:147
+#: ckanext/ytp/templates/package/resource_read.html:159
 msgid "Last updated"
 msgstr "Senast uppdaterad"
 
-#: ckanext/ytp/templates/package/resource_read.html:148
-#: ckanext/ytp/templates/package/resource_read.html:151
-#: ckanext/ytp/templates/package/resource_read.html:154
+#: ckanext/ytp/templates/package/resource_read.html:160
+#: ckanext/ytp/templates/package/resource_read.html:163
+#: ckanext/ytp/templates/package/resource_read.html:166
 msgid "unknown"
 msgstr "okänd"
 
-#: ckanext/ytp/templates/package/resource_read.html:153
+#: ckanext/ytp/templates/package/resource_read.html:165
 msgid "Format"
 msgstr "Format"
 
-#: ckanext/ytp/templates/package/resource_read.html:161
+#: ckanext/ytp/templates/package/resource_read.html:173
 msgid "Temporal Granularity"
 msgstr "Tidsmässig mätinterval"
 
-#: ckanext/ytp/templates/package/resource_read.html:166
+#: ckanext/ytp/templates/package/resource_read.html:178
 msgid "Update Frequency"
 msgstr "Uppdateringsfrekvens"
 
-#: ckanext/ytp/templates/package/resource_read.html:171
+#: ckanext/ytp/templates/package/resource_read.html:183
 msgid "Temporal Coverage"
 msgstr "Tidsmässig täckning"
 
-#: ckanext/ytp/templates/package/resource_read.html:184
+#: ckanext/ytp/templates/package/resource_read.html:196
 #: ckanext/ytp/templates/package/snippets/ytp_additional_info.html:82
 msgid "Technical extra information"
 msgstr "Teknisk tilläggsinformation"
 
-#: ckanext/ytp/templates/package/resource_read.html:229
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:161
+#: ckanext/ytp/templates/package/resource_read.html:240
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:158
 msgid "Stats"
 msgstr "Statistik"
 
-#: ckanext/ytp/templates/package/resource_read.html:230
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:162
+#: ckanext/ytp/templates/package/resource_read.html:241
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:159
 msgid "Last 30 days, updated daily"
 msgstr "Senaste 30 dagarna, uppdateras dagligen"
 
-#: ckanext/ytp/templates/package/resource_read.html:233
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:169
+#: ckanext/ytp/templates/package/resource_read.html:244
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:166
 msgid "All time downloads:"
 msgstr "Totalt nedladdningar:"
 
-#: ckanext/ytp/templates/package/resource_read.html:249
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/resource_read.html:260
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Year"
 msgstr "År"
 
-#: ckanext/ytp/templates/package/resource_read.html:249
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/resource_read.html:260
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Downloads"
 msgstr "Nedladdningar"
 
-#: ckanext/ytp/templates/package/search.html:27
+#: ckanext/ytp/templates/package/search.html:22
+msgid " Datasets "
+msgstr ""
+
+#: ckanext/ytp/templates/package/search.html:31
 #: ckanext/ytp/templates/user/dashboard_datasets.html:14
 msgid "Add Dataset"
 msgstr "Lägg till dataset"
 
-#: ckanext/ytp/templates/package/search.html:34
+#: ckanext/ytp/templates/package/search.html:38
 msgid "Add open data"
 msgstr "Lägg till öppen data"
 
-#: ckanext/ytp/templates/package/search.html:37
+#: ckanext/ytp/templates/package/search.html:41
 msgid "Add interoperability tools"
 msgstr "Lägg till interoperabilitetsverktyg"
 
-#: ckanext/ytp/templates/package/search.html:56
+#: ckanext/ytp/templates/package/search.html:60
 msgid "Relevance"
 msgstr "Relevans"
 
-#: ckanext/ytp/templates/package/search.html:57
+#: ckanext/ytp/templates/package/search.html:61
 #: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
 msgstr "Namn i stigande ordning"
 
-#: ckanext/ytp/templates/package/search.html:58
+#: ckanext/ytp/templates/package/search.html:62
 #: ckanext/ytp/templates/snippets/search_form.html:36
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
 msgstr "Namn i nedstigande ordning"
 
-#: ckanext/ytp/templates/package/search.html:59
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:224
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:236
+#: ckanext/ytp/templates/package/search.html:63
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:221
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:233
 msgid "Last Modified"
 msgstr "Senast redigerad"
 
-#: ckanext/ytp/templates/package/search.html:61
+#: ckanext/ytp/templates/package/search.html:65
 #: ckanext/ytp/templates/snippets/package_item.html:32
 #: ckanext/ytp/templates/snippets/popular.html:3
 msgid "Popular"
 msgstr "Popularitet"
 
-#: ckanext/ytp/templates/package/search.html:83
+#: ckanext/ytp/templates/package/search.html:87
 msgid "API Docs"
 msgstr "API dokumentation"
 
-#: ckanext/ytp/templates/package/search.html:85
+#: ckanext/ytp/templates/package/search.html:89
 msgid "full {format} dump"
 msgstr "full {format} dump"
 
-#: ckanext/ytp/templates/package/search.html:86
+#: ckanext/ytp/templates/package/search.html:90
 #, python-format
 msgid ""
 " You can also access this registry using the %(api_link)s (see "
@@ -1718,7 +1756,7 @@ msgstr ""
 "Du har också tillgång till detta register genom %(api_link)s (se "
 "%(api_doc_link)s) eller ladda ned %(dump_link)s."
 
-#: ckanext/ytp/templates/package/search.html:90
+#: ckanext/ytp/templates/package/search.html:94
 #, python-format
 msgid ""
 " You can also access this registry using the %(api_link)s (see "
@@ -1760,27 +1798,27 @@ msgstr ""
 msgid "Last Updated"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:70
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:67
 msgid "Content Link"
 msgstr "Innehållslink"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:112
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:109
 msgid "License Not Specified"
 msgstr "Ingen licens specifierad"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:123
 msgid "Dataset Quality"
 msgstr "Datasetets kvalitet"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:129
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Resource Quality"
 msgstr "Materiallänkskvalitet"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:138
 msgid "Metadata Quality"
 msgstr "Metadatas kvalitet"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:149
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:146
 msgid ""
 "Dataset's Resource Quality is the highest rating from the resources. It is "
 "automatically calculated and if it is zero, resources are unavailable or "
@@ -1788,31 +1826,31 @@ msgid ""
 "resource downloads, comments and translations into consideration."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:167
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:164
 msgid "Downloads during year"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:165
 msgid "All time visits:"
 msgstr "Sidvisningar totalt:"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:185
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:182
 msgid "Visits"
 msgstr "Sidvisningar"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:221
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:218
 msgid "Change log"
 msgstr "Versionshistorik"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:222
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:219
 msgid "Dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:232
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:229
 msgid "Resource"
 msgstr "Materiallänk"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:244
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:241
 msgid "Show change log"
 msgstr "Visa versionshistorik"
 
@@ -2459,12 +2497,6 @@ msgstr ""
 msgid "Submitter email"
 msgstr ""
 
-#: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:276
-#: ckanext/ytp/templates/snippets/search_form.html:19
-#: ckanext/ytp/templates/snippets/search_input.html:17
-msgid "Submit"
-msgstr "Skicka"
-
 #: ckanext/ytp/templates/snippets/datapreview_embed_dialog.html:6
 msgid "Embed Data Viewer"
 msgstr ""
@@ -2518,17 +2550,17 @@ msgstr "Det finns ingen beskriving för organisationen"
 msgid "Search datasets..."
 msgstr "Sök i dataseten..."
 
-#: ckanext/ytp/templates/snippets/search_form.html:42
+#: ckanext/ytp/templates/snippets/search_form.html:44
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:36
 msgid "Order by"
 msgstr "Sortera enligt"
 
-#: ckanext/ytp/templates/snippets/search_form.html:50
+#: ckanext/ytp/templates/snippets/search_form.html:54
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
 msgstr "Kör"
 
-#: ckanext/ytp/templates/snippets/search_form.html:85
+#: ckanext/ytp/templates/snippets/search_form.html:89
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:88
 msgid ""
 " <p class=\"extra\">Please try another search or change search facets.</p> "
@@ -2536,7 +2568,7 @@ msgstr ""
 "<p class=\"extra\">Försök en annan sökning eller ändra på dina "
 "sökkriterier.</p>"
 
-#: ckanext/ytp/templates/snippets/search_form.html:91
+#: ckanext/ytp/templates/snippets/search_form.html:95
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:94
 msgid ""
 " <p><strong>There was an error while searching.</strong> Please try "

--- a/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
+++ b/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
@@ -47,11 +47,11 @@ function toggle_search_filters() {
  */
 function update_search_filter_parameter_to_links(show_search_filters_value) {
   const all_links = document.links;
-  for(let i=0; i<all_links.length; i++) {
+  for (let i=0; i<all_links.length; i++) {
     const href_value = all_links[i].href;
     const link_without_url_parameters = href_value.split("?")[0];
     const current_page_without_url_parameters = location.href.split("?")[0];
-    if(current_page_without_url_parameters === link_without_url_parameters) {
+    if (current_page_without_url_parameters === link_without_url_parameters) {
       const new_url_parameters = get_url_with_updated_parameter(href_value, "_show_search_filters", show_search_filters_value).split("?")[1];
       all_links[i].href = "dataset?" + new_url_parameters;
     }
@@ -63,7 +63,7 @@ function update_search_filter_parameter_to_links(show_search_filters_value) {
  * @param param The url parameter that will be changed
  * @param param_val The new value for the url parameter
  */
-function updateURLParameter(param, param_val){
+function updateURLParameter(param, param_val) {
   const url = window.location.href;
   const new_url = get_url_with_updated_parameter(url, param, param_val)
   window.history.replaceState("", "", new_url);
@@ -76,8 +76,7 @@ function updateURLParameter(param, param_val){
  * @param param The url parameter that will be changed
  * @param paramVal The new value for the url parameter
  */
-function get_url_with_updated_parameter(url, param, paramVal)
-{
+function get_url_with_updated_parameter(url, param, paramVal) {
     let TheAnchor = null;
     let newAdditionalURL = "";
     let tempArray = url.split("?");
@@ -85,37 +84,33 @@ function get_url_with_updated_parameter(url, param, paramVal)
     let additionalURL = tempArray[1];
     let temp = "";
 
-    if (additionalURL)
-    {
-        let tmpAnchor = additionalURL.split("#");
-        let TheParams = tmpAnchor[0];
-            TheAnchor = tmpAnchor[1];
-        if(TheAnchor)
-            additionalURL = TheParams;
-
-        tempArray = additionalURL.split("&");
-
-        for (let i=0; i<tempArray.length; i++)
-        {
-            if(tempArray[i].split("=")[0] != param)
-            {
-                newAdditionalURL += temp + tempArray[i];
-                temp = "&";
-            }
+    if (additionalURL) {
+      let tmpAnchor = additionalURL.split("#");
+      let TheParams = tmpAnchor[0];
+      TheAnchor = tmpAnchor[1];
+      if (TheAnchor) {
+        additionalURL = TheParams;
+      }
+      tempArray = additionalURL.split("&");
+      for (let i=0; i<tempArray.length; i++) {
+        if (tempArray[i].split("=")[0] != param) {
+          newAdditionalURL += temp + tempArray[i];
+          temp = "&";
         }
-    }
-    else
-    {
-        let tmpAnchor = baseURL.split("#");
-        let TheParams = tmpAnchor[0];
-            TheAnchor  = tmpAnchor[1];
+      }
+    } else {
+      let tmpAnchor = baseURL.split("#");
+      let TheParams = tmpAnchor[0];
+      TheAnchor  = tmpAnchor[1];
 
-        if(TheParams)
-            baseURL = TheParams;
+      if (TheParams) {
+        baseURL = TheParams;
+      }
     }
 
-    if(TheAnchor)
-        paramVal += "#" + TheAnchor;
+    if (TheAnchor) {
+      paramVal += "#" + TheAnchor;
+    }
 
     let rows_txt = temp + "" + param + "=" + paramVal;
     return baseURL + "?" + newAdditionalURL + rows_txt;

--- a/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
+++ b/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
@@ -1,20 +1,26 @@
 document.getElementById("search-filter-toggle-button").addEventListener("click", toggle_search_filters);
+document.getElementById("search-filter-upper-toggle-button").addEventListener("click", toggle_search_filters);
 
 if (window.location.search.indexOf("_show_search_filters=true") > -1) {
   var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
+  var upper_toggle_button = document.getElementById("search-filter-upper-toggle-button");
   search_filters.classList.remove("search-filters-hidden");
   search_filters.classList.add("search-filters-visible");
+  upper_toggle_button.classList.add("upper-toggle-button-visible");
 } 
 
 function toggle_search_filters() {
   var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
+  var upper_toggle_button = document.getElementById("search-filter-upper-toggle-button");
   if (search_filters.classList.contains("search-filters-hidden")) {
     search_filters.classList.remove("search-filters-hidden");
     search_filters.classList.add("search-filters-visible");
+    upper_toggle_button.classList.add("upper-toggle-button-visible");
     updateURLParameter("_show_search_filters", "true");
   } else {
     search_filters.classList.remove("search-filters-visible");
     search_filters.classList.add("search-filters-hidden");
+    upper_toggle_button.classList.remove("upper-toggle-button-visible");
     updateURLParameter("_show_search_filters", "false");
   }
 }

--- a/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
+++ b/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
@@ -2,12 +2,13 @@ document.getElementById("search-filter-show-button").addEventListener("click", t
 document.getElementById("search-filter-upper-hide-button").addEventListener("click", toggle_search_filters);
 document.getElementById("search-filter-lower-hide-button").addEventListener("click", toggle_search_filters);
 
-// If url parameter exists, the search filters and both 'hide filters' buttons are shown. 
+const search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
+const upper_hide_button = document.getElementById("search-filter-upper-hide-button");
+const lower_hide_button = document.getElementById("search-filter-lower-hide-button");
+const show_button = document.getElementById("search-filter-show-button");
+
+// If url parameter exists, the search filters and both 'hide filters' buttons are shown.
 if (window.location.search.indexOf("_show_search_filters=true") > -1) {
-  var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
-  var upper_hide_button = document.getElementById("search-filter-upper-hide-button");
-  var lower_hide_button = document.getElementById("search-filter-lower-hide-button");
-  var show_button = document.getElementById("search-filter-show-button");
   search_filters.classList.remove("search-filters-hidden");
   search_filters.classList.add("search-filters-visible");
   upper_hide_button.classList.add("hide-button-visible");
@@ -15,11 +16,11 @@ if (window.location.search.indexOf("_show_search_filters=true") > -1) {
   show_button.classList.add("show-button-hidden");
 }
 
+/**
+ * If search filters are hidden, they become visible. If they are visible, they will become hidden.
+ * Classes for buttons are updated as well so that the correct buttons are visible.
+ */
 function toggle_search_filters() {
-  var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
-  var upper_hide_button = document.getElementById("search-filter-upper-hide-button");
-  var lower_hide_button = document.getElementById("search-filter-lower-hide-button");
-  var show_button = document.getElementById("search-filter-show-button");
   if (search_filters.classList.contains("search-filters-hidden")) {
     search_filters.classList.remove("search-filters-hidden");
     search_filters.classList.add("search-filters-visible");
@@ -27,6 +28,7 @@ function toggle_search_filters() {
     lower_hide_button.classList.add("hide-button-visible");
     show_button.classList.add("show-button-hidden");
     updateURLParameter("_show_search_filters", "true");
+    update_search_filter_parameter_to_links("true");
   } else {
     search_filters.classList.remove("search-filters-visible");
     search_filters.classList.add("search-filters-hidden");
@@ -34,33 +36,87 @@ function toggle_search_filters() {
     lower_hide_button.classList.remove("hide-button-visible");
     show_button.classList.remove("show-button-hidden");
     updateURLParameter("_show_search_filters", "false");
+    update_search_filter_parameter_to_links("false");
   }
 }
 
 /**
+ * Update all the links to the current page with the new '_show_search_filters' URL parameter value.
+ * Links to the current page are filter links that are used in the facet.
+ * @param show_search_filters_value The value for the _show_search_filters URL parameter. Should be either 'true' or 'false'
+ */
+function update_search_filter_parameter_to_links(show_search_filters_value) {
+  const all_links = document.links;
+  for(let i=0; i<all_links.length; i++) {
+    const href_value = all_links[i].href;
+    const link_without_url_parameters = href_value.split("?")[0];
+    const current_page_without_url_parameters = location.href.split("?")[0];
+    if(current_page_without_url_parameters === link_without_url_parameters) {
+      const new_url_parameters = get_url_with_updated_parameter(href_value, "_show_search_filters", show_search_filters_value).split("?")[1];
+      all_links[i].href = "dataset?" + new_url_parameters;
+    }
+  }
+}
+
+/**
+ * Changes the url by updating the given URL parameter
+ * @param param The url parameter that will be changed
+ * @param param_val The new value for the url parameter
+ */
+function updateURLParameter(param, param_val){
+  const url = window.location.href;
+  const new_url = get_url_with_updated_parameter(url, param, param_val)
+  window.history.replaceState("", "", new_url);
+}
+
+/**
  * http://stackoverflow.com/a/10997390/11236
- * This function changes the url by changing the value of the given url parameter
+ * This function changes the url by changing the value of the given url parameter and returns the new url
+ * @param url The url to be changed
  * @param param The url parameter that will be changed
  * @param paramVal The new value for the url parameter
  */
-function updateURLParameter(param, paramVal){
-  var url = window.location.href;
-  var newAdditionalURL = "";
-  var tempArray = url.split("?");
-  var baseURL = tempArray[0];
-  var additionalURL = tempArray[1];
-  var temp = "";
-  if (additionalURL) {
-      tempArray = additionalURL.split("&");
-      for (var i=0; i<tempArray.length; i++){
-          if(tempArray[i].split('=')[0] != param){
-              newAdditionalURL += temp + tempArray[i];
-              temp = "&";
-          }
-      }
-  }
+function get_url_with_updated_parameter(url, param, paramVal)
+{
+    let TheAnchor = null;
+    let newAdditionalURL = "";
+    let tempArray = url.split("?");
+    let baseURL = tempArray[0];
+    let additionalURL = tempArray[1];
+    let temp = "";
 
-  var rows_txt = temp + "" + param + "=" + paramVal;
-  var new_url = baseURL + "?" + newAdditionalURL + rows_txt;
-  window.history.replaceState('', '', new_url);
+    if (additionalURL)
+    {
+        let tmpAnchor = additionalURL.split("#");
+        let TheParams = tmpAnchor[0];
+            TheAnchor = tmpAnchor[1];
+        if(TheAnchor)
+            additionalURL = TheParams;
+
+        tempArray = additionalURL.split("&");
+
+        for (let i=0; i<tempArray.length; i++)
+        {
+            if(tempArray[i].split("=")[0] != param)
+            {
+                newAdditionalURL += temp + tempArray[i];
+                temp = "&";
+            }
+        }
+    }
+    else
+    {
+        let tmpAnchor = baseURL.split("#");
+        let TheParams = tmpAnchor[0];
+            TheAnchor  = tmpAnchor[1];
+
+        if(TheParams)
+            baseURL = TheParams;
+    }
+
+    if(TheAnchor)
+        paramVal += "#" + TheAnchor;
+
+    let rows_txt = temp + "" + param + "=" + paramVal;
+    return baseURL + "?" + newAdditionalURL + rows_txt;
 }

--- a/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
+++ b/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
@@ -1,27 +1,38 @@
-document.getElementById("search-filter-toggle-button").addEventListener("click", toggle_search_filters);
-document.getElementById("search-filter-upper-toggle-button").addEventListener("click", toggle_search_filters);
+document.getElementById("search-filter-show-button").addEventListener("click", toggle_search_filters);
+document.getElementById("search-filter-upper-hide-button").addEventListener("click", toggle_search_filters);
+document.getElementById("search-filter-lower-hide-button").addEventListener("click", toggle_search_filters);
 
-// If url parameter exists, the search filters and the second toggle button are shown. 
+// If url parameter exists, the search filters and both 'hide filters' buttons are shown. 
 if (window.location.search.indexOf("_show_search_filters=true") > -1) {
   var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
-  var upper_toggle_button = document.getElementById("search-filter-upper-toggle-button");
+  var upper_hide_button = document.getElementById("search-filter-upper-hide-button");
+  var lower_hide_button = document.getElementById("search-filter-lower-hide-button");
+  var show_button = document.getElementById("search-filter-show-button");
   search_filters.classList.remove("search-filters-hidden");
   search_filters.classList.add("search-filters-visible");
-  upper_toggle_button.classList.add("upper-toggle-button-visible");
+  upper_hide_button.classList.add("hide-button-visible");
+  lower_hide_button.classList.add("hide-button-visible");
+  show_button.classList.add("show-button-hidden");
 }
 
 function toggle_search_filters() {
   var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
-  var upper_toggle_button = document.getElementById("search-filter-upper-toggle-button");
+  var upper_hide_button = document.getElementById("search-filter-upper-hide-button");
+  var lower_hide_button = document.getElementById("search-filter-lower-hide-button");
+  var show_button = document.getElementById("search-filter-show-button");
   if (search_filters.classList.contains("search-filters-hidden")) {
     search_filters.classList.remove("search-filters-hidden");
     search_filters.classList.add("search-filters-visible");
-    upper_toggle_button.classList.add("upper-toggle-button-visible");
+    upper_hide_button.classList.add("hide-button-visible");
+    lower_hide_button.classList.add("hide-button-visible");
+    show_button.classList.add("show-button-hidden");
     updateURLParameter("_show_search_filters", "true");
   } else {
     search_filters.classList.remove("search-filters-visible");
     search_filters.classList.add("search-filters-hidden");
-    upper_toggle_button.classList.remove("upper-toggle-button-visible");
+    upper_hide_button.classList.remove("hide-button-visible");
+    lower_hide_button.classList.remove("hide-button-visible");
+    show_button.classList.remove("show-button-hidden");
     updateURLParameter("_show_search_filters", "false");
   }
 }

--- a/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
+++ b/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
@@ -1,0 +1,45 @@
+document.getElementById("search-filter-toggle-button").addEventListener("click", toggle_search_filters);
+
+if (window.location.search.indexOf("_show_search_filters=true") > -1) {
+  var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
+  search_filters.classList.remove("search-filters-hidden");
+  search_filters.classList.add("search-filters-visible");
+} 
+
+function toggle_search_filters() {
+  var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
+  if (search_filters.classList.contains("search-filters-hidden")) {
+    search_filters.classList.remove("search-filters-hidden");
+    search_filters.classList.add("search-filters-visible");
+    updateURLParameter("_show_search_filters", "true");
+  } else {
+    search_filters.classList.remove("search-filters-visible");
+    search_filters.classList.add("search-filters-hidden");
+    updateURLParameter("_show_search_filters", "false");
+  }
+}
+
+/**
+ * http://stackoverflow.com/a/10997390/11236
+ */
+function updateURLParameter(param, paramVal){
+  var url = window.location.href;
+  var newAdditionalURL = "";
+  var tempArray = url.split("?");
+  var baseURL = tempArray[0];
+  var additionalURL = tempArray[1];
+  var temp = "";
+  if (additionalURL) {
+      tempArray = additionalURL.split("&");
+      for (var i=0; i<tempArray.length; i++){
+          if(tempArray[i].split('=')[0] != param){
+              newAdditionalURL += temp + tempArray[i];
+              temp = "&";
+          }
+      }
+  }
+
+  var rows_txt = temp + "" + param + "=" + paramVal;
+  var new_url = baseURL + "?" + newAdditionalURL + rows_txt;
+  window.history.replaceState('', '', new_url);
+}

--- a/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
+++ b/modules/ckanext-ytp_main/ckanext/ytp/public/javascript/search_filtering.js
@@ -1,13 +1,14 @@
 document.getElementById("search-filter-toggle-button").addEventListener("click", toggle_search_filters);
 document.getElementById("search-filter-upper-toggle-button").addEventListener("click", toggle_search_filters);
 
+// If url parameter exists, the search filters and the second toggle button are shown. 
 if (window.location.search.indexOf("_show_search_filters=true") > -1) {
   var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
   var upper_toggle_button = document.getElementById("search-filter-upper-toggle-button");
   search_filters.classList.remove("search-filters-hidden");
   search_filters.classList.add("search-filters-visible");
   upper_toggle_button.classList.add("upper-toggle-button-visible");
-} 
+}
 
 function toggle_search_filters() {
   var search_filters = document.getElementsByClassName("sidebar-offcanvas")[0];
@@ -27,6 +28,9 @@ function toggle_search_filters() {
 
 /**
  * http://stackoverflow.com/a/10997390/11236
+ * This function changes the url by changing the value of the given url parameter
+ * @param param The url parameter that will be changed
+ * @param paramVal The new value for the url parameter
  */
 function updateURLParameter(param, paramVal){
   var url = window.location.href;

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/page.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/page.html
@@ -5,7 +5,7 @@
 {% block secondary %}
         {% set inner = self.secondary_inner() %}
         {% if inner | trim %}
-        <aside class="secondary col-xs-6 col-sm-3 sidebar-offcanvas">
+        <aside class="secondary col-xs-6 col-sm-3 sidebar-offcanvas search-filters-hidden">
         {% block secondary_inner %}
             {%- include('ytp/menu.html') -%}
             {% block secondary_content -%}{%- endblock %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/page.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/page.html
@@ -5,7 +5,13 @@
 {% block secondary %}
         {% set inner = self.secondary_inner() %}
         {% if inner | trim %}
-        <button type="button" class="btn" id="search-filter-upper-toggle-button"><i class="far fa-filter"></i> {{ _('Filter search') }}</button>
+        <button type="button" class="btn" id="search-filter-upper-hide-button">
+            <span class="fa-stack">
+              <i class="far fa-filter fa-stack-1x"></i>
+              <i class="far fa-times fa-stack-1x hide-filters-cross-icon"></i>
+            </span>
+            {{ _('Hide search filters') }}
+          </button>
         <aside class="secondary col-xs-6 col-sm-3 sidebar-offcanvas search-filters-hidden">
         {% block secondary_inner %}
             {%- include('ytp/menu.html') -%}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/page.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/page.html
@@ -5,6 +5,7 @@
 {% block secondary %}
         {% set inner = self.secondary_inner() %}
         {% if inner | trim %}
+        <button type="button" class="btn" id="search-filter-upper-toggle-button"><i class="far fa-filter"></i> {{ _('Filter search') }}</button>
         <aside class="secondary col-xs-6 col-sm-3 sidebar-offcanvas search-filters-hidden">
         {% block secondary_inner %}
             {%- include('ytp/menu.html') -%}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -37,16 +37,20 @@
 {% endif %}
 
   {% block search_sortby %}
+  {% resource 'ytp_common_js/search_filtering.js' %}
     {% if disableable_sorting %}
       <div class="form-select control-group control-order-by">
-        <label for="field-order-by">{{ _('Order by') }}</label>
-        <select id="field-order-by" class="form-control" name="sort">
-          {% for label, value in disableable_sorting %}
-            {% if label and value %}
-              <option value="{{ value }}"{% if sorting_selected == value %} selected="selected"{% endif %}>{{ label }}</option>
-            {% endif %}
-          {% endfor %}
-        </select>
+        <div id="field-order-by-container">
+          <label for="field-order-by">{{ _('Order by') }}</label>
+          <select id="field-order-by" class="form-control" name="sort">
+            {% for label, value in disableable_sorting %}
+              {% if label and value %}
+                <option value="{{ value }}"{% if sorting_selected == value %} selected="selected"{% endif %}>{{ label }}</option>
+              {% endif %}
+            {% endfor %}
+          </select>
+        </div>
+        <button type="button" class="btn" id="search-filter-toggle-button"><i class="far fa-filter"></i> {{ _('Filter search') }}</button>
         <button class="btn js-hide" type="submit">{{ _('Go') }}</button>
       </div>
     {% endif %}
@@ -65,14 +69,14 @@
           {% set search_facets_items = facets.search.get(field)['items'] %}
           <span class="facet">{{ facets.titles.get(field) }}:</span>
           {% for value in facets.fields[field] %}
-            <span class="filtered pill">
-              {%- if facets.translated_fields and facets.translated_fields.has_key((field,value)) -%}
-                {{ facets.translated_fields[(field,value)] }}
-              {%- else -%}
-                {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
-              {%- endif %}
-              <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fas fa-times-circle"></i></a>
-            </span>
+              <span class="filtered pill">
+                {%- if facets.translated_fields and facets.translated_fields.has_key((field,value)) -%}
+                  {{ facets.translated_fields[(field,value)] }}
+                {%- else -%}
+                  {{ h.list_dict_filter(search_facets_items, 'name', 'display_name', value) }}
+                {%- endif %}
+                <a href="{{ facets.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fas fa-times-circle"></i></a>
+              </span>
           {% endfor %}
         {% endfor %}
       </p>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -50,7 +50,14 @@
             {% endfor %}
           </select>
         </div>
-        <button type="button" class="btn" id="search-filter-toggle-button"><i class="far fa-filter"></i> {{ _('Filter search') }}</button>
+        <button type="button" class="btn" id="search-filter-show-button"><i class="far fa-filter"></i> {{ _('Filter search') }}</button>
+        <button type="button" class="btn" id="search-filter-lower-hide-button">
+          <span class="fa-stack">
+            <i class="far fa-filter fa-stack-1x"></i>
+            <i class="far fa-times fa-stack-1x hide-filters-cross-icon"></i>
+          </span>
+          {{ _('Hide search filters') }}
+        </button>
         <button class="btn js-hide" type="submit">{{ _('Go') }}</button>
       </div>
     {% endif %}

--- a/modules/ytp-assets-common/src/less/ckan/upstream_ckan/search.less
+++ b/modules/ytp-assets-common/src/less/ckan/upstream_ckan/search.less
@@ -52,7 +52,14 @@
 
         }
     }
+    #field-order-by-container {
+      margin-right: 10px;
+      margin-bottom: 10px;
+    }
     .control-order-by {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
         label,
         select {
             display: inline;

--- a/modules/ytp-assets-common/src/less/offcanvas.less
+++ b/modules/ytp-assets-common/src/less/offcanvas.less
@@ -55,25 +55,34 @@ body {
   .search-filters-hidden {
     display: none;
   }
-  #search-filter-toggle-button {
+  #search-filter-show-button {
     background-color: @opendata-brand-primary;
     color: @btn-dark-text-color;
+    &.show-button-hidden {
+      display: none;
+    }
   }
-  #search-filter-upper-toggle-button {
+  #search-filter-upper-hide-button, #search-filter-lower-hide-button {
     display: none;
-    &.upper-toggle-button-visible {
+    &.hide-button-visible {
       display: block;
       background-color: @opendata-brand-primary;
       color: @btn-dark-text-color;
-      margin-bottom: -25px;
     }
+    .hide-filters-cross-icon {
+      margin-left: 9px;
+      margin-top: 3px;
+    }
+  }
+  #search-filter-upper-hide-button {
+    margin-bottom: -25px;
   }
 }
 @media screen and (min-width: @screen-xs-max) {
-  #search-filter-toggle-button {
+  #search-filter-show-button {
     display: none;
-  }
-  #search-filter-upper-toggle-button {
+  } 
+  #search-filter-upper-hide-button, #search-filter-lower-hide-button {
     display: none;
   }
 }

--- a/modules/ytp-assets-common/src/less/offcanvas.less
+++ b/modules/ytp-assets-common/src/less/offcanvas.less
@@ -49,4 +49,19 @@ body {
   .sidebar-offcanvas {
     width: 90%; /* 6 columns */
   }
+  .search-filters-visible {
+    display: block;
+  }
+  .search-filters-hidden {
+    display: none;
+  }
+  #search-filter-toggle-button {
+    background-color: @opendata-brand-primary;
+    color: @btn-dark-text-color;
+  }
+}
+@media screen and (min-width: @screen-xs-max) {
+  #search-filter-toggle-button {
+    display: none;
+  }
 }

--- a/modules/ytp-assets-common/src/less/offcanvas.less
+++ b/modules/ytp-assets-common/src/less/offcanvas.less
@@ -59,9 +59,21 @@ body {
     background-color: @opendata-brand-primary;
     color: @btn-dark-text-color;
   }
+  #search-filter-upper-toggle-button {
+    display: none;
+    &.upper-toggle-button-visible {
+      display: block;
+      background-color: @opendata-brand-primary;
+      color: @btn-dark-text-color;
+      margin-bottom: -25px;
+    }
+  }
 }
 @media screen and (min-width: @screen-xs-max) {
   #search-filter-toggle-button {
+    display: none;
+  }
+  #search-filter-upper-toggle-button {
     display: none;
   }
 }


### PR DESCRIPTION
  - Search filters are always shown on desktop screen
  - By default, the filters are hidden in mobile view
  - The filters can be toggled on and off
  - URL parameter about current state of the search filter is used to allow transferring the state in links
  - Button names translated to Finnish and Swedish

![image](https://user-images.githubusercontent.com/10153647/57148455-4cc43e80-6dd2-11e9-9041-35a0de797704.png)

![image](https://user-images.githubusercontent.com/10153647/57148482-606fa500-6dd2-11e9-89ec-3c0c51fb7f0d.png)
