### PR TITLE
AV-805: Handle harvesters with None as last_job_status

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/harvesterstatusplugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/harvesterstatusplugin.py
@@ -14,7 +14,11 @@ def harvester_status(context=None, data_dict=None):
     sources = logic.get_action('harvest_source_list')(context, {'return_last_job_status': True})
 
     def last_job_status(source):
-        j = source.get('last_job_status', {})
+        j = source.get('last_job_status')
+
+        if j is None:
+            return {'status': 'not run', 'last_run': None}
+
         errors = j.get('stats', {}).get('errored')
         if errors is None:
             status = 'unknown'


### PR DESCRIPTION
- In some cases a harvester may report `None` in its `last_job_status` field. Handle these without crashing.