### PR TITLE
AV-982: Fix LazyJSONObject not JSON serializable errors

### DIFF
--- a/ansible/roles/ckan/defaults/main.yml
+++ b/ansible/roles/ckan/defaults/main.yml
@@ -212,6 +212,7 @@ ckan_patches:
   - group_admin_protection # https://github.com/ckan/ckan/pull/4821
   - remove_gravatar
   - add_chaining_of_core_actions # https://github.com/ckan/ckan/pull/4509
+  - json_serializable_lazyjsonobject # https://github.com/ckan/ckan/issues/4299
 
 ckan_config_files:
   - file: /etc/ckan/default/production.ini

--- a/ansible/roles/ckan/files/patches/json_serializable_lazyjsonobject.patch
+++ b/ansible/roles/ckan/files/patches/json_serializable_lazyjsonobject.patch
@@ -1,0 +1,14 @@
+diff --git a/ckan/lib/lazyjson.py b/ckan/lib/lazyjson.py
+index 54dd92428..beabc007b 100644
+--- a/ckan/lib/lazyjson.py
++++ b/ckan/lib/lazyjson.py
+@@ -30,6 +30,9 @@ class LazyJSONObject(RawJSON):
+             return u'<LazyJSONObject %r>' % self._json_string
+         return u'<LazyJSONObject %r>' % self._json_dict
+ 
++    def for_json(self):
++        return self._loads()
++
+     @property
+     def encoded_json(self):
+         if self._json_string:


### PR DESCRIPTION
- Added `for_json` method to LazyJSONObject with a patch, that makes it compatible with simplejson's `loads` function when also given `for_json=True`