### PR TITLE
AV-824: Better i18n'd labels for 'deprecated' field

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
+++ b/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
@@ -264,11 +264,11 @@
       "choices": [
         {
           "value": false,
-          "label": "False"
+          "label": "No"
         },
         {
           "value": true,
-          "label": "True"
+          "label": "Yes"
         }
       ],
       "form_snippet": null,


### PR DESCRIPTION
- Changed 'deprecated' field labels in dataset schema