### PR TITLE
AV-951: fix typo

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/dataset_info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/dataset_info.html
@@ -32,7 +32,7 @@
 
     {% block info_tags %}
         {{ layout.moduleBoxHead(_('Tags')) }}
-            {% snippet 'package/snippets/tags.html', tags=pkg.get('keywords', []), field='keywords' %}
+            {% snippet 'package/snippets/tags.html', tags=pkg.get('keywords', {}), field='keywords' %}
         {{ layout.moduleBoxFoot() }}
     {% endblock %}
 


### PR DESCRIPTION
- `keywords` is a dict of languages, not a list of keywords