### PR TITLE
AV-994: Added a temporary way to view resource SHA256 sums

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -576,4 +576,5 @@ def get_last_harvested_date(organization_name):
 
 
 def get_resource_sha256(resource_id):
-    return get_action('resource_status')({}, {'id': resource_id}).get('sha256') or _('-')
+    context = { 'model': model, 'session': model.Session, 'user': c.user }
+    return get_action('resource_status')(context {'id': resource_id}).get('sha256') or _('-')

--- a/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -574,5 +574,6 @@ def get_last_harvested_date(organization_name):
 
     return {"source": {'title': organization.get("last_harvested_harvester")}, "date": organization.get('last_harvested')}
 
+
 def get_resource_sha256(resource_id):
     return get_action('resource_status')({}, {'id': resource_id}).get('sha256') or _('-')

--- a/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -7,6 +7,7 @@ import itertools
 from ckan.common import _, c, request
 from ckan.lib import helpers, i18n
 from ckan.logic import get_action
+from ckan import model
 from ckan.plugins import toolkit
 from ckanext.scheming.helpers import lang
 from pylons import config
@@ -69,7 +70,6 @@ def dataset_display_name(package_or_package_dict):
 
 
 def group_title_by_id(group_id):
-    from ckan import model
     context = {'model': model, 'session': model.Session, 'ignore_auth': True}
     group_details = get_action('group_show')(context, {"id": group_id})
     return get_translated(group_details, 'title')
@@ -221,7 +221,6 @@ def get_sorted_facet_items_dict(facet, limit=50, exclude_active=False):
 
 def calculate_dataset_stars(dataset_id):
     from ckan.logic import NotFound
-    from ckan import model
 
     if not is_plugin_enabled('qa'):
         return (0, '', '')
@@ -253,8 +252,6 @@ def calculate_metadata_stars(dataset_id):
             - English or Swedish translations for both title and description: 5 points
 
     """
-
-    from ckan import model
 
     score = 0.0
 
@@ -469,7 +466,6 @@ def get_label_for_producer(producer_type):
 
 def scheming_category_list(args):
     from ckan.logic import NotFound
-    from ckan import model
     # FIXME: sometimes this might return 0 categories if in development
 
     try:
@@ -513,7 +509,6 @@ def check_group_selected(val, data):
 # Get a list of groups and add a selected field which is
 # true if they are selected in the dataset
 def group_list_with_selected(package_groups):
-    from ckan import model
     if not isinstance(package_groups, list):
         package_groups = []
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -576,5 +576,5 @@ def get_last_harvested_date(organization_name):
 
 
 def get_resource_sha256(resource_id):
-    context = { 'model': model, 'session': model.Session, 'user': c.user }
-    return get_action('resource_status')(context {'id': resource_id}).get('sha256') or _('-')
+    context = {'model': model, 'session': model.Session, 'user': c.user}
+    return get_action('resource_status')(context, {'id': resource_id}).get('sha256') or _('-')

--- a/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -573,3 +573,6 @@ def get_last_harvested_date(organization_name):
             return
 
     return {"source": {'title': organization.get("last_harvested_harvester")}, "date": organization.get('last_harvested')}
+
+def get_resource_sha256(resource_id):
+    return get_action('resource_status')({}, {'id': resource_id}).get('sha256') or _('-')

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -43,7 +43,7 @@ from helpers import extra_translation, render_date, service_database_enabled, ge
     get_lang_prefix, call_toolkit_function, get_translated, dataset_display_name, resource_display_name, \
     get_visits_count_for_dataset_during_last_year, get_current_date, get_download_count_for_dataset_during_last_year, \
     get_label_for_producer, scheming_category_list, check_group_selected, group_title_by_id, group_list_with_selected, \
-    get_last_harvested_date
+    get_last_harvested_date, get_resource_sha256
 
 from tools import create_system_context, get_original_method
 
@@ -410,6 +410,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
                 'scheming_category_list': scheming_category_list,
                 'check_group_selected': check_group_selected,
                 'group_list_with_selected': group_list_with_selected,
+                'get_resource_sha256': get_resource_sha256,
                 }
 
     def get_auth_functions(self):

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/resource_read.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/resource_read.html
@@ -200,6 +200,9 @@
               'description_translated',
               'url',
               'format',
+              'status_updated',
+              'malware',
+              'sha256'
             ] -%}
             <div>
               <dl class="dl-horizontal mt-2">
@@ -216,6 +219,12 @@
                     </dd>
                   {%- endif -%}
                 {%- endfor -%}
+                <dt scope="row">
+                  SHA256
+                </dt>
+                <dd>
+                {{ h.get_resource_sha256(res.id) }}
+                </dd>
               </dl>
             </div>
           </div>


### PR DESCRIPTION
- A temporary way to view resource SHA256 sums on the UI:
  - New helper that calls the `resource_status` action to update its state and returns the latest SHA256
  - Added SHA256 sum to resource template technical details section using the helper