### PR TITLE
AV-798 Removed most of custom /user page implementation

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/user/list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/user/list.html
@@ -1,51 +1,6 @@
 {% ckan_extends %}
 
-{% block primary_content %}
-  {% resource "ytp_common_js/ytp_form.js" %}
-  <article class="module">
-    <div class="module-content">
-      <h1 class="page-heading">
-        {% block page_heading %}{{ _('Users') }}{% endblock %}
-      </h1>
 
-      {% snippet 'user/snippets/user_search.html', query=c.q, order_by=c.order_by %}
-
-      <div class="user-search-pagination">
-        {{ page.pager(q=c.q, order_by=c.order_by) }}
-      </div>
-      {% block users_list %}
-        <ul class="user-list">
-          {% block users_list_inner %}
-            {% for user in page.items %}
-              <li>
-                {{ h.linked_user(user['name'], maxlength=20, avatar=60) }}
-                <p>
-                {% set main_organization = h.main_organization(user[0]).display_name %}
-                {# Translate the job_title field #}
-                {% set job_title = h.extra_translation(user[0], 'job_title') %}
-                {%- if job_title -%}
-                  {{ job_title }}
-                  {%- if main_organization -%}
-                  ,
-                  {%- endif %}
-                {%- endif %}
-                {{ main_organization }}
-                </p>
-              </li>
-            {% endfor %}
-          {% endblock %}
-        </ul>
-      {% endblock %}
-    </div>
-    <div style="clear: both;"></div>
-
-    <div class="user-search-pagination">
-    {% block page_pagination %}
-      {{ page.pager(q=c.q, order_by=c.order_by) }}
-    {% endblock %}
-    </div>  
-  </article>
-{% endblock %}
 
 {# Removed search from secondary #}
 {% block secondary_content %}


### PR DESCRIPTION
Previously, main_organization caused page to result in internal server error. We don't need that and other customisations anymore so we can use the core version. However, we don't want to use the search, so that is still removed. 