### PR TITLE
AV-773 Add permissions for showcase-admin

### DIFF
--- a/ansible/roles/solr/templates/schema.xml.j2
+++ b/ansible/roles/solr/templates/schema.xml.j2
@@ -103,7 +103,7 @@
     <field name="organization" type="string" indexed="true" stored="true" multiValued="false"/>
 
     <field name="capacity" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="permission_labels" type="textgen" indexed="true" stored="true" multiValued="false"/>
+    <field name="permission_labels" type="textgen" indexed="true" stored="true" multiValued="true"/>
 
     <field name="res_name" type="textgen" indexed="true" stored="true" multiValued="true" />
     <field name="res_description" type="textgen" indexed="true" stored="true" multiValued="true"/>

--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/schemas/showcase.json
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/schemas/showcase.json
@@ -188,7 +188,7 @@
       "label": "Visibility",
       "form_snippet": "private.html",
       "display_snippet": null,
-      "validators": "boolean_validator set_private_if_not_admin"
+      "validators": "boolean_validator set_private_if_not_admin_or_showcase_admin"
     }
   ]
 }

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -20,14 +20,14 @@ from ckan.lib import helpers
 from ckan.lib.munge import munge_title_to_name
 from ckan.lib.navl import dictization_functions
 from ckan.lib.navl.dictization_functions import Missing, StopOnError, missing, flatten_dict, unflatten, Invalid
-from ckan.lib.plugins import DefaultOrganizationForm, DefaultTranslation
+from ckan.lib.plugins import DefaultOrganizationForm, DefaultTranslation, DefaultPermissionLabels
 from ckan.logic import NotFound, NotAuthorized, get_action
 from ckan.model import Session
 from ckan.plugins import toolkit
 from ckan.plugins.toolkit import config
 from ckanext.report.interfaces import IReport
 from ckanext.spatial.interfaces import ISpatialHarvester
-
+from ckanext.showcase.model import ShowcaseAdmin
 from paste.deploy.converters import asbool
 from webhelpers.html import escape
 from webhelpers.html.builder import literal
@@ -671,7 +671,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
             'tag_string_or_tags_required': validators.tag_string_or_tags_required,
             'create_tags': validators.create_tags,
             'create_fluent_tags': validators.create_fluent_tags,
-            'set_private_if_not_admin': validators.set_private_if_not_admin,
+            'set_private_if_not_admin_or_showcase_admin': validators.set_private_if_not_admin_or_showcase_admin,
             'list_to_string': validators.list_to_string,
             'convert_to_list': validators.convert_to_list,
             'tag_list_output': validators.tag_list_output,
@@ -1414,3 +1414,36 @@ class YtpRestrictCategoryCreationAndUpdatingPlugin(plugins.SingletonPlugin):
     def get_auth_functions(self):
         return {'group_create': self.admin_only_for_categories,
                 'group_update': self.admin_only_for_categories}
+
+
+class YtpIPermissionLabelsPlugin(
+        plugins.SingletonPlugin, DefaultPermissionLabels):
+    '''
+    Permission labels for controlling permissions of different user roles
+    '''
+    plugins.implements(plugins.IPermissionLabels)
+
+    def get_dataset_labels(self, dataset_obj):
+        '''
+        Showcases get showcase-admin label so that showcase admins have
+        rights for that showcase
+        '''
+        # Default labels
+        labels = super(YtpIPermissionLabelsPlugin, self).get_dataset_labels(dataset_obj)
+
+        if dataset_obj.type == "showcase":
+            labels.append(u'showcase-admin')
+
+        return labels
+
+    def get_user_dataset_labels(self, user_obj):
+        '''
+        Showcase admin users get a showcase-admin label
+        '''
+        # Default labels
+        labels = super(YtpIPermissionLabelsPlugin, self).get_user_dataset_labels(user_obj)
+
+        if user_obj and ShowcaseAdmin.is_user_showcase_admin(user_obj):
+            labels.append(u'showcase-admin')
+
+        return labels

--- a/modules/ckanext-ytp_main/ckanext/ytp/validators.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/validators.py
@@ -5,6 +5,7 @@ import ckan.model as model
 import ckan.logic.validators as validators
 import ckan.lib.navl.dictization_functions as df
 from ckan.logic import get_action
+from ckanext.showcase.model import ShowcaseAdmin
 
 import re
 import json
@@ -66,8 +67,9 @@ def tag_string_or_tags_required(key, data, errors, context):
             raise df.StopOnError
 
 
-def set_private_if_not_admin(private):
-    return True if not authz.is_sysadmin(c.user) else private
+def set_private_if_not_admin_or_showcase_admin(private):
+    userobj = model.User.get(c.user)
+    return True if not (authz.is_sysadmin(c.user) or ShowcaseAdmin.is_user_showcase_admin(userobj)) else private
 
 
 def convert_to_list(value):

--- a/modules/ckanext-ytp_main/setup.py
+++ b/modules/ckanext-ytp_main/setup.py
@@ -38,6 +38,7 @@ setup(
         ytp_spatial=ckanext.ytp.plugin:YTPSpatialHarvester
         ytp_report=ckanext.ytp.plugin:YtpReportPlugin
         ytp_restrict_category_creation_and_updating=ckanext.ytp.plugin:YtpRestrictCategoryCreationAndUpdatingPlugin
+        ytp_ipermission_labels=ckanext.ytp.plugin:YtpIPermissionLabelsPlugin
 
         [ckan.celery_task]
         tasks = ckanext.ytp.celery_import:task_imports


### PR DESCRIPTION
  - Add permission_labels for showcase-admin in a plugin. This plugin can later be used for
    controlling permissions of other roles as well.
  - Allow multiple permission labels in schema
  - Allow showcase-admins to edit private showcase into public