### PR TITLE
Update publisher permissions to cover editing basic/restricted HTML

### DIFF
--- a/ansible/roles/drupal/templates/drupal_site_config/user.role.publisher.yml.j2
+++ b/ansible/roles/drupal/templates/drupal_site_config/user.role.publisher.yml.j2
@@ -90,6 +90,8 @@ permissions:
   - 'update content translations'
   - 'use text format filtered_html'
   - 'use text format full_html'
+  - 'use text format basic_html'
+  - 'use text format restricted_html'
   - 'view article revisions'
   - 'view avoindata_article revisions'
   - 'view avoindata_event revisions'


### PR DESCRIPTION
- Publishers had permission to edit only Full HTML content fields. Also allow more restricted ones.