### PR TITLE
AV-1022: Change showcase grid item width to fit three columns

### DIFF
--- a/modules/ytp-assets-common/src/less/components/media-grid.less
+++ b/modules/ytp-assets-common/src/less/components/media-grid.less
@@ -67,7 +67,7 @@
 // --------------------
 
 .showcase.media-item {
-  width: 250px;
+  width: 230px;
   height: 332px;
   border-right: 2px solid rgba(0, 0, 0, 0.17);
   border-bottom: 2px solid rgba(0, 0, 0, 0.17);


### PR DESCRIPTION
- JQuery masonry couldn't fit three columns of 250px into the available space, make the items smaller to compensate
  - If this isn't enough for all platforms, consider removing masonry and using flexbox