### PR TITLE
AV-902: Fix support for patched core requirements.txt

### DIFF
--- a/ansible/roles/ckan/tasks/main.yml
+++ b/ansible/roles/ckan/tasks/main.yml
@@ -67,6 +67,13 @@
     virtualenv: "{{ ckan_virtual_environment }}"
     extra_args: "--exists-action=s -e"
 
+- name: Apply CKAN patches
+  patch:
+    src: files/patches/{{ item }}.patch
+    basedir: "{{ ckan_source_path }}"
+    strip: 1
+  loop: "{{ ckan_patches }}"
+
 - name: Install CKAN requirements
   pip:
     requirements: "{{ ckan_virtual_environment }}/src/ckan/requirements.txt"
@@ -95,13 +102,6 @@
   pip:
     requirements: "{{ ckan_cache_path }}/override-requirements"
     virtualenv: "{{ ckan_virtual_environment }}"
-
-- name: Apply CKAN patches
-  patch:
-    src: files/patches/{{ item }}.patch
-    basedir: "{{ ckan_source_path }}"
-    strip: 1
-  loop: "{{ ckan_patches }}"
 
 - name: Create CKAN files path
   file:


### PR DESCRIPTION
- Move ckan patch task before install of ckan requirements to support patched requirements.txt