### PR TITLE
AV-798 Add the datepicker javascript for new datasets

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/new_resource.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/new_resource.html
@@ -4,6 +4,7 @@
 {% endblock  %}
 
 {% block primary %}
+{% resource 'ytp_dataset_js/form.js' %}
     <div >
         {% block primary_content %}
             {% block ytp_title %}


### PR DESCRIPTION
The javascript in form.js adds the datepicker for elements with the data-datepicker attribute. Earlier, the javascript was only added to the edit form, for some reason. 