### PR TITLE
AV-1013: Close advanced search dropdowns when another element focuses

### DIFF
--- a/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/ytp-multiselect.js
+++ b/modules/ckanext-advancedsearch/ckanext/advancedsearch/fanstatic/javascript/ytp-multiselect.js
@@ -10,6 +10,10 @@ ckan.module('ytp-multiselect', function($) {
       $.proxyAll(this, /_make/);
       $.proxy(this, /checkboxes/);
 
+      document.addEventListener('focusin', (e) => {
+        this.el.removeClass('expanded');
+      });
+
       // Add dropdown toggle event to main button
       this.el
         .find('.ytp-multiselect-toggle')


### PR DESCRIPTION
- Add a global event handler per dropdown that closes it when something else gains focus