### PR TITLE
AV-946: remove preset validator overrides from group schema

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/schemas/group.json
+++ b/modules/ckanext-ytp_main/ckanext/ytp/schemas/group.json
@@ -7,7 +7,6 @@
       "field_name": "title_translated",
       "label": "Title",
       "preset": "fluent_core_title_translated",
-      "validators": "fluent_text",
       "form_languages": [
         "fi",
         "sv",
@@ -27,7 +26,6 @@
     {
       "field_name": "description_translated",
       "preset": "fluent_core_markdown_translated",
-      "validators": "fluent_text",
       "form_placeholder": "A little information about my group...",
       "form_languages": [
         "fi",


### PR DESCRIPTION
- Overridden validator lists disabled group title overwriting with a translated one when updating groups. Use preset-provided validator lists instead.