### PR TITLE
AV-902: Added patch to update psycopg2 to 2.8.2

### DIFF
--- a/ansible/roles/ckan/defaults/main.yml
+++ b/ansible/roles/ckan/defaults/main.yml
@@ -221,6 +221,7 @@ ckan_patches:
   - group_admin_protection # https://github.com/ckan/ckan/pull/4821
   - remove_gravatar
   - resource-reorder-translations # https://github.com/ckan/ckan/pull/4838
+  - update_psycopg2_2.8.2 # https://github.com/ckan/ckan/pull/4841
 
 ckan_config_files:
   - file: /etc/ckan/default/production.ini

--- a/ansible/roles/ckan/files/patches/update_psycopg2_2.8.2.patch
+++ b/ansible/roles/ckan/files/patches/update_psycopg2_2.8.2.patch
@@ -1,0 +1,39 @@
+diff --git a/CHANGELOG.rst b/CHANGELOG.rst
+index f2e0d63cb..228dc4fb9 100644
+--- a/CHANGELOG.rst
++++ b/CHANGELOG.rst
+@@ -210,7 +210,7 @@ General notes:
+    This is due to a bug in the psycopg2 version pinned to the release. To solve
+    it, upgrade psycopg2 with the following command::
+ 
+-     pip install --upgrade psycopg2==2.7.3.2
++     pip install --upgrade psycopg2==2.8.2
+ 
+  * This release does not require a Solr schema upgrade, but if you are having the
+    issues described in #3863 (datasets wrongly indexed in multilingual setups),
+diff --git a/ckanext/datastore/backend/postgres.py b/ckanext/datastore/backend/postgres.py
+index fd4c33375..b3098cf63 100644
+--- a/ckanext/datastore/backend/postgres.py
++++ b/ckanext/datastore/backend/postgres.py
+@@ -284,7 +284,7 @@ def _cache_types(context):
+             # redo cache types with json now available.
+             return _cache_types(context)
+ 
+-        register_composite('nested', connection.connection, True)
++        register_composite('nested', connection.connection.connection, True)
+ 
+ 
+ def _pg_version_is_at_least(connection, version):
+diff --git a/requirements.in b/requirements.in
+index 4d45a9859..8fc8e4e83 100644
+--- a/requirements.in
++++ b/requirements.in
+@@ -13,7 +13,7 @@ Pairtree==0.7.1-T
+ passlib==1.6.5
+ paste==1.7.5.1
+ polib==1.0.7
+-psycopg2==2.7.3.2
++psycopg2==2.8.2
+ python-magic==0.4.15
+ pysolr==3.6.0
+ Pylons==0.9.7


### PR DESCRIPTION
- adapt core patch to update psycopg2 and fix an incompatibility between psycopg2 and sqlalchemy