### PR TITLE
AV-953: advanced search functionality

### DIFF
--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
@@ -1,14 +1,20 @@
+import logging
+
 import ckan.lib.base as base
-from ckan.common import c
+from helpers import advancedsearch_schema, query_helper
+from ckan.common import c, request
 from ckan.lib import helpers as h
 from ckan.lib.base import render
 from ckan.logic import get_action
+
+log = logging.getLogger(__name__)
 
 
 class YtpAdvancedSearchController(base.BaseController):
     def search(self):
         from ckan import model
 
+        schema = advancedsearch_schema()
         context = {
             'model': model,
             'session': model.Session,
@@ -18,13 +24,36 @@ class YtpAdvancedSearchController(base.BaseController):
         # TODO: get the page from the url
         page = 1
         limit = 2
+        search_query_filters = []
+        q = ''
+        main_query_field = schema['main_query_field']
+
+        if request.method == 'POST':
+            main_query_helper = query_helper(schema['input_fields'].get(main_query_field))
+            q = main_query_helper(main_query_field, request.POST, schema['input_fields'], context)
+            # Iterate through all fields in schema except the main_query_field
+            # and process every field with the provided query_helper
+            for key, val in schema['input_fields'].iteritems():
+                # Skip field used for main query
+                if key == main_query_field:
+                    continue
+                # Get query helper function from schema
+                query_helper_function = query_helper(val)
+                # TODO: handle no query_helper
+                if query_helper_function:
+                    res = query_helper_function(key, request.POST, schema['input_fields'], context)
+                    if res:
+                        search_query_filters.append(res)
 
         data_dict = {
-            'q': '*:*',
+            'q': q,
             'rows': limit,
             'start': (page - 1) * limit,
             'extras': {}
         }
+
+        if search_query_filters:
+            data_dict['fq'] = '(' + ') AND ('.join(search_query_filters) + ')'
 
         query = get_action('package_search')(context, data_dict)
 

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
@@ -21,8 +21,9 @@ class YtpAdvancedSearchController(base.BaseController):
             'user': c.user
         }
 
-        # FIXME: the page comes as a get parameter and all the query params come as POST params
-        # Results in onyl one working at a time.
+        # On initial page load there is no page parameter so display the first page
+        # On possible page navigations use the page parameter to move to the next page
+        # NOTE: this works also with a GET request but the POST filters will not be submitted so all datasets will be returned
         page = int(request.params.get('page', 1))
         # NOTE: this is for testing the pagination
         # TODO: Change to actual limit
@@ -32,8 +33,11 @@ class YtpAdvancedSearchController(base.BaseController):
         main_query_field = schema['main_query_field']
 
         if request.method == 'POST':
+            # Use the field labelled as the main_query to build the value for q
+            # TODO: Handle no main_query_field provided
             main_query_helper = query_helper(schema['input_fields'].get(main_query_field))
             q = main_query_helper(main_query_field, request.POST, schema['input_fields'], context)
+
             # Iterate through all fields in schema except the main_query_field
             # and process every field with the provided query_helper
             for key, val in schema['input_fields'].iteritems():
@@ -56,15 +60,18 @@ class YtpAdvancedSearchController(base.BaseController):
         }
 
         if search_query_filters:
