### PR TITLE
Optimize organization edit page

### DIFF
--- a/ansible/roles/ckan/defaults/main.yml
+++ b/ansible/roles/ckan/defaults/main.yml
@@ -212,6 +212,7 @@ ckan_patches:
   - remove_user_activity_from_group_activity_list # modification from ckan master, can be removed once 2.9 is released
   - optimize_group_show
   - optimize_template_loading # https://github.com/ckan/ckan/pull/4774
+  - group_include_extras # https://github.com/ckan/ckan/pull/4774
 
 ckan_config_files:
   - file: /etc/ckan/default/production.ini

--- a/ansible/roles/ckan/files/patches/group_include_extras.patch
+++ b/ansible/roles/ckan/files/patches/group_include_extras.patch
@@ -1,0 +1,39 @@
+diff --git a/ckan/model/group.py b/ckan/model/group.py
+index 18fe6a16c..c5f3975cd 100644
+--- a/ckan/model/group.py
++++ b/ckan/model/group.py
+@@ -142,11 +142,15 @@ class Group(vdm.sqlalchemy.RevisionedObjectMixin,
+     # Todo: Make sure group names can't be changed to look like group IDs?
+ 
+     @classmethod
+-    def all(cls, group_type=None, state=('active',)):
++    def all(cls, group_type=None, state=('active',), include_extras=False):
+         """
+         Returns all groups.
+         """
+         q = meta.Session.query(cls)
++
++        if include_extras:
++            q = q.options(orm.joinedload(cls._extras))
++
+         if state:
+             q = q.filter(cls.state.in_(state))
+ 
+@@ -239,7 +243,7 @@ class Group(vdm.sqlalchemy.RevisionedObjectMixin,
+             filter(Group.state == 'active').\
+             order_by(Group.title).all()
+ 
+-    def groups_allowed_to_be_its_parent(self, type='group'):
++    def groups_allowed_to_be_its_parent(self, type='group', include_extras=False):
+         '''Returns a list of the groups (of the specified type) which are
+         allowed to be this group's parent. It excludes ones which would
+         create a loop in the hierarchy, causing the recursive CTE to
+@@ -248,7 +252,7 @@ class Group(vdm.sqlalchemy.RevisionedObjectMixin,
+         :returns: A list of group objects ordered by group title
+ 
+         '''
+-        all_groups = self.all(group_type=type)
++        all_groups = self.all(group_type=type, include_extras=include_extras)
+         excluded_groups = set(group_name
+                               for group_id, group_name, group_title, parent in
+                               self.get_children_group_hierarchy(type=type))


### PR DESCRIPTION
- Added a core patch to allow getting parent organization options with enough data for translation
- Changed ckanext-hierarchy to use the feature if it's available