### PR TITLE
AV-805: Better harvester reporting

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/harvesterstatusplugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/harvesterstatusplugin.py
@@ -31,8 +31,6 @@ def harvester_status(context=None, data_dict=None):
         else:
             status = 'pending'
 
-        status = 'running' if finished is None else 'finished'
-
         return {'status': status,
                 'errors': errors,
                 'started': created,


### PR DESCRIPTION
- Better information from `harvester_status`
- Filtering options for `harvester_status`, default to skipping manual and never run harvesters
- Better error handling for `opendata-harvest send-status-emails`
- Command line options for `opendata-harvest send-status-emails`