+            # Outputs: (filter:value) AND (another_filter:another_value)
             data_dict['fq'] = '(' + ') AND ('.join(search_query_filters) + ')'
 
         query = get_action('package_search')(context, data_dict)
 
         c.advanced_search = {
             "item_count": query['count'],
+            # Round values up to get total amount of pages
             "total_pages": int(math.ceil(float(query['count']) / float(limit))),
-            "collection": list(query['results']),
-            # Can this cause security issues? Returning POST request params back to the client
+            "collection": query['results'],
+            # Return query parameters to the UI so that it can populate the fields with the previous query values
+            # NOTE: Can this cause security issues? Returning POST request params back to the client
             "last_query": params_to_dict(request.POST),
         }
         c.advanced_search['last_query']['page'] = page

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/post_pagination.js
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/post_pagination.js
@@ -5,12 +5,15 @@ ckan.module('post-pagination', function($) {
     initialize: function() {
         $.proxy(this, 'handlePaginationClick');
         // Get the actual dom element and not the JQuery version for event propagation
+        // Event is attached to parent container.
+        // The click events on children propagate and trigger the event on the parent.
         document
             .querySelector('.pagination')
             .addEventListener('click', (e) => this.handlePaginationClick(e), true)
     },
     handlePaginationClick: function(e) {
         if (!e.target.value) {
+            // Throw error for sentry.io tracking
             throw new Error('POST Pagination value empty')
         }
         this.post(this.options.prevQuery, e.target.value)
@@ -21,7 +24,7 @@ ckan.module('post-pagination', function($) {
 
         params.page = page_num
 
-        const newNormalField = (key, value) => {
+        const newField = (key, value) => {
             const hiddenField = document.createElement('input');
             hiddenField.type = 'hidden';
             hiddenField.name = key;
@@ -30,22 +33,15 @@ ckan.module('post-pagination', function($) {
             form.appendChild(hiddenField);
         }
 
-        const newCheckBoxField = (key, values) => {
-            for (let value of values) {
-                const hiddenField = document.createElement('input');
-                hiddenField.type = 'hidden';
-                hiddenField.name = key;
-                hiddenField.value = value;
-                form.appendChild(hiddenField)
-            }
-        }
-
         for (const key in params) {
             if (params.hasOwnProperty(key)) {
                 if (params[key].length > 1) {
-                    newCheckBoxField(key, params[key])
+                    // Checkbox fields contain multiple values for a single key
+                    for (let value of params[key]) {
+                        newField(key, value)
+                    }
                 } else {
-                    newNormalField(key, params[key])
+                    newField(key, params[key])
                 }
             }
         }

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/post_pagination.js
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/post_pagination.js
@@ -1,0 +1,57 @@
+'use strict';
+
+ckan.module('post-pagination', function($) {
+  return {
+    initialize: function() {
+        $.proxy(this, 'handlePaginationClick');
+        // Get the actual dom element and not the JQuery version for event propagation
+        document
+            .querySelector('.pagination')
+            .addEventListener('click', (e) => this.handlePaginationClick(e), true)
+    },
+    handlePaginationClick: function(e) {
+        if (!e.target.value) {
+            throw new Error('POST Pagination value empty')
+        }
+        this.post(this.options.prevQuery, e.target.value)
+    },
+    post: function(params, page_num) {
+        const form = document.createElement('form');
+        form.method = 'post';
+
+        params.page = page_num
+
+        const newNormalField = (key, value) => {
+            const hiddenField = document.createElement('input');
+            hiddenField.type = 'hidden';
+            hiddenField.name = key;
+            hiddenField.value = value;
+
+            form.appendChild(hiddenField);
+        }
+
+        const newCheckBoxField = (key, values) => {
+            for (let value of values) {
+                const hiddenField = document.createElement('input');
+                hiddenField.type = 'hidden';
+                hiddenField.name = key;
+                hiddenField.value = value;
+                form.appendChild(hiddenField)
+            }
+        }
+
+        for (const key in params) {
+            if (params.hasOwnProperty(key)) {
+                if (params[key].length > 1) {
+                    newCheckBoxField(key, params[key])
+                } else {
+                    newNormalField(key, params[key])
+                }
+            }
+        }
+    
+        document.body.appendChild(form);
+        form.submit();
+    }
+  }
+});

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/ytp-multiselect.js
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/ytp-multiselect.js
@@ -74,7 +74,7 @@ ckan.module('ytp-multiselect', function($) {
       }
 
       if (this.isAllSelected()) {
-        return 'All'
+        return this.options.allTranslation
       }
 
       if (selectedItems.length === 1) {

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/ytp-multiselect.js
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/ytp-multiselect.js
@@ -81,7 +81,7 @@ ckan.module('ytp-multiselect', function($) {
         return selectedItems[0].dataset.optionLabel
       }
 
-      return `${selectedItems.length} valittu`
+      return `${selectedItems.length} ${this.options.selectTranslation}`
     },
 
     // Returns array of checkboxes with specific name value combo

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/helpers.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/helpers.py
@@ -22,10 +22,41 @@ def field_options(field):
         return options_fn(field)
 
 
+# twig helper to get the value based on a dynamic key
+def value_or_blank(item, key):
+    if item:
+        return item[key] if key in item else ''
+    return ''
+
+
+# finds the index of previously selected radio
+# twig loop indexes start from 1
+def selected_indexes_checkboxes(options, prev_selected):
+    indexes = []
+    loop_index = 1
+    all_selected = True
+    for option in options:
+        if option['value'] in prev_selected:
+            indexes.append(loop_index)
+        else:
+            all_selected = False
+        loop_index = loop_index + 1
+    return {'indexes': indexes, 'all_selected': all_selected}
+
+
+def selected_index_radio(options, prev_selected):
+    index = 1
+    for option in options:
+        if option['value'] == prev_selected:
+            return index
+        index = index + 1
+    return 1
+
+
 def query_helper(field):
     """
     :param field: scheming field definition
-    :returns: options iterable or None if not found.
+    :returns: query helper function result or None if not found.
     """
     if 'query_helper' in field:
         from ckantoolkit import h
@@ -36,7 +67,7 @@ def query_helper(field):
             return getattr(h, name)(*args)
         else:
             return getattr(h, query_helper)()
-        
+
 
 def advancedsearch_schema():
     """
@@ -164,6 +195,7 @@ def advanced_daterange_query(custom_key=None):
         if key + '-after' in all_params:
             after = all_params.getone(key + '-after')
 
+        # exit early
         if not before and not after:
             return
 

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/helpers.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/helpers.py
@@ -1,4 +1,5 @@
 from ckan.logic import get_action
+from ckan import model
 
 # TODO: Should not be cross dependant to ckanext.ytp
 # This is specific to ytp
@@ -82,8 +83,6 @@ def advancedsearch_schema():
 # OPTIONS
 # NOTE: these are a bit ytp specific, these could be defined where the search_fields are
 def advanced_category_options(field=None):
-    from ckan import model
-
     context = {'model': model, 'session': model.Session}
     groups = get_action('group_list')(context, {})
 
@@ -96,9 +95,7 @@ def advanced_category_options(field=None):
 
 
 def advanced_publisher_options(field=None):
-    from ckan import model
     import ckan.plugins as p
-
     context = {'model': model, 'session': model.Session}
     publishers = p.toolkit.get_action('get_organizations')(context, {})
 
@@ -106,7 +103,6 @@ def advanced_publisher_options(field=None):
 
 
 def advanced_license_options(field=None):
-    from ckan import model
     context = {'model': model, 'session': model.Session}
 
     licenses = get_action('license_list')(context)
@@ -115,7 +111,6 @@ def advanced_license_options(field=None):
 
 
 def advanced_format_options(field=None):
-    from ckan import model
     context = {'model': model, 'session': model.Session}
 
     formats = get_action('get_formats')(context)

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/loader.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/loader.py
@@ -3,18 +3,17 @@ Load either yaml or json, based on the name of the resource
 """
 
 import json
+import yaml
 
 
 def load(f):
     if is_yaml(f.name):
-        import yaml
         return yaml.load(f)
     return json.load(f)
 
 
 def loads(s, url):
     if is_yaml(url):
-        import yaml
         return yaml.load(s)
     return json.loads(s)
 

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/plugin.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/plugin.py
@@ -39,7 +39,6 @@ class AdvancedsearchPlugin(plugins.SingletonPlugin):
         toolkit.add_public_directory(config, 'public')
         toolkit.add_resource('fanstatic', 'advancedsearch')
 
-        log.info(config.get('advancedsearch.schema', ""))
         self._schema = _load_schema(config.get('advancedsearch.schema', ""))
 
     # IActions
@@ -58,6 +57,10 @@ class AdvancedsearchPlugin(plugins.SingletonPlugin):
             'advanced_publisher_options': helpers.advanced_publisher_options,
             'advanced_license_options': helpers.advanced_license_options,
             'advanced_format_options': helpers.advanced_format_options,
+            'advanced_multiselect_query': helpers.advanced_multiselect_query,
+            'advanced_search_and_target_query': helpers.advanced_search_and_target_query,
+            'advanced_daterange_query': helpers.advanced_daterange_query,
+            'query_helper': helpers.query_helper,
         }
 
     # IRoutes

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/plugin.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/plugin.py
@@ -61,6 +61,9 @@ class AdvancedsearchPlugin(plugins.SingletonPlugin):
             'advanced_search_and_target_query': helpers.advanced_search_and_target_query,
             'advanced_daterange_query': helpers.advanced_daterange_query,
             'query_helper': helpers.query_helper,
+            'value_or_blank': helpers.value_or_blank,
+            'selected_index_radio': helpers.selected_index_radio,
+            'selected_indexes_checkboxes': helpers.selected_indexes_checkboxes,
         }
 
     # IRoutes

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/search_fields.json
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/search_fields.json
@@ -1,27 +1,29 @@
 {
+  "main_query_field": "search_query",
   "input_fields": {
-    "search_term": {
-      "field_name": "search_term",
+    "search_query": {
+      "field_name": "search_query",
       "label": "Search terms",
-      "display_snippet": "search-bar.html",
+      "display_snippet": "search-and-target.html",
+      "query_helper": "advanced_search_and_target_query(search_query,search_target)",
       "display_options": {
-        "placeholder": "Type what are you searching for"
+        "placeholder": "Type what are you searching for",
+        "target": {
+          "field_name": "search_target",
+          "label": "Search target",
+          "options": [
+            { "value": "all", "label": "All" },
+            { "value": "title_translated", "label": "Only title" },
+            { "value": "notes_translated", "label": "Only description" }
+          ]
+        }
       }
-    },
-    "search_target": {
-      "field_name": "search_target",
-      "label": "Search target",
-      "options": [
-        { "value": "all", "label": "All" },
-        { "value": "title", "label": "Only title" },
-        { "value": "description", "label": "Only description" }
-      ],
-      "display_snippet": "radio-select.html"
     },
     "category": {
       "field_name": "category",
       "label": "Category",
       "options_helper": "advanced_category_options",
+      "query_helper": "advanced_multiselect_query(groups)",
       "display_snippet": "multiselect.html",
       "display_options": {
         "allow_select_all": true
@@ -31,6 +33,7 @@
       "field_name": "publisher",
       "label": "Publisher",
       "options_helper": "advanced_publisher_options",
+      "query_helper": "advanced_multiselect_query(organization)",
       "display_snippet": "multiselect.html",
       "display_options": {
         "allow_select_all": true
@@ -40,6 +43,7 @@
       "field_name": "license",
       "label": "License",
       "options_helper": "advanced_license_options",
+      "query_helper": "advanced_multiselect_query(license_id)",
       "display_snippet": "multiselect.html",
       "display_options": {
         "allow_select_all": true
@@ -49,30 +53,33 @@
       "field_name": "format",
       "label": "Format",
       "options_helper": "advanced_format_options",
+      "query_helper": "advanced_multiselect_query(res_format)",
       "display_snippet": "multiselect.html",
       "display_options": {
-        "allow_select_all": false
+        "allow_select_all": true
       }
     },
     "released": {
       "field_name": "released",
       "label": "Date released",
+      "query_helper": "advanced_daterange_query(metadata_created)",
       "display_snippet": "datepicker-range.html",
       "display_options": {
         "label": {
-          "start": "Released before",
-          "end": "Released after"
+          "before": "Released before",
+          "after": "Released after"
         }
       }
     },
     "updated": {
       "field_name": "updated",
       "label": "Date updated",
+      "query_helper": "advanced_daterange_query(metadata_modified)",
       "display_snippet": "datepicker-range.html",
       "display_options": {
         "label": {
-          "start": "Updated before",
-          "end": "Updated after"
+          "before": "Updated before",
+          "after": "Updated after"
         }
       }
     }

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_field.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_field.html
@@ -9,4 +9,4 @@
 {%- endif -%}
 
 
-{%- snippet display_snippet, field=field -%}
+{%- snippet display_snippet, field=field, prev_query=prev_query -%}

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html
@@ -3,7 +3,7 @@
 <div>
     <h2>{{ _(label) }}</h2>
     <div class="d-flex flex-wrap">
-        {% snippet 'advanced_search/display_snippets/datepicker.html', label=field.display_options.label.start, name=field.field_name + "-start" %}
-        {% snippet 'advanced_search/display_snippets/datepicker.html', label=field.display_options.label.end, name=field.field_name + "-end" %}
+        {% snippet 'advanced_search/display_snippets/datepicker.html', label=field.display_options.label.before, name=field.field_name + "-before" %}
+        {% snippet 'advanced_search/display_snippets/datepicker.html', label=field.display_options.label.after, name=field.field_name + "-after" %}
     </div>
 </div>

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html
@@ -3,7 +3,9 @@
 <div>
     <h2>{{ _(label) }}</h2>
     <div class="d-flex flex-wrap">
-        {% snippet 'advanced_search/display_snippets/datepicker.html', label=field.display_options.label.before, name=field.field_name + "-before" %}
-        {% snippet 'advanced_search/display_snippets/datepicker.html', label=field.display_options.label.after, name=field.field_name + "-after" %}
+        {% set before_value = h.value_or_blank(prev_query, field.field_name + "-before")[0] %}
+        {% set after_value = h.value_or_blank(prev_query, field.field_name + "-after")[0] %}
+        {% snippet 'advanced_search/display_snippets/datepicker.html', label=field.display_options.label.before, name=field.field_name + "-before", value=before_value %}
+        {% snippet 'advanced_search/display_snippets/datepicker.html', label=field.display_options.label.after, name=field.field_name + "-after", value=after_value %}
     </div>
 </div>

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker.html
@@ -5,7 +5,7 @@
         {{_(label)}}
     </label>
     <div class="ytp-input-with-icon">
-        <input name="{{name}}" class="ytp-input-element" type="text" data-datepicker data-date-format="YYYY-MM-DD" placeholder="{{_('Choose')}}">
+        <input name="{{name}}" class="ytp-input-element" type="text" data-datepicker data-date-format="YYYY-MM-DD" placeholder="{{_('Choose')}}" value="{{value}}">
         <i class="far fa-calendar-alt color-highlight-base"></i>
     </div>
 </div>

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html
@@ -2,6 +2,11 @@
 {% set name = field.field_name %}
 {% set options = h.field_options(field) %}
 {% set allow_select_all = field.display_options.allow_select_all %}
+{% set prev_selected = h.value_or_blank(prev_query, name) %}
+
+{% if prev_selected %}
+    {% set stats_prev = h.selected_indexes_checkboxes(options, prev_selected) %}
+{% endif %}
 
 {% resource 'advancedsearch/javascript/ytp-multiselect.js' %}
 
@@ -12,6 +17,7 @@
     data-module-name="{{name}}"
     data-module-allow-all="{% if allow_select_all %}true{% else %}false{% endif %}"
     data-module-all-translation="{{_('All')}}"
+    data-module-select-translation="{{_('selected')}}"
 >
     <label for="advanced-search-dropdown-toggle-{{name}}" class="ytp-input-label">
         {{_(label)}}
@@ -21,19 +27,45 @@
         class="ytp-multiselect-toggle ytp-input-element"
         type="button"
         aria-expanded="false"
-    >
-        <span class="multiselect-status">{{_('All')}}</span>
+    >  
+        {% if prev_selected %}
+            {% if stats_prev %}
+                {% if not stats_prev.all_selected %}
+                    {% set status %}
+                        {{stats_prev.indexes|length}} {{_('selected')}}
+                    {% endset %}
+                {% else %}
+                    {% set status = _('All') %}
+                {% endif %}
+            {% endif %}
+        {% else %}
+            {% set status %}
+                0 {{_('selected')}}
+            {% endset %}
+        {% endif %}
+        <span class="multiselect-status">{{status}}</span>
         <i class="fa fa-caret-down" aria-hidden="true"></i>
         <i class="fa fa-caret-up" aria-hidden="true"></i>
     </button>
     <fieldset id="advanced-search-dropdown-{{name}}">
         <div class="choicelist" id="{{name}}-choicelist">
+            <!-- Get selection from previous query and apply it to the current inputs -->
             {% if allow_select_all %}
-                {% snippet 'advanced_search/snippets/multiselect-choice.html', name=name, option={"value": "all", "label": _('All')}, isChecked=true %}
+                {% if prev_selected %}
+                    {% set checked = stats_prev.all_selected %}
+                {% else %}
+                    {% set checked = false %}
+                {% endif %}
+                {% snippet 'advanced_search/snippets/multiselect-choice.html', name=name, option={"value": "all", "label": _('All')}, isChecked=checked %}
             {% endif %}
             {% if options %}
                 {% for option in options %}
-                    {% snippet 'advanced_search/snippets/multiselect-choice.html', name=name, option=option, isChecked=true %}
+                    {% if prev_selected %}
+                        {% set checked = (loop.index in stats_prev.indexes) %}
+                    {% else %}
+                        {% set checked = false %}
+                    {% endif %}
+                    {% snippet 'advanced_search/snippets/multiselect-choice.html', name=name, option=option, isChecked=checked %}
                 {% endfor %}
             {% endif %}
         </div>

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html
@@ -11,6 +11,7 @@
     data-module="ytp-multiselect"
     data-module-name="{{name}}"
     data-module-allow-all="{% if allow_select_all %}true{% else %}false{% endif %}"
+    data-module-all-translation="{{_('All')}}"
 >
     <label for="advanced-search-dropdown-toggle-{{name}}" class="ytp-input-label">
         {{_(label)}}

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/radio-select.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/radio-select.html
@@ -5,9 +5,12 @@
 <div>
     <label for="radio-target-fieldset" class="ytp-input-label">{{_(label)}}</label>
     <fieldset id="radio-target-fieldset">
-        <!-- Print all radio buttons and make the first option selected -->
+        <!-- Print all radio buttons and make the first or previous option selected -->
+        {% set prev_selected = h.value_or_blank(prev_query, name)[0] %}
+        {% set selected_index = h.selected_index_radio(options, prev_selected) %}
+
         {% for option in options %}
-            {% set checked = (loop.index == 1) %}
+            {% set checked = (loop.index == selected_index) %}
             {% snippet 'advanced_search/snippets/single-radio.html', name=name, option=option, isChecked=checked %}
         {% endfor %}
     </fieldset>

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/search-and-target.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/search-and-target.html
@@ -1,0 +1,6 @@
+<div class="mb-3 col-sm-8">
+    {% snippet 'advanced_search/display_snippets/search-bar.html', field=field %}
+</div>
+<div class="mb-3 col-sm-4">
+    {% snippet 'advanced_search/display_snippets/radio-select.html', field=field.display_options.target %}
+</div>

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/search-and-target.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/search-and-target.html
@@ -1,6 +1,6 @@
 <div class="mb-3 col-sm-8">
-    {% snippet 'advanced_search/display_snippets/search-bar.html', field=field %}
+    {% snippet 'advanced_search/display_snippets/search-bar.html', field=field, prev_query=prev_query %}
 </div>
 <div class="mb-3 col-sm-4">
-    {% snippet 'advanced_search/display_snippets/radio-select.html', field=field.display_options.target %}
+    {% snippet 'advanced_search/display_snippets/radio-select.html', field=field.display_options.target, prev_query=prev_query %}
 </div>

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/search-bar.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/search-bar.html
@@ -3,6 +3,12 @@
 {% set placeholder = field.display_options.placeholder %}
 
 <div>
+    <!-- Popoulate input with prev query value -->
+    {% set value_or_blank = h.value_or_blank(prev_query, field_name) %}
+    {% if value_or_blank %}
+        {% set value_or_blank = value_or_blank[0] %}
+    {% endif %}
+
     {% if label %}
         <label class="ytp-input-label" for="advanced-search-keywords">{{_(label)}}</label>
     {% endif %}
@@ -11,6 +17,7 @@
             id="advanced-search-keywords"
             type="text"
             name="{{field_name}}"
+            value="{{value_or_blank}}"
             class="ytp-input-element ytp-search-bar"
             placeholder="{{_(placeholder)}}"
         >

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/search-bar.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/search-bar.html
@@ -1,15 +1,16 @@
 {% set label = field.label %}
+{% set field_name = field.field_name %}
 {% set placeholder = field.display_options.placeholder %}
 
 <div>
     {% if label %}
         <label class="ytp-input-label" for="advanced-search-keywords">{{_(label)}}</label>
     {% endif %}
-    <!-- TODO: Add search icon -->
     <div class="ytp-input-with-icon">
         <input
             id="advanced-search-keywords"
             type="text"
+            name="{{field_name}}"
             class="ytp-input-element ytp-search-bar"
             placeholder="{{_(placeholder)}}"
         >

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/index.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/index.html
@@ -14,8 +14,11 @@
 
 {% block breadcrumb_content %}
     <li class="active">
-        <a href="{{ h.url_for(controller='ckanext.advancedsearch.controller:YtpAdvancedSearchController', action='search') }}" title="{{ _('Advanced search') }}">
-            {{_('Advanced search')}}
+        <a 
+            href="{{ h.url_for(controller='ckanext.advancedsearch.controller:YtpAdvancedSearchController', action='search') }}"
+            title="{{ _('Advanced search') }}"
+        >
+                {{_('Advanced search')}}
         </a>
     </li>
 {% endblock %}
@@ -30,14 +33,19 @@
 
   {% block advanced_result_list %}
     <div>
-        <h2>{{_('Search results')}} ({{ c.page.item_count }})</h2>
+        <h2>{{_('Search results')}} ({{ c.advanced_search.item_count }})</h2>
         <div class="mt-4">
-            {{ h.snippet('snippets/package_list.html', packages=c.page.items) }}
+            {{ h.snippet('snippets/package_list.html', packages=c.advanced_search.collection) }}
         </div>
         <div>
-            {% block page_pagination %}
-                {{ c.page.pager(q=c.q) }}
-            {% endblock %}
+            {{
+                h.snippet(
+                    'advanced_search/snippets/post_pagination.html',
+                    page=c.advanced_search.last_query.page,
+                    total_pages=c.advanced_search.total_pages,
+                    prev_query=c.advanced_search.last_query,
+                )
+            }}
         </div>
     </div>
   {% endblock %}

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/search_form.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/search_form.html
@@ -1,33 +1,28 @@
 {% resource 'advancedsearch/javascript/clear-all-fields.js' %}
 
 <div class="search-container control-group p-4">
-    <form class="advanced-search-form" method="get">
+    <form class="advanced-search-form" method="post">
         <div class="row">
-            <div class="mb-3 col-sm-8">
-                {% snippet 'advanced_search/display_field.html', field=input_fields.search_term %}
-            </div>
-            <div class="mb-3 col-sm-4">
-                {% snippet 'advanced_search/display_field.html', field=input_fields.search_target %}
-            </div>
+            {% snippet 'advanced_search/display_field.html', field=input_fields.search_query %}
         </div>
         <div>
-        <div>
-            <h2>{{_('Features')}}</h2>
-        </div>
-        <div class="row">
-            <div class="col-sm-6 col-md-3">
-                {% snippet 'advanced_search/display_field.html', field=input_fields.category %}
+            <div>
+                <h2>{{_('Features')}}</h2>
             </div>
-            <div class="col-sm-6 col-md-3">
-                {% snippet 'advanced_search/display_field.html', field=input_fields.publisher %}
+            <div class="row">
+                <div class="col-sm-6 col-md-3">
+                    {% snippet 'advanced_search/display_field.html', field=input_fields.category %}
+                </div>
+                <div class="col-sm-6 col-md-3">
+                    {% snippet 'advanced_search/display_field.html', field=input_fields.publisher %}
+                </div>
+                <div class="col-sm-6 col-md-3">
+                    {% snippet 'advanced_search/display_field.html', field=input_fields.license %}
+                </div>
+                <div class="col-sm-6 col-md-3">
+                    {% snippet 'advanced_search/display_field.html', field=input_fields.format %}
+                </div>
             </div>
-            <div class="col-sm-6 col-md-3">
-                {% snippet 'advanced_search/display_field.html', field=input_fields.license %}
-            </div>
-            <div class="col-sm-6 col-md-3">
-                {% snippet 'advanced_search/display_field.html', field=input_fields.format %}
-            </div>
-        </div>
         </div>
         <div class="d-flex flex-wrap mb-4 row">
             <!-- This margin is actually off by 1px, compared to the row margin, but it is not visible -->

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/search_form.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/search_form.html
@@ -1,9 +1,10 @@
 {% resource 'advancedsearch/javascript/clear-all-fields.js' %}
+{%- set prev_query = c.advanced_search.last_query -%}
 
 <div class="search-container control-group p-4">
     <form class="advanced-search-form" method="post">
         <div class="row">
-            {% snippet 'advanced_search/display_field.html', field=input_fields.search_query %}
+            {% snippet 'advanced_search/display_field.html', field=input_fields.search_query, prev_query=prev_query %}
         </div>
         <div>
             <div>
@@ -11,26 +12,26 @@
             </div>
             <div class="row">
                 <div class="col-sm-6 col-md-3">
-                    {% snippet 'advanced_search/display_field.html', field=input_fields.category %}
+                    {% snippet 'advanced_search/display_field.html', field=input_fields.category, prev_query=prev_query %}
                 </div>
                 <div class="col-sm-6 col-md-3">
-                    {% snippet 'advanced_search/display_field.html', field=input_fields.publisher %}
+                    {% snippet 'advanced_search/display_field.html', field=input_fields.publisher, prev_query=prev_query %}
                 </div>
                 <div class="col-sm-6 col-md-3">
-                    {% snippet 'advanced_search/display_field.html', field=input_fields.license %}
+                    {% snippet 'advanced_search/display_field.html', field=input_fields.license, prev_query=prev_query %}
                 </div>
                 <div class="col-sm-6 col-md-3">
-                    {% snippet 'advanced_search/display_field.html', field=input_fields.format %}
+                    {% snippet 'advanced_search/display_field.html', field=input_fields.format, prev_query=prev_query %}
                 </div>
             </div>
         </div>
         <div class="d-flex flex-wrap mb-4 row">
             <!-- This margin is actually off by 1px, compared to the row margin, but it is not visible -->
             <div class="mx-3">
-            {% snippet 'advanced_search/display_field.html', field=input_fields.released %}
+                {% snippet 'advanced_search/display_field.html', field=input_fields.released, prev_query=prev_query %}
             </div>
             <div class="mx-3">
-            {% snippet 'advanced_search/display_field.html', field=input_fields.updated %}
+                {% snippet 'advanced_search/display_field.html', field=input_fields.updated, prev_query=prev_query %}
             </div>
         </div>
         <div>

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/snippets/multiselect-choice.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/snippets/multiselect-choice.html
@@ -3,6 +3,7 @@
         class="m-0 sr-only"
         type="checkbox"
         name="{{name}}"
+        value="{{option.value}}"
         id="{{name}}-checkbox-{{option.value}}"
         data-option-value="{{option.value}}"
         data-option-label="{{option.label}}"

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/snippets/post_pagination.html
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/snippets/post_pagination.html
@@ -1,0 +1,88 @@
+{%- resource 'advancedsearch/javascript/post_pagination.js' -%}
+
+{%- set current_page = 1 if not page else page -%}
+{%- set plus_minus = 2 -%} 
+
+<div class="pagination-wrapper">
+  <ul
+    class="pagination"
+    data-module="post-pagination"
+    data-module-prev-query="{{ h.dump_json(prev_query) }}"
+  >
+    <!-- "On page back" -button -->
+    {%- if current_page != 1 -%} 
+        <li>
+            <button aria-label="{{_('Previous page')}}" value="{{current_page - 1}}">«</button>
+        </li>
+    {%- endif -%} 
+    <!-- First page button -->
+    {%- if current_page - plus_minus > 1 -%} 
+        <li>
+            <button value="1">
+                <span class="sr-only">{{_('Page number:')}}</span>1
+            </button>
+        </li>
+    {%- endif -%} 
+    <!-- Rest button or if only one in between render the button -->
+    {%- if current_page - (plus_minus + 1) > 1 -%} 
+        {%- if current_page - (plus_minus + 1) == 2 -%} 
+            <li>
+                <button value="2">
+                    <span class="sr-only">{{_('Page number:')}}</span>2
+                </button>
+            </li>
+        {%- else -%} 
+            <li><button disabled>...</button></li>
+        {%- endif -%} 
+    {%- endif -%} 
+    <!-- Show middle section -->
+    {%- for page in range(current_page - plus_minus, current_page + plus_minus + 1) -%}
+        {%- if page > 0 and page < total_pages + 1 -%}
+            {%- if page == current_page -%}
+                <li class="active">
+                    <button value="{{page}}">
+                        <span class="sr-only">{{_('Current page number:')}}</span>{{ page }}
+                    </button>
+                </li>
+            {%- else -%}
+                <li>
+                    <button value="{{page}}">
+                        <span class="sr-only">{{_('Page number:')}}</span>{{ page }}
+                    </button>
+                </li>
+            {%- endif -%}
+        {%- endif -%}
+    {%- endfor -%}
+    <!-- Rest button or if only one in between render the button -->
+    {%- if current_page + plus_minus + 1 < total_pages -%} 
+        {%- if current_page + plus_minus + 1 == total_pages - 1 -%} 
+            <li>
+                <button value="{{total_pages - 1}}">
+                    <span class="sr-only">{{_('Page number:')}}</span>{{ total_pages - 1 }}
+                </button>
+            </li>
+        {%- else -%} 
+            <li><button disabled>...</button></li>
+        {%- endif -%} 
+    {%- endif -%} 
+    <!-- Last page button -->
+    {%- if current_page + plus_minus < total_pages -%} 
+        <li>
+            <button aria-label="{{_('Last page')}}" value="{{total_pages}}">
+                <span class="sr-only">{{_('Page number:')}}</span>{{ total_pages }}
+            </button>
+        </li>
+    {%- endif -%} 
+    <!-- "On page forward" -button -->
+    {%- if current_page != total_pages -%} 
+        <li>
+            <button
+                value="{{current_page + 1}}"
+                aria-label="{{_('Next page')}}"
+            >
+                »
+            </button>
+        </li>
+    {%- endif -%} 
+  </ul>
+</div>

--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/tests/test_plugin.py
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/tests/test_plugin.py
@@ -1,5 +1,5 @@
 """Tests for plugin.py."""
-import ckanext.advancedsearch.plugin as plugin
+
 
 def test_plugin():
     pass

--- a/modules/ytp-assets-common/src/less/forms.less
+++ b/modules/ytp-assets-common/src/less/forms.less
@@ -279,11 +279,7 @@ fieldset.checkboxes {
     text-shadow: 0 1px 1px rgba(@suomi-brandBase, 0.5);
 
     &:hover {
-      background:
-        linear-gradient(
-          @suomi-highlightLight4,
-          @suomi-highlightBase
-        );
+      background: linear-gradient(@suomi-highlightLight4, @suomi-highlightBase);
     }
 
     &:active {
@@ -313,5 +309,38 @@ fieldset.checkboxes {
       border: 1px solid @suomi-depthLight13;
       color: @suomi-depthBase;
     }
+  }
+}
+
+.pagination > li {
+  display: inline-block;
+
+  &.active {
+    button {
+      color: @suomi-whiteBase;
+      background-color: @suomi-highlightBase;
+      border-color: @suomi-highlightBase;
+    }
+  }
+
+  button {
+    color: @suomi-highlightBase;
+    cursor: pointer;
+    background-color: transparent;
+    border-color: transparent;
+    border-style: none;
+    padding: 6px 12px;
+
+    &:hover {
+      background-color: @suomi-depthLight26;
+    }
+  }
+
+  &:last-of-type button {
+    border-radius: 0 3px 3px 0;
+  }
+
+  &:first-of-type button {
+    border-radius: 3px 0 0 3px;
   }
 }


### PR DESCRIPTION
## Changes
- Query helper functions (field: `query_helper`) to generate solr query parameters for input fields. These are defined in the schema file. The solr query is built based on these.
- Return previous query to the UI so it can display the previous query.
- Made pagination work with POST request.
  - It uses the previous query values and builds a new hidden form with the new page parameter also included and submits it.
  - This is done with Javascript in the "post-pagination" file.

### Minor changes
- Changed daterange input `start` and `end` fields to `before` and `after` to match the UI spec.
- Added `selected-` helper functions to populate custom fields with the prev query selected values.
- Added styles for pagination that uses buttons instead of links.
- Moved some imports to the top scope.
