### PR TITLE
AV-735 datepicker in adding resources for datasets

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/new_resource_not_draft.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/new_resource_not_draft.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block primary %}
+{% resource 'ytp_dataset_js/form.js' %}
     <div >
         {% block primary_content %}
             {% block ytp_title %}


### PR DESCRIPTION
Originally, I had tested with adding a resource when creating a new dataset. However, adding a new resource to an existing dataset uses a different template. The form.js is now added to that template as well. 