### PR TITLE
AV-877: Fix drupal translations

### DIFF
--- a/ansible/roles/drupal/files/i18n/en_GB/drupal8.po
+++ b/ansible/roles/drupal/files/i18n/en_GB/drupal8.po
@@ -4,13 +4,14 @@
 # Meeri Hakala <meeri.hakala@vrk.fi>, 2019
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2019
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2019
+# Zharktas <jari-pekka.voutilainen@gofore.com>, 2019
 # 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "POT-Creation-Date: 2019-09-12 06:38+0000\n"
 "PO-Revision-Date: 2018-10-17 06:12+0000\n"
-"Last-Translator: Teemu Erkkola <teemu.erkkola@iki.fi>, 2019\n"
+"Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2019\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,5470 +20,5546 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Next"
-msgstr ""
+msgstr "Next"
 
 msgid "Pages"
-msgstr ""
+msgstr "Pages"
 
 msgid "delete"
-msgstr ""
+msgstr "delete"
 
 msgid "Create a new user account."
-msgstr ""
+msgstr "Create a new user account."
 
 msgid "Markup"
-msgstr ""
+msgstr "Markup"
 
 msgid "Prefix"
-msgstr ""
+msgstr "Prefix"
 
 msgid "Suffix"
-msgstr ""
+msgstr "Suffix"
 
 msgid "Approve"
-msgstr ""
+msgstr "Approve"
 
 msgid "Moderated content"
-msgstr ""
+msgstr "Moderated content"
 
 msgid "Attribute"
-msgstr ""
+msgstr "Attribute"
 
 msgid "Groups"
-msgstr ""
+msgstr "Groups"
 
 msgid "Group"
-msgstr ""
+msgstr "Group"
 
 msgid "Replies"
-msgstr ""
+msgstr "Replies"
 
 msgid "Closed"
-msgstr ""
+msgstr "Closed"
 
 msgid "yes"
-msgstr ""
+msgstr "yes"
 
 msgid "Send email"
-msgstr ""
+msgstr "Send email"
 
 msgid "Actions"
-msgstr ""
+msgstr "Actions"
 
 msgid "disabled"
-msgstr ""
+msgstr "disabled"
 
 msgid "Last comment"
-msgstr ""
+msgstr "Last comment"
 
 msgid "Enable"
-msgstr ""
+msgstr "Enable"
 
 msgid "Disable"
-msgstr ""
+msgstr "Disable"
 
 msgid "Explanation or submission guidelines"
-msgstr ""
+msgstr "Explanation or submission guidelines"
 
 msgid "Email settings"
-msgstr ""
+msgstr "Email settings"
 
 msgid "Disabled"
-msgstr ""
+msgstr "Disabled"
 
 msgid "Articles"
-msgstr ""
+msgstr "Articles"
 
 msgid "footer"
-msgstr ""
+msgstr "footer"
 
 msgid "not verified"
-msgstr ""
+msgstr "not verified"
 
 msgid "Last updated"
-msgstr ""
+msgstr "Last updated"
 
 msgid "For"
-msgstr ""
+msgstr "For"
 
 msgid "new"
-msgstr ""
+msgstr "new"
 
 msgid "Block title"
-msgstr ""
+msgstr "Block title"
 
 msgid "The title of the block as shown to the user."
-msgstr ""
+msgstr "The title of the block as shown to the user."
 
 msgid "Logging"
-msgstr ""
+msgstr "Logging"
 
 msgid "Yes"
-msgstr ""
+msgstr "Yes"
 
 msgid "No"
-msgstr ""
+msgstr "No"
 
 msgid "Homepage"
-msgstr ""
+msgstr "Homepage"
 
 msgid "Version"
-msgstr ""
+msgstr "Version"
 
 msgid "view"
-msgstr ""
+msgstr "view"
 
 msgid "unpublished"
-msgstr ""
+msgstr "unpublished"
 
 msgid "updated"
-msgstr ""
+msgstr "updated"
 
 msgid "Overview"
-msgstr ""
+msgstr "Overview"
 
 msgid "File information"
-msgstr ""
+msgstr "File information"
 
 msgid "Tag"
-msgstr ""
+msgstr "Tag"
 
 msgid "File path"
-msgstr ""
+msgstr "File path"
 
 msgid "Release notes"
-msgstr ""
+msgstr "Release notes"
 
 msgid "Links"
-msgstr ""
+msgstr "Links"
 
 msgid "Daily"
-msgstr ""
+msgstr "Daily"
 
 msgid "Weekly"
-msgstr ""
+msgstr "Weekly"
 
 msgid "Monthly"
-msgstr ""
+msgstr "Monthly"
 
 msgid "None"
-msgstr ""
+msgstr "None"
 
 msgid "Display settings"
-msgstr ""
+msgstr "Display settings"
 
 msgid "This action cannot be undone."
-msgstr ""
+msgstr "This action cannot be undone."
 
 msgid "Test"
-msgstr ""
+msgstr "Test"
 
 msgid "Block settings"
-msgstr ""
+msgstr "Block settings"
 
 msgid "- None -"
-msgstr ""
+msgstr "- None -"
 
 msgid "Country"
-msgstr ""
+msgstr "Country"
 
 msgid "Center"
 msgstr "Centre"
 
 msgid "Help text"
-msgstr ""
+msgstr "Help text"
 
 msgid "Types"
-msgstr ""
+msgstr "Types"
 
 msgid "Multiple"
-msgstr ""
+msgstr "Multiple"
 
 msgid "Required"
-msgstr ""
+msgstr "Required"
 
 msgid "root"
-msgstr ""
+msgstr "root"
 
 msgid "Pages at a given level are ordered first by weight and then by title."
-msgstr ""
+msgstr "Pages at a given level are ordered first by weight and then by title."
 
 msgid "Depth"
-msgstr ""
+msgstr "Depth"
 
 msgid "none"
-msgstr ""
+msgstr "none"
 
 msgid "Category"
-msgstr ""
+msgstr "Category"
 
 msgid "Add container"
-msgstr ""
+msgstr "Add container"
 
 msgid "edit container"
-msgstr ""
+msgstr "edit container"
 
 msgid "edit"
-msgstr ""
+msgstr "edit"
 
 msgid "Go to previous page"
-msgstr ""
+msgstr "Go to previous page"
 
 msgid "Go to parent page"
-msgstr ""
+msgstr "Go to parent page"
 
 msgid "Book"
-msgstr ""
+msgstr "Book"
 
 msgid "Description field"
-msgstr ""
+msgstr "Description field"
 
 msgid "settings"
-msgstr ""
+msgstr "settings"
 
 msgid "Back"
-msgstr ""
+msgstr "Back"
 
 msgid "Node ID"
-msgstr ""
+msgstr "Node ID"
 
 msgid "Outline"
-msgstr ""
+msgstr "Outline"
 
 msgid "header"
-msgstr ""
+msgstr "header"
 
 msgid "Session opened for %name."
-msgstr ""
+msgstr "Session opened for %name."
 
 msgid "Image settings"
-msgstr ""
+msgstr "Image settings"
 
 msgid "True"
-msgstr ""
+msgstr "True"
 
 msgid "False"
-msgstr ""
+msgstr "False"
 
 msgid "Move"
-msgstr ""
+msgstr "Move"
 
 msgid "Open"
-msgstr ""
+msgstr "Open"
 
 msgid "Blank"
-msgstr ""
+msgstr "Blank"
 
 msgid "Tags"
-msgstr ""
+msgstr "Tags"
 
 msgid "Forms"
-msgstr ""
+msgstr "Forms"
 
 msgid "On"
-msgstr ""
+msgstr "On"
 
 msgid "Body"
-msgstr ""
+msgstr "Body"
 
 msgid "Language"
-msgstr ""
+msgstr "Language"
 
 msgid "Comments"
-msgstr ""
+msgstr "Comments"
 
 msgid "Article"
-msgstr ""
+msgstr "Article"
 
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 msgid "Administration"
-msgstr ""
+msgstr "Administration"
 
 msgid "Register"
-msgstr ""
+msgstr "Register"
 
 msgid "Taxonomy term"
-msgstr ""
+msgstr "Taxonomy term"
 
 msgid "Feed"
-msgstr ""
+msgstr "Feed"
 
 msgid "Action"
-msgstr ""
+msgstr "Action"
 
 msgid "Subject"
-msgstr ""
+msgstr "Subject"
 
 msgid "Description"
-msgstr ""
+msgstr "Description"
 
 msgid "More"
-msgstr ""
+msgstr "More"
 
 msgid "Reset"
-msgstr ""
+msgstr "Reset"
 
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 msgid "Message"
-msgstr ""
+msgstr "Message"
 
 msgid "Name"
-msgstr ""
+msgstr "Name"
 
 msgid "Use count"
-msgstr ""
+msgstr "Use count"
 
 msgid "Title"
-msgstr ""
+msgstr "Title"
 
 msgid "Operations"
-msgstr ""
+msgstr "Operations"
 
 msgid "more"
-msgstr ""
+msgstr "more"
 
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 msgid "File"
-msgstr ""
+msgstr "File"
 
 msgid "Username"
-msgstr ""
+msgstr "Username"
 
 msgid "List"
-msgstr ""
+msgstr "List"
 
 msgid "Preview"
-msgstr ""
+msgstr "Preview"
 
 msgid "Save"
-msgstr ""
+msgstr "Save"
 
 msgid "user"
-msgstr ""
+msgstr "user"
 
 msgid "Content"
-msgstr ""
+msgstr "Content"
 
 msgid "Go to next page"
-msgstr ""
+msgstr "Go to next page"
 
 msgid "Label"
-msgstr ""
+msgstr "Label"
 
 msgid "Advanced options"
-msgstr ""
+msgstr "Advanced options"
 
 msgid "Weight"
-msgstr ""
+msgstr "Weight"
 
 msgid "Link"
-msgstr ""
+msgstr "Link"
 
 msgid "Search"
-msgstr ""
+msgstr "Search"
 
 msgid "Submit"
-msgstr ""
+msgstr "Submit"
 
 msgid "Password"
-msgstr ""
+msgstr "Password"
 
 msgid "Save configuration"
-msgstr ""
+msgstr "Save configuration"
 
 msgid "Confirm"
-msgstr ""
+msgstr "Confirm"
 
 msgid "Settings"
-msgstr ""
+msgstr "Settings"
 
 msgid "Delete"
-msgstr ""
+msgstr "Delete"
 
 msgid "Remove"
-msgstr ""
+msgstr "Remove"
 
 msgid "Export"
-msgstr ""
+msgstr "Export"
 
 msgid "Import"
-msgstr ""
+msgstr "Import"
 
 msgid "Update"
-msgstr ""
+msgstr "Update"
 
 msgid "Download"
-msgstr ""
+msgstr "Download"
 
 msgid "Edit"
-msgstr ""
+msgstr "Edit"
 
 msgid "Cancel"
-msgstr ""
+msgstr "Cancel"
 
 msgid "Taxonomy"
-msgstr ""
+msgstr "Taxonomy"
 
 msgid "Development"
-msgstr ""
+msgstr "Development"
 
 msgid "User interface"
-msgstr ""
+msgstr "User interface"
 
 msgid "The configuration options have been saved."
-msgstr ""
+msgstr "The configuration options have been saved."
 
 msgid "closed"
-msgstr ""
+msgstr "closed"
 
 msgid "Field"
-msgstr ""
+msgstr "Field"
 
 msgid "Home"
-msgstr ""
+msgstr "Home"
 
 msgid "Sunday"
-msgstr ""
+msgstr "Sunday"
 
 msgid "Saturday"
-msgstr ""
+msgstr "Saturday"
 
 msgid "High"
-msgstr ""
+msgstr "High"
 
 msgid "Low"
-msgstr ""
+msgstr "Low"
 
 msgid "Album"
-msgstr ""
+msgstr "Album"
 
 msgid "Artist"
-msgstr ""
+msgstr "Artist"
 
 msgid "Add new"
-msgstr ""
+msgstr "Add new"
 
 msgid "Time"
-msgstr ""
+msgstr "Time"
 
 msgid "Access"
-msgstr ""
+msgstr "Access"
 
 msgid "View"
-msgstr ""
+msgstr "View"
 
 msgid "Length"
-msgstr ""
+msgstr "Length"
 
 msgid "Format"
-msgstr ""
+msgstr "Format"
 
 msgid "History"
-msgstr ""
+msgstr "History"
 
 msgid "hidden"
-msgstr ""
+msgstr "hidden"
 
 msgid "File extensions"
-msgstr ""
+msgstr "File extensions"
 
 msgid "Modules"
-msgstr ""
+msgstr "Modules"
 
 msgid "Clear index"
-msgstr ""
+msgstr "Clear index"
 
 msgid "General discussion"
-msgstr ""
+msgstr "General discussion"
 
 msgid "edit forum"
-msgstr ""
+msgstr "edit forum"
 
 msgid "Forum name"
-msgstr ""
+msgstr "Forum name"
 
 msgid "forum"
-msgstr ""
+msgstr "forum"
 
 msgid "Refresh"
-msgstr ""
+msgstr "Refresh"
 
 msgid "Region"
-msgstr ""
+msgstr "Region"
 
 msgid "link"
-msgstr ""
+msgstr "link"
 
 msgid "Anchor"
-msgstr ""
+msgstr "Anchor"
 
 msgid "Display"
-msgstr ""
+msgstr "Display"
 
 msgid "Advanced settings"
-msgstr ""
+msgstr "Advanced settings"
 
 msgid "GUID"
-msgstr ""
+msgstr "GUID"
 
 msgid "never"
-msgstr ""
+msgstr "never"
 
 msgid "actions"
-msgstr ""
+msgstr "actions"
 
 msgid "Theme"
-msgstr ""
+msgstr "Theme"
 
 msgid "Layout"
-msgstr ""
+msgstr "Layout"
 
 msgid "Select a layout"
-msgstr ""
+msgstr "Select a layout"
 
 msgid "aggregator"
-msgstr ""
+msgstr "aggregator"
 
 msgid "Update interval"
-msgstr ""
+msgstr "Update interval"
 
 msgid "The fully-qualified URL of the feed."
-msgstr ""
+msgstr "The fully-qualified URL of the feed."
 
 msgid "Add forum"
-msgstr ""
+msgstr "Add forum"
 
 msgid "Add term"
-msgstr ""
+msgstr "Add term"
 
 msgid "Search keywords"
-msgstr ""
+msgstr "Search keywords"
 
 msgid "Timestamp"
-msgstr ""
+msgstr "Timestamp"
 
 msgid "Keywords"
-msgstr ""
+msgstr "Keywords"
 
 msgid "Search Keywords"
-msgstr ""
+msgstr "Search Keywords"
 
 msgid "Preview comment"
-msgstr ""
+msgstr "Preview comment"
 
 msgid "Component"
-msgstr ""
+msgstr "Component"
 
 msgid "Advanced search"
-msgstr ""
+msgstr "Advanced search"
 
 msgid "You are not authorized to access this page."
-msgstr ""
+msgstr "You are not authorized to access this page."
 
 msgid "Unknown"
-msgstr ""
+msgstr "Unknown"
 
 msgid "States"
-msgstr ""
+msgstr "States"
 
 msgid "n/a"
-msgstr ""
+msgstr "n/a"
 
 msgid "Upload image"
-msgstr ""
+msgstr "Upload image"
 
 msgid "Taxonomy settings"
-msgstr ""
+msgstr "Taxonomy settings"
 
 msgid "Before"
-msgstr ""
+msgstr "Before"
 
 msgid "After"
-msgstr ""
+msgstr "After"
 
 msgid "Database type"
-msgstr ""
+msgstr "Database type"
 
 msgid "action"
-msgstr ""
+msgstr "action"
 
 msgid "Continue"
-msgstr ""
+msgstr "Continue"
 
 msgid "Error"
-msgstr ""
+msgstr "Error"
 
 msgid "no"
-msgstr ""
+msgstr "no"
 
 msgid "New user: %name %email."
-msgstr ""
+msgstr "New user: %name %email."
 
 msgid "Node"
-msgstr ""
+msgstr "Node"
 
 msgid "Sent email to %recipient"
-msgstr ""
+msgstr "Sent email to %recipient"
 
 msgid "The subject of the message."
-msgstr ""
+msgstr "The subject of the message."
 
 msgid "Number of columns"
-msgstr ""
+msgstr "Number of columns"
 
 msgid "Data type"
-msgstr ""
+msgstr "Data type"
 
 msgid "Separator"
-msgstr ""
+msgstr "Separator"
 
 msgid "Include"
-msgstr ""
+msgstr "Include"
 
 msgid "Exclude"
-msgstr ""
+msgstr "Exclude"
 
 msgid "Horizontal"
-msgstr ""
+msgstr "Horizontal"
 
 msgid "Vertical"
-msgstr ""
+msgstr "Vertical"
 
 msgid "Open link in new window"
-msgstr ""
+msgstr "Open link in new window"
 
 msgid "vocabularies"
-msgstr ""
+msgstr "vocabularies"
 
 msgid "term"
-msgstr ""
+msgstr "term"
 
 msgid "Expanded"
-msgstr ""
+msgstr "Expanded"
 
 msgid "Parent item"
-msgstr ""
+msgstr "Parent item"
 
 msgid "Add child page"
-msgstr ""
+msgstr "Add child page"
 
 msgid "Printer-friendly version"
-msgstr ""
+msgstr "Printer-friendly version"
 
 msgid "Content type for child pages"
-msgstr ""
+msgstr "Content type for child pages"
 
 msgid "Update options"
-msgstr ""
+msgstr "Update options"
 
 msgid "Remove from outline"
-msgstr ""
+msgstr "Remove from outline"
 
 msgid "Unknown export format."
-msgstr ""
+msgstr "Unknown export format."
 
 msgid "Done"
-msgstr ""
+msgstr "Done"
 
 msgid "Last post"
-msgstr ""
+msgstr "Last post"
 
 msgid "Access denied"
-msgstr ""
+msgstr "Access denied"
 
 msgid "Year"
-msgstr ""
+msgstr "Year"
 
 msgid "Add content"
-msgstr ""
+msgstr "Add content"
 
 msgid "Area"
-msgstr ""
+msgstr "Area"
 
 msgid "Override title"
-msgstr ""
+msgstr "Override title"
 
 msgid "CSS class"
-msgstr ""
+msgstr "CSS class"
 
 msgid "Add view"
-msgstr ""
+msgstr "Add view"
 
 msgid "Pager ID"
-msgstr ""
+msgstr "Pager ID"
 
 msgid "View arguments"
-msgstr ""
+msgstr "View arguments"
 
 msgid "Configuration saved."
-msgstr ""
+msgstr "Configuration saved."
 
 msgid "Logo"
-msgstr ""
+msgstr "Logo"
 
 msgid "Site name"
-msgstr ""
+msgstr "Site name"
 
 msgid "Site slogan"
-msgstr ""
+msgstr "Site slogan"
 
 msgid "Good"
-msgstr ""
+msgstr "Good"
 
 msgid "Node types"
-msgstr ""
+msgstr "Node types"
 
 msgid "User settings"
-msgstr ""
+msgstr "User settings"
 
 msgid "Site"
-msgstr ""
+msgstr "Site"
 
 msgid "Web Server"
-msgstr ""
+msgstr "Web Server"
 
 msgid "Database"
-msgstr ""
+msgstr "Database"
 
 msgid "Drupal"
-msgstr ""
+msgstr "Drupal"
 
 msgid "Not found"
-msgstr ""
+msgstr "Not found"
 
 msgid "Module"
-msgstr ""
+msgstr "Module"
 
 msgid "Host"
-msgstr ""
+msgstr "Host"
 
 msgid "Options"
-msgstr ""
+msgstr "Options"
 
 msgid "Off"
-msgstr ""
+msgstr "Off"
 
 msgid "Picture"
-msgstr ""
+msgstr "Picture"
 
 msgid "RSS"
-msgstr ""
+msgstr "RSS"
 
 msgid "Teaser"
-msgstr ""
+msgstr "Teaser"
 
 msgid "Updated"
-msgstr ""
+msgstr "Updated"
 
 msgid "All"
-msgstr ""
+msgstr "All"
 
 msgid "Icon"
-msgstr ""
+msgstr "Icon"
 
 msgid "Files"
-msgstr ""
+msgstr "Files"
 
 msgid "Filename"
-msgstr ""
+msgstr "Filename"
 
 msgid "Menu"
-msgstr ""
+msgstr "Menu"
 
 msgid "Archive"
-msgstr ""
+msgstr "Archive"
 
 msgid "Content type"
-msgstr ""
+msgstr "Content type"
 
 msgid "Attachment"
-msgstr ""
+msgstr "Attachment"
 
 msgid "Active"
-msgstr ""
+msgstr "Active"
 
 msgid "Date format"
-msgstr ""
+msgstr "Date format"
 
 msgid "file"
-msgstr ""
+msgstr "file"
 
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 msgid "Created"
-msgstr ""
+msgstr "Created"
 
 msgid "Page"
-msgstr ""
+msgstr "Page"
 
 msgid "Components"
-msgstr ""
+msgstr "Components"
 
 msgid "Contact"
-msgstr ""
+msgstr "Contact"
 
 msgid "Upload"
-msgstr ""
+msgstr "Upload"
 
 msgid "Add"
-msgstr ""
+msgstr "Add"
 
 msgid "Create"
-msgstr ""
+msgstr "Create"
 
 msgid "Manage"
-msgstr ""
+msgstr "Manage"
 
 msgid "Configure"
-msgstr ""
+msgstr "Configure"
 
 msgid "Views"
-msgstr ""
+msgstr "Views"
 
 msgid "PHP"
-msgstr ""
+msgstr "PHP"
 
 msgid "Breadcrumb"
-msgstr ""
+msgstr "Breadcrumb"
 
 msgid "1 hour"
 msgid_plural "@count hours"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 hour"
+msgstr[1] "@count hours"
 
 msgid "1 day"
 msgid_plural "@count days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 day"
+msgstr[1] "@count days"
 
 msgid "Friday"
-msgstr ""
+msgstr "Friday"
 
 msgid "Monday"
-msgstr ""
+msgstr "Monday"
 
 msgid "Tuesday"
-msgstr ""
+msgstr "Tuesday"
 
 msgid "Wednesday"
-msgstr ""
+msgstr "Wednesday"
 
 msgid "Mail"
-msgstr ""
+msgstr "Mail"
 
 msgid "Statistics"
-msgstr ""
+msgstr "Statistics"
 
 msgid "Core"
-msgstr ""
+msgstr "Core"
 
 msgid "PostgreSQL"
-msgstr ""
+msgstr "PostgreSQL"
 
 msgid "Manual update check"
-msgstr ""
+msgstr "Manual update check"
 
 msgid "Never"
-msgstr ""
+msgstr "Never"
 
 msgid "Check manually"
-msgstr ""
+msgstr "Check manually"
 
 msgid "Update available"
-msgstr ""
+msgstr "Update available"
 
 msgid "Out of date"
-msgstr ""
+msgstr "Out of date"
 
 msgid "Header"
-msgstr ""
+msgstr "Header"
 
 msgid "Left sidebar"
-msgstr ""
+msgstr "Left sidebar"
 
 msgid "Right sidebar"
-msgstr ""
+msgstr "Right sidebar"
 
 msgid "Inline"
-msgstr ""
+msgstr "Inline"
 
 msgid "Recipients"
-msgstr ""
+msgstr "Recipients"
 
 msgid "Selected"
-msgstr ""
+msgstr "Selected"
 
 msgid "Your name"
-msgstr ""
+msgstr "Your name"
 
 msgid "Aggregator feed"
-msgstr ""
+msgstr "Aggregator feed"
 
 msgid "Aggregator feed ID"
-msgstr ""
+msgstr "Aggregator feed ID"
 
 msgid "Feed description"
-msgstr ""
+msgstr "Feed description"
 
 msgid "Aggregator item"
-msgstr ""
+msgstr "Aggregator item"
 
 msgid "Aggregator item ID"
-msgstr ""
+msgstr "Aggregator item ID"
 
 msgid "Throttle"
-msgstr ""
+msgstr "Throttle"
 
 msgid "Visibility"
-msgstr ""
+msgstr "Visibility"
 
 msgid "Role ID"
-msgstr ""
+msgstr "Role ID"
 
 msgid "Hostname"
-msgstr ""
+msgstr "Hostname"
 
 msgid "Score"
-msgstr ""
+msgstr "Score"
 
 msgid "Signature"
-msgstr ""
+msgstr "Signature"
 
 msgid "Cacheable"
-msgstr ""
+msgstr "Cacheable"
 
 msgid "Location"
-msgstr ""
+msgstr "Location"
 
 msgid "Locale"
-msgstr ""
+msgstr "Locale"
 
 msgid "Title field label"
-msgstr ""
+msgstr "Title field label"
 
 msgid "Sticky at top of lists"
-msgstr ""
+msgstr "Sticky at top of lists"
 
 msgid "Revisions"
-msgstr ""
+msgstr "Revisions"
 
 msgid "Log message"
-msgstr ""
+msgstr "Log message"
 
 msgid "URL alias"
-msgstr ""
+msgstr "URL alias"
 
 msgid "File MIME type"
-msgstr ""
+msgstr "File MIME type"
 
 msgid "Node revision ID"
-msgstr ""
+msgstr "Node revision ID"
 
 msgid "Vocabulary name"
-msgstr ""
+msgstr "Vocabulary name"
 
 msgid "Term"
-msgstr ""
+msgstr "Term"
 
 msgid "User role"
-msgstr ""
+msgstr "User role"
 
 msgid "Role name"
-msgstr ""
+msgstr "Role name"
 
 msgid "Time zone"
-msgstr ""
+msgstr "Time zone"
 
 msgid "Field name"
-msgstr ""
+msgstr "Field name"
 
 msgid "Field type"
-msgstr ""
+msgstr "Field type"
 
 msgid "Global settings"
-msgstr ""
+msgstr "Global settings"
 
 msgid "Multiple values"
-msgstr ""
+msgstr "Multiple values"
 
 msgid "Widget type"
-msgstr ""
+msgstr "Widget type"
 
 msgid "Contains"
-msgstr ""
+msgstr "Contains"
 
 msgid "Does not contain"
-msgstr ""
+msgstr "Does not contain"
 
 msgid "Is less than"
-msgstr ""
+msgstr "Is less than"
 
 msgid "Is less than or equal to"
-msgstr ""
+msgstr "Is less than or equal to"
 
 msgid "Is equal to"
-msgstr ""
+msgstr "Is equal to"
 
 msgid "Is greater than or equal to"
-msgstr ""
+msgstr "Is greater than or equal to"
 
 msgid "Is greater than"
-msgstr ""
+msgstr "Is greater than"
 
 msgid "Is not equal to"
-msgstr ""
+msgstr "Is not equal to"
 
 msgid "Average"
-msgstr ""
+msgstr "Average"
 
 msgid "Overridden"
-msgstr ""
+msgstr "Overridden"
 
 msgid "Add action"
-msgstr ""
+msgstr "Add action"
 
 msgid "Set name"
-msgstr ""
+msgstr "Set name"
 
 msgid "Original image"
-msgstr ""
+msgstr "Original image"
 
 msgid "Link to URL"
-msgstr ""
+msgstr "Link to URL"
 
 msgid "Search settings"
-msgstr ""
+msgstr "Search settings"
 
 msgid "Mode"
-msgstr ""
+msgstr "Mode"
 
 msgid "Warning"
-msgstr ""
+msgstr "Warning"
 
 msgid "blocked"
-msgstr ""
+msgstr "blocked"
 
 msgid "active"
-msgstr ""
+msgstr "active"
 
 msgid "N/A"
-msgstr ""
+msgstr "N/A"
 
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 msgid "OPML feed"
-msgstr ""
+msgstr "OPML feed"
 
 msgid "Number of news items in block"
-msgstr ""
+msgstr "Number of news items in block"
 
 msgid "View this feed's recent news."
-msgstr ""
+msgstr "View this feed's recent news."
 
 msgid "Feed overview"
-msgstr ""
+msgstr "Feed overview"
 
 msgid "Items"
-msgstr ""
+msgstr "Items"
 
 msgid "Next update"
-msgstr ""
+msgstr "Next update"
 
 msgid "%time ago"
-msgstr ""
+msgstr "%time ago"
 
 msgid "%time left"
-msgstr ""
+msgstr "%time left"
 
 msgid "Authored by"
-msgstr ""
+msgstr "Authored by"
 
 msgid "Processor"
-msgstr ""
+msgstr "Processor"
 
 msgid "The feed %feed has been updated."
-msgstr ""
+msgstr "The feed %feed has been updated."
 
 msgid "Feed %feed added."
-msgstr ""
+msgstr "Feed %feed added."
 
 msgid "The feed %feed has been added."
-msgstr ""
+msgstr "The feed %feed has been added."
 
 msgid "Disclaimer"
-msgstr ""
+msgstr "Disclaimer"
 
 msgid "Sort order"
-msgstr ""
+msgstr "Sort order"
 
 msgid "Up"
-msgstr ""
+msgstr "Up"
 
 msgid "Textfield"
-msgstr ""
+msgstr "Textfield"
 
 msgid "Display options"
-msgstr ""
+msgstr "Display options"
 
 msgid "Maximum"
-msgstr ""
+msgstr "Maximum"
 
 msgid "Scale"
-msgstr ""
+msgstr "Scale"
 
 msgid "Thumbnail"
-msgstr ""
+msgstr "Thumbnail"
 
 msgid "Medium"
-msgstr ""
+msgstr "Medium"
 
 msgid "Sortable"
-msgstr ""
+msgstr "Sortable"
 
 msgid "standard"
-msgstr ""
+msgstr "standard"
 
 msgid "Month"
-msgstr ""
+msgstr "Month"
 
 msgid "Details"
-msgstr ""
+msgstr "Details"
 
 msgid "Widget"
-msgstr ""
+msgstr "Widget"
 
 msgid "Last reply"
-msgstr ""
+msgstr "Last reply"
 
 msgid "Prev"
-msgstr ""
+msgstr "Prev"
 
 msgid "Domain"
-msgstr ""
+msgstr "Domain"
 
 msgid "Processors"
-msgstr ""
+msgstr "Processors"
 
 msgid "Unlimited"
-msgstr ""
+msgstr "Unlimited"
 
 msgid "Current"
-msgstr ""
+msgstr "Current"
 
 msgid "State"
-msgstr ""
+msgstr "State"
 
 msgid "Filter by"
-msgstr ""
+msgstr "Filter by"
 
 msgid "Enter a valid username."
-msgstr ""
+msgstr "Enter a valid username."
 
 msgid "Recipient"
-msgstr ""
+msgstr "Recipient"
 
 msgid "OR"
-msgstr ""
+msgstr "OR"
 
 msgid "Add a role to the selected users"
-msgstr ""
+msgstr "Add a role to the selected users"
 
 msgid "Remove a role from the selected users"
-msgstr ""
+msgstr "Remove a role from the selected users"
 
 msgid "node"
-msgstr ""
+msgstr "node"
 
 msgid "Administer content"
-msgstr ""
+msgstr "Administer content"
 
 msgid "Directory"
-msgstr ""
+msgstr "Directory"
 
 msgid "Method"
-msgstr ""
+msgstr "Method"
 
 msgid "Egypt"
-msgstr ""
+msgstr "Egypt"
 
 msgid "Namibia"
-msgstr ""
+msgstr "Namibia"
 
 msgid "To"
-msgstr ""
+msgstr "To"
 
 msgid "Comment"
-msgstr ""
+msgstr "Comment"
 
 msgid "Plain text"
-msgstr ""
+msgstr "Plain text"
 
 msgid "Footer"
-msgstr ""
+msgstr "Footer"
 
 msgid "Last access"
-msgstr ""
+msgstr "Last access"
 
 msgid "From"
-msgstr ""
+msgstr "From"
 
 msgid "Revision ID"
-msgstr ""
+msgstr "Revision ID"
 
 msgid "Severity"
-msgstr ""
+msgstr "Severity"
 
 msgid "Published"
-msgstr ""
+msgstr "Published"
 
 msgid "Last update"
-msgstr ""
+msgstr "Last update"
 
 msgid "Roles"
-msgstr ""
+msgstr "Roles"
 
 msgid "Vocabulary"
-msgstr ""
+msgstr "Vocabulary"
 
 msgid "Fields"
-msgstr ""
+msgstr "Fields"
 
 msgid "Advanced"
-msgstr ""
+msgstr "Advanced"
 
 msgid ", "
-msgstr ""
+msgstr ", "
 
 msgid "Desc"
-msgstr ""
+msgstr "Desc"
 
 msgid "General"
-msgstr ""
+msgstr "General"
 
 msgid "Media"
-msgstr ""
+msgstr "Media"
 
 msgid "Performance"
-msgstr ""
+msgstr "Performance"
 
 msgid "System"
-msgstr ""
+msgstr "System"
 
 msgid "Available updates"
-msgstr ""
+msgstr "Available updates"
 
 msgid "Drupal core update status"
-msgstr ""
+msgstr "Drupal core update status"
 
 msgid "Caching"
-msgstr ""
+msgstr "Caching"
 
 msgid "Source string"
-msgstr ""
+msgstr "Source string"
 
 msgid "Up to date"
-msgstr ""
+msgstr "Up to date"
 
 msgid "Custom"
-msgstr ""
+msgstr "Custom"
 
 msgid "Israel"
-msgstr ""
+msgstr "Israel"
 
 msgid "Iran"
-msgstr ""
+msgstr "Iran"
 
 msgid "New Zealand"
-msgstr ""
+msgstr "New Zealand"
 
 msgid "Tonga"
-msgstr ""
+msgstr "Tonga"
 
 msgid "Cuba"
-msgstr ""
+msgstr "Cuba"
 
 msgid "Brazil"
-msgstr ""
+msgstr "Brazil"
 
 msgid "Chile"
-msgstr ""
+msgstr "Chile"
 
 msgid "Paraguay"
-msgstr ""
+msgstr "Paraguay"
 
 msgid "Jamaica"
-msgstr ""
+msgstr "Jamaica"
 
 msgid "Japan"
-msgstr ""
+msgstr "Japan"
 
 msgid "Libya"
-msgstr ""
+msgstr "Libya"
 
 msgid "Poland"
-msgstr ""
+msgstr "Poland"
 
 msgid "Portugal"
-msgstr ""
+msgstr "Portugal"
 
 msgid "Singapore"
-msgstr ""
+msgstr "Singapore"
 
 msgid "Turkey"
-msgstr ""
+msgstr "Turkey"
 
 msgid "Day"
-msgstr ""
+msgstr "Day"
 
 msgid "Table"
-msgstr ""
+msgstr "Table"
 
 msgid "Sat"
-msgstr ""
+msgstr "Sat"
 
 msgid "Sun"
-msgstr ""
+msgstr "Sun"
 
 msgid "May"
-msgstr ""
+msgstr "May"
 
 msgid "am"
-msgstr ""
+msgstr "am"
 
 msgid "pm"
-msgstr ""
+msgstr "pm"
 
 msgid "Start date"
-msgstr ""
+msgstr "Start date"
 
 msgid "End date"
-msgstr ""
+msgstr "End date"
 
 msgid "Forum"
-msgstr ""
+msgstr "Forum"
 
 msgid "Security"
-msgstr ""
+msgstr "Security"
 
 msgid "Align"
-msgstr ""
+msgstr "Align"
 
 msgid "Loop"
-msgstr ""
+msgstr "Loop"
 
 msgid "Display title"
-msgstr ""
+msgstr "Display title"
 
 msgid "Background color"
-msgstr ""
+msgstr "Background color"
 
 msgid "Text color"
-msgstr ""
+msgstr "Text color"
 
 msgid "Navigation"
-msgstr ""
+msgstr "Navigation"
 
 msgid "Basic"
-msgstr ""
+msgstr "Basic"
 
 msgid "Color"
-msgstr ""
+msgstr "Color"
 
 msgid "Link URL"
-msgstr ""
+msgstr "Link URL"
 
 msgid "List type"
-msgstr ""
+msgstr "List type"
 
 msgid "Attributes"
-msgstr ""
+msgstr "Attributes"
 
 msgid "Select all"
-msgstr ""
+msgstr "Select all"
 
 msgid "Allow"
-msgstr ""
+msgstr "Allow"
 
 msgid "Ignore"
-msgstr ""
+msgstr "Ignore"
 
 msgid "User data"
-msgstr ""
+msgstr "User data"
 
 msgid "User login"
-msgstr ""
+msgstr "User login"
 
 msgid "Updated URL for feed %title to %url."
-msgstr ""
+msgstr "Updated URL for feed %title to %url."
 
 msgid "Add new comment"
-msgstr ""
+msgstr "Add new comment"
 
 msgid "No terms available."
-msgstr ""
+msgstr "No terms available."
 
 msgid "Counter"
-msgstr ""
+msgstr "Counter"
 
 msgid "String"
-msgstr ""
+msgstr "String"
 
 msgid "Case"
-msgstr ""
+msgstr "Case"
 
 msgid "Not installed"
-msgstr ""
+msgstr "Not installed"
 
 msgid "Referrer"
-msgstr ""
+msgstr "Referrer"
 
 msgid "Default front page"
-msgstr ""
+msgstr "Default front page"
 
 msgid "Button"
-msgstr ""
+msgstr "Button"
 
 msgid "Square"
-msgstr ""
+msgstr "Square"
 
 msgid "Both"
-msgstr ""
+msgstr "Both"
 
 msgid "Maximum length"
-msgstr ""
+msgstr "Maximum length"
 
 msgid "Rows"
-msgstr ""
+msgstr "Rows"
 
 msgid "Cache"
-msgstr ""
+msgstr "Cache"
 
 msgid "Argument"
-msgstr ""
+msgstr "Argument"
 
 msgid "Provider"
-msgstr ""
+msgstr "Provider"
 
 msgid "Save and edit"
-msgstr ""
+msgstr "Save and edit"
 
 msgid "Edit view"
-msgstr ""
+msgstr "Edit view"
 
 msgid "Administer views"
-msgstr ""
+msgstr "Administer views"
 
 msgid "Ascending"
-msgstr ""
+msgstr "Ascending"
 
 msgid "Descending"
-msgstr ""
+msgstr "Descending"
 
 msgid "Normal menu item"
-msgstr ""
+msgstr "Normal menu item"
 
 msgid "Expose"
-msgstr ""
+msgstr "Expose"
 
 msgid "Option"
-msgstr ""
+msgstr "Option"
 
 msgid "Operator"
-msgstr ""
+msgstr "Operator"
 
 msgid "Filters"
-msgstr ""
+msgstr "Filters"
 
 msgid "Optional"
-msgstr ""
+msgstr "Optional"
 
 msgid "Exposed Filters"
-msgstr ""
+msgstr "Exposed Filters"
 
 msgid "Order"
-msgstr ""
+msgstr "Order"
 
 msgid "Views UI"
-msgstr ""
+msgstr "Views UI"
 
 msgid "Uncategorized"
-msgstr ""
+msgstr "Uncategorized"
 
 msgid "Plain"
-msgstr ""
+msgstr "Plain"
 
 msgid "Position"
-msgstr ""
+msgstr "Position"
 
 msgid "Integer"
-msgstr ""
+msgstr "Integer"
 
 msgid "Pattern"
-msgstr ""
+msgstr "Pattern"
 
 msgid "The comment and all its replies have been deleted."
-msgstr ""
+msgstr "The comment and all its replies have been deleted."
 
 msgid "Cron settings"
-msgstr ""
+msgstr "Cron settings"
 
 msgid "Preformatted"
-msgstr ""
+msgstr "Preformatted"
 
 msgid "Anonymous users"
-msgstr ""
+msgstr "Anonymous users"
 
 msgid "Found"
-msgstr ""
+msgstr "Found"
 
 msgid "fields"
-msgstr ""
+msgstr "fields"
 
 msgid "Add group"
-msgstr ""
+msgstr "Add group"
 
 msgid "Save settings"
-msgstr ""
+msgstr "Save settings"
 
 msgid "UID"
-msgstr ""
+msgstr "UID"
 
 msgid "Duration"
-msgstr ""
+msgstr "Duration"
 
 msgid "Multiplier"
-msgstr ""
+msgstr "Multiplier"
 
 msgid "Session closed for %name."
-msgstr ""
+msgstr "Session closed for %name."
 
 msgid "Defaults"
-msgstr ""
+msgstr "Defaults"
 
 msgid "Your search yielded no results."
-msgstr ""
+msgstr "Your search yielded no results."
 
 msgid "="
-msgstr ""
+msgstr "="
 
 msgid "Germany"
-msgstr ""
+msgstr "Germany"
 
 msgid "Created date"
-msgstr ""
+msgstr "Created date"
 
 msgid "Updated date"
-msgstr ""
+msgstr "Updated date"
 
 msgid "comments"
-msgstr ""
+msgstr "comments"
 
 msgid "1 new"
 msgid_plural "@count new"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 new"
+msgstr[1] "@count new"
 
 msgid "Default language"
-msgstr ""
+msgstr "Default language"
 
 msgid "Condition"
-msgstr ""
+msgstr "Condition"
 
 msgid "Afghanistan"
-msgstr ""
+msgstr "Afghanistan"
 
 msgid "Albania"
-msgstr ""
+msgstr "Albania"
 
 msgid "Algeria"
-msgstr ""
+msgstr "Algeria"
 
 msgid "American Samoa"
-msgstr ""
+msgstr "American Samoa"
 
 msgid "Angola"
-msgstr ""
+msgstr "Angola"
 
 msgid "Anguilla"
-msgstr ""
+msgstr "Anguilla"
 
 msgid "Antarctica"
-msgstr ""
+msgstr "Antarctica"
 
 msgid "Antigua and Barbuda"
-msgstr ""
+msgstr "Antigua and Barbuda"
 
 msgid "Argentina"
-msgstr ""
+msgstr "Argentina"
 
 msgid "Armenia"
-msgstr ""
+msgstr "Armenia"
 
 msgid "Aruba"
-msgstr ""
+msgstr "Aruba"
 
 msgid "Australia"
-msgstr ""
+msgstr "Australia"
 
 msgid "Austria"
-msgstr ""
+msgstr "Austria"
 
 msgid "Azerbaijan"
-msgstr ""
+msgstr "Azerbaijan"
 
 msgid "Bahamas"
-msgstr ""
+msgstr "Bahamas"
 
 msgid "Bahrain"
-msgstr ""
+msgstr "Bahrain"
 
 msgid "Bangladesh"
-msgstr ""
+msgstr "Bangladesh"
 
 msgid "Barbados"
-msgstr ""
+msgstr "Barbados"
 
 msgid "Belarus"
-msgstr ""
+msgstr "Belarus"
 
 msgid "Belgium"
-msgstr ""
+msgstr "Belgium"
 
 msgid "Belize"
-msgstr ""
+msgstr "Belize"
 
 msgid "Benin"
-msgstr ""
+msgstr "Benin"
 
 msgid "Bermuda"
-msgstr ""
+msgstr "Bermuda"
 
 msgid "Bhutan"
-msgstr ""
+msgstr "Bhutan"
 
 msgid "Bolivia"
-msgstr ""
+msgstr "Bolivia"
 
 msgid "Bosnia and Herzegovina"
-msgstr ""
+msgstr "Bosnia and Herzegovina"
 
 msgid "Botswana"
-msgstr ""
+msgstr "Botswana"
 
 msgid "Bouvet Island"
-msgstr ""
+msgstr "Bouvet Island"
 
 msgid "Brunei"
-msgstr ""
+msgstr "Brunei"
 
 msgid "Thu"
-msgstr ""
+msgstr "Thu"
 
 msgid "Anonymous"
-msgstr ""
+msgstr "Anonymous"
 
 msgid "Full"
-msgstr ""
+msgstr "Full"
 
 msgid "Tracker"
-msgstr ""
+msgstr "Tracker"
 
 msgid "Recent comments"
-msgstr ""
+msgstr "Recent comments"
 
 msgid "Users"
-msgstr ""
+msgstr "Users"
 
 msgid "Role"
-msgstr ""
+msgstr "Role"
 
 msgid "Sort Criteria"
-msgstr ""
+msgstr "Sort Criteria"
 
 msgid "Log in"
-msgstr ""
+msgstr "Log in"
 
 msgid "External"
-msgstr ""
+msgstr "External"
 
 msgid "Sort by"
-msgstr ""
+msgstr "Sort by"
 
 msgid "Uninstall"
-msgstr ""
+msgstr "Uninstall"
 
 msgid "Install"
-msgstr ""
+msgstr "Install"
 
 msgid "Appearance"
-msgstr ""
+msgstr "Appearance"
 
 msgid "Configuration"
-msgstr ""
+msgstr "Configuration"
 
 msgid "Clear cache"
-msgstr ""
+msgstr "Clear cache"
 
 msgid "Mon"
-msgstr ""
+msgstr "Mon"
 
 msgid "Fri"
-msgstr ""
+msgstr "Fri"
 
 msgid "Tue"
-msgstr ""
+msgstr "Tue"
 
 msgid "Wed"
-msgstr ""
+msgstr "Wed"
 
 msgid "Other"
-msgstr ""
+msgstr "Other"
 
 msgid "Close"
-msgstr ""
+msgstr "Close"
 
 msgid "Bulgaria"
-msgstr ""
+msgstr "Bulgaria"
 
 msgid "Burkina Faso"
-msgstr ""
+msgstr "Burkina Faso"
 
 msgid "Burundi"
-msgstr ""
+msgstr "Burundi"
 
 msgid "Cambodia"
-msgstr ""
+msgstr "Cambodia"
 
 msgid "Cameroon"
-msgstr ""
+msgstr "Cameroon"
 
 msgid "Canada"
-msgstr ""
+msgstr "Canada"
 
 msgid "Cape Verde"
-msgstr ""
+msgstr "Cape Verde"
 
 msgid "Cayman Islands"
-msgstr ""
+msgstr "Cayman Islands"
 
 msgid "Central African Republic"
-msgstr ""
+msgstr "Central African Republic"
 
 msgid "Chad"
-msgstr ""
+msgstr "Chad"
 
 msgid "China"
-msgstr ""
+msgstr "China"
 
 msgid "Christmas Island"
-msgstr ""
+msgstr "Christmas Island"
 
 msgid "Colombia"
-msgstr ""
+msgstr "Colombia"
 
 msgid "Comoros"
-msgstr ""
+msgstr "Comoros"
 
 msgid "Cook Islands"
-msgstr ""
+msgstr "Cook Islands"
 
 msgid "Costa Rica"
-msgstr ""
+msgstr "Costa Rica"
 
 msgid "Cyprus"
-msgstr ""
+msgstr "Cyprus"
 
 msgid "Czech Republic"
-msgstr ""
+msgstr "Czech Republic"
 
 msgid "Denmark"
-msgstr ""
+msgstr "Denmark"
 
 msgid "Djibouti"
-msgstr ""
+msgstr "Djibouti"
 
 msgid "Dominica"
-msgstr ""
+msgstr "Dominica"
 
 msgid "Dominican Republic"
-msgstr ""
+msgstr "Dominican Republic"
 
 msgid "Ecuador"
-msgstr ""
+msgstr "Ecuador"
 
 msgid "El Salvador"
-msgstr ""
+msgstr "El Salvador"
 
 msgid "Equatorial Guinea"
-msgstr ""
+msgstr "Equatorial Guinea"
 
 msgid "Eritrea"
-msgstr ""
+msgstr "Eritrea"
 
 msgid "Estonia"
-msgstr ""
+msgstr "Estonia"
 
 msgid "Ethiopia"
-msgstr ""
+msgstr "Ethiopia"
 
 msgid "Faroe Islands"
-msgstr ""
+msgstr "Faroe Islands"
 
 msgid "Finland"
-msgstr ""
+msgstr "Finland"
 
 msgid "France"
-msgstr ""
+msgstr "France"
 
 msgid "French Guiana"
-msgstr ""
+msgstr "French Guiana"
 
 msgid "French Polynesia"
-msgstr ""
+msgstr "French Polynesia"
 
 msgid "Gabon"
-msgstr ""
+msgstr "Gabon"
 
 msgid "Gambia"
-msgstr ""
+msgstr "Gambia"
 
 msgid "Georgia"
-msgstr ""
+msgstr "Georgia"
 
 msgid "Ghana"
-msgstr ""
+msgstr "Ghana"
 
 msgid "Gibraltar"
-msgstr ""
+msgstr "Gibraltar"
 
 msgid "Greece"
-msgstr ""
+msgstr "Greece"
 
 msgid "Greenland"
-msgstr ""
+msgstr "Greenland"
 
 msgid "Grenada"
-msgstr ""
+msgstr "Grenada"
 
 msgid "Guadeloupe"
-msgstr ""
+msgstr "Guadeloupe"
 
 msgid "Guam"
-msgstr ""
+msgstr "Guam"
 
 msgid "Guatemala"
-msgstr ""
+msgstr "Guatemala"
 
 msgid "Guinea"
-msgstr ""
+msgstr "Guinea"
 
 msgid "Guinea-Bissau"
-msgstr ""
+msgstr "Guinea-Bissau"
 
 msgid "Guyana"
-msgstr ""
+msgstr "Guyana"
 
 msgid "Haiti"
-msgstr ""
+msgstr "Haiti"
 
 msgid "Heard Island and McDonald Islands"
-msgstr ""
+msgstr "Heard Island and McDonald Islands"
 
 msgid "Honduras"
-msgstr ""
+msgstr "Honduras"
 
 msgid "Hungary"
-msgstr ""
+msgstr "Hungary"
 
 msgid "Iceland"
-msgstr ""
+msgstr "Iceland"
 
 msgid "India"
-msgstr ""
+msgstr "India"
 
 msgid "Indonesia"
-msgstr ""
+msgstr "Indonesia"
 
 msgid "Iraq"
-msgstr ""
+msgstr "Iraq"
 
 msgid "Ireland"
-msgstr ""
+msgstr "Ireland"
 
 msgid "Italy"
-msgstr ""
+msgstr "Italy"
 
 msgid "Jordan"
-msgstr ""
+msgstr "Jordan"
 
 msgid "Kazakhstan"
-msgstr ""
+msgstr "Kazakhstan"
 
 msgid "Kenya"
-msgstr ""
+msgstr "Kenya"
 
 msgid "Kiribati"
-msgstr ""
+msgstr "Kiribati"
 
 msgid "Kuwait"
-msgstr ""
+msgstr "Kuwait"
 
 msgid "Kyrgyzstan"
-msgstr ""
+msgstr "Kyrgyzstan"
 
 msgid "Laos"
-msgstr ""
+msgstr "Laos"
 
 msgid "Latvia"
-msgstr ""
+msgstr "Latvia"
 
 msgid "Lebanon"
-msgstr ""
+msgstr "Lebanon"
 
 msgid "Lesotho"
-msgstr ""
+msgstr "Lesotho"
 
 msgid "Liberia"
-msgstr ""
+msgstr "Liberia"
 
 msgid "Liechtenstein"
-msgstr ""
+msgstr "Liechtenstein"
 
 msgid "Lithuania"
-msgstr ""
+msgstr "Lithuania"
 
 msgid "Luxembourg"
-msgstr ""
+msgstr "Luxembourg"
 
 msgid "Madagascar"
-msgstr ""
+msgstr "Madagascar"
 
 msgid "Malawi"
-msgstr ""
+msgstr "Malawi"
 
 msgid "Malaysia"
-msgstr ""
+msgstr "Malaysia"
 
 msgid "Maldives"
-msgstr ""
+msgstr "Maldives"
 
 msgid "Mali"
-msgstr ""
+msgstr "Mali"
 
 msgid "Malta"
-msgstr ""
+msgstr "Malta"
 
 msgid "Marshall Islands"
-msgstr ""
+msgstr "Marshall Islands"
 
 msgid "Martinique"
-msgstr ""
+msgstr "Martinique"
 
 msgid "Mauritania"
-msgstr ""
+msgstr "Mauritania"
 
 msgid "Mauritius"
-msgstr ""
+msgstr "Mauritius"
 
 msgid "Mayotte"
-msgstr ""
+msgstr "Mayotte"
 
 msgid "Mexico"
-msgstr ""
+msgstr "Mexico"
 
 msgid "Micronesia"
-msgstr ""
+msgstr "Micronesia"
 
 msgid "Moldova"
-msgstr ""
+msgstr "Moldova"
 
 msgid "Monaco"
-msgstr ""
+msgstr "Monaco"
 
 msgid "Mongolia"
-msgstr ""
+msgstr "Mongolia"
 
 msgid "Montserrat"
-msgstr ""
+msgstr "Montserrat"
 
 msgid "Morocco"
-msgstr ""
+msgstr "Morocco"
 
 msgid "Mozambique"
-msgstr ""
+msgstr "Mozambique"
 
 msgid "Nauru"
-msgstr ""
+msgstr "Nauru"
 
 msgid "Nepal"
-msgstr ""
+msgstr "Nepal"
 
 msgid "Netherlands"
-msgstr ""
+msgstr "Netherlands"
 
 msgid "Netherlands Antilles"
-msgstr ""
+msgstr "Netherlands Antilles"
 
 msgid "New Caledonia"
-msgstr ""
+msgstr "New Caledonia"
 
 msgid "Nicaragua"
-msgstr ""
+msgstr "Nicaragua"
 
 msgid "Niger"
-msgstr ""
+msgstr "Niger"
 
 msgid "Nigeria"
-msgstr ""
+msgstr "Nigeria"
 
 msgid "Niue"
-msgstr ""
+msgstr "Niue"
 
 msgid "Norfolk Island"
-msgstr ""
+msgstr "Norfolk Island"
 
 msgid "North Korea"
-msgstr ""
+msgstr "North Korea"
 
 msgid "Northern Mariana Islands"
-msgstr ""
+msgstr "Northern Mariana Islands"
 
 msgid "Norway"
-msgstr ""
+msgstr "Norway"
 
 msgid "Oman"
-msgstr ""
+msgstr "Oman"
 
 msgid "Pakistan"
-msgstr ""
+msgstr "Pakistan"
 
 msgid "Palau"
-msgstr ""
+msgstr "Palau"
 
 msgid "Panama"
-msgstr ""
+msgstr "Panama"
 
 msgid "Papua New Guinea"
-msgstr ""
+msgstr "Papua New Guinea"
 
 msgid "Peru"
-msgstr ""
+msgstr "Peru"
 
 msgid "Philippines"
-msgstr ""
+msgstr "Philippines"
 
 msgid "Pitcairn Islands"
-msgstr ""
+msgstr "Pitcairn Islands"
 
 msgid "Puerto Rico"
-msgstr ""
+msgstr "Puerto Rico"
 
 msgid "Qatar"
-msgstr ""
+msgstr "Qatar"
 
 msgid "Romania"
-msgstr ""
+msgstr "Romania"
 
 msgid "Russia"
-msgstr ""
+msgstr "Russia"
 
 msgid "Rwanda"
-msgstr ""
+msgstr "Rwanda"
 
 msgid "Samoa"
-msgstr ""
+msgstr "Samoa"
 
 msgid "San Marino"
-msgstr ""
+msgstr "San Marino"
 
 msgid "Saudi Arabia"
-msgstr ""
+msgstr "Saudi Arabia"
 
 msgid "Senegal"
-msgstr ""
+msgstr "Senegal"
 
 msgid "Seychelles"
-msgstr ""
+msgstr "Seychelles"
 
 msgid "Sierra Leone"
-msgstr ""
+msgstr "Sierra Leone"
 
 msgid "Slovakia"
-msgstr ""
+msgstr "Slovakia"
 
 msgid "Slovenia"
-msgstr ""
+msgstr "Slovenia"
 
 msgid "Solomon Islands"
-msgstr ""
+msgstr "Solomon Islands"
 
 msgid "Somalia"
-msgstr ""
+msgstr "Somalia"
 
 msgid "South Africa"
-msgstr ""
+msgstr "South Africa"
 
 msgid "South Georgia and the South Sandwich Islands"
-msgstr ""
+msgstr "South Georgia and the South Sandwich Islands"
 
 msgid "Spain"
-msgstr ""
+msgstr "Spain"
 
 msgid "Sri Lanka"
-msgstr ""
+msgstr "Sri Lanka"
 
 msgid "Sudan"
-msgstr ""
+msgstr "Sudan"
 
 msgid "Suriname"
-msgstr ""
+msgstr "Suriname"
 
 msgid "Svalbard and Jan Mayen"
-msgstr ""
+msgstr "Svalbard and Jan Mayen"
 
 msgid "Swaziland"
-msgstr ""
+msgstr "Swaziland"
 
 msgid "Sweden"
-msgstr ""
+msgstr "Sweden"
 
 msgid "Switzerland"
-msgstr ""
+msgstr "Switzerland"
 
 msgid "Syria"
-msgstr ""
+msgstr "Syria"
 
 msgid "Taiwan"
-msgstr ""
+msgstr "Taiwan"
 
 msgid "Tajikistan"
-msgstr ""
+msgstr "Tajikistan"
 
 msgid "Tanzania"
-msgstr ""
+msgstr "Tanzania"
 
 msgid "Thailand"
-msgstr ""
+msgstr "Thailand"
 
 msgid "Togo"
-msgstr ""
+msgstr "Togo"
 
 msgid "Tokelau"
-msgstr ""
+msgstr "Tokelau"
 
 msgid "Trinidad and Tobago"
-msgstr ""
+msgstr "Trinidad and Tobago"
 
 msgid "Tunisia"
-msgstr ""
+msgstr "Tunisia"
 
 msgid "Turkmenistan"
-msgstr ""
+msgstr "Turkmenistan"
 
 msgid "Turks and Caicos Islands"
-msgstr ""
+msgstr "Turks and Caicos Islands"
 
 msgid "Tuvalu"
-msgstr ""
+msgstr "Tuvalu"
 
 msgid "Uganda"
-msgstr ""
+msgstr "Uganda"
 
 msgid "Ukraine"
-msgstr ""
+msgstr "Ukraine"
 
 msgid "United Arab Emirates"
-msgstr ""
+msgstr "United Arab Emirates"
 
 msgid "United Kingdom"
-msgstr ""
+msgstr "United Kingdom"
 
 msgid "United States"
-msgstr ""
+msgstr "United States"
 
 msgid "Uruguay"
-msgstr ""
+msgstr "Uruguay"
 
 msgid "Uzbekistan"
-msgstr ""
+msgstr "Uzbekistan"
 
 msgid "Vanuatu"
-msgstr ""
+msgstr "Vanuatu"
 
 msgid "Vatican City"
-msgstr ""
+msgstr "Vatican City"
 
 msgid "Venezuela"
-msgstr ""
+msgstr "Venezuela"
 
 msgid "Wallis and Futuna"
-msgstr ""
+msgstr "Wallis and Futuna"
 
 msgid "Yemen"
-msgstr ""
+msgstr "Yemen"
 
 msgid "Zambia"
-msgstr ""
+msgstr "Zambia"
 
 msgid "Zimbabwe"
-msgstr ""
+msgstr "Zimbabwe"
 
 msgid "Identity"
-msgstr ""
+msgstr "Identity"
 
 msgid "Database username"
-msgstr ""
+msgstr "Database username"
 
 msgid "Database password"
-msgstr ""
+msgstr "Database password"
 
 msgid "Database name"
-msgstr ""
+msgstr "Database name"
 
 msgid "Add user"
-msgstr ""
+msgstr "Add user"
 
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 msgid "Regular expression"
-msgstr ""
+msgstr "Regular expression"
 
 msgid "Size of textfield"
-msgstr ""
+msgstr "Size of textfield"
 
 msgid "Authoring information"
-msgstr ""
+msgstr "Authoring information"
 
 msgid "Authored on"
-msgstr ""
+msgstr "Authored on"
 
 msgid "Leave blank for %anonymous."
-msgstr ""
+msgstr "Leave blank for %anonymous."
 
 msgid "Hidden"
-msgstr ""
+msgstr "Hidden"
 
 msgid "Are you sure you want to delete %name?"
-msgstr ""
+msgstr "Are you sure you want to delete %name?"
 
 msgid "Undefined"
-msgstr ""
+msgstr "Undefined"
 
 msgid "Queued"
-msgstr ""
+msgstr "Queued"
 
 msgid "Syslog"
-msgstr ""
+msgstr "Syslog"
 
 msgid "Other queries"
-msgstr ""
+msgstr "Other queries"
 
 msgid "Key"
-msgstr ""
+msgstr "Key"
 
 msgid "Link to node"
-msgstr ""
+msgstr "Link to node"
 
 msgid "File Upload"
-msgstr ""
+msgstr "File Upload"
 
 msgid "block"
-msgstr ""
+msgstr "block"
 
 msgid "Site language"
-msgstr ""
+msgstr "Site language"
 
 msgid "Change"
-msgstr ""
+msgstr "Change"
 
 msgid "Spanish"
-msgstr ""
+msgstr "Spanish"
 
 msgid "in"
-msgstr ""
+msgstr "in"
 
 msgid "Messages"
-msgstr ""
+msgstr "Messages"
 
 msgid "Edit term"
-msgstr ""
+msgstr "Edit term"
 
 msgid "Switch"
-msgstr ""
+msgstr "Switch"
 
 msgid "Import OPML"
-msgstr ""
+msgstr "Import OPML"
 
 msgid "OPML File"
-msgstr ""
+msgstr "OPML File"
 
 msgid "Allowed HTML tags"
-msgstr ""
+msgstr "Allowed HTML tags"
 
 msgid "Sources"
-msgstr ""
+msgstr "Sources"
 
 msgid "1 item"
 msgid_plural "@count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 item"
+msgstr[1] "@count items"
 
 msgid "Feed items"
-msgstr ""
+msgstr "Feed items"
 
 msgid "Add menu"
-msgstr ""
+msgstr "Add menu"
 
 msgid "menu"
-msgstr ""
+msgstr "menu"
 
 msgid "No items selected."
-msgstr ""
+msgstr "No items selected."
 
 msgid "The update has been performed."
-msgstr ""
+msgstr "The update has been performed."
 
 msgid "Node title"
-msgstr ""
+msgstr "Node title"
 
 msgid "Result"
-msgstr ""
+msgstr "Result"
 
 msgid "Browser"
-msgstr ""
+msgstr "Browser"
 
 msgid "View user profile."
-msgstr ""
+msgstr "View user profile."
 
 msgid "Titles only"
-msgstr ""
+msgstr "Titles only"
 
 msgid "Full text"
-msgstr ""
+msgstr "Full text"
 
 msgid "Feed settings"
-msgstr ""
+msgstr "Feed settings"
 
 msgid "Source"
-msgstr ""
+msgstr "Source"
 
 msgid "Add Block"
-msgstr ""
+msgstr "Add Block"
 
 msgid "published"
-msgstr ""
+msgstr "published"
 
 msgid "The changes have been saved."
-msgstr ""
+msgstr "The changes have been saved."
 
 msgid "Undo"
-msgstr ""
+msgstr "Undo"
 
 msgid "@time ago"
-msgstr ""
+msgstr "@time ago"
 
 msgid "No users selected."
-msgstr ""
+msgstr "No users selected."
 
 msgid "Select all rows in this table"
-msgstr ""
+msgstr "Select all rows in this table"
 
 msgid "Deselect all rows in this table"
-msgstr ""
+msgstr "Deselect all rows in this table"
 
 msgid "User search"
-msgstr ""
+msgstr "User search"
 
 msgid "Search results"
-msgstr ""
+msgstr "Search results"
 
 msgid "Please enter some keywords."
-msgstr ""
+msgstr "Please enter some keywords."
 
 msgid "Replacement patterns"
-msgstr ""
+msgstr "Replacement patterns"
 
 msgid "Deleted"
-msgstr ""
+msgstr "Deleted"
 
 msgid "Successful"
-msgstr ""
+msgstr "Successful"
 
 msgid "Display name"
-msgstr ""
+msgstr "Display name"
 
 msgid "Topics"
-msgstr ""
+msgstr "Topics"
 
 msgid "Topic"
-msgstr ""
+msgstr "Topic"
 
 msgid "Definition"
-msgstr ""
+msgstr "Definition"
 
 msgid "Allowed values list"
-msgstr ""
+msgstr "Allowed values list"
 
 msgid "Textfield size"
-msgstr ""
+msgstr "Textfield size"
 
 msgid "Today"
-msgstr ""
+msgstr "Today"
 
 msgid "Activity"
-msgstr ""
+msgstr "Activity"
 
 msgid "Edit menu"
-msgstr ""
+msgstr "Edit menu"
 
 msgid "Delete menu"
-msgstr ""
+msgstr "Delete menu"
 
 msgid "Publishing options"
-msgstr ""
+msgstr "Publishing options"
 
 msgid "Create new revision"
-msgstr ""
+msgstr "Create new revision"
 
 msgid "Lists"
-msgstr ""
+msgstr "Lists"
 
 msgid "Limit"
-msgstr ""
+msgstr "Limit"
 
 msgid "Minimum height"
-msgstr ""
+msgstr "Minimum height"
 
 msgid "Minimum width"
-msgstr ""
+msgstr "Minimum width"
 
 msgid "Query"
-msgstr ""
+msgstr "Query"
 
 msgid "Locale settings"
-msgstr ""
+msgstr "Locale settings"
 
 msgid "Search fields"
-msgstr ""
+msgstr "Search fields"
 
 msgid "Configure block"
-msgstr ""
+msgstr "Configure block"
 
 msgid "Block name"
-msgstr ""
+msgstr "Block name"
 
 msgid "How many content items to display in \"day\" list."
-msgstr ""
+msgstr "How many content items to display in \"day\" list."
 
 msgid "Jan"
-msgstr ""
+msgstr "Jan"
 
 msgid "Feb"
-msgstr ""
+msgstr "Feb"
 
 msgid "Mar"
-msgstr ""
+msgstr "Mar"
 
 msgid "Apr"
-msgstr ""
+msgstr "Apr"
 
 msgid "Jun"
-msgstr ""
+msgstr "Jun"
 
 msgid "Jul"
-msgstr ""
+msgstr "Jul"
 
 msgid "Aug"
-msgstr ""
+msgstr "Aug"
 
 msgid "Sep"
-msgstr ""
+msgstr "Sep"
 
 msgid "Oct"
-msgstr ""
+msgstr "Oct"
 
 msgid "Nov"
-msgstr ""
+msgstr "Nov"
 
 msgid "Dec"
-msgstr ""
+msgstr "Dec"
 
 msgid "Hour"
-msgstr ""
+msgstr "Hour"
 
 msgid "Minute"
-msgstr ""
+msgstr "Minute"
 
 msgid "Second"
-msgstr ""
+msgstr "Second"
 
 msgid "Select list"
-msgstr ""
+msgstr "Select list"
 
 msgid "Text field"
-msgstr ""
+msgstr "Text field"
 
 msgid "Granularity"
-msgstr ""
+msgstr "Granularity"
 
 msgid "Posts"
-msgstr ""
+msgstr "Posts"
 
 msgid "Map"
-msgstr ""
+msgstr "Map"
 
 msgid "Node settings"
-msgstr ""
+msgstr "Node settings"
 
 msgid "Alignment"
-msgstr ""
+msgstr "Alignment"
 
 msgid "Randomize"
-msgstr ""
+msgstr "Randomize"
 
 msgid "Link label"
-msgstr ""
+msgstr "Link label"
 
 msgid "author"
-msgstr ""
+msgstr "author"
 
 msgid "AND"
-msgstr ""
+msgstr "AND"
 
 msgid "Fixed"
-msgstr ""
+msgstr "Fixed"
 
 msgid "Revert"
-msgstr ""
+msgstr "Revert"
 
 msgid "Negate"
-msgstr ""
+msgstr "Negate"
 
 msgid "Empty"
-msgstr ""
+msgstr "Empty"
 
 msgid "Existing system path"
-msgstr ""
+msgstr "Existing system path"
 
 msgid "Path alias"
-msgstr ""
+msgstr "Path alias"
 
 msgid "Greater than"
-msgstr ""
+msgstr "Greater than"
 
 msgid "Less than"
-msgstr ""
+msgstr "Less than"
 
 msgid "Notice"
-msgstr ""
+msgstr "Notice"
 
 msgid "Caption"
-msgstr ""
+msgstr "Caption"
 
 msgid "Number of day's top views to display"
-msgstr ""
+msgstr "Number of day's top views to display"
 
 msgid "Number of all time views to display"
-msgstr ""
+msgstr "Number of all time views to display"
 
 msgid "Number of most recent views to display"
-msgstr ""
+msgstr "Number of most recent views to display"
 
 msgid "characters"
-msgstr ""
+msgstr "characters"
 
 msgid "Su"
-msgstr ""
+msgstr "Su"
 
 msgid "Mo"
-msgstr ""
+msgstr "Mo"
 
 msgid "Tu"
-msgstr ""
+msgstr "Tu"
 
 msgid "We"
-msgstr ""
+msgstr "We"
 
 msgid "Th"
-msgstr ""
+msgstr "Th"
 
 msgid "Fr"
-msgstr ""
+msgstr "Fr"
 
 msgid "Sa"
-msgstr ""
+msgstr "Sa"
 
 msgid "First day of week"
-msgstr ""
+msgstr "First day of week"
 
 msgid "Add workflow"
-msgstr ""
+msgstr "Add workflow"
 
 msgid "Add state"
-msgstr ""
+msgstr "Add state"
 
 msgid "Transition"
-msgstr ""
+msgstr "Transition"
 
 msgid "Left"
-msgstr ""
+msgstr "Left"
 
 msgid "Right"
-msgstr ""
+msgstr "Right"
 
 msgid "Buttons"
-msgstr ""
+msgstr "Buttons"
 
 msgid "next ›"
-msgstr ""
+msgstr "next ›"
 
 msgid "Front page"
-msgstr ""
+msgstr "Front page"
 
 msgid "Entity"
-msgstr ""
+msgstr "Entity"
 
 msgid "Languages"
-msgstr ""
+msgstr "Languages"
 
 msgid "Member for"
-msgstr ""
+msgstr "Member for"
 
 msgid "Log out"
-msgstr ""
+msgstr "Log out"
 
 msgid "Workflow"
-msgstr ""
+msgstr "Workflow"
 
 msgid "Modified"
-msgstr ""
+msgstr "Modified"
 
 msgid "Show"
-msgstr ""
+msgstr "Show"
 
 msgid "Configure permissions"
-msgstr ""
+msgstr "Configure permissions"
 
 msgid "Extend"
-msgstr ""
+msgstr "Extend"
 
 msgid "Create new account"
-msgstr ""
+msgstr "Create new account"
 
 msgid "Seconds"
-msgstr ""
+msgstr "Seconds"
 
 msgid "role"
-msgstr ""
+msgstr "role"
 
 msgid "User registration"
-msgstr ""
+msgstr "User registration"
 
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 msgid "Created new term %term."
-msgstr ""
+msgstr "Created new term %term."
 
 msgid "Deleted term %name."
-msgstr ""
+msgstr "Deleted term %name."
 
 msgid "Notify user when account is activated"
-msgstr ""
+msgstr "Notify user when account is activated"
 
 msgid "Notify user when account is blocked"
-msgstr ""
+msgstr "Notify user when account is blocked"
 
 msgid "Reference"
-msgstr ""
+msgstr "Reference"
 
 msgid "Enabled filters"
-msgstr ""
+msgstr "Enabled filters"
 
 msgid "Updating"
-msgstr ""
+msgstr "Updating"
 
 msgid "or"
-msgstr ""
+msgstr "or"
 
 msgid "Getting Started"
-msgstr ""
+msgstr "Getting Started"
 
 msgid "Convert"
-msgstr ""
+msgstr "Convert"
 
 msgid "Binary"
-msgstr ""
+msgstr "Binary"
 
 msgid "Delete term"
-msgstr ""
+msgstr "Delete term"
 
 msgid "List terms"
-msgstr ""
+msgstr "List terms"
 
 msgid ""
 "Deleting a term will delete all its children if there are any. This action "
 "cannot be undone."
 msgstr ""
+"Deleting a term will delete all its children if there are any. This action "
+"cannot be undone."
 
 msgid "Parent terms"
-msgstr ""
+msgstr "Parent terms"
 
 msgid "Syndicate"
-msgstr ""
+msgstr "Syndicate"
 
 msgid "Books"
-msgstr ""
+msgstr "Books"
 
 msgid "Style"
-msgstr ""
+msgstr "Style"
 
 msgid "Forums"
-msgstr ""
+msgstr "Forums"
 
 msgid "Superscript"
-msgstr ""
+msgstr "Superscript"
 
 msgid "Revisions for %title"
-msgstr ""
+msgstr "Revisions for %title"
 
 msgid "Revision"
-msgstr ""
+msgstr "Revision"
 
 msgid "The specified passwords do not match."
-msgstr ""
+msgstr "The specified passwords do not match."
 
 msgid "Session"
-msgstr ""
+msgstr "Session"
 
 msgid "Missing"
-msgstr ""
+msgstr "Missing"
 
 msgid "No forums defined"
-msgstr ""
+msgstr "No forums defined"
 
 msgid "This topic has been moved"
-msgstr ""
+msgstr "This topic has been moved"
 
 msgid "roles"
-msgstr ""
+msgstr "roles"
 
 msgid "Your settings have been saved."
-msgstr ""
+msgstr "Your settings have been saved."
 
 msgid "Plugin"
-msgstr ""
+msgstr "Plugin"
 
 msgid "Link color"
-msgstr ""
+msgstr "Link color"
 
 msgid "Duplicate"
-msgstr ""
+msgstr "Duplicate"
 
 msgid "Display label"
-msgstr ""
+msgstr "Display label"
 
 msgid "Reverse"
-msgstr ""
+msgstr "Reverse"
 
 msgid "Testing"
-msgstr ""
+msgstr "Testing"
 
 msgid "Standard"
-msgstr ""
+msgstr "Standard"
 
 msgid "Interval"
-msgstr ""
+msgstr "Interval"
 
 msgid "Ascension Island"
-msgstr ""
+msgstr "Ascension Island"
 
 msgid "Fiji"
-msgstr ""
+msgstr "Fiji"
 
 msgid "Falkland Islands"
-msgstr ""
+msgstr "Falkland Islands"
 
 msgid "Saint Kitts and Nevis"
-msgstr ""
+msgstr "Saint Kitts and Nevis"
 
 msgid "South Korea"
-msgstr ""
+msgstr "South Korea"
 
 msgid "Saint Lucia"
-msgstr ""
+msgstr "Saint Lucia"
 
 msgid "Saint Helena"
-msgstr ""
+msgstr "Saint Helena"
 
 msgid "French Southern Territories"
-msgstr ""
+msgstr "French Southern Territories"
 
 msgid "Saint Vincent and the Grenadines"
-msgstr ""
+msgstr "Saint Vincent and the Grenadines"
 
 msgid "U.S. Virgin Islands"
-msgstr ""
+msgstr "U.S. Virgin Islands"
 
 msgid "Vietnam"
-msgstr ""
+msgstr "Vietnam"
 
 msgid "Guernsey"
-msgstr ""
+msgstr "Guernsey"
 
 msgid "Jersey"
-msgstr ""
+msgstr "Jersey"
 
 msgid "User name"
-msgstr ""
+msgstr "User name"
 
 msgid "Theme settings"
-msgstr ""
+msgstr "Theme settings"
 
 msgid "Authentication"
-msgstr ""
+msgstr "Authentication"
 
 msgid "Not published"
-msgstr ""
+msgstr "Not published"
 
 msgid "File settings"
-msgstr ""
+msgstr "File settings"
 
 msgid "Menu settings"
-msgstr ""
+msgstr "Menu settings"
 
 msgid "Color scheme"
-msgstr ""
+msgstr "Color scheme"
 
 msgid "width"
-msgstr ""
+msgstr "width"
 
 msgid "height"
-msgstr ""
+msgstr "height"
 
 msgid "Unformatted"
-msgstr ""
+msgstr "Unformatted"
 
 msgid "Formats"
-msgstr ""
+msgstr "Formats"
 
 msgid "@type: deleted %title."
-msgstr ""
+msgstr "@type: deleted %title."
 
 msgid "RSS Feed"
-msgstr ""
+msgstr "RSS Feed"
 
 msgid "Allowed file extensions"
-msgstr ""
+msgstr "Allowed file extensions"
 
 msgid "New comments"
-msgstr ""
+msgstr "New comments"
 
 msgid "New"
-msgstr ""
+msgstr "New"
 
 msgid "Redirect to URL"
-msgstr ""
+msgstr "Redirect to URL"
 
 msgid "Top left"
-msgstr ""
+msgstr "Top left"
 
 msgid "Top right"
-msgstr ""
+msgstr "Top right"
 
 msgid "Bottom right"
-msgstr ""
+msgstr "Bottom right"
 
 msgid "Bottom left"
-msgstr ""
+msgstr "Bottom left"
 
 msgid "Relationships"
-msgstr ""
+msgstr "Relationships"
 
 msgid "Relationship"
-msgstr ""
+msgstr "Relationship"
 
 msgid "relationships"
-msgstr ""
+msgstr "relationships"
 
 msgid "Migrate"
-msgstr ""
+msgstr "Migrate"
 
 msgid "The username %name has not been activated or is blocked."
-msgstr ""
+msgstr "The username %name has not been activated or is blocked."
 
 msgid "Login attempt failed for %user."
-msgstr ""
+msgstr "Login attempt failed for %user."
 
 msgid "Oldest first"
-msgstr ""
+msgstr "Oldest first"
 
 msgid "Sort criteria"
-msgstr ""
+msgstr "Sort criteria"
 
 msgid "Base path"
-msgstr ""
+msgstr "Base path"
 
 msgid "Revision of %title from %date"
-msgstr ""
+msgstr "Revision of %title from %date"
 
 msgid "Parent menu item"
-msgstr ""
+msgstr "Parent menu item"
 
 msgid "The username of the user to which you would like to assign ownership."
-msgstr ""
+msgstr "The username of the user to which you would like to assign ownership."
 
 msgid "Delete action"
-msgstr ""
+msgstr "Delete action"
 
 msgid "The action has been successfully saved."
-msgstr ""
+msgstr "The action has been successfully saved."
 
 msgid "Themes"
-msgstr ""
+msgstr "Themes"
 
 msgid "JPEG quality"
-msgstr ""
+msgstr "JPEG quality"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "Content options"
-msgstr ""
+msgstr "Content options"
 
 msgid "Last changed"
-msgstr ""
+msgstr "Last changed"
 
 msgid "not published"
-msgstr ""
+msgstr "not published"
 
 msgid "Loading..."
-msgstr ""
+msgstr "Loading..."
 
 msgid "Protected"
-msgstr ""
+msgstr "Protected"
 
 msgid "Comment settings"
-msgstr ""
+msgstr "Comment settings"
 
 msgid "Sticky"
-msgstr ""
+msgstr "Sticky"
 
 msgid "Default options"
-msgstr ""
+msgstr "Default options"
 
 msgid "Ok"
-msgstr ""
+msgstr "Ok"
 
 msgid "Contact settings"
-msgstr ""
+msgstr "Contact settings"
 
 msgid "Ban"
-msgstr ""
+msgstr "Ban"
 
 msgid "Processing"
-msgstr ""
+msgstr "Processing"
 
 msgid "Temporary directory"
-msgstr ""
+msgstr "Temporary directory"
 
 msgid "File upload error. Could not move uploaded file."
-msgstr ""
+msgstr "File upload error. Could not move uploaded file."
 
 msgid "User status"
-msgstr ""
+msgstr "User status"
 
 msgid "Shortcut"
-msgstr ""
+msgstr "Shortcut"
 
 msgid "Default value"
-msgstr ""
+msgstr "Default value"
 
 msgid "Timezone"
-msgstr ""
+msgstr "Timezone"
 
 msgid "Password strength:"
-msgstr ""
+msgstr "Password strength:"
 
 msgid "Passwords match:"
-msgstr ""
+msgstr "Passwords match:"
 
 msgid "The name used to indicate anonymous users."
-msgstr ""
+msgstr "The name used to indicate anonymous users."
 
 msgid "Image crop"
-msgstr ""
+msgstr "Image crop"
 
 msgid "@message"
-msgstr ""
+msgstr "@message"
 
 msgid "‹ Previous"
-msgstr ""
+msgstr "‹ Previous"
 
 msgid "comment"
-msgstr ""
+msgstr "comment"
 
 msgid "Anonymous user"
-msgstr ""
+msgstr "Anonymous user"
 
 msgid "Next ›"
-msgstr ""
+msgstr "Next ›"
 
 msgid "Published comments"
-msgstr ""
+msgstr "Published comments"
 
 msgid "Author Name"
-msgstr ""
+msgstr "Author Name"
 
 msgid "Unpublished"
-msgstr ""
+msgstr "Unpublished"
 
 msgid "Glossary"
-msgstr ""
+msgstr "Glossary"
 
 msgid "People"
-msgstr ""
+msgstr "People"
 
 msgid "Blocked"
-msgstr ""
+msgstr "Blocked"
 
 msgid "Output format"
-msgstr ""
+msgstr "Output format"
 
 msgid "Reset password"
-msgstr ""
+msgstr "Reset password"
 
 msgid "Next page"
-msgstr ""
+msgstr "Next page"
 
 msgid "Cron"
-msgstr ""
+msgstr "Cron"
 
 msgid "Shortcuts"
-msgstr ""
+msgstr "Shortcuts"
 
 msgid "Aggregate JavaScript files"
-msgstr ""
+msgstr "Aggregate JavaScript files"
 
 msgid "Changed"
-msgstr ""
+msgstr "Changed"
 
 msgid "Multilingual"
-msgstr ""
+msgstr "Multilingual"
 
 msgid "Installed"
-msgstr ""
+msgstr "Installed"
 
 msgid "Permissions"
-msgstr ""
+msgstr "Permissions"
 
 msgid "Enabled modules"
-msgstr ""
+msgstr "Enabled modules"
 
 msgid "Not translated"
-msgstr ""
+msgstr "Not translated"
 
 msgid "Select"
-msgstr ""
+msgstr "Select"
 
 msgid "Translatable"
-msgstr ""
+msgstr "Translatable"
 
 msgid "Location of comment submission form"
-msgstr ""
+msgstr "Location of comment submission form"
 
 msgid "Show blocks"
-msgstr ""
+msgstr "Show blocks"
 
 msgid "Go to first page"
-msgstr ""
+msgstr "Go to first page"
 
 msgid "Enter the terms you wish to search for."
-msgstr ""
+msgstr "Enter the terms you wish to search for."
 
 msgid "Bold"
-msgstr ""
+msgstr "Bold"
 
 msgid "Underlined"
-msgstr ""
+msgstr "Underlined"
 
 msgid "Variables"
-msgstr ""
+msgstr "Variables"
 
 msgid "Tasks"
-msgstr ""
+msgstr "Tasks"
 
 msgid "Plugins"
-msgstr ""
+msgstr "Plugins"
 
 msgid "Delete role"
-msgstr ""
+msgstr "Delete role"
 
 msgid "PHP Code"
-msgstr ""
+msgstr "PHP Code"
 
 msgid "Basic configuration"
-msgstr ""
+msgstr "Basic configuration"
 
 msgid "Recipe"
-msgstr ""
+msgstr "Recipe"
 
 msgid "Ingredients"
-msgstr ""
+msgstr "Ingredients"
 
 msgid "Recipes"
-msgstr ""
+msgstr "Recipes"
 
 msgid "No caching"
-msgstr ""
+msgstr "No caching"
 
 msgid "British Indian Ocean Territory"
-msgstr ""
+msgstr "British Indian Ocean Territory"
 
 msgid "Croatia"
-msgstr ""
+msgstr "Croatia"
 
 msgid "Macedonia"
-msgstr ""
+msgstr "Macedonia"
 
 msgid "Western Sahara"
-msgstr ""
+msgstr "Western Sahara"
 
 msgid "Language switcher"
-msgstr ""
+msgstr "Language switcher"
 
 msgid "Source field"
-msgstr ""
+msgstr "Source field"
 
 msgid "Translation status"
-msgstr ""
+msgstr "Translation status"
 
 msgid "Blocks"
-msgstr ""
+msgstr "Blocks"
 
 msgid "Delete block"
-msgstr ""
+msgstr "Delete block"
 
 msgid "Save blocks"
-msgstr ""
+msgstr "Save blocks"
 
 msgid "The block settings have been updated."
-msgstr ""
+msgstr "The block settings have been updated."
 
 msgid "Save block"
-msgstr ""
+msgstr "Save block"
 
 msgid "The block configuration has been saved."
-msgstr ""
+msgstr "The block configuration has been saved."
 
 msgid "Any customizations will be lost. This action cannot be undone."
-msgstr ""
+msgstr "Any customizations will be lost. This action cannot be undone."
 
 msgid "Add vocabulary"
-msgstr ""
+msgstr "Add vocabulary"
 
 msgid "Edit vocabulary"
-msgstr ""
+msgstr "Edit vocabulary"
 
 msgid "Created new vocabulary %name."
-msgstr ""
+msgstr "Created new vocabulary %name."
 
 msgid "Updated vocabulary %name."
-msgstr ""
+msgstr "Updated vocabulary %name."
 
 msgid "Are you sure you want to delete the vocabulary %title?"
-msgstr ""
+msgstr "Are you sure you want to delete the vocabulary %title?"
 
 msgid ""
 "Deleting a vocabulary will delete all the terms in it. This action cannot be"
 " undone."
 msgstr ""
+"Deleting a vocabulary will delete all the terms in it. This action cannot be"
+" undone."
 
 msgid "Deleted vocabulary %name."
-msgstr ""
+msgstr "Deleted vocabulary %name."
 
 msgid "Above"
-msgstr ""
+msgstr "Above"
 
 msgid "@min and @max"
-msgstr ""
+msgstr "@min and @max"
 
 msgid "Default time zone"
-msgstr ""
+msgstr "Default time zone"
 
 msgid "Manage fields"
-msgstr ""
+msgstr "Manage fields"
 
 msgid "Add field"
-msgstr ""
+msgstr "Add field"
 
 msgid "Trimmed"
-msgstr ""
+msgstr "Trimmed"
 
 msgid "Text area"
-msgstr ""
+msgstr "Text area"
 
 msgid "Add a new field"
-msgstr ""
+msgstr "Add a new field"
 
 msgid "Save field settings"
-msgstr ""
+msgstr "Save field settings"
 
 msgid "The update has encountered an error."
-msgstr ""
+msgstr "The update has encountered an error."
 
 msgid "1 item successfully processed:"
 msgid_plural "@count items successfully processed:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 item successfully processed:"
+msgstr[1] "@count items successfully processed:"
 
 msgid "Provide a comma separated list of arguments to pass to the view."
-msgstr ""
+msgstr "Provide a comma separated list of arguments to pass to the view."
 
 msgid "Decimal"
-msgstr ""
+msgstr "Decimal"
 
 msgid "Float"
-msgstr ""
+msgstr "Float"
 
 msgid "Minimum"
-msgstr ""
+msgstr "Minimum"
 
 msgid "Precision"
-msgstr ""
+msgstr "Precision"
 
 msgid ""
 "The total number of digits to store in the database, including those to the "
 "right of the decimal."
 msgstr ""
+"The total number of digits to store in the database, including those to the "
+"right of the decimal."
 
 msgid "The number of digits to the right of the decimal."
-msgstr ""
+msgstr "The number of digits to the right of the decimal."
 
 msgid "Decimal marker"
-msgstr ""
+msgstr "Decimal marker"
 
 msgid "Check boxes/radio buttons"
-msgstr ""
+msgstr "Check boxes/radio buttons"
 
 msgid "Single on/off checkbox"
-msgstr ""
+msgstr "Single on/off checkbox"
 
 msgid "Text area (multiple rows)"
-msgstr ""
+msgstr "Text area (multiple rows)"
 
 msgid "Index"
-msgstr ""
+msgstr "Index"
 
 msgid "Permalink"
-msgstr ""
+msgstr "Permalink"
 
 msgid "Theme-engine-specific settings"
-msgstr ""
+msgstr "Theme-engine-specific settings"
 
 msgid "Form"
-msgstr ""
+msgstr "Form"
 
 msgid "Debug"
-msgstr ""
+msgstr "Debug"
 
 msgid "Exceptions"
-msgstr ""
+msgstr "Exceptions"
 
 msgid "The parent comment"
-msgstr ""
+msgstr "The parent comment"
 
 msgid "1 minute"
-msgstr ""
+msgstr "1 minute"
 
 msgid "@module module"
-msgstr ""
+msgstr "@module module"
 
 msgid "More information"
-msgstr ""
+msgstr "More information"
 
 msgid "Grid"
-msgstr ""
+msgstr "Grid"
 
 msgid "Redo"
-msgstr ""
+msgstr "Redo"
 
 msgid "Italic"
-msgstr ""
+msgstr "Italic"
 
 msgid "Editor"
-msgstr ""
+msgstr "Editor"
 
 msgid "Date range"
-msgstr ""
+msgstr "Date range"
 
 msgid "Anonymous commenting"
-msgstr ""
+msgstr "Anonymous commenting"
 
 msgid "Anonymous posters may not enter their contact information"
-msgstr ""
+msgstr "Anonymous posters may not enter their contact information"
 
 msgid "Anonymous posters may leave their contact information"
-msgstr ""
+msgstr "Anonymous posters may leave their contact information"
 
 msgid "Anonymous posters must leave their contact information"
-msgstr ""
+msgstr "Anonymous posters must leave their contact information"
 
 msgid "Default comment setting"
-msgstr ""
+msgstr "Default comment setting"
 
 msgid ""
 "The content of this field is kept private and will not be shown publicly."
 msgstr ""
+"The content of this field is kept private and will not be shown publicly."
 
 msgid "parent"
-msgstr ""
+msgstr "parent"
 
 msgid "Date - newest first"
-msgstr ""
+msgstr "Date - newest first"
 
 msgid "Date - oldest first"
-msgstr ""
+msgstr "Date - oldest first"
 
 msgid "1 comment"
 msgid_plural "@count comments"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 comment"
+msgstr[1] "@count comments"
 
 msgid "1 new comment"
 msgid_plural "@count new comments"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 new comment"
+msgstr[1] "@count new comments"
 
 msgid "Save content type"
-msgstr ""
+msgstr "Save content type"
 
 msgid "Show descriptions"
-msgstr ""
+msgstr "Show descriptions"
 
 msgid "Subtitle"
-msgstr ""
+msgstr "Subtitle"
 
 msgid "Copyright"
-msgstr ""
+msgstr "Copyright"
 
 msgid "Not present"
-msgstr ""
+msgstr "Not present"
 
 msgid "Source code"
-msgstr ""
+msgstr "Source code"
 
 msgid "Contact link"
-msgstr ""
+msgstr "Contact link"
 
 msgid "Edit container"
-msgstr ""
+msgstr "Edit container"
 
 msgid "Plugin settings"
-msgstr ""
+msgstr "Plugin settings"
 
 msgid "Subscript"
-msgstr ""
+msgstr "Subscript"
 
 msgid "Indent"
-msgstr ""
+msgstr "Indent"
 
 msgid "Outdent"
-msgstr ""
+msgstr "Outdent"
 
 msgid "Unlink"
-msgstr ""
+msgstr "Unlink"
 
 msgid "Thread"
-msgstr ""
+msgstr "Thread"
 
 msgid "Reply"
-msgstr ""
+msgstr "Reply"
 
 msgid "Hot topic threshold"
-msgstr ""
+msgstr "Hot topic threshold"
 
 msgid "Publish"
-msgstr ""
+msgstr "Publish"
 
 msgid "Apply"
-msgstr ""
+msgstr "Apply"
 
 msgid "Block description"
-msgstr ""
+msgstr "Block description"
 
 msgid "Used in"
-msgstr ""
+msgstr "Used in"
 
 msgid "Language code"
-msgstr ""
+msgstr "Language code"
 
 msgid "Translation"
-msgstr ""
+msgstr "Translation"
 
 msgid "Permission"
-msgstr ""
+msgstr "Permission"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Unpublish"
 
 msgid "Copy"
-msgstr ""
+msgstr "Copy"
 
 msgid "Global"
-msgstr ""
+msgstr "Global"
 
 msgid "Menu name"
-msgstr ""
+msgstr "Menu name"
 
 msgid "Add another item"
-msgstr ""
+msgstr "Add another item"
 
 msgid "Go to last page"
-msgstr ""
+msgstr "Go to last page"
 
 msgid "1 second"
 msgid_plural "@count seconds"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 second"
+msgstr[1] "@count seconds"
 
 msgid ""
 "Configure what block content appears in your site's sidebars and other "
 "regions."
 msgstr ""
+"Configure what block content appears in your site's sidebars and other "
+"regions."
 
 msgid "Edit profile"
-msgstr ""
+msgstr "Edit profile"
 
 msgid "Hide"
-msgstr ""
+msgstr "Hide"
 
 msgid "Text Editor"
-msgstr ""
+msgstr "Text Editor"
 
 msgid "Allows administrators to customize the site navigation menu."
-msgstr ""
+msgstr "Allows administrators to customize the site navigation menu."
 
 msgid ""
 "Defines selection, check box and radio button widgets for text and numeric "
 "fields."
 msgstr ""
+"Defines selection, check box and radio button widgets for text and numeric "
+"fields."
 
 msgid "Defines simple text field types."
-msgstr ""
+msgstr "Defines simple text field types."
 
 msgid "Please wait..."
-msgstr ""
+msgstr "Please wait..."
 
 msgid "Topics per page"
-msgstr ""
+msgstr "Topics per page"
 
 msgid "Posts - most active first"
-msgstr ""
+msgstr "Posts - most active first"
 
 msgid "Posts - least active first"
-msgstr ""
+msgstr "Posts - least active first"
 
 msgid "URL path settings"
-msgstr ""
+msgstr "URL path settings"
 
 msgid "Title text"
-msgstr ""
+msgstr "Title text"
 
 msgid "Mapping"
-msgstr ""
+msgstr "Mapping"
 
 msgid "Are you sure you want to revert to the revision from %revision-date?"
-msgstr ""
+msgstr "Are you sure you want to revert to the revision from %revision-date?"
 
 msgid "Are you sure you want to delete the revision from %revision-date?"
-msgstr ""
+msgstr "Are you sure you want to delete the revision from %revision-date?"
 
 msgid "Distinct"
-msgstr ""
+msgstr "Distinct"
 
 msgid "Maximum upload size"
-msgstr ""
+msgstr "Maximum upload size"
 
 msgid "Space"
-msgstr ""
+msgstr "Space"
 
 msgid "New forum topics"
-msgstr ""
+msgstr "New forum topics"
 
 msgid "@type: deleted %title revision %revision."
-msgstr ""
+msgstr "@type: deleted %title revision %revision."
 
 msgid "Page not found"
-msgstr ""
+msgstr "Page not found"
 
 msgid "More help"
-msgstr ""
+msgstr "More help"
 
 msgid "Bullet list"
-msgstr ""
+msgstr "Bullet list"
 
 msgid "Account blocked"
-msgstr ""
+msgstr "Account blocked"
 
 msgid "Expand"
-msgstr ""
+msgstr "Expand"
 
 msgid "Change layout"
-msgstr ""
+msgstr "Change layout"
 
 msgid "Provided by"
-msgstr ""
+msgstr "Provided by"
 
 msgid "Aggregate"
-msgstr ""
+msgstr "Aggregate"
 
 msgid "Node access"
-msgstr ""
+msgstr "Node access"
 
 msgid "Sizes"
-msgstr ""
+msgstr "Sizes"
 
 msgid "Add terms"
-msgstr ""
+msgstr "Add terms"
 
 msgid "Resize"
-msgstr ""
+msgstr "Resize"
 
 msgid "Zip"
-msgstr ""
+msgstr "Zip"
 
 msgid "The directory %directory does not exist."
-msgstr ""
+msgstr "The directory %directory does not exist."
 
 msgid "Blockquote"
-msgstr ""
+msgstr "Blockquote"
 
 msgid "Activate"
-msgstr ""
+msgstr "Activate"
 
 msgid "empty"
-msgstr ""
+msgstr "empty"
 
 msgid "Rebuild permissions"
-msgstr ""
+msgstr "Rebuild permissions"
 
 msgid "@type: updated %title."
-msgstr ""
+msgstr "@type: updated %title."
 
 msgid "@type: added %title."
-msgstr ""
+msgstr "@type: added %title."
 
 msgid "Telephone"
-msgstr ""
+msgstr "Telephone"
 
 msgid "Add role"
-msgstr ""
+msgstr "Add role"
 
 msgid "Path to custom logo"
-msgstr ""
+msgstr "Path to custom logo"
 
 msgid "Supported formats"
-msgstr ""
+msgstr "Supported formats"
 
 msgid "Updated term %term."
-msgstr ""
+msgstr "Updated term %term."
 
 msgid "- None selected -"
-msgstr ""
+msgstr "- None selected -"
 
 msgid "Parser"
-msgstr ""
+msgstr "Parser"
 
 msgid "Discard items older than"
-msgstr ""
+msgstr "Discard items older than"
 
 msgid "Aggregator"
-msgstr ""
+msgstr "Aggregator"
 
 msgid "There is no new syndicated content from %site."
-msgstr ""
+msgstr "There is no new syndicated content from %site."
 
 msgid "There is new syndicated content from %site."
-msgstr ""
+msgstr "There is new syndicated content from %site."
 
 msgid "URL to the feed."
-msgstr ""
+msgstr "URL to the feed."
 
 msgid "Last time feed was checked for new items, as Unix timestamp."
-msgstr ""
+msgstr "Last time feed was checked for new items, as Unix timestamp."
 
 msgid "An image representing the feed."
-msgstr ""
+msgstr "An image representing the feed."
 
 msgid "Entity tag HTTP response header, used for validating cache."
-msgstr ""
+msgstr "Entity tag HTTP response header, used for validating cache."
 
 msgid "When the feed was last modified, as a Unix timestamp."
-msgstr ""
+msgstr "When the feed was last modified, as a Unix timestamp."
 
 msgid "Primary Key: Unique ID for feed item."
-msgstr ""
+msgstr "Primary Key: Unique ID for feed item."
 
 msgid "Title of the feed item."
-msgstr ""
+msgstr "Title of the feed item."
 
 msgid "Link to the feed item."
-msgstr ""
+msgstr "Link to the feed item."
 
 msgid "Author of the feed item."
-msgstr ""
+msgstr "Author of the feed item."
 
 msgid "Body of the feed item."
-msgstr ""
+msgstr "Body of the feed item."
 
 msgid "Post date of feed item, as a Unix timestamp."
-msgstr ""
+msgstr "Post date of feed item, as a Unix timestamp."
 
 msgid "Unique identifier for the feed item."
-msgstr ""
+msgstr "Unique identifier for the feed item."
 
 msgid "Alias"
-msgstr ""
+msgstr "Alias"
 
 msgid "Values"
-msgstr ""
+msgstr "Values"
 
 msgid "Enter your keywords"
-msgstr ""
+msgstr "Enter your keywords"
 
 msgid "Clean URLs"
-msgstr ""
+msgstr "Clean URLs"
 
 msgid "Number of topics"
-msgstr ""
+msgstr "Number of topics"
 
 msgid "Active forum topics"
-msgstr ""
+msgstr "Active forum topics"
 
 msgid "Read the latest forum topics."
-msgstr ""
+msgstr "Read the latest forum topics."
 
 msgid "HTTP authentication"
-msgstr ""
+msgstr "HTTP authentication"
 
 msgid "Attach to"
-msgstr ""
+msgstr "Attach to"
 
 msgid "Context"
-msgstr ""
+msgstr "Context"
 
 msgid "Book navigation"
-msgstr ""
+msgstr "Book navigation"
 
 msgid "Pager"
-msgstr ""
+msgstr "Pager"
 
 msgid "Identifier"
-msgstr ""
+msgstr "Identifier"
 
 msgid "Remove this item"
-msgstr ""
+msgstr "Remove this item"
 
 msgid "Keyword"
-msgstr ""
+msgstr "Keyword"
 
 msgid "1 year"
 msgid_plural "@count years"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 year"
+msgstr[1] "@count years"
 
 msgid "1 week"
 msgid_plural "@count weeks"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 week"
+msgstr[1] "@count weeks"
 
 msgid "1 sec"
 msgid_plural "@count sec"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 sec"
+msgstr[1] "@count sec"
 
 msgid "Columns"
-msgstr ""
+msgstr "Columns"
 
 msgid "Module name"
-msgstr ""
+msgstr "Module name"
 
 msgid "Layout settings"
-msgstr ""
+msgstr "Layout settings"
 
 msgid "Page settings"
-msgstr ""
+msgstr "Page settings"
 
 msgid "Use pager"
-msgstr ""
+msgstr "Use pager"
 
 msgid "Items to display"
-msgstr ""
+msgstr "Items to display"
 
 msgid "More link"
-msgstr ""
+msgstr "More link"
 
 msgid "More link text"
-msgstr ""
+msgstr "More link text"
 
 msgid "Top level book"
-msgstr ""
+msgstr "Top level book"
 
 msgid "No temporary directories to remove."
-msgstr ""
+msgstr "No temporary directories to remove."
 
 msgid "German"
-msgstr ""
+msgstr "German"
 
 msgid "Link to file"
-msgstr ""
+msgstr "Link to file"
 
 msgid "contains"
-msgstr ""
+msgstr "contains"
 
 msgid "Send message"
-msgstr ""
+msgstr "Send message"
 
 msgid "Allow Upscaling"
-msgstr ""
+msgstr "Allow Upscaling"
 
 msgid "Rotation angle"
-msgstr ""
+msgstr "Rotation angle"
 
 msgid ""
 "The number of degrees the image should be rotated. Positive numbers are "
 "clockwise, negative are counter-clockwise."
 msgstr ""
+"The number of degrees the image should be rotated. Positive numbers are "
+"clockwise, negative are counter-clockwise."
 
 msgid ""
 "Randomize the rotation angle for each image. The angle specified above is "
 "used as a maximum."
 msgstr ""
+"Randomize the rotation angle for each image. The angle specified above is "
+"used as a maximum."
 
 msgid "Flush"
-msgstr ""
+msgstr "Flush"
 
 msgid "Print"
-msgstr ""
+msgstr "Print"
 
 msgid "Field mapping"
-msgstr ""
+msgstr "Field mapping"
 
 msgid "The file could not be created."
-msgstr ""
+msgstr "The file could not be created."
 
 msgid "Locked"
-msgstr ""
+msgstr "Locked"
 
 msgid "Password reset instructions mailed to %name at %email."
-msgstr ""
+msgstr "Password reset instructions mailed to %name at %email."
 
 msgid "types"
-msgstr ""
+msgstr "types"
 
 msgid "Data"
-msgstr ""
+msgstr "Data"
 
 msgid "Selection type"
-msgstr ""
+msgstr "Selection type"
 
 msgid "Any"
-msgstr ""
+msgstr "Any"
 
 msgid "Check for updates"
-msgstr ""
+msgstr "Check for updates"
 
 msgid "All newer versions"
-msgstr ""
+msgstr "All newer versions"
 
 msgid "Only security updates"
-msgstr ""
+msgstr "Only security updates"
 
 msgid "No update data available"
-msgstr ""
+msgstr "No update data available"
 
 msgid "Not secure!"
-msgstr ""
+msgstr "Not secure!"
 
 msgid "Revoked!"
-msgstr ""
+msgstr "Revoked!"
 
 msgid "Unsupported release"
-msgstr ""
+msgstr "Unsupported release"
 
 msgid "Can not determine status"
-msgstr ""
+msgstr "Can not determine status"
 
 msgid "(version @version available)"
-msgstr ""
+msgstr "(version @version available)"
 
 msgid "See the available updates page for more information:"
-msgstr ""
+msgstr "See the available updates page for more information:"
 
 msgid ""
 "There is a security update available for your version of Drupal. To ensure "
 "the security of your server, you should update immediately!"
 msgstr ""
+"There is a security update available for your version of Drupal. To ensure "
+"the security of your server, you should update immediately!"
 
 msgid "Display the depth of the comment if it is threaded."
-msgstr ""
+msgstr "Display the depth of the comment if it is threaded."
 
 msgid "Taxonomy vocabulary"
-msgstr ""
+msgstr "Taxonomy vocabulary"
 
 msgid "No comments available."
-msgstr ""
+msgstr "No comments available."
 
 msgid "last »"
-msgstr ""
+msgstr "last »"
 
 msgid "Extension"
-msgstr ""
+msgstr "Extension"
 
 msgid "Account settings"
-msgstr ""
+msgstr "Account settings"
 
 msgid "« first"
-msgstr ""
+msgstr "« first"
 
 msgid "Machine name"
-msgstr ""
+msgstr "Machine name"
 
 msgid "Offset"
-msgstr ""
+msgstr "Offset"
 
 msgid "My account"
-msgstr ""
+msgstr "My account"
 
 msgid "GD library"
-msgstr ""
+msgstr "GD library"
 
 msgid "1 min"
 msgid_plural "@count min"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 min"
+msgstr[1] "@count min"
 
 msgid "Defines a file field type."
-msgstr ""
+msgstr "Defines a file field type."
 
 msgid ""
 "Your version of Drupal has been revoked and is no longer available for "
 "download. Upgrading is strongly recommended!"
 msgstr ""
+"Your version of Drupal has been revoked and is no longer available for "
+"download. Upgrading is strongly recommended!"
 
 msgid ""
 "The installed version of at least one of your modules or themes has been "
 "revoked and is no longer available for download. Upgrading or disabling is "
 "strongly recommended!"
 msgstr ""
+"The installed version of at least one of your modules or themes has been "
+"revoked and is no longer available for download. Upgrading or disabling is "
+"strongly recommended!"
 
 msgid ""
 "Your version of Drupal is no longer supported. Upgrading is strongly "
 "recommended!"
 msgstr ""
+"Your version of Drupal is no longer supported. Upgrading is strongly "
+"recommended!"
 
 msgid ""
 "There are updates available for your version of Drupal. To ensure the proper"
 " functioning of your site, you should update as soon as possible."
 msgstr ""
+"There are updates available for your version of Drupal. To ensure the proper"
+" functioning of your site, you should update as soon as possible."
 
 msgid "Project not secure"
-msgstr ""
+msgstr "Project not secure"
 
 msgid ""
 "This project has been labeled insecure by the Drupal security team, and is "
 "no longer available for download. Immediately disabling everything included "
 "by this project is strongly recommended!"
 msgstr ""
+"This project has been labeled insecure by the Drupal security team, and is "
+"no longer available for download. Immediately disabling everything included "
+"by this project is strongly recommended!"
 
 msgid "Project revoked"
-msgstr ""
+msgstr "Project revoked"
 
 msgid ""
 "This project has been revoked, and is no longer available for download. "
 "Disabling everything included by this project is strongly recommended!"
 msgstr ""
+"This project has been revoked, and is no longer available for download. "
+"Disabling everything included by this project is strongly recommended!"
 
 msgid "Project not supported"
-msgstr ""
+msgstr "Project not supported"
 
 msgid ""
 "This project is no longer supported, and is no longer available for "
 "download. Disabling everything included by this project is strongly "
 "recommended!"
 msgstr ""
+"This project is no longer supported, and is no longer available for "
+"download. Disabling everything included by this project is strongly "
+"recommended!"
 
 msgid "No available releases found"
-msgstr ""
+msgstr "No available releases found"
 
 msgid "Release revoked"
-msgstr ""
+msgstr "Release revoked"
 
 msgid ""
 "Your currently installed release has been revoked, and is no longer "
 "available for download. Disabling everything included in this release or "
 "upgrading is strongly recommended!"
 msgstr ""
+"Your currently installed release has been revoked, and is no longer "
+"available for download. Disabling everything included in this release or "
+"upgrading is strongly recommended!"
 
 msgid "Release not supported"
-msgstr ""
+msgstr "Release not supported"
 
 msgid ""
 "Your currently installed release is now unsupported, and is no longer "
 "available for download. Disabling everything included in this release or "
 "upgrading is strongly recommended!"
 msgstr ""
+"Your currently installed release is now unsupported, and is no longer "
+"available for download. Disabling everything included in this release or "
+"upgrading is strongly recommended!"
 
 msgid "Invalid info"
-msgstr ""
+msgstr "Invalid info"
 
 msgid "Security update required!"
-msgstr ""
+msgstr "Security update required!"
 
 msgid "Not supported!"
-msgstr ""
+msgstr "Not supported!"
 
 msgid "Recommended version:"
-msgstr ""
+msgstr "Recommended version:"
 
 msgid "Security update:"
-msgstr ""
+msgstr "Security update:"
 
 msgid "Latest version:"
-msgstr ""
+msgstr "Latest version:"
 
 msgid "Development version:"
-msgstr ""
+msgstr "Development version:"
 
 msgid "Also available:"
-msgstr ""
+msgstr "Also available:"
 
 msgid "No name"
-msgstr ""
+msgstr "No name"
 
 msgid "File MIME"
-msgstr ""
+msgstr "File MIME"
 
 msgid "User Role"
-msgstr ""
+msgstr "User Role"
 
 msgid "Search help"
-msgstr ""
+msgstr "Search help"
 
 msgid "Field settings"
-msgstr ""
+msgstr "Field settings"
 
 msgid "Edit forum"
-msgstr ""
+msgstr "Edit forum"
 
 msgid "Default order"
-msgstr ""
+msgstr "Default order"
 
 msgid ""
 "This is the designated forum vocabulary. Some of the normal vocabulary "
 "options have been removed."
 msgstr ""
+"This is the designated forum vocabulary. Some of the normal vocabulary "
+"options have been removed."
 
 msgid "Leave shadow copy"
-msgstr ""
+msgstr "Leave shadow copy"
 
 msgid ""
 "If you move this topic, you can leave a link in the old forum to the new "
 "forum."
 msgstr ""
+"If you move this topic, you can leave a link in the old forum to the new "
+"forum."
 
 msgid "Container name"
-msgstr ""
+msgstr "Container name"
 
 msgid "forum container"
-msgstr ""
+msgstr "forum container"
 
 msgid "Created new @type %term."
-msgstr ""
+msgstr "Created new @type %term."
 
 msgid "The @type %term has been updated."
-msgstr ""
+msgstr "The @type %term has been updated."
 
 msgid "AJAX"
-msgstr ""
+msgstr "AJAX"
 
 msgid "Emails"
-msgstr ""
+msgstr "Emails"
 
 msgid "Favicon"
-msgstr ""
+msgstr "Favicon"
 
 msgid "Containing any of the words"
-msgstr ""
+msgstr "Containing any of the words"
 
 msgid "Containing the phrase"
-msgstr ""
+msgstr "Containing the phrase"
 
 msgid "Containing none of the words"
-msgstr ""
+msgstr "Containing none of the words"
 
 msgid "Only of the type(s)"
-msgstr ""
+msgstr "Only of the type(s)"
 
 msgid "Content ranking"
-msgstr ""
+msgstr "Content ranking"
 
 msgid "Keyword relevance"
-msgstr ""
+msgstr "Keyword relevance"
 
 msgid "Number of views"
-msgstr ""
+msgstr "Number of views"
 
 msgid "Factor"
-msgstr ""
+msgstr "Factor"
 
 msgid "Content search"
-msgstr ""
+msgstr "Content search"
 
 msgid "Expand layout to include descriptions."
-msgstr ""
+msgstr "Expand layout to include descriptions."
 
 msgid "Or"
-msgstr ""
+msgstr "Or"
 
 msgid "Color set"
-msgstr ""
+msgstr "Color set"
 
 msgid "Underline"
-msgstr ""
+msgstr "Underline"
 
 msgid "Cut"
-msgstr ""
+msgstr "Cut"
 
 msgid "Paste"
-msgstr ""
+msgstr "Paste"
 
 msgid "Ordered list"
-msgstr ""
+msgstr "Ordered list"
 
 msgid "Unordered list"
-msgstr ""
+msgstr "Unordered list"
 
 msgid "Case sensitive"
-msgstr ""
+msgstr "Case sensitive"
 
 msgid "Maximum link text length"
-msgstr ""
+msgstr "Maximum link text length"
 
 msgid ""
 "URLs longer than this number of characters will be truncated to prevent long"
 " strings that break formatting. The link itself will be retained; just the "
 "text portion of the link will be truncated."
 msgstr ""
+"URLs longer than this number of characters will be truncated to prevent long"
+" strings that break formatting. The link itself will be retained; just the "
+"text portion of the link will be truncated."
 
 msgid "Setting"
-msgstr ""
+msgstr "Setting"
 
 msgid ""
 "If you don't have direct file access to the server, use this field to upload"
 " your logo."
 msgstr ""
+"If you don't have direct file access to the server, use this field to upload"
+" your logo."
 
 msgid "Link class"
-msgstr ""
+msgstr "Link class"
 
 msgid "Install profile"
-msgstr ""
+msgstr "Install profile"
 
 msgid "%percentage of the site has been indexed."
-msgstr ""
+msgstr "%percentage of the site has been indexed."
 
 msgid "File directory"
-msgstr ""
+msgstr "File directory"
 
 msgid "Default theme"
-msgstr ""
+msgstr "Default theme"
 
 msgid "Teaser length"
-msgstr ""
+msgstr "Teaser length"
 
 msgid "not set"
-msgstr ""
+msgstr "not set"
 
 msgid "Memory limit"
-msgstr ""
+msgstr "Memory limit"
 
 msgid "regex"
-msgstr ""
+msgstr "regex"
 
 msgid "Indexes"
-msgstr ""
+msgstr "Indexes"
 
 msgid "Cardinality"
-msgstr ""
+msgstr "Cardinality"
 
 msgid "There is 1 item left to index."
 msgid_plural "There are @count items left to index."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "There is 1 item left to index."
+msgstr[1] "There are @count items left to index."
 
 msgid "The content access permissions have been rebuilt."
-msgstr ""
+msgstr "The content access permissions have been rebuilt."
 
 msgid "Column"
-msgstr ""
+msgstr "Column"
 
 msgid "Default sort"
-msgstr ""
+msgstr "Default sort"
 
 msgid "sort by @s"
-msgstr ""
+msgstr "sort by @s"
 
 msgid "and"
-msgstr ""
+msgstr "and"
 
 msgid "Manage actions"
-msgstr ""
+msgstr "Manage actions"
 
 msgid "Action type"
-msgstr ""
+msgstr "Action type"
 
 msgid "Display a message to the user"
-msgstr ""
+msgstr "Display a message to the user"
 
 msgid "Unpublish comment containing keyword(s)"
-msgstr ""
+msgstr "Unpublish comment containing keyword(s)"
 
 msgid "Page path"
-msgstr ""
+msgstr "Page path"
 
 msgid "Banner image"
-msgstr ""
+msgstr "Banner image"
 
 msgid "- Select -"
-msgstr ""
+msgstr "- Select -"
 
 msgid "Content language"
-msgstr ""
+msgstr "Content language"
 
 msgid "Path prefix"
-msgstr ""
+msgstr "Path prefix"
 
 msgid "Auto-reply"
-msgstr ""
+msgstr "Auto-reply"
 
 msgid ""
 "Optional auto-reply. Leave empty if you do not want to send the user an "
 "auto-reply message."
 msgstr ""
+"Optional auto-reply. Leave empty if you do not want to send the user an "
+"auto-reply message."
 
 msgid "Add @type"
-msgstr ""
+msgstr "Add @type"
 
 msgid "Synchronize"
-msgstr ""
+msgstr "Synchronize"
 
 msgid "Set as default"
-msgstr ""
+msgstr "Set as default"
 
 msgid "Not promoted"
-msgstr ""
+msgstr "Not promoted"
 
 msgid "Not sticky"
-msgstr ""
+msgstr "Not sticky"
 
 msgid "Errors"
-msgstr ""
+msgstr "Errors"
 
 msgid "Nid"
-msgstr ""
+msgstr "Nid"
 
 msgid "Parent comment"
-msgstr ""
+msgstr "Parent comment"
 
 msgid "Author's website"
-msgstr ""
+msgstr "Author's website"
 
 msgid "Content ID"
-msgstr ""
+msgstr "Content ID"
 
 msgid "Publish content"
-msgstr ""
+msgstr "Publish content"
 
 msgid "Node count"
-msgstr ""
+msgstr "Node count"
 
 msgid "Skip to main content"
-msgstr ""
+msgstr "Skip to main content"
 
 msgid "Reports"
-msgstr ""
+msgstr "Reports"
 
 msgid "Web server"
-msgstr ""
+msgstr "Web server"
 
 msgid "Compress layout by hiding descriptions."
-msgstr ""
+msgstr "Compress layout by hiding descriptions."
 
 msgid "Hide descriptions"
-msgstr ""
+msgstr "Hide descriptions"
 
 msgid "Enables the categorization of content."
-msgstr ""
+msgstr "Enables the categorization of content."
 
 msgid ""
 "Sort by the threaded order. This will keep child comments together with "
 "their parents."
 msgstr ""
+"Sort by the threaded order. This will keep child comments together with "
+"their parents."
 
 msgid "Provide a simple link to reply to the comment."
-msgstr ""
+msgstr "Provide a simple link to reply to the comment."
 
 msgid "Text to display"
-msgstr ""
+msgstr "Text to display"
 
 msgid "UI settings"
-msgstr ""
+msgstr "UI settings"
 
 msgid "Newest first"
-msgstr ""
+msgstr "Newest first"
 
 msgid "field"
-msgstr ""
+msgstr "field"
 
 msgid "Update settings"
-msgstr ""
+msgstr "Update settings"
 
 msgid "nodes"
-msgstr ""
+msgstr "nodes"
 
 msgid "Formatter"
-msgstr ""
+msgstr "Formatter"
 
 msgid "Some required modules must be enabled"
-msgstr ""
+msgstr "Some required modules must be enabled"
 
 msgid "New posts"
-msgstr ""
+msgstr "New posts"
 
 msgid "View settings"
-msgstr ""
+msgstr "View settings"
 
 msgid "Week @week"
-msgstr ""
+msgstr "Week @week"
 
 msgid "mm/dd/yy"
-msgstr ""
+msgstr "mm/dd/yy"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Delete view"
 
 msgid "Accessibility features"
-msgstr ""
+msgstr "Accessibility features"
 
 msgid "Translation file"
-msgstr ""
+msgstr "Translation file"
 
 msgid "File to import not found."
-msgstr ""
+msgstr "File to import not found."
 
 msgid "Cache options"
-msgstr ""
+msgstr "Cache options"
 
 msgid "Target"
-msgstr ""
+msgstr "Target"
 
 msgid "Time ago"
-msgstr ""
+msgstr "Time ago"
 
 msgid "Create @name"
-msgstr ""
+msgstr "Create @name"
 
 msgid "Crop"
-msgstr ""
+msgstr "Crop"
 
 msgid "Not enabled"
-msgstr ""
+msgstr "Not enabled"
 
 msgid "Insert Image"
-msgstr ""
+msgstr "Insert Image"
 
 msgid ""
 "Instructions to present to the user below this field on the editing form.<br"
 " />Allowed HTML tags: @tags"
 msgstr ""
+"Instructions to present to the user below this field on the editing form.<br"
+" />Allowed HTML tags: @tags"
 
 msgid "Sort direction"
-msgstr ""
+msgstr "Sort direction"
 
 msgid "Element"
-msgstr ""
+msgstr "Element"
 
 msgid "Radios"
-msgstr ""
+msgstr "Radios"
 
 msgid "Field options"
-msgstr ""
+msgstr "Field options"
 
 msgid "Save permissions"
-msgstr ""
+msgstr "Save permissions"
 
 msgid "Effect"
-msgstr ""
+msgstr "Effect"
 
 msgid "Route"
-msgstr ""
+msgstr "Route"
 
 msgid "Sequence"
-msgstr ""
+msgstr "Sequence"
 
 msgid "starting from @count"
-msgstr ""
+msgstr "starting from @count"
 
 msgid "Embed"
-msgstr ""
+msgstr "Embed"
 
 msgid "Menu block"
-msgstr ""
+msgstr "Menu block"
 
 msgid "Test settings"
-msgstr ""
+msgstr "Test settings"
 
 msgid "Quick edit"
-msgstr ""
+msgstr "Quick edit"
 
 msgid "Change book (update list of parents)"
-msgstr ""
+msgstr "Change book (update list of parents)"
 
 msgid "Manage your site's book outlines."
-msgstr ""
+msgstr "Manage your site's book outlines."
 
 msgid "For security reasons, your upload has been renamed to %filename."
-msgstr ""
+msgstr "For security reasons, your upload has been renamed to %filename."
 
 msgid "vocabulary"
-msgstr ""
+msgstr "vocabulary"
 
 msgid "Installed version"
-msgstr ""
+msgstr "Installed version"
 
 msgid "Recommended version"
-msgstr ""
+msgstr "Recommended version"
 
 msgid "User roles"
-msgstr ""
+msgstr "User roles"
 
 msgid "Acronym"
-msgstr ""
+msgstr "Acronym"
 
 msgid "More link path"
-msgstr ""
+msgstr "More link path"
 
 msgid "No vocabularies available."
-msgstr ""
+msgstr "No vocabularies available."
 
 msgid "original"
-msgstr ""
+msgstr "original"
 
 msgid "Starting level"
-msgstr ""
+msgstr "Starting level"
 
 msgid "Title only"
-msgstr ""
+msgstr "Title only"
 
 msgid "Notification settings"
-msgstr ""
+msgstr "Notification settings"
 
 msgid "Not defined"
-msgstr ""
+msgstr "Not defined"
 
 msgid "Validator"
-msgstr ""
+msgstr "Validator"
 
 msgid "Debugging"
-msgstr ""
+msgstr "Debugging"
 
 msgid "Inherit"
-msgstr ""
+msgstr "Inherit"
 
 msgid "No preview"
-msgstr ""
+msgstr "No preview"
 
 msgid "Save as"
-msgstr ""
+msgstr "Save as"
 
 msgid "Preview image"
-msgstr ""
+msgstr "Preview image"
 
 msgid "pixels"
-msgstr ""
+msgstr "pixels"
 
 msgid "Use default"
-msgstr ""
+msgstr "Use default"
 
 msgid "1 month"
 msgid_plural "@count months"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 month"
+msgstr[1] "@count months"
 
 msgid "Parameter"
-msgstr ""
+msgstr "Parameter"
 
 msgid "done"
-msgstr ""
+msgstr "done"
 
 msgid "Display format"
-msgstr ""
+msgstr "Display format"
 
 msgid "Current state"
-msgstr ""
+msgstr "Current state"
 
 msgid "The date the node was last updated."
-msgstr ""
+msgstr "The date the node was last updated."
 
 msgid "Direction"
-msgstr ""
+msgstr "Direction"
 
 msgid "Drupal core"
-msgstr ""
+msgstr "Drupal core"
 
 msgid "Book navigation block display"
-msgstr ""
+msgstr "Book navigation block display"
 
 msgid "Relations"
-msgstr ""
+msgstr "Relations"
 
 msgid "Invalid display id @display"
-msgstr ""
+msgstr "Invalid display id @display"
 
 msgid "Error: handler for @table > @field doesn't exist!"
-msgstr ""
+msgstr "Error: handler for @table > @field doesn't exist!"
 
 msgid "Do not use a relationship"
-msgstr ""
+msgstr "Do not use a relationship"
 
 msgid "Password field is required."
-msgstr ""
+msgstr "Password field is required."
 
 msgid "Display type"
-msgstr ""
+msgstr "Display type"
 
 msgid "Confirm password"
-msgstr ""
+msgstr "Confirm password"
 
 msgid "button"
-msgstr ""
+msgstr "button"
 
 msgid "Default display order"
-msgstr ""
+msgstr "Default display order"
 
 msgid "Administration theme"
-msgstr ""
+msgstr "Administration theme"
 
 msgid "The cache has been cleared."
-msgstr ""
+msgstr "The cache has been cleared."
 
 msgid "Isle of Man"
-msgstr ""
+msgstr "Isle of Man"
 
 msgid "Montenegro"
-msgstr ""
+msgstr "Montenegro"
 
 msgid "Saint Pierre and Miquelon"
-msgstr ""
+msgstr "Saint Pierre and Miquelon"
 
 msgid "Serbia"
-msgstr ""
+msgstr "Serbia"
 
 msgid "Uri"
-msgstr ""
+msgstr "Uri"
 
 msgid "Kosovo"
-msgstr ""
+msgstr "Kosovo"
 
 msgid "Diego Garcia"
-msgstr ""
+msgstr "Diego Garcia"
 
 msgid "Tristan da Cunha"
-msgstr ""
+msgstr "Tristan da Cunha"
 
 msgid "Role ID."
-msgstr ""
+msgstr "Role ID."
 
 msgid "Run cron"
-msgstr ""
+msgstr "Run cron"
 
 msgid "Run updates"
-msgstr ""
+msgstr "Run updates"
 
 msgid "Combine"
-msgstr ""
+msgstr "Combine"
 
 msgid "of"
-msgstr ""
+msgstr "of"
 
 msgid "Title field"
-msgstr ""
+msgstr "Title field"
 
 msgid "The file %file could not be saved. An unknown error has occurred."
-msgstr ""
+msgstr "The file %file could not be saved. An unknown error has occurred."
 
 msgid "The specified file %name could not be uploaded."
-msgstr ""
+msgstr "The specified file %name could not be uploaded."
 
 msgid "The file's name is empty. Please give a name to the file."
-msgstr ""
+msgstr "The file's name is empty. Please give a name to the file."
 
 msgid "Only files with the following extensions are allowed: %files-allowed."
-msgstr ""
+msgstr "Only files with the following extensions are allowed: %files-allowed."
 
 msgid "The file is %filesize exceeding the maximum file size of %maxsize."
-msgstr ""
+msgstr "The file is %filesize exceeding the maximum file size of %maxsize."
 
 msgid "The file is %filesize which would exceed your disk quota of %quota."
-msgstr ""
+msgstr "The file is %filesize which would exceed your disk quota of %quota."
 
 msgid ""
 "Upload error. Could not move uploaded file %file to destination "
 "%destination."
 msgstr ""
+"Upload error. Could not move uploaded file %file to destination "
+"%destination."
 
 msgid "Add to book outline"
-msgstr ""
+msgstr "Add to book outline"
 
 msgid "Stark"
-msgstr ""
+msgstr "Stark"
 
 msgid "New set"
-msgstr ""
+msgstr "New set"
 
 msgid "No link"
-msgstr ""
+msgstr "No link"
 
 msgid "Add Link"
-msgstr ""
+msgstr "Add Link"
 
 msgid "Edit Link"
-msgstr ""
+msgstr "Edit Link"
 
 msgid "outdated"
-msgstr ""
+msgstr "outdated"
 
 msgid "Is not one of"
-msgstr ""
+msgstr "Is not one of"
 
 msgid "Re-index site"
-msgstr ""
+msgstr "Re-index site"
 
 msgid "Log searches"
-msgstr ""
+msgstr "Log searches"
 
 msgid "Are you sure you want to re-index the site?"
-msgstr ""
+msgstr "Are you sure you want to re-index the site?"
 
 msgid "cURL"
-msgstr ""
+msgstr "cURL"
 
 msgid "No test results to display."
-msgstr ""
+msgstr "No test results to display."
 
 msgid "Save and continue"
-msgstr ""
+msgstr "Save and continue"
 
 msgid "Dates"
-msgstr ""
+msgstr "Dates"
 
 msgid "Not applicable"
-msgstr ""
+msgstr "Not applicable"
 
 msgid "User account"
-msgstr ""
+msgstr "User account"
 
 msgid "Block type"
-msgstr ""
+msgstr "Block type"
 
 msgid "Entity type"
-msgstr ""
+msgstr "Entity type"
 
 msgid "Translate"
-msgstr ""
+msgstr "Translate"
 
 msgid "Custom format"
-msgstr ""
+msgstr "Custom format"
 
 msgid "Web services"
-msgstr ""
+msgstr "Web services"
 
 msgid "@module (<span class=\"admin-disabled\">disabled</span>)"
-msgstr ""
+msgstr "@module (<span class=\"admin-disabled\">disabled</span>)"
 
 msgid "Admin menu"
-msgstr ""
+msgstr "Admin menu"
 
 msgid "Tour"
-msgstr ""
+msgstr "Tour"
 
 msgid "Save translations"
-msgstr ""
+msgstr "Save translations"
 
 msgid "Warning message"
-msgstr ""
+msgstr "Warning message"
 
 msgid "Error message"
-msgstr ""
+msgstr "Error message"
 
 msgid "Row"
-msgstr ""
+msgstr "Row"
 
 msgid "Date settings"
-msgstr ""
+msgstr "Date settings"
 
 msgid "Table name prefix"
-msgstr ""
+msgstr "Table name prefix"
 
 msgid "Maximum height"
-msgstr ""
+msgstr "Maximum height"
 
 msgid "Maximum width"
-msgstr ""
+msgstr "Maximum width"
 
 msgid "Autocomplete matching"
-msgstr ""
+msgstr "Autocomplete matching"
 
 msgid "Starts with"
-msgstr ""
+msgstr "Starts with"
 
 msgid "Link options"
-msgstr ""
+msgstr "Link options"
 
 msgid "Timor-Leste"
-msgstr ""
+msgstr "Timor-Leste"
 
 msgid "Åland Islands"
-msgstr ""
+msgstr "Åland Islands"
 
 msgid "Properties"
-msgstr ""
+msgstr "Properties"
 
 msgid "Cached"
-msgstr ""
+msgstr "Cached"
 
 msgid "Autocomplete"
-msgstr ""
+msgstr "Autocomplete"
 
 msgid "Boolean"
-msgstr ""
+msgstr "Boolean"
 
 msgid "Maximum image resolution"
-msgstr ""
+msgstr "Maximum image resolution"
 
 msgid ""
 "An illegal choice has been detected. Please contact the site administrator."
 msgstr ""
+"An illegal choice has been detected. Please contact the site administrator."
 
 msgid "Tips"
-msgstr ""
+msgstr "Tips"
 
 msgid "Bundles"
-msgstr ""
+msgstr "Bundles"
 
 msgid "Not writable"
-msgstr ""
+msgstr "Not writable"
 
 msgid "Bundle"
-msgstr ""
+msgstr "Bundle"
 
 msgid "Decimal point"
-msgstr ""
+msgstr "Decimal point"
 
 msgid "Configuration name"
-msgstr ""
+msgstr "Configuration name"
 
 msgid "Custom date format"
-msgstr ""
+msgstr "Custom date format"
 
 msgid "Drupal version"
-msgstr ""
+msgstr "Drupal version"
 
 msgid "Book outline"
-msgstr ""
+msgstr "Book outline"
 
 msgid "This will be the top-level page in this book."
-msgstr ""
+msgstr "This will be the top-level page in this book."
 
 msgid "Revision information"
-msgstr ""
+msgstr "Revision information"
 
 msgid "Notify user of new account"
-msgstr ""
+msgstr "Notify user of new account"
 
 msgid "Created timestamp"
-msgstr ""
+msgstr "Created timestamp"
 
 msgid "Is one of"
-msgstr ""
+msgstr "Is one of"
 
 msgid "View comment"
-msgstr ""
+msgstr "View comment"
 
 msgid "Access will be granted to users with the specified permission string."
-msgstr ""
+msgstr "Access will be granted to users with the specified permission string."
 
 msgid "Decimal value"
-msgstr ""
+msgstr "Decimal value"
 
 msgid "Comma"
-msgstr ""
+msgstr "Comma"
 
 msgid "Show All"
-msgstr ""
+msgstr "Show All"
 
 msgid "Uses"
-msgstr ""
+msgstr "Uses"
 
 msgid "Path to custom icon"
-msgstr ""
+msgstr "Path to custom icon"
 
 msgid "Your email address"
-msgstr ""
+msgstr "Your email address"
 
 msgid "‹"
-msgstr ""
+msgstr "‹"
 
 msgid "›"
-msgstr ""
+msgstr "›"
 
 msgid "Users who have created accounts on your site."
-msgstr ""
+msgstr "Users who have created accounts on your site."
 
 msgid "Digest"
-msgstr ""
+msgstr "Digest"
 
 msgid "Default display mode"
-msgstr ""
+msgstr "Default display mode"
 
 msgid "Default comments per page"
-msgstr ""
+msgstr "Default comments per page"
 
 msgid "Comment controls"
-msgstr ""
+msgstr "Comment controls"
 
 msgid "Comment subject field"
-msgstr ""
+msgstr "Comment subject field"
 
 msgid ""
 "Any replies to this comment will be lost. This action cannot be undone."
 msgstr ""
+"Any replies to this comment will be lost. This action cannot be undone."
 
 msgid "Publish the selected comments"
-msgstr ""
+msgstr "Publish the selected comments"
 
 msgid "Unpublish the selected comments"
-msgstr ""
+msgstr "Unpublish the selected comments"
 
 msgid "(No subject)"
-msgstr ""
+msgstr "(No subject)"
 
 msgid "!="
-msgstr ""
+msgstr "!="
 
 msgid "Is empty (NULL)"
-msgstr ""
+msgstr "Is empty (NULL)"
 
 msgid "not empty"
-msgstr ""
+msgstr "not empty"
 
 msgid "Access type"
-msgstr ""
+msgstr "Access type"
 
 msgid "Default image"
-msgstr ""
+msgstr "Default image"
 
 msgid "Add feed"
-msgstr ""
+msgstr "Add feed"
 
 msgid "List links"
-msgstr ""
+msgstr "List links"
 
 msgid "Text settings"
-msgstr ""
+msgstr "Text settings"
 
 msgid "Ends with"
-msgstr ""
+msgstr "Ends with"
 
 msgid "Toolbar"
-msgstr ""
+msgstr "Toolbar"
 
 msgid ""
 "Comment: unauthorized comment submitted or comment submitted to a closed "
 "post %subject."
 msgstr ""
+"Comment: unauthorized comment submitted or comment submitted to a closed "
+"post %subject."
 
 msgid "Link this field to its user"
-msgstr ""
+msgstr "Link this field to its user"
 
 msgid "Parent ID"
-msgstr ""
+msgstr "Parent ID"
 
 msgid "Default style"
-msgstr ""
+msgstr "Default style"
 
 msgid "The node ID of the node."
-msgstr ""
+msgstr "The node ID of the node."
 
 msgid "Tab weight"
-msgstr ""
+msgstr "Tab weight"
 
 msgid "Files directory"
-msgstr ""
+msgstr "Files directory"
 
 msgid "Delete all revisions"
-msgstr ""
+msgstr "Delete all revisions"
 
 msgid "No role"
-msgstr ""
+msgstr "No role"
 
 msgid "Block title."
-msgstr ""
+msgstr "Block title."
 
 msgid "1 view"
 msgid_plural "@count views"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 view"
+msgstr[1] "@count views"
 
 msgid "The file's MIME type."
-msgstr ""
+msgstr "The file's MIME type."
 
 msgid "The size of the file."
-msgstr ""
+msgstr "The size of the file."
 
 msgid "The MIME type of the file."
-msgstr ""
+msgstr "The MIME type of the file."
 
 msgid "@type %title has been created."
-msgstr ""
+msgstr "@type %title has been created."
 
 msgid "@type %title has been updated."
-msgstr ""
+msgstr "@type %title has been updated."
 
 msgid "The post could not be saved."
-msgstr ""
+msgstr "The post could not be saved."
 
 msgid "Menu link ID"
-msgstr ""
+msgstr "Menu link ID"
 
 msgid "1 character"
 msgid_plural "@count characters"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 character"
+msgstr[1] "@count characters"
 
 msgid "Filter settings"
-msgstr ""
+msgstr "Filter settings"
 
 msgid "You do not have any administrative items."
-msgstr ""
+msgstr "You do not have any administrative items."
 
 msgid "No help is available for module %module."
-msgstr ""
+msgstr "No help is available for module %module."
 
 msgid "@module administration pages"
-msgstr ""
+msgstr "@module administration pages"
 
 msgid "Filter the view to the currently logged in user."
-msgstr ""
+msgstr "Filter the view to the currently logged in user."
 
 msgid "Save translation"
-msgstr ""
+msgstr "Save translation"
 
 msgid "Add language"
-msgstr ""
+msgstr "Add language"
 
 msgid "AM"
-msgstr ""
+msgstr "AM"
 
 msgid "PM"
-msgstr ""
+msgstr "PM"
 
 msgid "Comments per page"
-msgstr ""
+msgstr "Comments per page"
 
 msgid "The file could not be uploaded."
-msgstr ""
+msgstr "The file could not be uploaded."
 
 msgid "Export configuration"
-msgstr ""
+msgstr "Export configuration"
 
 msgid "FTP"
-msgstr ""
+msgstr "FTP"
 
 msgid "Collaboration"
-msgstr ""
+msgstr "Collaboration"
 
 msgid "Administration pages"
-msgstr ""
+msgstr "Administration pages"
 
 msgid "Capitalize first letter"
-msgstr ""
+msgstr "Capitalize first letter"
 
 msgid "Run tests"
-msgstr ""
+msgstr "Run tests"
 
 msgid "Clean test environment"
-msgstr ""
+msgstr "Clean test environment"
 
 msgid "Clean environment"
-msgstr ""
+msgstr "Clean environment"
 
 msgid "No tests to display."
-msgstr ""
+msgstr "No tests to display."
 
 msgid "Processing test @num of @max - %test."
-msgstr ""
+msgstr "Processing test @num of @max - %test."
 
 msgid "Processed test @num of @max - %test."
-msgstr ""
+msgstr "Processed test @num of @max - %test."
 
 msgid "1 pass"
 msgid_plural "@count passes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 pass"
+msgstr[1] "@count passes"
 
 msgid "1 fail"
 msgid_plural "@count fails"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 fail"
+msgstr[1] "@count fails"
 
 msgid "1 exception"
 msgid_plural "@count exceptions"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 exception"
+msgstr[1] "@count exceptions"
 
 msgid "User %name used one-time login link at time %timestamp."
-msgstr ""
+msgstr "User %name used one-time login link at time %timestamp."
 
 msgid "Registration successful. You are now logged in."
-msgstr ""
+msgstr "Registration successful. You are now logged in."
 
 msgid "Uid"
-msgstr ""
+msgstr "Uid"
 
 msgid "Custom text"
-msgstr ""
+msgstr "Custom text"
 
 msgid "Sum"
-msgstr ""
+msgstr "Sum"
 
 msgid "The comment body."
-msgstr ""
+msgstr "The comment body."
 
 msgid "Default argument"
-msgstr ""
+msgstr "Default argument"
 
 msgid "Form mode"
-msgstr ""
+msgstr "Form mode"
 
 msgid "Secondary tabs"
-msgstr ""
+msgstr "Secondary tabs"
 
 msgid "Delete comment"
-msgstr ""
+msgstr "Delete comment"
 
 msgid "Publish comment"
-msgstr ""
+msgstr "Publish comment"
 
 msgid "Search index"
-msgstr ""
+msgstr "Search index"
 
 msgid "Posted in"
-msgstr ""
+msgstr "Posted in"
 
 msgid "Permanent"
-msgstr ""
+msgstr "Permanent"
 
 msgid "Upload date"
-msgstr ""
+msgstr "Upload date"
 
 msgid "No files available."
-msgstr ""
+msgstr "No files available."
 
 msgid "Frontpage"
 msgstr "Home"
 
 msgid "Current user"
-msgstr ""
+msgstr "Current user"
 
 msgid "IP address"
-msgstr ""
+msgstr "IP address"
 
 msgid "Enter your @s username."
-msgstr ""
+msgstr "Enter your @s username."
 
 msgid "File system"
-msgstr ""
+msgstr "File system"
 
 msgid "Status report"
-msgstr ""
+msgstr "Status report"
 
 msgid "PHP extensions"
-msgstr ""
+msgstr "PHP extensions"
 
 msgid "RDF mapping"
-msgstr ""
+msgstr "RDF mapping"
 
 msgid "Migration"
-msgstr ""
+msgstr "Migration"
 
 msgid "Provides a framework for unit and functional testing."
-msgstr ""
+msgstr "Provides a framework for unit and functional testing."
 
 msgid "sorted by"
-msgstr ""
+msgstr "sorted by"
 
 msgid "Feed display options"
-msgstr ""
+msgstr "Feed display options"
 
 msgid "Available actions"
-msgstr ""
+msgstr "Available actions"
 
 msgid "Remove group"
-msgstr ""
+msgstr "Remove group"
 
 msgid "The comment ID."
-msgstr ""
+msgstr "The comment ID."
 
 msgid "Add link"
-msgstr ""
+msgstr "Add link"
 
 msgid "Link settings"
-msgstr ""
+msgstr "Link settings"
 
 msgid "Numbered list"
-msgstr ""
+msgstr "Numbered list"
 
 msgid "View comments"
-msgstr ""
+msgstr "View comments"
 
 msgid "Not set"
-msgstr ""
+msgstr "Not set"
 
 msgid "Set password"
-msgstr ""
+msgstr "Set password"
 
 msgid "%name: this field cannot hold more than @count values."
-msgstr ""
+msgstr "%name: this field cannot hold more than @count values."
 
 msgid "No fields available."
-msgstr ""
+msgstr "No fields available."
 
 msgid "Content author"
-msgstr ""
+msgstr "Content author"
 
 msgid "Vertical Tabs"
-msgstr ""
+msgstr "Vertical Tabs"
 
 msgid "Not in book"
-msgstr ""
+msgstr "Not in book"
 
 msgid "New book"
-msgstr ""
+msgstr "New book"
 
 msgid "By @name on @date"
-msgstr ""
+msgstr "By @name on @date"
 
 msgid "By @name"
-msgstr ""
+msgstr "By @name"
 
 msgid "Not in menu"
-msgstr ""
+msgstr "Not in menu"
 
 msgid "Alias: @alias"
-msgstr ""
+msgstr "Alias: @alias"
 
 msgid "No alias"
-msgstr ""
+msgstr "No alias"
 
 msgid "Source language"
-msgstr ""
+msgstr "Source language"
 
 msgid "An error has occurred."
-msgstr ""
+msgstr "An error has occurred."
 
 msgid "Your page will be a part of the selected book."
-msgstr ""
+msgstr "Your page will be a part of the selected book."
 
 msgid "Numeric"
-msgstr ""
+msgstr "Numeric"
 
 msgid "mobile"
-msgstr ""
+msgstr "mobile"
 
 msgid "Media settings"
-msgstr ""
+msgstr "Media settings"
 
 msgid "Custom URL"
-msgstr ""
+msgstr "Custom URL"
 
 msgid "Notify user"
-msgstr ""
+msgstr "Notify user"
 
 msgid "0 sec"
-msgstr ""
+msgstr "0 sec"
 
 msgid "Submit button text"
-msgstr ""
+msgstr "Submit button text"
 
 msgid "Card"
-msgstr ""
+msgstr "Card"
 
 msgid "Is published"
-msgstr ""
+msgstr "Is published"
 
 msgid "Configure @block"
-msgstr ""
+msgstr "Configure @block"
 
 msgid "Filter log messages"
-msgstr ""
+msgstr "Filter log messages"
 
 msgid "You must select something to filter by."
-msgstr ""
+msgstr "You must select something to filter by."
 
 msgid "New revision"
-msgstr ""
+msgstr "New revision"
 
 msgid "Callback"
-msgstr ""
+msgstr "Callback"
 
 msgid ""
 "To change the current user password, enter the new password in both fields."
 msgstr ""
+"To change the current user password, enter the new password in both fields."
 
 msgid ""
 "You have tried to use a one-time login link that has expired. Please request"
 " a new one using the form below."
 msgstr ""
+"You have tried to use a one-time login link that has expired. Please request"
+" a new one using the form below."
 
 msgid "This login can be used only once."
-msgstr ""
+msgstr "This login can be used only once."
 
 msgid "Add comment link"
-msgstr ""
+msgstr "Add comment link"
 
 msgid "Strike-through"
-msgstr ""
+msgstr "Strike-through"
 
 msgid "Align left"
-msgstr ""
+msgstr "Align left"
 
 msgid "Align center"
 msgstr "Align centre"
 
 msgid "Align right"
-msgstr ""
+msgstr "Align right"
 
 msgid "Justify"
-msgstr ""
+msgstr "Justify"
 
 msgid "Horizontal rule"
-msgstr ""
+msgstr "Horizontal rule"
 
 msgid "Paste Text"
-msgstr ""
+msgstr "Paste Text"
 
 msgid "Paste from Word"
-msgstr ""
+msgstr "Paste from Word"
 
 msgid "Remove format"
-msgstr ""
+msgstr "Remove format"
 
 msgid "Character map"
-msgstr ""
+msgstr "Character map"
 
 msgid "HTML block format"
-msgstr ""
+msgstr "HTML block format"
 
 msgid "Font style"
-msgstr ""
+msgstr "Font style"
 
 msgid "Abbreviation"
-msgstr ""
+msgstr "Abbreviation"
 
 msgid "Inserted"
-msgstr ""
+msgstr "Inserted"
 
 msgid "Provide a password for the new account in both fields."
-msgstr ""
+msgstr "Provide a password for the new account in both fields."
 
 msgid "Changes cannot be made to a locked view."
-msgstr ""
+msgstr "Changes cannot be made to a locked view."
 
 msgid "Broken/missing handler"
-msgstr ""
+msgstr "Broken/missing handler"
 
 msgid "Current node's creation time"
-msgstr ""
+msgstr "Current node's creation time"
 
 msgid "Current node's update time"
-msgstr ""
+msgstr "Current node's update time"
 
 msgid "Do not display items with no value in summary"
-msgstr ""
+msgstr "Do not display items with no value in summary"
 
 msgid "Invalid input"
-msgstr ""
+msgstr "Invalid input"
 
 msgid "Fail basic validation if any argument is given"
-msgstr ""
+msgstr "Fail basic validation if any argument is given"
 
 msgid ""
 "By checking this field, you can use this to make sure views with more "
 "arguments than necessary fail validation."
 msgstr ""
+"By checking this field, you can use this to make sure views with more "
+"arguments than necessary fail validation."
 
 msgid "Glossary mode"
-msgstr ""
+msgstr "Glossary mode"
 
 msgid "Character limit"
-msgstr ""
+msgstr "Character limit"
 
 msgid "No transform"
-msgstr ""
+msgstr "No transform"
 
 msgid "Upper case"
-msgstr ""
+msgstr "Upper case"
 
 msgid "Lower case"
-msgstr ""
+msgstr "Lower case"
 
 msgid "Capitalize each word"
-msgstr ""
+msgstr "Capitalize each word"
 
 msgid "Case in path"
-msgstr ""
+msgstr "Case in path"
 
 msgid "Transform spaces to dashes in URL"
-msgstr ""
+msgstr "Transform spaces to dashes in URL"
 
 msgid "Exclude from display"
-msgstr ""
+msgstr "Exclude from display"
 
 msgid "Link path"
-msgstr ""
+msgstr "Link path"
 
 msgid ""
 "The Drupal path or absolute URL for this link. You may enter data from this "
 "view as per the \"Replacement patterns\" below."
 msgstr ""
+"The Drupal path or absolute URL for this link. You may enter data from this "
+"view as per the \"Replacement patterns\" below."
 
 msgid "The CSS class to apply to the link."
-msgstr ""
+msgstr "The CSS class to apply to the link."
 
 msgid "Prefix text"
-msgstr ""
+msgstr "Prefix text"
 
 msgid "Suffix text"
-msgstr ""
+msgstr "Suffix text"
 
 msgid "Any text to display after this link. You may include HTML."
-msgstr ""
+msgstr "Any text to display after this link. You may include HTML."
 
 msgid "Trim only on a word boundary"
-msgstr ""
+msgstr "Trim only on a word boundary"
 
 msgid ""
 "If checked, this field be trimmed only on a word boundary. This is "
 "guaranteed to be the maximum characters stated or less. If there are no word"
 " boundaries this could trim a field to nothing."
 msgstr ""
+"If checked, this field be trimmed only on a word boundary. This is "
+"guaranteed to be the maximum characters stated or less. If there are no word"
+" boundaries this could trim a field to nothing."
 
 msgid "Strip HTML tags"
-msgstr ""
+msgstr "Strip HTML tags"
 
 msgid "Field can contain HTML"
-msgstr ""
+msgstr "Field can contain HTML"
 
 msgid "File size display"
-msgstr ""
+msgstr "File size display"
 
 msgid "Formatted (in KB or MB)"
-msgstr ""
+msgstr "Formatted (in KB or MB)"
 
 msgid "Raw bytes"
-msgstr ""
+msgstr "Raw bytes"
 
 msgid "If checked, true will be displayed as false."
-msgstr ""
+msgstr "If checked, true will be displayed as false."
 
 msgid "Time ago (with \"ago\" appended)"
-msgstr ""
+msgstr "Time ago (with \"ago\" appended)"
 
 msgid "Time span (with \"ago/hence\" appended)"
-msgstr ""
+msgstr "Time span (with \"ago/hence\" appended)"
 
 msgid "Round"
-msgstr ""
+msgstr "Round"
 
 msgid "If checked, the number will be rounded."
-msgstr ""
+msgstr "If checked, the number will be rounded."
 
 msgid "Specify how many digits to print after the decimal point."
-msgstr ""
+msgstr "Specify how many digits to print after the decimal point."
 
 msgid "What single character to use as a decimal point."
-msgstr ""
+msgstr "What single character to use as a decimal point."
 
 msgid "What single character to use as the thousands separator."
-msgstr ""
+msgstr "What single character to use as the thousands separator."
 
 msgid "Text to put before the number, such as currency symbol."
-msgstr ""
+msgstr "Text to put before the number, such as currency symbol."
 
 msgid "Text to put after the number, such as currency symbol."
-msgstr ""
+msgstr "Text to put after the number, such as currency symbol."
 
 msgid "Simple separator"
-msgstr ""
+msgstr "Simple separator"
 
 msgid "Display as link"
-msgstr ""
+msgstr "Display as link"
 
 msgid "Operator identifier"
-msgstr ""
+msgstr "Operator identifier"
 
 msgid "This will appear in the URL after the ? to identify this operator."
-msgstr ""
+msgstr "This will appear in the URL after the ? to identify this operator."
 
 msgid "Filter identifier"
-msgstr ""
+msgstr "Filter identifier"
 
 msgid ""
 "This exposed filter is optional and will have added options to allow it not "
 "to be set."
 msgstr ""
+"This exposed filter is optional and will have added options to allow it not "
+"to be set."
 
 msgid "Remember"
-msgstr ""
+msgstr "Remember"
 
 msgid "Remember the last setting the user gave this filter."
-msgstr ""
+msgstr "Remember the last setting the user gave this filter."
 
 msgid "The identifier is required if the filter is exposed."
-msgstr ""
+msgstr "The identifier is required if the filter is exposed."
 
 msgid "This identifier is not allowed."
-msgstr ""
+msgstr "This identifier is not allowed."
 
 msgid "- Any -"
-msgstr ""
+msgstr "- Any -"
 
 msgid "exposed"
-msgstr ""
+msgstr "exposed"
 
 msgid "Value type"
-msgstr ""
+msgstr "Value type"
 
 msgid ""
 "A date in any machine readable format. CCYY-MM-DD HH:MM:SS is preferred."
 msgstr ""
+"A date in any machine readable format. CCYY-MM-DD HH:MM:SS is preferred."
 
 msgid "Invalid date format."
-msgstr ""
+msgstr "Invalid date format."
 
 msgid "Limit list to selected items"
-msgstr ""
+msgstr "Limit list to selected items"
 
 msgid "Delete the selected comments"
-msgstr ""
+msgstr "Delete the selected comments"
 
 msgid "Current date"
-msgstr ""
+msgstr "Current date"
 
 msgid ""
 "If checked, the only items presented to the user will be the ones selected "
 "here."
 msgstr ""
+"If checked, the only items presented to the user will be the ones selected "
+"here."
 
 msgid "not in"
-msgstr ""
+msgstr "not in"
 
 msgid "<>"
-msgstr ""
+msgstr "<>"
 
 msgid "Is all of"
-msgstr ""
+msgstr "Is all of"
 
 msgid "Is none of"
-msgstr ""
+msgstr "Is none of"
 
 msgid "not"
-msgstr ""
+msgstr "not"
 
 msgid "<"
-msgstr ""
+msgstr "<"
 
 msgid "<="
-msgstr ""
+msgstr "<="
 
 msgid ">="
-msgstr ""
+msgstr ">="
 
 msgid ">"
-msgstr ""
+msgstr ">"
 
 msgid "Is between"
-msgstr ""
+msgstr "Is between"
 
 msgid "between"
-msgstr ""
+msgstr "between"
 
 msgid "Is not between"
-msgstr ""
+msgstr "Is not between"
 
 msgid "not between"
-msgstr ""
+msgstr "not between"
 
 msgid "Min"
-msgstr ""
+msgstr "Min"
 
 msgid "And max"
-msgstr ""
+msgstr "And max"
 
 msgid "And"
-msgstr ""
+msgstr "And"
 
 msgid "Contains any word"
-msgstr ""
+msgstr "Contains any word"
 
 msgid "has word"
-msgstr ""
+msgstr "has word"
 
 msgid "Contains all words"
-msgstr ""
+msgstr "Contains all words"
 
 msgid "has all"
-msgstr ""
+msgstr "has all"
 
 msgid "begins"
-msgstr ""
+msgstr "begins"
 
 msgid "ends"
-msgstr ""
+msgstr "ends"
 
 msgid "!has"
-msgstr ""
+msgstr "!has"
 
 msgid "Require this relationship"
-msgstr ""
+msgstr "Require this relationship"
 
 msgid "asc"
-msgstr ""
+msgstr "asc"
 
 msgid "desc"
-msgstr ""
+msgstr "desc"
 
 msgid ""
 "The granularity is the smallest unit to use when determining whether two "
@@ -5490,78 +5567,82 @@ msgid ""
 "dates in 1999, regardless of when they fall in 1999, will be considered the "
 "same date."
 msgstr ""
+"The granularity is the smallest unit to use when determining whether two "
+"dates are the same; for example, if the granularity is \"Year\" then all "
+"dates in 1999, regardless of when they fall in 1999, will be considered the "
+"same date."
 
 msgid "Broken"
-msgstr ""
+msgstr "Broken"
 
 msgid "Displays"
-msgstr ""
+msgstr "Displays"
 
 msgid "These queries were run during view rendering:"
-msgstr ""
+msgstr "These queries were run during view rendering:"
 
 msgid "This display has no path."
-msgstr ""
+msgstr "This display has no path."
 
 msgid "Query build time"
-msgstr ""
+msgstr "Query build time"
 
 msgid "@time ms"
-msgstr ""
+msgstr "@time ms"
 
 msgid "Query execute time"
-msgstr ""
+msgstr "Query execute time"
 
 msgid "View render time"
-msgstr ""
+msgstr "View render time"
 
 msgid "No query was run"
-msgstr ""
+msgstr "No query was run"
 
 msgid "Unable to preview due to validation errors."
-msgstr ""
+msgstr "Unable to preview due to validation errors."
 
 msgid "View name"
-msgstr ""
+msgstr "View name"
 
 msgid "Break lock"
-msgstr ""
+msgstr "Break lock"
 
 msgid "The lock has been broken and you may now edit this view."
-msgstr ""
+msgstr "The lock has been broken and you may now edit this view."
 
 msgid "Go to the real page for this display"
-msgstr ""
+msgstr "Go to the real page for this display"
 
 msgid "Missing style plugin"
-msgstr ""
+msgstr "Missing style plugin"
 
 msgid "Change settings for this style"
-msgstr ""
+msgstr "Change settings for this style"
 
 msgid "View analysis"
-msgstr ""
+msgstr "View analysis"
 
 msgid "Rearrange @type"
-msgstr ""
+msgstr "Rearrange @type"
 
 msgid "Broken field @id"
-msgstr ""
+msgstr "Broken field @id"
 
 msgid "There are no @types available to add."
-msgstr ""
+msgstr "There are no @types available to add."
 
 msgid "Configure extra settings for @type %item"
-msgstr ""
+msgstr "Configure extra settings for @type %item"
 
 msgid "Clear Views' cache"
-msgstr ""
+msgstr "Clear Views' cache"
 
 msgid "Add Views signature to all SQL queries"
-msgstr ""
+msgstr "Add Views signature to all SQL queries"
 
 msgid "Disable views data caching"
-msgstr ""
+msgstr "Disable views data caching"
 
 msgid ""
 "Views caches data about tables, modules and views available, to increase "
@@ -5569,368 +5650,402 @@ msgid ""
 "rebuild this data when needed. This can have a serious performance impact on"
 " your site."
 msgstr ""
+"Views caches data about tables, modules and views available, to increase "
+"performance. By checking this box, Views will skip this cache and always "
+"rebuild this data when needed. This can have a serious performance impact on"
+" your site."
 
 msgid "Show other queries run during render during live preview"
-msgstr ""
+msgstr "Show other queries run during render during live preview"
 
 msgid ""
 "Drupal has the potential to run many queries while a view is being rendered."
 " Checking this box will display every query run during view render as part "
 "of the live preview."
 msgstr ""
+"Drupal has the potential to run many queries while a view is being rendered."
+" Checking this box will display every query run during view render as part "
+"of the live preview."
 
 msgid "View analysis can find nothing to report."
-msgstr ""
+msgstr "View analysis can find nothing to report."
 
 msgid ""
 "This view has only a default display and therefore will not be placed "
 "anywhere on your site; perhaps you want to add a page or a block display."
 msgstr ""
+"This view has only a default display and therefore will not be placed "
+"anywhere on your site; perhaps you want to add a page or a block display."
 
 msgid "Reduce duplicates"
-msgstr ""
+msgstr "Reduce duplicates"
 
 msgid "Default settings for this view."
-msgstr ""
+msgstr "Default settings for this view."
 
 msgid "Display the view as a page, with a URL and menu links."
-msgstr ""
+msgstr "Display the view as a page, with a URL and menu links."
 
 msgid "Display the view as a block."
-msgstr ""
+msgstr "Display the view as a block."
 
 msgid ""
 "Attachments added to other displays to achieve multiple views in the same "
 "view."
 msgstr ""
+"Attachments added to other displays to achieve multiple views in the same "
+"view."
 
 msgid "Display the view as a feed, such as an RSS feed."
-msgstr ""
+msgstr "Display the view as a feed, such as an RSS feed."
 
 msgid "Displays rows one after another."
-msgstr ""
+msgstr "Displays rows one after another."
 
 msgid "HTML List"
-msgstr ""
+msgstr "HTML List"
 
 msgid "Displays rows in a grid."
-msgstr ""
+msgstr "Displays rows in a grid."
 
 msgid "Displays rows in a table."
-msgstr ""
+msgstr "Displays rows in a table."
 
 msgid "Displays the default summary as a list."
-msgstr ""
+msgstr "Displays the default summary as a list."
 
 msgid ""
 "Displays the summary unformatted, with option for one after another or "
 "inline."
 msgstr ""
+"Displays the summary unformatted, with option for one after another or "
+"inline."
 
 msgid "Generates an RSS feed from a view."
-msgstr ""
+msgstr "Generates an RSS feed from a view."
 
 msgid "Displays the fields with an optional template."
-msgstr ""
+msgstr "Displays the fields with an optional template."
 
 msgid "Will be available to all users."
-msgstr ""
+msgstr "Will be available to all users."
 
 msgid "Access will be granted to users with any of the specified roles."
-msgstr ""
+msgstr "Access will be granted to users with any of the specified roles."
 
 msgid "No caching of Views data."
-msgstr ""
+msgstr "No caching of Views data."
 
 msgid "Time-based"
-msgstr ""
+msgstr "Time-based"
 
 msgid "Simple time-based caching of data."
-msgstr ""
+msgstr "Simple time-based caching of data."
 
 msgid "sort criteria"
-msgstr ""
+msgstr "sort criteria"
 
 msgid "Sort criterion"
-msgstr ""
+msgstr "Sort criterion"
 
 msgid "sort criterion"
-msgstr ""
+msgstr "sort criterion"
 
 msgid "Aggregator items are imported from external RSS and Atom news feeds."
-msgstr ""
+msgstr "Aggregator items are imported from external RSS and Atom news feeds."
 
 msgid "The title of the aggregator item."
-msgstr ""
+msgstr "The title of the aggregator item."
 
 msgid "The link to the original source URL of the item."
-msgstr ""
+msgstr "The link to the original source URL of the item."
 
 msgid "The author of the original imported item."
-msgstr ""
+msgstr "The author of the original imported item."
 
 msgid "The actual content of the imported item."
-msgstr ""
+msgstr "The actual content of the imported item."
 
 msgid ""
 "The date the original feed item was posted. (With some feeds, this will be "
 "the date it was imported.)"
 msgstr ""
+"The date the original feed item was posted. (With some feeds, this will be "
+"the date it was imported.)"
 
 msgid "Feed ID"
-msgstr ""
+msgstr "Feed ID"
 
 msgid "The unique ID of the aggregator feed."
-msgstr ""
+msgstr "The unique ID of the aggregator feed."
 
 msgid "The title of the aggregator feed."
-msgstr ""
+msgstr "The title of the aggregator feed."
 
 msgid "The link to the source URL of the feed."
-msgstr ""
+msgstr "The link to the source URL of the feed."
 
 msgid "The date the feed was last checked for new content."
-msgstr ""
+msgstr "The date the feed was last checked for new content."
 
 msgid "The description of the aggregator feed."
-msgstr ""
+msgstr "The description of the aggregator feed."
 
 msgid "Display the aggregator item using the data from the original source."
-msgstr ""
+msgstr "Display the aggregator item using the data from the original source."
 
 msgid "The book the node is in."
-msgstr ""
+msgstr "The book the node is in."
 
 msgid "The weight of the book page."
-msgstr ""
+msgstr "The weight of the book page."
 
 msgid ""
 "The depth of the book page in the hierarchy; top level books have a depth of"
 " 1."
 msgstr ""
+"The depth of the book page in the hierarchy; top level books have a depth of"
+" 1."
 
 msgid "The parent book node."
-msgstr ""
+msgstr "The parent book node."
 
 msgid "The title of the comment."
-msgstr ""
+msgstr "The title of the comment."
 
 msgid ""
 "The name of the comment's author. Can be rendered as a link to the author's "
 "homepage."
 msgstr ""
+"The name of the comment's author. Can be rendered as a link to the author's "
+"homepage."
 
 msgid ""
 "The website address of the comment's author. Can be rendered as a link. Will"
 " be empty if the author is a registered user."
 msgstr ""
+"The website address of the comment's author. Can be rendered as a link. Will"
+" be empty if the author is a registered user."
 
 msgid "Post date"
-msgstr ""
+msgstr "Post date"
 
 msgid "Node link"
-msgstr ""
+msgstr "Node link"
 
 msgid "The User ID of the comment's author."
-msgstr ""
+msgstr "The User ID of the comment's author."
 
 msgid "Parent CID"
-msgstr ""
+msgstr "Parent CID"
 
 msgid "Last comment time"
-msgstr ""
+msgstr "Last comment time"
 
 msgid "Date and time of when the last comment was posted."
-msgstr ""
+msgstr "Date and time of when the last comment was posted."
 
 msgid "Last comment author"
-msgstr ""
+msgstr "Last comment author"
 
 msgid "The name of the author of the last posted comment."
-msgstr ""
+msgstr "The name of the author of the last posted comment."
 
 msgid "The number of comments a node has."
-msgstr ""
+msgstr "The number of comments a node has."
 
 msgid "Updated/commented date"
-msgstr ""
+msgstr "Updated/commented date"
 
 msgid "The number of new comments on the node."
-msgstr ""
+msgstr "The number of new comments on the node."
 
 msgid "User posted or commented"
-msgstr ""
+msgstr "User posted or commented"
 
 msgid "Display nodes only if a user posted the node or commented on the node."
 msgstr ""
+"Display nodes only if a user posted the node or commented on the node."
 
 msgid "Display the comment as RSS."
-msgstr ""
+msgstr "Display the comment as RSS."
 
 msgid "Provide a simple link to the user contact page."
-msgstr ""
+msgstr "Provide a simple link to the user contact page."
 
 msgid "Whether or not the node is published."
-msgstr ""
+msgstr "Whether or not the node is published."
 
 msgid "Created year + month"
-msgstr ""
+msgstr "Created year + month"
 
 msgid "Created year"
-msgstr ""
+msgstr "Created year"
 
 msgid "Created month"
-msgstr ""
+msgstr "Created month"
 
 msgid "Created day"
-msgstr ""
+msgstr "Created day"
 
 msgid "Created week"
-msgstr ""
+msgstr "Created week"
 
 msgid "Updated year + month"
-msgstr ""
+msgstr "Updated year + month"
 
 msgid "Updated year"
-msgstr ""
+msgstr "Updated year"
 
 msgid "Updated month"
-msgstr ""
+msgstr "Updated month"
 
 msgid "Updated day"
-msgstr ""
+msgstr "Updated day"
 
 msgid "Updated week"
-msgstr ""
+msgstr "Updated week"
 
 msgid "Provide a simple link to revert to the revision."
-msgstr ""
+msgstr "Provide a simple link to revert to the revision."
 
 msgid "Filter by access."
-msgstr ""
+msgstr "Filter by access."
 
 msgid "Has new content"
-msgstr ""
+msgstr "Has new content"
 
 msgid ""
 "Display %display has no access control but does not contain a filter for "
 "published nodes."
 msgstr ""
+"Display %display has no access control but does not contain a filter for "
+"published nodes."
 
 msgid ""
 "The score of the search item. This will not be used if the search filter is "
 "not also present."
 msgstr ""
+"The score of the search item. This will not be used if the search filter is "
+"not also present."
 
 msgid "Total views"
-msgstr ""
+msgstr "Total views"
 
 msgid "The total number of times the node has been viewed."
-msgstr ""
+msgstr "The total number of times the node has been viewed."
 
 msgid "Views today"
-msgstr ""
+msgstr "Views today"
 
 msgid "The total number of times the node has been viewed today."
-msgstr ""
+msgstr "The total number of times the node has been viewed today."
 
 msgid "Most recent view"
-msgstr ""
+msgstr "Most recent view"
 
 msgid "The most recent time the node has been viewed."
-msgstr ""
+msgstr "The most recent time the node has been viewed."
 
 msgid "Files maintained by Drupal and various modules."
-msgstr ""
+msgstr "Files maintained by Drupal and various modules."
 
 msgid "Taxonomy terms are attached to nodes."
-msgstr ""
+msgstr "Taxonomy terms are attached to nodes."
 
 msgid "Filter the results of \"Taxonomy: Term\" to a particular vocabulary."
-msgstr ""
+msgstr "Filter the results of \"Taxonomy: Term\" to a particular vocabulary."
 
 msgid ""
 "Display all taxonomy terms associated with a node from specified "
 "vocabularies."
 msgstr ""
+"Display all taxonomy terms associated with a node from specified "
+"vocabularies."
 
 msgid ""
 "The parent term of the term. This can produce duplicate entries if you are "
 "using a vocabulary that allows multiple parents."
 msgstr ""
+"The parent term of the term. This can produce duplicate entries if you are "
+"using a vocabulary that allows multiple parents."
 
 msgid "The user ID"
-msgstr ""
+msgstr "The user ID"
 
 msgid "The user or author name."
-msgstr ""
+msgstr "The user or author name."
 
 msgid ""
 "Email address for a given user. This field is normally not shown to users, "
 "so be cautious when using it."
 msgstr ""
+"Email address for a given user. This field is normally not shown to users, "
+"so be cautious when using it."
 
 msgid "User ID from URL"
-msgstr ""
+msgstr "User ID from URL"
 
 msgid "User ID from logged in user"
-msgstr ""
+msgstr "User ID from logged in user"
 
 msgid "Randomize the display order."
-msgstr ""
+msgstr "Randomize the display order."
 
 msgid "Null"
-msgstr ""
+msgstr "Null"
 
 msgid "Provide custom text or link."
-msgstr ""
+msgstr "Provide custom text or link."
 
 msgid "View result counter"
-msgstr ""
+msgstr "View result counter"
 
 msgid "Displays the actual position of the view result"
-msgstr ""
+msgstr "Displays the actual position of the view result"
 
 msgid "No user"
-msgstr ""
+msgstr "No user"
 
 msgid "Show teaser-style link"
-msgstr ""
+msgstr "Show teaser-style link"
 
 msgid "Link this field to new comments"
-msgstr ""
+msgstr "Link this field to new comments"
 
 msgid "contact"
-msgstr ""
+msgstr "contact"
 
 msgid "Contact %user"
-msgstr ""
+msgstr "Contact %user"
 
 msgid "Unknown language"
-msgstr ""
+msgstr "Unknown language"
 
 msgid "Check for new comments as well"
-msgstr ""
+msgstr "Check for new comments as well"
 
 msgid "Alternative sort"
-msgstr ""
+msgstr "Alternative sort"
 
 msgid "Alternate sort order"
-msgstr ""
+msgstr "Alternate sort order"
 
 msgid "On empty input"
-msgstr ""
+msgstr "On empty input"
 
 msgid "Show None"
-msgstr ""
+msgstr "Show None"
 
 msgid ""
 "Search for either of the two terms with uppercase <strong>OR</strong>. For "
 "example, <strong>cats OR dogs</strong>."
 msgstr ""
+"Search for either of the two terms with uppercase <strong>OR</strong>. For "
+"example, <strong>cats OR dogs</strong>."
 
 msgid "Link this field to download the file"
-msgstr ""
+msgstr "Link this field to download the file"
 
 msgid ""
 "The depth will match nodes tagged with terms in the hierarchy. For example, "
@@ -5940,134 +6055,142 @@ msgid ""
 "true; searching for \"apple\" will also pick up nodes tagged with \"fruit\" "
 "if depth is -1 (or lower)."
 msgstr ""
+"The depth will match nodes tagged with terms in the hierarchy. For example, "
+"if you have the term \"fruit\" and a child term \"apple\", with a depth of 1"
+" (or higher) then filtering for the term \"fruit\" will get nodes that are "
+"tagged with \"apple\" as well as \"fruit\". If negative, the reverse is "
+"true; searching for \"apple\" will also pick up nodes tagged with \"fruit\" "
+"if depth is -1 (or lower)."
 
 msgid "No vocabulary"
-msgstr ""
+msgstr "No vocabulary"
 
 msgid "Link this field to its term page"
-msgstr ""
+msgstr "Link this field to its term page"
 
 msgid "Limit terms by vocabulary"
-msgstr ""
+msgstr "Limit terms by vocabulary"
 
 msgid "Select which vocabulary to show terms for in the regular options."
-msgstr ""
+msgstr "Select which vocabulary to show terms for in the regular options."
 
 msgid "Dropdown"
-msgstr ""
+msgstr "Dropdown"
 
 msgid "Show hierarchy in dropdown"
-msgstr ""
+msgstr "Show hierarchy in dropdown"
 
 msgid "An invalid vocabulary is selected. Please change it in the options."
-msgstr ""
+msgstr "An invalid vocabulary is selected. Please change it in the options."
 
 msgid "Select terms from vocabulary @voc"
-msgstr ""
+msgstr "Select terms from vocabulary @voc"
 
 msgid "Select terms"
-msgstr ""
+msgstr "Select terms"
 
 msgid "Is the logged in user"
-msgstr ""
+msgstr "Is the logged in user"
 
 msgid "Usernames"
-msgstr ""
+msgstr "Usernames"
 
 msgid "Enter a comma separated list of user names."
-msgstr ""
+msgstr "Enter a comma separated list of user names."
 
 msgid "Also look for a node and use the node author"
-msgstr ""
+msgstr "Also look for a node and use the node author"
 
 msgid "Restrict user based on role"
-msgstr ""
+msgstr "Restrict user based on role"
 
 msgid "Restrict to the selected roles"
-msgstr ""
+msgstr "Restrict to the selected roles"
 
 msgid "If no roles are selected, users from any role will be allowed."
-msgstr ""
+msgstr "If no roles are selected, users from any role will be allowed."
 
 msgid "Unrestricted"
-msgstr ""
+msgstr "Unrestricted"
 
 msgid "No role(s) selected"
-msgstr ""
+msgstr "No role(s) selected"
 
 msgid "Multiple roles"
-msgstr ""
+msgstr "Multiple roles"
 
 msgid "You must select at least one role if type is \"by role\""
-msgstr ""
+msgstr "You must select at least one role if type is \"by role\""
 
 msgid "PHP validate code"
-msgstr ""
+msgstr "PHP validate code"
 
 msgid "Never cache"
-msgstr ""
+msgstr "Never cache"
 
 msgid "Query results"
-msgstr ""
+msgstr "Query results"
 
 msgid "The length of time raw query results should be cached."
-msgstr ""
+msgstr "The length of time raw query results should be cached."
 
 msgid "Rendered output"
-msgstr ""
+msgstr "Rendered output"
 
 msgid "The length of time rendered HTML output should be cached."
-msgstr ""
+msgstr "The length of time rendered HTML output should be cached."
 
 msgid "Broken field"
-msgstr ""
+msgstr "Broken field"
 
 msgid "Change the title that this display will use."
-msgstr ""
+msgstr "Change the title that this display will use."
 
 msgid "Use AJAX"
-msgstr ""
+msgstr "Use AJAX"
 
 msgid "Change whether or not this display will use AJAX."
-msgstr ""
+msgstr "Change whether or not this display will use AJAX."
 
 msgid "Mini"
-msgstr ""
+msgstr "Mini"
 
 msgid "Change this display's pager setting."
-msgstr ""
+msgstr "Change this display's pager setting."
 
 msgid "Specify whether this display will provide a \"more\" link."
-msgstr ""
+msgstr "Specify whether this display will provide a \"more\" link."
 
 msgid "Specify access control type for this display."
-msgstr ""
+msgstr "Specify access control type for this display."
 
 msgid "Change settings for this access type."
-msgstr ""
+msgstr "Change settings for this access type."
 
 msgid "Specify caching type for this display."
-msgstr ""
+msgstr "Specify caching type for this display."
 
 msgid "Change settings for this caching type."
-msgstr ""
+msgstr "Change settings for this caching type."
 
 msgid "Link display"
-msgstr ""
+msgstr "Link display"
 
 msgid "Exposed form in block"
-msgstr ""
+msgstr "Exposed form in block"
 
 msgid "Allow the exposed form to appear in a block instead of the view."
-msgstr ""
+msgstr "Allow the exposed form to appear in a block instead of the view."
 
 msgid "The title of this view"
-msgstr ""
+msgstr "The title of this view"
 
 msgid ""
 "This title will be displayed with the view, wherever titles are normally "
 "displayed; i.e, as the page title, block title, etc."
 msgstr ""
+"This title will be displayed with the view, wherever titles are normally "
+"displayed; i.e, as the page title, block title, etc."
 
 msgid ""
 "Unless you're experiencing problems with pagers related to this view, you "
@@ -6076,15 +6199,20 @@ msgid ""
 "array. Large values will add a lot of commas to your URLs, so avoid if "
 "possible."
 msgstr ""
+"Unless you're experiencing problems with pagers related to this view, you "
+"should leave this at 0. If using multiple pagers on one page you may need to"
+" set this number to a higher value so as not to conflict within the ?page= "
+"array. Large values will add a lot of commas to your URLs, so avoid if "
+"possible."
 
 msgid "Add a more link to the bottom of the display."
-msgstr ""
+msgstr "Add a more link to the bottom of the display."
 
 msgid "Create more link"
-msgstr ""
+msgstr "Create more link"
 
 msgid "The text to display for the more link."
-msgstr ""
+msgstr "The text to display for the more link."
 
 msgid ""
 "This will make the view display only distinct items. If there are multiple "
@@ -6092,46 +6220,54 @@ msgid ""
 "and remove duplicates from a view, though it does not always work. Note that"
 " this can slow queries down, so use it with caution."
 msgstr ""
+"This will make the view display only distinct items. If there are multiple "
+"identical items, each will be displayed only once. You can use this to try "
+"and remove duplicates from a view, though it does not always work. Note that"
+" this can slow queries down, so use it with caution."
 
 msgid "Access restrictions"
-msgstr ""
+msgstr "Access restrictions"
 
 msgid "Access options"
-msgstr ""
+msgstr "Access options"
 
 msgid "Caching options"
-msgstr ""
+msgstr "Caching options"
 
 msgid "Display even if view has no result"
-msgstr ""
+msgstr "Display even if view has no result"
 
 msgid "How should this view be styled"
-msgstr ""
+msgstr "How should this view be styled"
 
 msgid ""
 "If the style you choose has settings, be sure to click the settings button "
 "that will appear next to it in the View summary."
 msgstr ""
+"If the style you choose has settings, be sure to click the settings button "
+"that will appear next to it in the View summary."
 
 msgid "Style options"
-msgstr ""
+msgstr "Style options"
 
 msgid "Row style options"
-msgstr ""
+msgstr "Row style options"
 
 msgid "How should each row in this view be styled"
-msgstr ""
+msgstr "How should each row in this view be styled"
 
 msgid "Which display to use for path"
-msgstr ""
+msgstr "Which display to use for path"
 
 msgid ""
 "Which display to use to get this display's path for things like summary "
 "links, rss feed links, more links, etc."
 msgstr ""
+"Which display to use to get this display's path for things like summary "
+"links, rss feed links, more links, etc."
 
 msgid "Put the exposed form in a block"
-msgstr ""
+msgstr "Put the exposed form in a block"
 
 msgid ""
 "If set, any exposed widgets will not appear with this view. Instead, a block"
@@ -6139,88 +6275,96 @@ msgid ""
 "exposed form will appear there. Note that this block must be enabled "
 "manually, Views will not enable it for you."
 msgstr ""
+"If set, any exposed widgets will not appear with this view. Instead, a block"
+" will be made available to the Drupal block administration system, and the "
+"exposed form will appear there. Note that this block must be enabled "
+"manually, Views will not enable it for you."
 
 msgid ""
 "Display \"@display\" uses fields but there are none defined for it or all "
 "are excluded."
 msgstr ""
+"Display \"@display\" uses fields but there are none defined for it or all "
+"are excluded."
 
 msgid "Display \"@display\" uses a path but the path is undefined."
-msgstr ""
+msgstr "Display \"@display\" uses a path but the path is undefined."
 
 msgid "Display \"@display\" has an invalid style plugin."
-msgstr ""
+msgstr "Display \"@display\" has an invalid style plugin."
 
 msgid "Exposed form: @view-@display_id"
-msgstr ""
+msgstr "Exposed form: @view-@display_id"
 
 msgid "Attachment settings"
-msgstr ""
+msgstr "Attachment settings"
 
 msgid "Inherit exposed filters"
-msgstr ""
+msgstr "Inherit exposed filters"
 
 msgid "Multiple displays"
-msgstr ""
+msgstr "Multiple displays"
 
 msgid ""
 "Should this display inherit its exposed filter values from the parent "
 "display to which it is attached?"
 msgstr ""
+"Should this display inherit its exposed filter values from the parent "
+"display to which it is attached?"
 
 msgid "Attach before or after the parent display?"
-msgstr ""
+msgstr "Attach before or after the parent display?"
 
 msgid "Select which display or displays this should attach to."
-msgstr ""
+msgstr "Select which display or displays this should attach to."
 
 msgid "@view: @display"
-msgstr ""
+msgstr "@view: @display"
 
 msgid "Block admin description"
-msgstr ""
+msgstr "Block admin description"
 
 msgid "Using the site name"
-msgstr ""
+msgstr "Using the site name"
 
 msgid "Use the site name for the title"
-msgstr ""
+msgstr "Use the site name for the title"
 
 msgid "The feed icon will be available only to the selected displays."
-msgstr ""
+msgstr "The feed icon will be available only to the selected displays."
 
 msgid "No menu"
-msgstr ""
+msgstr "No menu"
 
 msgid "Normal: @title"
-msgstr ""
+msgstr "Normal: @title"
 
 msgid "Tab: @title"
-msgstr ""
+msgstr "Tab: @title"
 
 msgid "Change settings for the parent menu"
-msgstr ""
+msgstr "Change settings for the parent menu"
 
 msgid "The menu path or URL of this view"
-msgstr ""
+msgstr "The menu path or URL of this view"
 
 msgid "Menu item entry"
-msgstr ""
+msgstr "Menu item entry"
 
 msgid "No menu entry"
-msgstr ""
+msgstr "No menu entry"
 
 msgid "Normal menu entry"
-msgstr ""
+msgstr "Normal menu entry"
 
 msgid "Menu tab"
-msgstr ""
+msgstr "Menu tab"
 
 msgid "Default menu tab"
-msgstr ""
+msgstr "Default menu tab"
 
 msgid "Default tab options"
-msgstr ""
+msgstr "Default tab options"
 
 msgid ""
 "When providing a menu item as a tab, Drupal needs to know what the parent "
@@ -6230,79 +6374,95 @@ msgid ""
 "to this view is <em>foo/bar/baz</em>, the parent path would be "
 "<em>foo/bar</em>."
 msgstr ""
+"When providing a menu item as a tab, Drupal needs to know what the parent "
+"menu item of that tab will be. Sometimes the parent will already exist, but "
+"other times you will need to have one created. The path of a parent item "
+"will always be the same path with the last part left off. i.e, if the path "
+"to this view is <em>foo/bar/baz</em>, the parent path would be "
+"<em>foo/bar</em>."
 
 msgid "Already exists"
-msgstr ""
+msgstr "Already exists"
 
 msgid "If creating a parent menu item, enter the title of the item."
-msgstr ""
+msgstr "If creating a parent menu item, enter the title of the item."
 
 msgid "If creating a parent menu item, enter the description of the item."
-msgstr ""
+msgstr "If creating a parent menu item, enter the description of the item."
 
 msgid "\"%\" may not be used for the first segment of a path."
-msgstr ""
+msgstr "\"%\" may not be used for the first segment of a path."
 
 msgid "Views cannot create normal menu items for paths with a % in them."
-msgstr ""
+msgstr "Views cannot create normal menu items for paths with a % in them."
 
 msgid "A display whose path ends with a % cannot be a tab."
-msgstr ""
+msgstr "A display whose path ends with a % cannot be a tab."
 
 msgid "Title is required for this menu type."
-msgstr ""
+msgstr "Title is required for this menu type."
 
 msgid "Inline fields"
-msgstr ""
+msgstr "Inline fields"
 
 msgid ""
 "The separator may be placed between inline fields to keep them from "
 "squishing up next to each other. You can use HTML in this field."
 msgstr ""
+"The separator may be placed between inline fields to keep them from "
+"squishing up next to each other. You can use HTML in this field."
 
 msgid ""
 "You may optionally specify a field by which to group the records. Leave "
 "blank to not group."
 msgstr ""
+"You may optionally specify a field by which to group the records. Leave "
+"blank to not group."
 
 msgid "Style @style requires a row style but the row plugin is invalid."
-msgstr ""
+msgstr "Style @style requires a row style but the row plugin is invalid."
 
 msgid ""
 "Horizontal alignment will place items starting in the upper left and moving "
 "right. Vertical alignment will place items starting in the upper left and "
 "moving down."
 msgstr ""
+"Horizontal alignment will place items starting in the upper left and moving "
+"right. Vertical alignment will place items starting in the upper left and "
+"moving down."
 
 msgid "RSS description"
-msgstr ""
+msgstr "RSS description"
 
 msgid "This will appear in the RSS feed itself."
-msgstr ""
+msgstr "This will appear in the RSS feed itself."
 
 msgid "Display record count with link"
-msgstr ""
+msgstr "Display record count with link"
 
 msgid "Override number of items to display"
-msgstr ""
+msgstr "Override number of items to display"
 
 msgid "Display items inline"
-msgstr ""
+msgstr "Display items inline"
 
 msgid ""
 "You need at least one field before you can configure your table settings"
 msgstr ""
+"You need at least one field before you can configure your table settings"
 
 msgid "Override normal sorting if click sorting is used"
-msgstr ""
+msgstr "Override normal sorting if click sorting is used"
 
 msgid "Enable Drupal style \"sticky\" table headers (Javascript)"
-msgstr ""
+msgstr "Enable Drupal style \"sticky\" table headers (Javascript)"
 
 msgid ""
 "(Sticky header effects will not be active for preview below, only on live "
 "output.)"
 msgstr ""
+"(Sticky header effects will not be active for preview below, only on live "
+"output.)"
 
 msgid ""
 "Place fields into columns; you may combine multiple fields into the same "
@@ -6312,269 +6472,288 @@ msgid ""
 " sorted by default, if any. You may control column order and field labels in"
 " the fields section."
 msgstr ""
+"Place fields into columns; you may combine multiple fields into the same "
+"column. If you do, the separator in the column specified will be used to "
+"separate the fields. Check the sortable box to make that column click "
+"sortable, and check the default sort radio to determine which column will be"
+" sorted by default, if any. You may control column order and field labels in"
+" the fields section."
 
 msgid "Parent link ID"
-msgstr ""
+msgstr "Parent link ID"
 
 msgid "Placeholder"
-msgstr ""
+msgstr "Placeholder"
 
 msgid "Language settings"
-msgstr ""
+msgstr "Language settings"
 
 msgid "Attempting to re-run cron while it is already running."
-msgstr ""
+msgstr "Attempting to re-run cron while it is already running."
 
 msgid "Cron run completed."
-msgstr ""
+msgstr "Cron run completed."
 
 msgid "Visitors"
-msgstr ""
+msgstr "Visitors"
 
 msgid "Allow multiple values"
-msgstr ""
+msgstr "Allow multiple values"
 
 msgid "The maximum length of the field in characters."
-msgstr ""
+msgstr "The maximum length of the field in characters."
 
 msgid "Module dependencies"
-msgstr ""
+msgstr "Module dependencies"
 
 msgid "Update translations"
-msgstr ""
+msgstr "Update translations"
 
 msgid "Indexing throttle"
-msgstr ""
+msgstr "Indexing throttle"
 
 msgid "Administration menu"
-msgstr ""
+msgstr "Administration menu"
 
 msgid "››"
-msgstr ""
+msgstr "››"
 
 msgid "‹‹"
-msgstr ""
+msgstr "‹‹"
 
 msgid "- All -"
-msgstr ""
+msgstr "- All -"
 
 msgid "A boolean indicating whether this translation needs to be updated."
-msgstr ""
+msgstr "A boolean indicating whether this translation needs to be updated."
 
 msgid "Publishing status"
-msgstr ""
+msgstr "Publishing status"
 
 msgid "Edit language"
-msgstr ""
+msgstr "Edit language"
 
 msgid "External links only"
-msgstr ""
+msgstr "External links only"
 
 msgid "Filter criteria"
-msgstr ""
+msgstr "Filter criteria"
 
 msgid "The content type %name has been updated."
-msgstr ""
+msgstr "The content type %name has been updated."
 
 msgid "The content type %name has been added."
-msgstr ""
+msgstr "The content type %name has been added."
 
 msgid "Drag to re-order"
-msgstr ""
+msgstr "Drag to re-order"
 
 msgid "Block Content"
-msgstr ""
+msgstr "Block Content"
 
 msgid "Blue Lagoon (default)"
-msgstr ""
+msgstr "Blue Lagoon (default)"
 
 msgid "The requested page could not be found."
-msgstr ""
+msgstr "The requested page could not be found."
 
 msgid "Standard deviation"
-msgstr ""
+msgstr "Standard deviation"
 
 msgid "The user account %id does not exist."
-msgstr ""
+msgstr "The user account %id does not exist."
 
 msgid "Attempted to cancel non-existing user account: %id."
-msgstr ""
+msgstr "Attempted to cancel non-existing user account: %id."
 
 msgid "Requirements problem"
-msgstr ""
+msgstr "Requirements problem"
 
 msgid "Database configuration"
-msgstr ""
+msgstr "Database configuration"
 
 msgid "Select an installation profile"
-msgstr ""
+msgstr "Select an installation profile"
 
 msgid "Choose language"
-msgstr ""
+msgstr "Choose language"
 
 msgid "No profiles available"
-msgstr ""
+msgstr "No profiles available"
 
 msgid "Drupal already installed"
-msgstr ""
+msgstr "Drupal already installed"
 
 msgid "Installing @drupal"
-msgstr ""
+msgstr "Installing @drupal"
 
 msgid "The installation has encountered an error."
-msgstr ""
+msgstr "The installation has encountered an error."
 
 msgid "Configure site"
-msgstr ""
+msgstr "Configure site"
 
 msgid "Installed %module module."
-msgstr ""
+msgstr "Installed %module module."
 
 msgid "Choose profile"
-msgstr ""
+msgstr "Choose profile"
 
 msgid "Verify requirements"
-msgstr ""
+msgstr "Verify requirements"
 
 msgid "Set up database"
-msgstr ""
+msgstr "Set up database"
 
 msgid "Set up translations"
-msgstr ""
+msgstr "Set up translations"
 
 msgid "Install site"
-msgstr ""
+msgstr "Install site"
 
 msgid "Finish translations"
-msgstr ""
+msgstr "Finish translations"
 
 msgid "Check for updates automatically"
-msgstr ""
+msgstr "Check for updates automatically"
 
 msgid "1 byte"
 msgid_plural "@count bytes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 byte"
+msgstr[1] "@count bytes"
 
 msgid "Illegal choice %choice in %name element."
-msgstr ""
+msgstr "Illegal choice %choice in %name element."
 
 msgid "GD2 image manipulation toolkit"
-msgstr ""
+msgstr "GD2 image manipulation toolkit"
 
 msgid ""
 "Define the image quality for JPEG manipulations. Ranges from 0 to 100. "
 "Higher values mean better image quality but bigger files."
 msgstr ""
+"Define the image quality for JPEG manipulations. Ranges from 0 to 100. "
+"Higher values mean better image quality but bigger files."
 
 msgid "Right to left"
-msgstr ""
+msgstr "Right to left"
 
 msgid "Left to right"
-msgstr ""
+msgstr "Left to right"
 
 msgid "Add custom language"
-msgstr ""
+msgstr "Add custom language"
 
 msgid "Save language"
-msgstr ""
+msgstr "Save language"
 
 msgid "Direction that text in this language is presented."
-msgstr ""
+msgstr "Direction that text in this language is presented."
 
 msgid "Languages not yet added"
-msgstr ""
+msgstr "Languages not yet added"
 
 msgid "The language %language has been created."
-msgstr ""
+msgstr "The language %language has been created."
 
 msgid "The submitted string contains disallowed HTML: %string"
-msgstr ""
+msgstr "The submitted string contains disallowed HTML: %string"
 
 msgid "Importing interface translations"
-msgstr ""
+msgstr "Importing interface translations"
 
 msgid "Error importing interface translations"
-msgstr ""
+msgstr "Error importing interface translations"
 
 msgid ""
 "Attempted submission of a translation string with disallowed HTML: %string"
 msgstr ""
+"Attempted submission of a translation string with disallowed HTML: %string"
 
 msgid "Updated JavaScript translation file for the language %language."
-msgstr ""
+msgstr "Updated JavaScript translation file for the language %language."
 
 msgid "Created JavaScript translation file for the language %language."
-msgstr ""
+msgstr "Created JavaScript translation file for the language %language."
 
 msgid ""
 "An error occurred during creation of the JavaScript translation file for the"
 " language %language."
 msgstr ""
+"An error occurred during creation of the JavaScript translation file for the"
+" language %language."
 
 msgid "Standard PHP"
-msgstr ""
+msgstr "Standard PHP"
 
 msgid "PHP Mbstring Extension"
-msgstr ""
+msgstr "PHP Mbstring Extension"
 
 msgid "Could not convert XML encoding %s to UTF-8."
-msgstr ""
+msgstr "Could not convert XML encoding %s to UTF-8."
 
 msgid "The name of the feed (or the name of the website providing the feed)."
-msgstr ""
+msgstr "The name of the feed (or the name of the website providing the feed)."
 
 msgid "Add a feed in RSS, RDF or Atom format. A feed may only have one entry."
 msgstr ""
+"Add a feed in RSS, RDF or Atom format. A feed may only have one entry."
 
 msgid "Update items"
-msgstr ""
+msgstr "Update items"
 
 msgid "No blocks in this region"
-msgstr ""
+msgstr "No blocks in this region"
 
 msgid ""
 "The block %info was assigned to the invalid region %region and has been "
 "disabled."
 msgstr ""
+"The block %info was assigned to the invalid region %region and has been "
+"disabled."
 
 msgid ""
 "The content type for the %add-child link must be one of those selected as an"
 " allowed book outline type."
 msgstr ""
+"The content type for the %add-child link must be one of those selected as an"
+" allowed book outline type."
 
 msgid ""
 "This book has been modified by another user, the changes could not be saved."
 msgstr ""
+"This book has been modified by another user, the changes could not be saved."
 
 msgid "Title changed from %original to %current."
-msgstr ""
+msgstr "Title changed from %original to %current."
 
 msgid "Updated book %title."
-msgstr ""
+msgstr "Updated book %title."
 
 msgid "book: updated %title."
-msgstr ""
+msgstr "book: updated %title."
 
 msgid "Update book outline"
-msgstr ""
+msgstr "Update book outline"
 
 msgid "Remove from book outline"
-msgstr ""
+msgstr "Remove from book outline"
 
 msgid "No changes were made"
-msgstr ""
+msgstr "No changes were made"
 
 msgid ""
 "The post has been added to the selected book. You may now position it "
 "relative to other pages."
 msgstr ""
+"The post has been added to the selected book. You may now position it "
+"relative to other pages."
 
 msgid "The book outline has been updated."
-msgstr ""
+msgstr "The book outline has been updated."
 
 msgid "There was an error adding the post to the book."
-msgstr ""
+msgstr "There was an error adding the post to the book."
 
 msgid ""
 "%title has associated child pages, which will be relocated automatically to "
@@ -6582,24 +6761,28 @@ msgid ""
 "before removing this page), %title may be added again using the Outline tab,"
 " and each of its former child pages will need to be relocated manually."
 msgstr ""
+"%title has associated child pages, which will be relocated automatically to "
+"maintain their connection to the book. To recreate the hierarchy (as it was "
+"before removing this page), %title may be added again using the Outline tab,"
+" and each of its former child pages will need to be relocated manually."
 
 msgid "%title may be added to hierarchy again using the Outline tab."
-msgstr ""
+msgstr "%title may be added to hierarchy again using the Outline tab."
 
 msgid "Are you sure you want to remove %title from the book hierarchy?"
-msgstr ""
+msgstr "Are you sure you want to remove %title from the book hierarchy?"
 
 msgid "The post has been removed from the book."
-msgstr ""
+msgstr "The post has been removed from the book."
 
 msgid "Show a printer-friendly version of this book page and its sub-pages."
-msgstr ""
+msgstr "Show a printer-friendly version of this book page and its sub-pages."
 
 msgid "Show block on all pages"
-msgstr ""
+msgstr "Show block on all pages"
 
 msgid "Show block only on book pages"
-msgstr ""
+msgstr "Show block only on book pages"
 
 msgid ""
 "If <em>Show block on all pages</em> is selected, the block will contain the "
@@ -6610,72 +6793,82 @@ msgid ""
 "visibility settings</em> or other visibility settings can be used in "
 "addition to selectively display this block."
 msgstr ""
+"If <em>Show block on all pages</em> is selected, the block will contain the "
+"automatically generated menus for all of the site's books. If <em>Show block"
+" only on book pages</em> is selected, the block will contain only the one "
+"menu corresponding to the current page's book. In this case, if the current "
+"page is not in a book, no block will be displayed. The <em>Page specific "
+"visibility settings</em> or other visibility settings can be used in "
+"addition to selectively display this block."
 
 msgid "This is the top-level page in this book."
-msgstr ""
+msgstr "This is the top-level page in this book."
 
 msgid "No book selected."
-msgstr ""
+msgstr "No book selected."
 
 msgid ""
 "%title is part of a book outline, and has associated child pages. If you "
 "proceed with deletion, the child pages will be relocated automatically."
 msgstr ""
+"%title is part of a book outline, and has associated child pages. If you "
+"proceed with deletion, the child pages will be relocated automatically."
 
 msgid "Re-order book pages and change titles"
-msgstr ""
+msgstr "Re-order book pages and change titles"
 
 msgid "Book page"
-msgstr ""
+msgstr "Book page"
 
 msgid "Contact form"
-msgstr ""
+msgstr "Contact form"
 
 msgid "Language name"
-msgstr ""
+msgstr "Language name"
 
 msgid "Who's new"
-msgstr ""
+msgstr "Who's new"
 
 msgid "Update notifications"
-msgstr ""
+msgstr "Update notifications"
 
 msgid "Unicode library"
-msgstr ""
+msgstr "Unicode library"
 
 msgid "String contains"
-msgstr ""
+msgstr "String contains"
 
 msgid "Both translated and untranslated strings"
-msgstr ""
+msgstr "Both translated and untranslated strings"
 
 msgid "Only translated strings"
-msgstr ""
+msgstr "Only translated strings"
 
 msgid "Only untranslated strings"
-msgstr ""
+msgstr "Only untranslated strings"
 
 msgid "Search in"
-msgstr ""
+msgstr "Search in"
 
 msgid "Pagination"
-msgstr ""
+msgstr "Pagination"
 
 msgid ""
 "Changes made in this table will not be saved until the form is submitted."
 msgstr ""
+"Changes made in this table will not be saved until the form is submitted."
 
 msgid "Example: 'website feedback' or 'product information'."
-msgstr ""
+msgstr "Example: 'website feedback' or 'product information'."
 
 msgid "No roles may use this format"
-msgstr ""
+msgstr "No roles may use this format"
 
 msgid "Allowed HTML tags: @tags"
-msgstr ""
+msgstr "Allowed HTML tags: @tags"
 
 msgid "Anchors are used to make links to other pages."
-msgstr ""
+msgstr "Anchors are used to make links to other pages."
 
 msgid ""
 "By default line break tags are automatically added, so use this tag to add "
@@ -6683,436 +6876,469 @@ msgid ""
 " open/close pair like all the others. Use the extra \" /\" inside the tag to"
 " maintain XHTML 1.0 compatibility"
 msgstr ""
+"By default line break tags are automatically added, so use this tag to add "
+"additional ones. Use of this tag is different because it is not used with an"
+" open/close pair like all the others. Use the extra \" /\" inside the tag to"
+" maintain XHTML 1.0 compatibility"
 
 msgid "Text with <br />line break"
-msgstr ""
+msgstr "Text with <br />line break"
 
 msgid ""
 "By default paragraph tags are automatically added, so use this tag to add "
 "additional ones."
 msgstr ""
+"By default paragraph tags are automatically added, so use this tag to add "
+"additional ones."
 
 msgid "Paragraph one."
-msgstr ""
+msgstr "Paragraph one."
 
 msgid "Paragraph two."
-msgstr ""
+msgstr "Paragraph two."
 
 msgid "Strong"
-msgstr ""
+msgstr "Strong"
 
 msgid "Emphasized"
-msgstr ""
+msgstr "Emphasized"
 
 msgid "Cited"
-msgstr ""
+msgstr "Cited"
 
 msgid "Coded text used to show programming source code"
-msgstr ""
+msgstr "Coded text used to show programming source code"
 
 msgid "Coded"
-msgstr ""
+msgstr "Coded"
 
 msgid "Bolded"
-msgstr ""
+msgstr "Bolded"
 
 msgid "Italicized"
-msgstr ""
+msgstr "Italicized"
 
 msgid "Superscripted"
-msgstr ""
+msgstr "Superscripted"
 
 msgid "<sup>Super</sup>scripted"
-msgstr ""
+msgstr "<sup>Super</sup>scripted"
 
 msgid "Subscripted"
-msgstr ""
+msgstr "Subscripted"
 
 msgid "<sub>Sub</sub>scripted"
-msgstr ""
+msgstr "<sub>Sub</sub>scripted"
 
 msgid "<abbr title=\"Abbreviation\">Abbrev.</abbr>"
-msgstr ""
+msgstr "<abbr title=\"Abbreviation\">Abbrev.</abbr>"
 
 msgid "<acronym title=\"Three-Letter Acronym\">TLA</acronym>"
-msgstr ""
+msgstr "<acronym title=\"Three-Letter Acronym\">TLA</acronym>"
 
 msgid "Block quoted"
-msgstr ""
+msgstr "Block quoted"
 
 msgid "Quoted inline"
-msgstr ""
+msgstr "Quoted inline"
 
 msgid "Table header"
-msgstr ""
+msgstr "Table header"
 
 msgid "Table cell"
-msgstr ""
+msgstr "Table cell"
 
 msgid "Ordered list - use the &lt;li&gt; to begin each list item"
-msgstr ""
+msgstr "Ordered list - use the &lt;li&gt; to begin each list item"
 
 msgid "First item"
-msgstr ""
+msgstr "First item"
 
 msgid "Second item"
-msgstr ""
+msgstr "Second item"
 
 msgid "Unordered list - use the &lt;li&gt; to begin each list item"
-msgstr ""
+msgstr "Unordered list - use the &lt;li&gt; to begin each list item"
 
 msgid ""
 "Definition lists are similar to other HTML lists. &lt;dl&gt; begins the "
 "definition list, &lt;dt&gt; begins the definition term and &lt;dd&gt; begins"
 " the definition description."
 msgstr ""
+"Definition lists are similar to other HTML lists. &lt;dl&gt; begins the "
+"definition list, &lt;dt&gt; begins the definition term and &lt;dd&gt; begins"
+" the definition description."
 
 msgid "First term"
-msgstr ""
+msgstr "First term"
 
 msgid "First definition"
-msgstr ""
+msgstr "First definition"
 
 msgid "Second term"
-msgstr ""
+msgstr "Second term"
 
 msgid "Second definition"
-msgstr ""
+msgstr "Second definition"
 
 msgid "Subtitle three"
-msgstr ""
+msgstr "Subtitle three"
 
 msgid "Subtitle four"
-msgstr ""
+msgstr "Subtitle four"
 
 msgid "Subtitle five"
-msgstr ""
+msgstr "Subtitle five"
 
 msgid "Subtitle six"
-msgstr ""
+msgstr "Subtitle six"
 
 msgid "Tag Description"
-msgstr ""
+msgstr "Tag Description"
 
 msgid "You Type"
-msgstr ""
+msgstr "You Type"
 
 msgid "You Get"
-msgstr ""
+msgstr "You Get"
 
 msgid "No help provided for tag %tag."
-msgstr ""
+msgstr "No help provided for tag %tag."
 
 msgid "Ampersand"
-msgstr ""
+msgstr "Ampersand"
 
 msgid "Quotation mark"
-msgstr ""
+msgstr "Quotation mark"
 
 msgid "Character Description"
-msgstr ""
+msgstr "Character Description"
 
 msgid "Lines and paragraphs break automatically."
-msgstr ""
+msgstr "Lines and paragraphs break automatically."
 
 msgid "Compose tips"
-msgstr ""
+msgstr "Compose tips"
 
 msgid "Short but meaningful name for this collection of threaded discussions."
 msgstr ""
+"Short but meaningful name for this collection of threaded discussions."
 
 msgid "Description and guidelines for discussions within this forum."
-msgstr ""
+msgstr "Description and guidelines for discussions within this forum."
 
 msgid "Short but meaningful name for this collection of related forums."
-msgstr ""
+msgstr "Short but meaningful name for this collection of related forums."
 
 msgid "Default number of forum topics displayed per page."
-msgstr ""
+msgstr "Default number of forum topics displayed per page."
 
 msgid "Default display order for topics."
-msgstr ""
+msgstr "Default display order for topics."
 
 msgid ""
 "Containers are usually placed at the top (root) level, but may also be "
 "placed inside another container or forum."
 msgstr ""
+"Containers are usually placed at the top (root) level, but may also be "
+"placed inside another container or forum."
 
 msgid ""
 "Forums may be placed at the top (root) level, or inside another container or"
 " forum."
 msgstr ""
+"Forums may be placed at the top (root) level, or inside another container or"
+" forum."
 
 msgid "Forum topic"
-msgstr ""
+msgstr "Forum topic"
 
 msgid "You are not allowed to post new content in the forum."
-msgstr ""
+msgstr "You are not allowed to post new content in the forum."
 
 msgid "Submission form settings"
-msgstr ""
+msgstr "Submission form settings"
 
 msgid ""
 "The machine-readable name must contain only lowercase letters, numbers, and "
 "underscores."
 msgstr ""
+"The machine-readable name must contain only lowercase letters, numbers, and "
+"underscores."
 
 msgid "Added content type %name."
-msgstr ""
+msgstr "Added content type %name."
 
 msgid "Changed the content type of 1 post from %old-type to %type."
 msgid_plural ""
 "Changed the content type of @count posts from %old-type to %type."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Changed the content type of 1 post from %old-type to %type."
+msgstr[1] "Changed the content type of @count posts from %old-type to %type."
 
 msgid "Are you sure you want to rebuild the permissions on site content?"
-msgstr ""
+msgstr "Are you sure you want to rebuild the permissions on site content?"
 
 msgid ""
 "This action rebuilds all permissions on site content, and may be a lengthy "
 "process. This action cannot be undone."
 msgstr ""
+"This action rebuilds all permissions on site content, and may be a lengthy "
+"process. This action cannot be undone."
 
 msgid "language"
-msgstr ""
+msgstr "language"
 
 msgid "An error occurred and processing did not complete."
-msgstr ""
+msgstr "An error occurred and processing did not complete."
 
 msgid "Copy of the revision from %date."
-msgstr ""
+msgstr "Copy of the revision from %date."
 
 msgid "Revision from %revision-date of @type %title has been deleted."
-msgstr ""
+msgstr "Revision from %revision-date of @type %title has been deleted."
 
 msgid "@type: reverted %title revision %revision."
-msgstr ""
+msgstr "@type: reverted %title revision %revision."
 
 msgid "The content access permissions need to be rebuilt."
-msgstr ""
+msgstr "The content access permissions need to be rebuilt."
 
 msgid "Rebuilding content access permissions"
-msgstr ""
+msgstr "Rebuilding content access permissions"
 
 msgid "Content permissions have been rebuilt."
-msgstr ""
+msgstr "Content permissions have been rebuilt."
 
 msgid "The content access permissions have not been properly rebuilt."
-msgstr ""
+msgstr "The content access permissions have not been properly rebuilt."
 
 msgid "Add content type"
-msgstr ""
+msgstr "Add content type"
 
 msgid "Revert to earlier revision"
-msgstr ""
+msgstr "Revert to earlier revision"
 
 msgid "Delete earlier revision"
-msgstr ""
+msgstr "Delete earlier revision"
 
 msgid "The alias %alias is already in use in this language."
-msgstr ""
+msgstr "The alias %alias is already in use in this language."
 
 msgid "The alias has been saved."
-msgstr ""
+msgstr "The alias has been saved."
 
 msgid "Are you sure you want to delete path alias %title?"
-msgstr ""
+msgstr "Are you sure you want to delete path alias %title?"
 
 msgid "Filter aliases"
-msgstr ""
+msgstr "Filter aliases"
 
 msgid ""
 "Enter the path you wish to create the alias for, followed by the name of the"
 " new alias."
 msgstr ""
+"Enter the path you wish to create the alias for, followed by the name of the"
+" new alias."
 
 msgid "Edit alias"
-msgstr ""
+msgstr "Edit alias"
 
 msgid "Delete alias"
-msgstr ""
+msgstr "Delete alias"
 
 msgid "Add alias"
-msgstr ""
+msgstr "Add alias"
 
 msgid "URL aliases"
-msgstr ""
+msgstr "URL aliases"
 
 msgid "Top 'page not found' errors"
-msgstr ""
+msgstr "Top 'page not found' errors"
 
 msgid "Top 'access denied' errors"
-msgstr ""
+msgstr "Top 'access denied' errors"
 
 msgid "View events that have recently been logged."
-msgstr ""
+msgstr "View events that have recently been logged."
 
 msgid "View 'access denied' errors (403s)."
-msgstr ""
+msgstr "View 'access denied' errors (403s)."
 
 msgid "View 'page not found' errors (404s)."
-msgstr ""
+msgstr "View 'page not found' errors (404s)."
 
 msgid "Allows users to comment on and discuss published content."
-msgstr ""
+msgstr "Allows users to comment on and discuss published content."
 
 msgid "Enables the use of both personal and site-wide contact forms."
-msgstr ""
+msgstr "Enables the use of both personal and site-wide contact forms."
 
 msgid "Logs and records system events to the database."
-msgstr ""
+msgstr "Logs and records system events to the database."
 
 msgid "Manages the display of online help."
-msgstr ""
+msgstr "Manages the display of online help."
 
 msgid "Allows content to be submitted to the site and displayed on pages."
-msgstr ""
+msgstr "Allows content to be submitted to the site and displayed on pages."
 
 msgid "Allows users to rename URLs."
-msgstr ""
+msgstr "Allows users to rename URLs."
 
 msgid "Number of items to index per cron run"
-msgstr ""
+msgstr "Number of items to index per cron run"
 
 msgid "Indexing settings"
-msgstr ""
+msgstr "Indexing settings"
 
 msgid "Minimum word length to index"
-msgstr ""
+msgstr "Minimum word length to index"
 
 msgid "Simple CJK handling"
-msgstr ""
+msgstr "Simple CJK handling"
 
 msgid ""
 "Whether to apply a simple Chinese/Japanese/Korean tokenizer based on "
 "overlapping sequences. Turn this off if you want to use an external "
 "preprocessor for this instead. Does not affect other languages."
 msgstr ""
+"Whether to apply a simple Chinese/Japanese/Korean tokenizer based on "
+"overlapping sequences. Turn this off if you want to use an external "
+"preprocessor for this instead. Does not affect other languages."
 
 msgid "Search form"
-msgstr ""
+msgstr "Search form"
 
 msgid "Top search phrases"
-msgstr ""
+msgstr "Top search phrases"
 
 msgid "View most popular search phrases."
-msgstr ""
+msgstr "View most popular search phrases."
 
 msgid "Content viewing counter settings"
-msgstr ""
+msgstr "Content viewing counter settings"
 
 msgid "Count content views"
-msgstr ""
+msgstr "Count content views"
 
 msgid "Increment a counter each time content is viewed."
-msgstr ""
+msgstr "Increment a counter each time content is viewed."
 
 msgid "Popular content"
-msgstr ""
+msgstr "Popular content"
 
 msgid "How many content items to display in \"all time\" list."
-msgstr ""
+msgstr "How many content items to display in \"all time\" list."
 
 msgid "How many content items to display in \"recently viewed\" list."
-msgstr ""
+msgstr "How many content items to display in \"recently viewed\" list."
 
 msgid "Today's:"
-msgstr ""
+msgstr "Today's:"
 
 msgid "All time:"
-msgstr ""
+msgstr "All time:"
 
 msgid "Last viewed:"
-msgstr ""
+msgstr "Last viewed:"
 
 msgid "User pictures in posts"
-msgstr ""
+msgstr "User pictures in posts"
 
 msgid "User pictures in comments"
-msgstr ""
+msgstr "User pictures in comments"
 
 msgid "Shortcut icon"
-msgstr ""
+msgstr "Shortcut icon"
 
 msgid "Upload logo image"
-msgstr ""
+msgstr "Upload logo image"
 
 msgid "Shortcut icon settings"
-msgstr ""
+msgstr "Shortcut icon settings"
 
 msgid ""
 "If you don't have direct file access to the server, use this field to upload"
 " your shortcut icon."
 msgstr ""
+"If you don't have direct file access to the server, use this field to upload"
+" your shortcut icon."
 
 msgid "No modules selected."
-msgstr ""
+msgstr "No modules selected."
 
 msgid "Default 403 (access denied) page"
-msgstr ""
+msgstr "Default 403 (access denied) page"
 
 msgid "Default 404 (not found) page"
-msgstr ""
+msgstr "Default 404 (not found) page"
 
 msgid "Select an image processing toolkit"
-msgstr ""
+msgstr "Select an image processing toolkit"
 
 msgid "Number of items in each feed"
-msgstr ""
+msgstr "Number of items in each feed"
 
 msgid "Default number of items to include in each feed."
-msgstr ""
+msgstr "Default number of items to include in each feed."
 
 msgid "Feed content"
-msgstr ""
+msgstr "Feed content"
 
 msgid "Titles plus teaser"
-msgstr ""
+msgstr "Titles plus teaser"
 
 msgid "Global setting for the default display of content items in each feed."
-msgstr ""
+msgstr "Global setting for the default display of content items in each feed."
 
 msgid "Formatting"
-msgstr ""
+msgstr "Formatting"
 
 msgid "Cron ran successfully."
-msgstr ""
+msgstr "Cron ran successfully."
 
 msgid "Cron run failed."
-msgstr ""
+msgstr "Cron run failed."
 
 msgid "No modules are available to uninstall."
-msgstr ""
+msgstr "No modules are available to uninstall."
 
 msgid ""
 "This page shows you all available administration tasks for each module."
 msgstr ""
+"This page shows you all available administration tasks for each module."
 
 msgid ""
 "The <em>Powered by Drupal</em> block is an optional link to the home page of"
 " the Drupal project. While there is absolutely no requirement that sites "
 "feature this link, it may be used to show support for Drupal."
 msgstr ""
+"The <em>Powered by Drupal</em> block is an optional link to the home page of"
+" the Drupal project. While there is absolutely no requirement that sites "
+"feature this link, it may be used to show support for Drupal."
 
 msgid "Compact mode"
-msgstr ""
+msgstr "Compact mode"
 
 msgid "Date and time"
-msgstr ""
+msgstr "Date and time"
 
 msgid "-1 (Unlimited)"
-msgstr ""
+msgstr "-1 (Unlimited)"
 
 msgid ""
 "Consider increasing your PHP memory limit to %memory_minimum_limit to help "
 "prevent errors in the installation process."
 msgstr ""
+"Consider increasing your PHP memory limit to %memory_minimum_limit to help "
+"prevent errors in the installation process."
 
 msgid ""
 "Consider increasing your PHP memory limit to %memory_minimum_limit to help "
 "prevent errors in the update process."
 msgstr ""
+"Consider increasing your PHP memory limit to %memory_minimum_limit to help "
+"prevent errors in the update process."
 
 msgid ""
 "Depending on your configuration, Drupal can run with a %memory_limit PHP "
@@ -7120,78 +7346,94 @@ msgid ""
 "recommended, especially if your site uses additional custom or contributed "
 "modules."
 msgstr ""
+"Depending on your configuration, Drupal can run with a %memory_limit PHP "
+"memory limit. However, a %memory_minimum_limit PHP memory limit or above is "
+"recommended, especially if your site uses additional custom or contributed "
+"modules."
 
 msgid ""
 "Increase the memory limit by editing the memory_limit parameter in the file "
 "%configuration-file and then restart your web server (or contact your system"
 " administrator or hosting provider for assistance)."
 msgstr ""
+"Increase the memory limit by editing the memory_limit parameter in the file "
+"%configuration-file and then restart your web server (or contact your system"
+" administrator or hosting provider for assistance)."
 
 msgid ""
 "Contact your system administrator or hosting provider for assistance with "
 "increasing your PHP memory limit."
 msgstr ""
+"Contact your system administrator or hosting provider for assistance with "
+"increasing your PHP memory limit."
 
 msgid "Not protected"
-msgstr ""
+msgstr "Not protected"
 
 msgid ""
 "The file %file is not protected from modifications and poses a security "
 "risk. You must change the file's permissions to be non-writable."
 msgstr ""
+"The file %file is not protected from modifications and poses a security "
+"risk. You must change the file's permissions to be non-writable."
 
 msgid "Cron has not run recently."
-msgstr ""
+msgstr "Cron has not run recently."
 
 msgid "The directory %directory is not writable."
-msgstr ""
+msgstr "The directory %directory is not writable."
 
 msgid "Writable (<em>public</em> download method)"
-msgstr ""
+msgstr "Writable (<em>public</em> download method)"
 
 msgid "Writable (<em>private</em> download method)"
-msgstr ""
+msgstr "Writable (<em>private</em> download method)"
 
 msgid "Reset to alphabetical"
-msgstr ""
+msgstr "Reset to alphabetical"
 
 msgid "Terms are displayed in ascending order by weight."
-msgstr ""
+msgstr "Terms are displayed in ascending order by weight."
 
 msgid "Weight value must be numeric."
-msgstr ""
+msgstr "Weight value must be numeric."
 
 msgid ""
 "Are you sure you want to reset the vocabulary %title to alphabetical order?"
 msgstr ""
+"Are you sure you want to reset the vocabulary %title to alphabetical order?"
 
 msgid ""
 "Resetting a vocabulary will discard all custom ordering and sort items "
 "alphabetically."
 msgstr ""
+"Resetting a vocabulary will discard all custom ordering and sort items "
+"alphabetically."
 
 msgid "Reset vocabulary %name to alphabetical order."
-msgstr ""
+msgstr "Reset vocabulary %name to alphabetical order."
 
 msgid "Translation settings"
-msgstr ""
+msgstr "Translation settings"
 
 msgid "This translation needs to be updated"
-msgstr ""
+msgstr "This translation needs to be updated"
 
 msgid "Unknown release date"
-msgstr ""
+msgstr "Unknown release date"
 
 msgid "Last checked: never"
-msgstr ""
+msgstr "Last checked: never"
 
 msgid "Includes: %includes"
-msgstr ""
+msgstr "Includes: %includes"
 
 msgid ""
 "Select how frequently you want to automatically check for new releases of "
 "your currently installed modules and themes."
 msgstr ""
+"Select how frequently you want to automatically check for new releases of "
+"your currently installed modules and themes."
 
 msgid ""
 "Here you can find information about available updates for your installed "
@@ -7199,144 +7441,160 @@ msgid ""
 " which may or may not have the same name, and might include multiple modules"
 " or themes within it."
 msgstr ""
+"Here you can find information about available updates for your installed "
+"modules and themes. Note that each module or theme is part of a \"project\","
+" which may or may not have the same name, and might include multiple modules"
+" or themes within it."
 
 msgid ""
 "There are security updates available for one or more of your modules or "
 "themes. To ensure the security of your server, you should update "
 "immediately!"
 msgstr ""
+"There are security updates available for one or more of your modules or "
+"themes. To ensure the security of your server, you should update "
+"immediately!"
 
 msgid ""
 "There are updates available for one or more of your modules or themes. To "
 "ensure the proper functioning of your site, you should update as soon as "
 "possible."
 msgstr ""
+"There are updates available for one or more of your modules or themes. To "
+"ensure the proper functioning of your site, you should update as soon as "
+"possible."
 
 msgid "%name has been deleted."
-msgstr ""
+msgstr "%name has been deleted."
 
 msgid "Image toolkit"
-msgstr ""
+msgstr "Image toolkit"
 
 msgid "RSS publishing"
-msgstr ""
+msgstr "RSS publishing"
 
 msgid ""
 "Get a status report about available updates for your installed modules and "
 "themes."
 msgstr ""
+"Get a status report about available updates for your installed modules and "
+"themes."
 
 msgid "Access to update.php"
-msgstr ""
+msgstr "Access to update.php"
 
 msgid "Database updates"
-msgstr ""
+msgstr "Database updates"
 
 msgid "Cron maintenance tasks"
-msgstr ""
+msgstr "Cron maintenance tasks"
 
 msgid "PHP memory limit"
-msgstr ""
+msgstr "PHP memory limit"
 
 msgid "Caches cleared."
-msgstr ""
+msgstr "Caches cleared."
 
 msgid "Module and theme update status"
-msgstr ""
+msgstr "Module and theme update status"
 
 msgid "Enables site-wide keyword searching."
-msgstr ""
+msgstr "Enables site-wide keyword searching."
 
 msgid "Logs and records system events to syslog."
-msgstr ""
+msgstr "Logs and records system events to syslog."
 
 msgid "Handles general site configuration for administrators."
-msgstr ""
+msgstr "Handles general site configuration for administrators."
 
 msgid "@module (<span class=\"admin-missing\">missing</span>)"
-msgstr ""
+msgstr "@module (<span class=\"admin-missing\">missing</span>)"
 
 msgid "Would you like to continue with uninstalling the above?"
-msgstr ""
+msgstr "Would you like to continue with uninstalling the above?"
 
 msgid "Confirm uninstall"
-msgstr ""
+msgstr "Confirm uninstall"
 
 msgid "The selected modules have been uninstalled."
-msgstr ""
+msgstr "The selected modules have been uninstalled."
 
 msgid "You must enter a username."
-msgstr ""
+msgstr "You must enter a username."
 
 msgid "The username cannot begin with a space."
-msgstr ""
+msgstr "The username cannot begin with a space."
 
 msgid "The username cannot end with a space."
-msgstr ""
+msgstr "The username cannot end with a space."
 
 msgid "The username cannot contain multiple spaces in a row."
-msgstr ""
+msgstr "The username cannot contain multiple spaces in a row."
 
 msgid "The username contains an illegal character."
-msgstr ""
+msgstr "The username contains an illegal character."
 
 msgid "The username %name is too long: it must be %max characters or less."
-msgstr ""
+msgstr "The username %name is too long: it must be %max characters or less."
 
 msgid "Unblock the selected users"
-msgstr ""
+msgstr "Unblock the selected users"
 
 msgid "Block the selected users"
-msgstr ""
+msgstr "Block the selected users"
 
 msgid "Deleted user: %name %email."
-msgstr ""
+msgstr "Deleted user: %name %email."
 
 msgid "Edit role"
-msgstr ""
+msgstr "Edit role"
 
 msgid "Language list"
-msgstr ""
+msgstr "Language list"
 
 msgid "File extension"
-msgstr ""
+msgstr "File extension"
 
 msgid "wide"
-msgstr ""
+msgstr "wide"
 
 msgid ""
 "The title is used as a tool tip when the user hovers the mouse over the "
 "image."
 msgstr ""
+"The title is used as a tool tip when the user hovers the mouse over the "
+"image."
 
 msgid "Progress indicator"
-msgstr ""
+msgstr "Progress indicator"
 
 msgid "Bar with progress meter"
-msgstr ""
+msgstr "Bar with progress meter"
 
 msgid "Throbber"
-msgstr ""
+msgstr "Throbber"
 
 msgid "Path settings"
-msgstr ""
+msgstr "Path settings"
 
 msgid "The file upload failed. %upload"
-msgstr ""
+msgstr "The file upload failed. %upload"
 
 msgid "URL to file"
-msgstr ""
+msgstr "URL to file"
 
 msgid ""
 "An unrecoverable error occurred. The uploaded file likely exceeded the "
 "maximum file size (@size) that this server supports."
 msgstr ""
+"An unrecoverable error occurred. The uploaded file likely exceeded the "
+"maximum file size (@size) that this server supports."
 
 msgid "Starting upload..."
-msgstr ""
+msgstr "Starting upload..."
 
 msgid "Uploading... (@current of @total)"
-msgstr ""
+msgstr "Uploading... (@current of @total)"
 
 msgid ""
 "Your server is capable of displaying file upload progress using APC RFC1867."
@@ -7344,116 +7602,122 @@ msgid ""
 "the <a href=\"http://pecl.php.net/package/uploadprogress\">PECL "
 "uploadprogress library</a> if possible."
 msgstr ""
+"Your server is capable of displaying file upload progress using APC RFC1867."
+" Note that only one upload at a time is supported. It is recommended to use "
+"the <a href=\"http://pecl.php.net/package/uploadprogress\">PECL "
+"uploadprogress library</a> if possible."
 
 msgid ""
 "Enabled (<a href=\"http://pecl.php.net/package/uploadprogress\">PECL "
 "uploadprogress</a>)"
 msgstr ""
+"Enabled (<a href=\"http://pecl.php.net/package/uploadprogress\">PECL "
+"uploadprogress</a>)"
 
 msgid "Preferred language"
-msgstr ""
+msgstr "Preferred language"
 
 msgid "Number field"
-msgstr ""
+msgstr "Number field"
 
 msgid "Styles"
-msgstr ""
+msgstr "Styles"
 
 msgid "Item ID"
-msgstr ""
+msgstr "Item ID"
 
 msgid "Posted on"
-msgstr ""
+msgstr "Posted on"
 
 msgid "The size of the file in bytes."
-msgstr ""
+msgstr "The size of the file in bytes."
 
 msgid "Interface"
-msgstr ""
+msgstr "Interface"
 
 msgid "Thresholds"
-msgstr ""
+msgstr "Thresholds"
 
 msgid "@size KB"
-msgstr ""
+msgstr "@size KB"
 
 msgid "@size MB"
-msgstr ""
+msgstr "@size MB"
 
 msgid "@size GB"
-msgstr ""
+msgstr "@size GB"
 
 msgid "@size TB"
-msgstr ""
+msgstr "@size TB"
 
 msgid "@size PB"
-msgstr ""
+msgstr "@size PB"
 
 msgid "@size EB"
-msgstr ""
+msgstr "@size EB"
 
 msgid "@size ZB"
-msgstr ""
+msgstr "@size ZB"
 
 msgid "@size YB"
-msgstr ""
+msgstr "@size YB"
 
 msgid "All messages"
-msgstr ""
+msgstr "All messages"
 
 msgid "Serialized"
-msgstr ""
+msgstr "Serialized"
 
 msgid "Discard changes"
-msgstr ""
+msgstr "Discard changes"
 
 msgid "No new posts"
-msgstr ""
+msgstr "No new posts"
 
 msgid "Sticky topic"
-msgstr ""
+msgstr "Sticky topic"
 
 msgid "Emergency"
-msgstr ""
+msgstr "Emergency"
 
 msgid "Sort descending"
-msgstr ""
+msgstr "Sort descending"
 
 msgid "Sort ascending"
-msgstr ""
+msgstr "Sort ascending"
 
 msgid "The name of the site."
-msgstr ""
+msgstr "The name of the site."
 
 msgid "The name of the term."
-msgstr ""
+msgstr "The name of the term."
 
 msgid "Optional features"
-msgstr ""
+msgstr "Optional features"
 
 msgid "Administrative title"
-msgstr ""
+msgstr "Administrative title"
 
 msgid "Administrative description"
-msgstr ""
+msgstr "Administrative description"
 
 msgid "Allow settings"
-msgstr ""
+msgstr "Allow settings"
 
 msgid "Title override"
-msgstr ""
+msgstr "Title override"
 
 msgid "Style settings"
-msgstr ""
+msgstr "Style settings"
 
 msgid "Views Block"
-msgstr ""
+msgstr "Views Block"
 
 msgid "Alert"
-msgstr ""
+msgstr "Alert"
 
 msgid "Critical"
-msgstr ""
+msgstr "Critical"
 
 msgid "Top center"
 msgstr "Top centre"
@@ -7462,233 +7726,246 @@ msgid "Bottom center"
 msgstr "Bottom centre"
 
 msgid "Content Translation"
-msgstr ""
+msgstr "Content Translation"
 
 msgid "Warnings"
-msgstr ""
+msgstr "Warnings"
 
 msgid "Format string"
-msgstr ""
+msgstr "Format string"
 
 msgid "Add format"
-msgstr ""
+msgstr "Add format"
 
 msgid "Delete date format"
-msgstr ""
+msgstr "Delete date format"
 
 msgid "Content type name"
-msgstr ""
+msgstr "Content type name"
 
 msgid "Taxonomy Term"
-msgstr ""
+msgstr "Taxonomy Term"
 
 msgid "Slate"
-msgstr ""
+msgstr "Slate"
 
 msgid "Check settings"
-msgstr ""
+msgstr "Check settings"
 
 msgid "@field_name (Locked)"
-msgstr ""
+msgstr "@field_name (Locked)"
 
 msgid "- Select a field type -"
-msgstr ""
+msgstr "- Select a field type -"
 
 msgid "- Select an existing field -"
-msgstr ""
+msgstr "- Select an existing field -"
 
 msgid "Add new field: you need to provide a label."
-msgstr ""
+msgstr "Add new field: you need to provide a label."
 
 msgid "The field %field is locked and cannot be edited."
-msgstr ""
+msgstr "The field %field is locked and cannot be edited."
 
 msgid "%name must be a number."
-msgstr ""
+msgstr "%name must be a number."
 
 msgid "Field formatter"
-msgstr ""
+msgstr "Field formatter"
 
 msgid "(first item is 0)"
-msgstr ""
+msgstr "(first item is 0)"
 
 msgid "(start from last values)"
-msgstr ""
+msgstr "(start from last values)"
 
 msgid "New group"
-msgstr ""
+msgstr "New group"
 
 msgid "Content moderation"
-msgstr ""
+msgstr "Content moderation"
 
 msgid "Unsigned"
-msgstr ""
+msgstr "Unsigned"
 
 msgid "Number of pages"
-msgstr ""
+msgstr "Number of pages"
 
 msgid "The weight of this term in relation to other terms."
-msgstr ""
+msgstr "The weight of this term in relation to other terms."
 
 msgid "Help text to display for the vocabulary."
-msgstr ""
+msgstr "Help text to display for the vocabulary."
 
 msgid ""
 "Whether or not related terms are enabled within the vocabulary. (0 = "
 "disabled, 1 = enabled)"
 msgstr ""
+"Whether or not related terms are enabled within the vocabulary. (0 = "
+"disabled, 1 = enabled)"
 
 msgid ""
 "The type of hierarchy allowed within the vocabulary. (0 = disabled, 1 = "
 "single, 2 = multiple)"
 msgstr ""
+"The type of hierarchy allowed within the vocabulary. (0 = disabled, 1 = "
+"single, 2 = multiple)"
 
 msgid ""
 "Whether or not multiple terms from this vocabulary may be assigned to a "
 "node. (0 = disabled, 1 = enabled)"
 msgstr ""
+"Whether or not multiple terms from this vocabulary may be assigned to a "
+"node. (0 = disabled, 1 = enabled)"
 
 msgid ""
 "Whether or not terms are required for nodes using this vocabulary. (0 = "
 "disabled, 1 = enabled)"
 msgstr ""
+"Whether or not terms are required for nodes using this vocabulary. (0 = "
+"disabled, 1 = enabled)"
 
 msgid ""
 "Whether or not free tagging is enabled for the vocabulary. (0 = disabled, 1 "
 "= enabled)"
 msgstr ""
+"Whether or not free tagging is enabled for the vocabulary. (0 = disabled, 1 "
+"= enabled)"
 
 msgid "The weight of the vocabulary in relation to other vocabularies."
-msgstr ""
+msgstr "The weight of the vocabulary in relation to other vocabularies."
 
 msgid "Views settings"
-msgstr ""
+msgstr "Views settings"
 
 msgid "Rotate"
-msgstr ""
+msgstr "Rotate"
 
 msgid "Relative date"
-msgstr ""
+msgstr "Relative date"
 
 msgid "Remove selected"
-msgstr ""
+msgstr "Remove selected"
 
 msgid "Facility"
-msgstr ""
+msgstr "Facility"
 
 msgid "Page bottom"
-msgstr ""
+msgstr "Page bottom"
 
 msgid "Show links"
-msgstr ""
+msgstr "Show links"
 
 msgid "Lock"
-msgstr ""
+msgstr "Lock"
 
 msgid "Limited"
-msgstr ""
+msgstr "Limited"
 
 msgid "Current revision"
-msgstr ""
+msgstr "Current revision"
 
 msgid " minutes"
-msgstr ""
+msgstr " minutes"
 
 msgid "Definitions"
-msgstr ""
+msgstr "Definitions"
 
 msgid "Drupal 6"
-msgstr ""
+msgstr "Drupal 6"
 
 msgid "Drupal 7"
-msgstr ""
+msgstr "Drupal 7"
 
 msgid "Regional settings"
-msgstr ""
+msgstr "Regional settings"
 
 msgid "Your virtual face or picture."
-msgstr ""
+msgstr "Your virtual face or picture."
 
 msgid "Delete content"
-msgstr ""
+msgstr "Delete content"
 
 msgid "Author name"
-msgstr ""
+msgstr "Author name"
 
 msgid "Text format"
-msgstr ""
+msgstr "Text format"
 
 msgid "Last »"
-msgstr ""
+msgstr "Last »"
 
 msgid "Who's online"
-msgstr ""
+msgstr "Who's online"
 
 msgid "Page count"
-msgstr ""
+msgstr "Page count"
 
 msgid "« First"
-msgstr ""
+msgstr "« First"
 
 msgid "Upload progress"
-msgstr ""
+msgstr "Upload progress"
 
 msgid "Manages the user registration and login system."
-msgstr ""
+msgstr "Manages the user registration and login system."
 
 msgid "Show description"
-msgstr ""
+msgstr "Show description"
 
 msgid "URL of the origin of the event."
-msgstr ""
+msgstr "URL of the origin of the event."
 
 msgid "Referer"
-msgstr ""
+msgstr "Referer"
 
 msgid "Hostname of the user who triggered the event."
-msgstr ""
+msgstr "Hostname of the user who triggered the event."
 
 msgid "Database is encoded in UTF-8"
-msgstr ""
+msgstr "Database is encoded in UTF-8"
 
 msgid ""
 "Drupal could not determine the encoding of the database was set to UTF-8"
 msgstr ""
+"Drupal could not determine the encoding of the database was set to UTF-8"
 
 msgid "PostgreSQL has initialized itself."
-msgstr ""
+msgstr "PostgreSQL has initialized itself."
 
 msgid "Workflows"
-msgstr ""
+msgstr "Workflows"
 
 msgid "Default values"
-msgstr ""
+msgstr "Default values"
 
 msgid "Saving"
-msgstr ""
+msgstr "Saving"
 
 msgid ""
 "Select the test(s) or test group(s) you would like to run, and click <em>Run"
 " tests</em>."
 msgstr ""
+"Select the test(s) or test group(s) you would like to run, and click <em>Run"
+" tests</em>."
 
 msgid "All (@count)"
-msgstr ""
+msgstr "All (@count)"
 
 msgid "Pass (@count)"
-msgstr ""
+msgstr "Pass (@count)"
 
 msgid "Fail (@count)"
-msgstr ""
+msgstr "Fail (@count)"
 
 msgid "Return to list"
-msgstr ""
+msgstr "Return to list"
 
 msgid "Clear results after each complete test suite run"
-msgstr ""
+msgstr "Clear results after each complete test suite run"
 
 msgid "Provide verbose information when running tests"
-msgstr ""
+msgstr "Provide verbose information when running tests"
 
 msgid ""
 "The verbose data will be printed along with the standard assertions and is "
@@ -7696,124 +7973,133 @@ msgid ""
 "suite run. The verbose data output is very detailed and should only be used "
 "when debugging."
 msgstr ""
+"The verbose data will be printed along with the standard assertions and is "
+"useful for debugging. The verbose data will be erased between each test "
+"suite run. The verbose data output is very detailed and should only be used "
+"when debugging."
 
 msgid ""
 "HTTP auth settings to be used by the SimpleTest browser during testing. "
 "Useful when the site requires basic HTTP authentication."
 msgstr ""
+"HTTP auth settings to be used by the SimpleTest browser during testing. "
+"Useful when the site requires basic HTTP authentication."
 
 msgid "The test run did not successfully finish."
-msgstr ""
+msgstr "The test run did not successfully finish."
 
 msgid ""
 "Clear results is disabled and the test results table will not be cleared."
 msgstr ""
+"Clear results is disabled and the test results table will not be cleared."
 
 msgid "No leftover tables to remove."
-msgstr ""
+msgstr "No leftover tables to remove."
 
 msgid "1 debug message"
 msgid_plural "@count debug messages"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 debug message"
+msgstr[1] "@count debug messages"
 
 msgid "Removed 1 test result."
 msgid_plural "Removed @count test results."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Removed 1 test result."
+msgstr[1] "Removed @count test results."
 
 msgid "Removed 1 leftover table."
 msgid_plural "Removed @count leftover tables."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Removed 1 leftover table."
+msgstr[1] "Removed @count leftover tables."
 
 msgid "Removed 1 temporary directory."
 msgid_plural "Removed @count temporary directories."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Removed 1 temporary directory."
+msgstr[1] "Removed @count temporary directories."
 
 msgid "Test result"
-msgstr ""
+msgstr "Test result"
 
 msgid "Node status"
-msgstr ""
+msgstr "Node status"
 
 msgid "Edit style"
-msgstr ""
+msgstr "Edit style"
 
 msgid "All content"
-msgstr ""
+msgstr "All content"
 
 msgid "Maximum file size"
-msgstr ""
+msgstr "Maximum file size"
 
 msgid "Machine name:"
-msgstr ""
+msgstr "Machine name:"
 
 msgid "Content statistics"
-msgstr ""
+msgstr "Content statistics"
 
 msgid "Translation files"
-msgstr ""
+msgstr "Translation files"
 
 msgid "Upgrade"
-msgstr ""
+msgstr "Upgrade"
 
 msgid "Delete items"
-msgstr ""
+msgstr "Delete items"
 
 msgid "Fetcher"
-msgstr ""
+msgstr "Fetcher"
 
 msgid "This permission is inherited from the authenticated user role."
-msgstr ""
+msgstr "This permission is inherited from the authenticated user role."
 
 msgid "Seven"
-msgstr ""
+msgstr "Seven"
 
 msgid "Filter format"
-msgstr ""
+msgstr "Filter format"
 
 msgid "Pager type"
-msgstr ""
+msgstr "Pager type"
 
 msgid ""
 "Target of the link, such as _blank, _parent or an iframe's name. This field "
 "is rarely used."
 msgstr ""
+"Target of the link, such as _blank, _parent or an iframe's name. This field "
+"is rarely used."
 
 msgid "@argument title"
-msgstr ""
+msgstr "@argument title"
 
 msgid "@argument input"
-msgstr ""
+msgstr "@argument input"
 
 msgid "Count the number 0 as empty"
-msgstr ""
+msgstr "Count the number 0 as empty"
 
 msgid "Hide if empty"
-msgstr ""
+msgstr "Hide if empty"
 
 msgid "Starting value"
-msgstr ""
+msgstr "Starting value"
 
 msgid "Specify the number the counter should start at."
-msgstr ""
+msgstr "Specify the number the counter should start at."
 
 msgid "Does not start with"
-msgstr ""
+msgstr "Does not start with"
 
 msgid "not_begins"
-msgstr ""
+msgstr "not_begins"
 
 msgid "Does not end with"
-msgstr ""
+msgstr "Does not end with"
 
 msgid "not_ends"
-msgstr ""
+msgstr "not_ends"
 
 msgid "The view %name has been saved."
-msgstr ""
+msgstr "The view %name has been saved."
 
 msgid ""
 "This filter can cause items that have more than one of the selected options "
@@ -7823,585 +8109,622 @@ msgid ""
 "caution. Shouldn't be set on single-value fields, as it may cause values to "
 "disappear from display, if used on an incompatible field."
 msgstr ""
+"This filter can cause items that have more than one of the selected options "
+"to appear as duplicate results. If this filter causes duplicate results to "
+"occur, this checkbox can reduce those duplicates; however, the more terms it"
+" has to search for, the less performant the query will be, so use this with "
+"caution. Shouldn't be set on single-value fields, as it may cause values to "
+"disappear from display, if used on an incompatible field."
 
 msgid ""
 "Email of user that posted the comment. Will be empty if the author is a "
 "registered user."
 msgstr ""
+"Email of user that posted the comment. Will be empty if the author is a "
+"registered user."
 
 msgid "The taxonomy term ID for the term."
-msgstr ""
+msgstr "The taxonomy term ID for the term."
 
 msgid "The taxonomy term name for the term."
-msgstr ""
+msgstr "The taxonomy term name for the term."
 
 msgid "The name for the vocabulary the term belongs to."
-msgstr ""
+msgstr "The name for the vocabulary the term belongs to."
 
 msgid ""
 "Choose which vocabularies you wish to relate. Remember that every term found"
 " will create a new record, so this relationship is best used on just one "
 "vocabulary that has only one term per node."
 msgstr ""
+"Choose which vocabularies you wish to relate. Remember that every term found"
+" will create a new record, so this relationship is best used on just one "
+"vocabulary that has only one term per node."
 
 msgid "The name of the role."
-msgstr ""
+msgstr "The name of the role."
 
 msgid "Hide empty fields"
-msgstr ""
+msgstr "Hide empty fields"
 
 msgid "Do not display fields, labels or markup for fields that are empty."
-msgstr ""
+msgstr "Do not display fields, labels or markup for fields that are empty."
 
 msgid "Title of the feed."
-msgstr ""
+msgstr "Title of the feed."
 
 msgid "Language select"
-msgstr ""
+msgstr "Language select"
 
 msgid "Site email address"
-msgstr ""
+msgstr "Site email address"
 
 msgid ""
 "The <em>From</em> address in automated emails sent during registration and "
 "new password requests, and other notifications. (Use an address ending in "
 "your site's domain to help prevent this email being flagged as spam.)"
 msgstr ""
+"The <em>From</em> address in automated emails sent during registration and "
+"new password requests, and other notifications. (Use an address ending in "
+"your site's domain to help prevent this email being flagged as spam.)"
 
 msgid "Administer forums"
-msgstr ""
+msgstr "Administer forums"
 
 msgid "Length is shorter than"
-msgstr ""
+msgstr "Length is shorter than"
 
 msgid "shorter than"
-msgstr ""
+msgstr "shorter than"
 
 msgid "Length is longer than"
-msgstr ""
+msgstr "Length is longer than"
 
 msgid "longer than"
-msgstr ""
+msgstr "longer than"
 
 msgid "SQL Query"
-msgstr ""
+msgstr "SQL Query"
 
 msgid "Query will be generated and run using the Drupal database API."
-msgstr ""
+msgstr "Query will be generated and run using the Drupal database API."
 
 msgid "revision user"
-msgstr ""
+msgstr "revision user"
 
 msgid "Exposed form"
-msgstr ""
+msgstr "Exposed form"
 
 msgid "Cancel account"
-msgstr ""
+msgstr "Cancel account"
 
 msgid "Maximum number of characters"
-msgstr ""
+msgstr "Maximum number of characters"
 
 msgid "Current Theme"
-msgstr ""
+msgstr "Current Theme"
 
 msgid "Dependencies"
-msgstr ""
+msgstr "Dependencies"
 
 msgid "Administrator role"
-msgstr ""
+msgstr "Administrator role"
 
 msgid "Inherit pager"
-msgstr ""
+msgstr "Inherit pager"
 
 msgid "Render pager"
-msgstr ""
+msgstr "Render pager"
 
 msgid "Render"
-msgstr ""
+msgstr "Render"
 
 msgid "Image scale"
-msgstr ""
+msgstr "Image scale"
 
 msgid "No revision"
-msgstr ""
+msgstr "No revision"
 
 msgid "Requires a title"
-msgstr ""
+msgstr "Requires a title"
 
 msgid "CKEditor"
-msgstr ""
+msgstr "CKEditor"
 
 msgid "Filter value"
-msgstr ""
+msgstr "Filter value"
 
 msgid "Entities"
-msgstr ""
+msgstr "Entities"
 
 msgid "Private files"
-msgstr ""
+msgstr "Private files"
 
 msgid "Not restricted"
-msgstr ""
+msgstr "Not restricted"
 
 msgid "Operations links"
-msgstr ""
+msgstr "Operations links"
 
 msgid "Choose a block"
-msgstr ""
+msgstr "Choose a block"
 
 msgid "Toolbar buttons"
-msgstr ""
+msgstr "Toolbar buttons"
 
 msgid "Book ID"
-msgstr ""
+msgstr "Book ID"
 
 msgid "The unique ID of the comment."
-msgstr ""
+msgstr "The unique ID of the comment."
 
 msgid "The IP address of the computer the comment was posted from."
-msgstr ""
+msgstr "The IP address of the computer the comment was posted from."
 
 msgid "The email address left by the comment author."
-msgstr ""
+msgstr "The email address left by the comment author."
 
 msgid "The home page URL left by the comment author."
-msgstr ""
+msgstr "The home page URL left by the comment author."
 
 msgid "The formatted content of the comment itself."
-msgstr ""
+msgstr "The formatted content of the comment itself."
 
 msgid "The URL of the comment."
-msgstr ""
+msgstr "The URL of the comment."
 
 msgid "Base table"
-msgstr ""
+msgstr "Base table"
 
 msgid "Published status"
-msgstr ""
+msgstr "Published status"
 
 msgid "Structure"
-msgstr ""
+msgstr "Structure"
 
 msgid "The URL of the comment's edit page."
-msgstr ""
+msgstr "The URL of the comment's edit page."
 
 msgid "The date the comment was posted."
-msgstr ""
+msgstr "The date the comment was posted."
 
 msgid "The comment's parent, if comment threading is active."
-msgstr ""
+msgstr "The comment's parent, if comment threading is active."
 
 msgid "The unique ID of the node's latest revision."
-msgstr ""
+msgstr "The unique ID of the node's latest revision."
 
 msgid "The human-readable name of the node type."
-msgstr ""
+msgstr "The human-readable name of the node type."
 
 msgid "The URL of the node."
-msgstr ""
+msgstr "The URL of the node."
 
 msgid "The URL of the node's edit page."
-msgstr ""
+msgstr "The URL of the node's edit page."
 
 msgid "The date the node was most recently updated."
-msgstr ""
+msgstr "The date the node was most recently updated."
 
 msgid "The number of visitors who have read the node."
-msgstr ""
+msgstr "The number of visitors who have read the node."
 
 msgid "The number of visitors who have read the node today."
-msgstr ""
+msgstr "The number of visitors who have read the node today."
 
 msgid "Last view"
-msgstr ""
+msgstr "Last view"
 
 msgid "The date on which a visitor last read the node."
-msgstr ""
+msgstr "The date on which a visitor last read the node."
 
 msgid "The slogan of the site."
-msgstr ""
+msgstr "The slogan of the site."
 
 msgid "The administrative email address for the site."
-msgstr ""
+msgstr "The administrative email address for the site."
 
 msgid "The URL of the site's front page."
-msgstr ""
+msgstr "The URL of the site's front page."
 
 msgid "The URL of the site's login page."
-msgstr ""
+msgstr "The URL of the site's login page."
 
 msgid "The unique ID of the uploaded file."
-msgstr ""
+msgstr "The unique ID of the uploaded file."
 
 msgid "The name of the file on disk."
-msgstr ""
+msgstr "The name of the file on disk."
 
 msgid "The web-accessible URL for the file."
-msgstr ""
+msgstr "The web-accessible URL for the file."
 
 msgid "The date the file was most recently changed."
-msgstr ""
+msgstr "The date the file was most recently changed."
 
 msgid "The user who originally uploaded the file."
-msgstr ""
+msgstr "The user who originally uploaded the file."
 
 msgid "The unique ID of the taxonomy term."
-msgstr ""
+msgstr "The unique ID of the taxonomy term."
 
 msgid "The name of the taxonomy term."
-msgstr ""
+msgstr "The name of the taxonomy term."
 
 msgid "The optional description of the taxonomy term."
-msgstr ""
+msgstr "The optional description of the taxonomy term."
 
 msgid "The number of nodes tagged with the taxonomy term."
-msgstr ""
+msgstr "The number of nodes tagged with the taxonomy term."
 
 msgid "The URL of the taxonomy term."
-msgstr ""
+msgstr "The URL of the taxonomy term."
 
 msgid "The vocabulary the taxonomy term belongs to."
-msgstr ""
+msgstr "The vocabulary the taxonomy term belongs to."
 
 msgid "The parent term of the taxonomy term, if one exists."
-msgstr ""
+msgstr "The parent term of the taxonomy term, if one exists."
 
 msgid "The unique ID of the taxonomy vocabulary."
-msgstr ""
+msgstr "The unique ID of the taxonomy vocabulary."
 
 msgid "The name of the taxonomy vocabulary."
-msgstr ""
+msgstr "The name of the taxonomy vocabulary."
 
 msgid "The optional description of the taxonomy vocabulary."
-msgstr ""
+msgstr "The optional description of the taxonomy vocabulary."
 
 msgid ""
 "The number of nodes tagged with terms belonging to the taxonomy vocabulary."
 msgstr ""
+"The number of nodes tagged with terms belonging to the taxonomy vocabulary."
 
 msgid "The number of terms belonging to the taxonomy vocabulary."
-msgstr ""
+msgstr "The number of terms belonging to the taxonomy vocabulary."
 
 msgid "The unique ID of the user account."
-msgstr ""
+msgstr "The unique ID of the user account."
 
 msgid "The login name of the user account."
-msgstr ""
+msgstr "The login name of the user account."
 
 msgid "The email address of the user account."
-msgstr ""
+msgstr "The email address of the user account."
 
 msgid "The URL of the account profile page."
-msgstr ""
+msgstr "The URL of the account profile page."
 
 msgid "The date the user last logged in to the site."
-msgstr ""
+msgstr "The date the user last logged in to the site."
 
 msgid "The date the user account was created."
-msgstr ""
+msgstr "The date the user account was created."
 
 msgid "Review log"
-msgstr ""
+msgstr "Review log"
 
 msgid "Sender name"
-msgstr ""
+msgstr "Sender name"
 
 msgid "Sender email"
-msgstr ""
+msgstr "Sender email"
 
 msgid "Time zone settings"
-msgstr ""
+msgstr "Time zone settings"
 
 msgid "Content Moderation"
-msgstr ""
+msgstr "Content Moderation"
 
 msgid "You are not allowed to access this page."
-msgstr ""
+msgstr "You are not allowed to access this page."
 
 msgid "Authorize file system changes"
-msgstr ""
+msgstr "Authorize file system changes"
 
 msgid "It appears you have reached this page in error."
-msgstr ""
+msgstr "It appears you have reached this page in error."
 
 msgid "authorize.php"
-msgstr ""
+msgstr "authorize.php"
 
 msgid "Cron could not run because an invalid key was used."
-msgstr ""
+msgstr "Cron could not run because an invalid key was used."
 
 msgid "Cron could not run because the site is in maintenance mode."
-msgstr ""
+msgstr "Cron could not run because the site is in maintenance mode."
 
 msgid "Default country"
-msgstr ""
+msgstr "Default country"
 
 msgid ""
 "In your %settings_file file you have configured @drupal to use a %driver "
 "server, however your PHP installation currently does not support this "
 "database type."
 msgstr ""
+"In your %settings_file file you have configured @drupal to use a %driver "
+"server, however your PHP installation currently does not support this "
+"database type."
 
 msgid ""
 "We were unable to find any installation profiles. Installation profiles tell"
 " us what modules to enable and what schema to install in the database. A "
 "profile is necessary to continue with the installation process."
 msgstr ""
+"We were unable to find any installation profiles. Installation profiles tell"
+" us what modules to enable and what schema to install in the database. A "
+"profile is necessary to continue with the installation process."
 
 msgid "Congratulations, you installed @drupal!"
-msgstr ""
+msgstr "Congratulations, you installed @drupal!"
 
 msgid "Settings file"
-msgstr ""
+msgstr "Settings file"
 
 msgid "Site maintenance account"
-msgstr ""
+msgstr "Site maintenance account"
 
 msgid "No pending updates."
-msgstr ""
+msgstr "No pending updates."
 
 msgid "1 pending update"
 msgid_plural "@count pending updates"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 pending update"
+msgstr[1] "@count pending updates"
 
 msgid "Unable to continue, no available methods of file transfer"
-msgstr ""
+msgstr "Unable to continue, no available methods of file transfer"
 
 msgid "To continue, provide your server connection details"
-msgstr ""
+msgstr "To continue, provide your server connection details"
 
 msgid "Connection method"
-msgstr ""
+msgstr "Connection method"
 
 msgid "Enter connection settings"
-msgstr ""
+msgstr "Enter connection settings"
 
 msgid "@backend connection settings"
-msgstr ""
+msgstr "@backend connection settings"
 
 msgid "Change connection type"
-msgstr ""
+msgstr "Change connection type"
 
 msgid "No active batch."
-msgstr ""
+msgstr "No active batch."
 
 msgid "Site under maintenance"
-msgstr ""
+msgstr "Site under maintenance"
 
 msgid "Archivers can only operate on local files: %file not supported"
-msgstr ""
+msgstr "Archivers can only operate on local files: %file not supported"
 
 msgid ""
 "The file %source could not be uploaded because a file by that name already "
 "exists in the destination %directory."
 msgstr ""
+"The file %source could not be uploaded because a file by that name already "
+"exists in the destination %directory."
 
 msgid ""
 "The file's name exceeds the 240 characters limit. Please rename the file and"
 " try again."
 msgstr ""
+"The file's name exceeds the 240 characters limit. Please rename the file and"
+" try again."
 
 msgid "The file permissions could not be set on %uri."
-msgstr ""
+msgstr "The file permissions could not be set on %uri."
 
 msgid "Completed @current of @total."
-msgstr ""
+msgstr "Completed @current of @total."
 
 msgid ""
 "Failed to run all tasks against the database server. The task %task wasn't "
 "found."
 msgstr ""
+"Failed to run all tasks against the database server. The task %task wasn't "
+"found."
 
 msgid "Failed to modify %settings. Verify the file permissions."
-msgstr ""
+msgstr "Failed to modify %settings. Verify the file permissions."
 
 msgid "Failed to open %settings. Verify the file permissions."
-msgstr ""
+msgstr "Failed to open %settings. Verify the file permissions."
 
 msgid "Required modules"
-msgstr ""
+msgstr "Required modules"
 
 msgid "Required modules not found."
-msgstr ""
+msgstr "Required modules not found."
 
 msgid "%module module uninstalled."
-msgstr ""
+msgstr "%module module uninstalled."
 
 msgid "Saint Barthélemy"
-msgstr ""
+msgstr "Saint Barthélemy"
 
 msgid "No strings available."
-msgstr ""
+msgstr "No strings available."
 
 msgid "JavaScript translation file %file.js was lost."
-msgstr ""
+msgstr "JavaScript translation file %file.js was lost."
 
 msgid "Operating in maintenance mode."
-msgstr ""
+msgstr "Operating in maintenance mode."
 
 msgid "Unable to determine the type of the source directory."
-msgstr ""
+msgstr "Unable to determine the type of the source directory."
 
 msgid "Cannot determine the type of project."
-msgstr ""
+msgstr "Cannot determine the type of project."
 
 msgid ""
 "Fatal error in update, cowardly refusing to wipe out the install directory."
 msgstr ""
+"Fatal error in update, cowardly refusing to wipe out the install directory."
 
 msgid "Unable to create %directory due to the following: %reason"
-msgstr ""
+msgstr "Unable to create %directory due to the following: %reason"
 
 msgid "New comment count"
-msgstr ""
+msgstr "New comment count"
 
 msgid "Field types"
-msgstr ""
+msgstr "Field types"
 
 msgid "Path: !uri"
-msgstr ""
+msgstr "Path: !uri"
 
 msgid "StatusText: !statusText"
-msgstr ""
+msgstr "StatusText: !statusText"
 
 msgid "(active tab)"
-msgstr ""
+msgstr "(active tab)"
 
 msgid "HTTP Result Code: !status"
-msgstr ""
+msgstr "HTTP Result Code: !status"
 
 msgid "Status message"
-msgstr ""
+msgstr "Status message"
 
 msgid "An AJAX HTTP request terminated abnormally."
-msgstr ""
+msgstr "An AJAX HTTP request terminated abnormally."
 
 msgid "An AJAX HTTP error occurred."
-msgstr ""
+msgstr "An AJAX HTTP error occurred."
 
 msgid "Debugging information follows."
-msgstr ""
+msgstr "Debugging information follows."
 
 msgid "Upload an OPML file containing a list of feeds to be imported."
-msgstr ""
+msgstr "Upload an OPML file containing a list of feeds to be imported."
 
 msgid "OPML Remote URL"
-msgstr ""
+msgstr "OPML Remote URL"
 
 msgid ""
 "Enter the URL of an OPML file. This file will be downloaded and processed "
 "only once on submission of the form."
 msgstr ""
+"Enter the URL of an OPML file. This file will be downloaded and processed "
+"only once on submission of the form."
 
 msgid "No new feed has been added."
-msgstr ""
+msgstr "No new feed has been added."
 
 msgid "The URL %url is invalid."
-msgstr ""
+msgstr "The URL %url is invalid."
 
 msgid "A feed named %title already exists."
-msgstr ""
+msgstr "A feed named %title already exists."
 
 msgid "A feed with the URL %url already exists."
-msgstr ""
+msgstr "A feed with the URL %url already exists."
 
 msgid ""
 "Fetchers download data from an external source. Choose a fetcher suitable "
 "for the external source you would like to download from."
 msgstr ""
+"Fetchers download data from an external source. Choose a fetcher suitable "
+"for the external source you would like to download from."
 
 msgid ""
 "Parsers transform downloaded data into standard structures. Choose a parser "
 "suitable for the type of feeds you would like to aggregate."
 msgstr ""
+"Parsers transform downloaded data into standard structures. Choose a parser "
+"suitable for the type of feeds you would like to aggregate."
 
 msgid ""
 "Processors act on parsed feed data, for example they store feed items. "
 "Choose the processors suitable for your task."
 msgstr ""
+"Processors act on parsed feed data, for example they store feed items. "
+"Choose the processors suitable for your task."
 
 msgid "For most aggregation tasks, the default settings are fine."
-msgstr ""
+msgstr "For most aggregation tasks, the default settings are fine."
 
 msgid "Default fetcher"
-msgstr ""
+msgstr "Default fetcher"
 
 msgid "Downloads data from a URL using Drupal's HTTP request handler."
-msgstr ""
+msgstr "Downloads data from a URL using Drupal's HTTP request handler."
 
 msgid "Default parser"
-msgstr ""
+msgstr "Default parser"
 
 msgid "Default processor"
-msgstr ""
+msgstr "Default processor"
 
 msgid "Creates lightweight records from feed items."
-msgstr ""
+msgstr "Creates lightweight records from feed items."
 
 msgid "Default processor settings"
-msgstr ""
+msgstr "Default processor settings"
 
 msgid "Number of items shown in listing pages"
-msgstr ""
+msgstr "Number of items shown in listing pages"
 
 msgid "Length of trimmed description"
-msgstr ""
+msgstr "Length of trimmed description"
 
 msgid ""
 "The maximum number of characters used in the trimmed version of content."
 msgstr ""
+"The maximum number of characters used in the trimmed version of content."
 
 msgid "Viewing feeds"
-msgstr ""
+msgstr "Viewing feeds"
 
 msgid "Adding, editing, and deleting feeds"
-msgstr ""
+msgstr "Adding, editing, and deleting feeds"
 
 msgid "Configuring cron"
-msgstr ""
+msgstr "Configuring cron"
 
 msgid "Administer news feeds"
-msgstr ""
+msgstr "Administer news feeds"
 
 msgid "View news feeds"
-msgstr ""
+msgstr "View news feeds"
 
 msgid "Controlling visibility"
-msgstr ""
+msgstr "Controlling visibility"
 
 msgid "Creating custom blocks"
-msgstr ""
+msgstr "Creating custom blocks"
 
 msgid "Demonstrate block regions (@theme)"
-msgstr ""
+msgstr "Demonstrate block regions (@theme)"
 
 msgid "Administer blocks"
-msgstr ""
+msgstr "Administer blocks"
 
 msgid "Restricted to certain pages"
-msgstr ""
+msgstr "Restricted to certain pages"
 
 msgid "The block cannot be placed in this region."
-msgstr ""
+msgstr "The block cannot be placed in this region."
 
 msgid "No books available."
-msgstr ""
+msgstr "No books available."
 
 msgid "Content types allowed in book outlines"
-msgstr ""
+msgstr "Content types allowed in book outlines"
 
 msgid "Users with the %outline-perm permission can add all content types."
-msgstr ""
+msgstr "Users with the %outline-perm permission can add all content types."
 
 msgid "Administer book outlines"
-msgstr ""
+msgstr "Administer book outlines"
 
 msgid "Adding and managing book content"
-msgstr ""
+msgstr "Adding and managing book content"
 
 msgid "Printing books"
-msgstr ""
+msgstr "Printing books"
 
 msgid ""
 "Users with the <em>View printer-friendly books</em> permission can select "
@@ -8409,6 +8732,10 @@ msgid ""
 "page's content to generate a printer-friendly display of the page and all of"
 " its subsections."
 msgstr ""
+"Users with the <em>View printer-friendly books</em> permission can select "
+"the <em>printer-friendly version</em> link visible at the bottom of a book "
+"page's content to generate a printer-friendly display of the page and all of"
+" its subsections."
 
 msgid ""
 "The book module offers a means to organize a collection of related content "
@@ -8422,278 +8749,314 @@ msgstr ""
 " for creating and reviewing structured content."
 
 msgid "Create new books"
-msgstr ""
+msgstr "Create new books"
 
 msgid "View printer-friendly books"
-msgstr ""
+msgstr "View printer-friendly books"
 
 msgid ""
 "View a book page and all of its sub-pages as a single document for ease of "
 "printing. Can be performance heavy."
 msgstr ""
+"View a book page and all of its sub-pages as a single document for ease of "
+"printing. Can be performance heavy."
 
 msgid ""
 "<em>Books</em> have a built-in hierarchical navigation. Use for handbooks or"
 " tutorials."
 msgstr ""
+"<em>Books</em> have a built-in hierarchical navigation. Use for handbooks or"
+" tutorials."
 
 msgid "Changing colors"
-msgstr ""
+msgstr "Changing colors"
 
 msgid "Select one or more comments to perform the update on."
-msgstr ""
+msgstr "Select one or more comments to perform the update on."
 
 msgid "Deleted comment @cid and its replies."
-msgstr ""
+msgstr "Deleted comment @cid and its replies."
 
 msgid "Comment approved."
-msgstr ""
+msgstr "Comment approved."
 
 msgid "Tokens for comments posted on the site."
-msgstr ""
+msgstr "Tokens for comments posted on the site."
 
 msgid "Unapproved comments (@count)"
-msgstr ""
+msgstr "Unapproved comments (@count)"
 
 msgid "Administer comments and comment settings"
-msgstr ""
+msgstr "Administer comments and comment settings"
 
 msgid "Edit own comments"
-msgstr ""
+msgstr "Edit own comments"
 
 msgid "Threading"
-msgstr ""
+msgstr "Threading"
 
 msgid "Show comment replies in a threaded list."
-msgstr ""
+msgstr "Show comment replies in a threaded list."
 
 msgid "Allow comment title"
-msgstr ""
+msgstr "Allow comment title"
 
 msgid "Show reply form on the same page as comments"
-msgstr ""
+msgstr "Show reply form on the same page as comments"
 
 msgid "Users with the \"Post comments\" permission can post comments."
-msgstr ""
+msgstr "Users with the \"Post comments\" permission can post comments."
 
 msgid "Users cannot post comments, but existing comments will be displayed."
-msgstr ""
+msgstr "Users cannot post comments, but existing comments will be displayed."
 
 msgid "Comments are hidden from view."
-msgstr ""
+msgstr "Comments are hidden from view."
 
 msgid ""
 "Your comment has been queued for review by site administrators and will be "
 "published after approval."
 msgstr ""
+"Your comment has been queued for review by site administrators and will be "
+"published after approval."
 
 msgid "Your comment has been posted."
-msgstr ""
+msgstr "Your comment has been posted."
 
 msgid ""
 "The comment will be unpublished if it contains any of the phrases above. Use"
 " a case-sensitive, comma-separated list of phrases. Example: funny, bungee "
 "jumping, \"Company, Inc.\""
 msgstr ""
+"The comment will be unpublished if it contains any of the phrases above. Use"
+" a case-sensitive, comma-separated list of phrases. Example: funny, bungee "
+"jumping, \"Company, Inc.\""
 
 msgid ""
 "You cannot send more than %limit messages in @interval. Try again later."
 msgstr ""
+"You cannot send more than %limit messages in @interval. Try again later."
 
 msgid "Contact @username"
-msgstr ""
+msgstr "Contact @username"
 
 msgid "Administer contact forms and contact form settings"
-msgstr ""
+msgstr "Administer contact forms and contact form settings"
 
 msgid "Use the site-wide contact form"
-msgstr ""
+msgstr "Use the site-wide contact form"
 
 msgid "Use users' personal contact forms"
-msgstr ""
+msgstr "Use users' personal contact forms"
 
 msgid "Changing this setting will not affect existing users."
-msgstr ""
+msgstr "Changing this setting will not affect existing users."
 
 msgid "Displaying contextual links"
-msgstr ""
+msgstr "Displaying contextual links"
 
 msgid "Use contextual links"
-msgstr ""
+msgstr "Use contextual links"
 
 msgid "Contextual links"
-msgstr ""
+msgstr "Contextual links"
 
 msgid "Database log cleared."
-msgstr ""
+msgstr "Database log cleared."
 
 msgid "Monitoring your site"
-msgstr ""
+msgstr "Monitoring your site"
 
 msgid "Debugging site problems"
-msgstr ""
+msgstr "Debugging site problems"
 
 msgid "Allowed HTML tags in labels: @tags"
-msgstr ""
+msgstr "Allowed HTML tags in labels: @tags"
 
 msgid ""
 "The value of this field is being determined by the %function function and "
 "may not be changed."
 msgstr ""
+"The value of this field is being determined by the %function function and "
+"may not be changed."
 
 msgid "Allowed values list: each key must be a valid integer or decimal."
-msgstr ""
+msgstr "Allowed values list: each key must be a valid integer or decimal."
 
 msgid ""
 "Allowed values list: each key must be a string at most 255 characters long."
 msgstr ""
+"Allowed values list: each key must be a string at most 255 characters long."
 
 msgid "Allowed values list: keys must be integers."
-msgstr ""
+msgstr "Allowed values list: keys must be integers."
 
 msgid "Allows users to create and organize related content in an outline."
 msgstr "Allows users to create and organise related content in an outline."
 
 msgid "Unapproved comments"
-msgstr ""
+msgstr "Unapproved comments"
 
 msgid "ResponseText: !responseText"
-msgstr ""
+msgstr "ResponseText: !responseText"
 
 msgid "Allows administrators to change the color scheme of compatible themes."
 msgstr ""
+"Allows administrators to change the color scheme of compatible themes."
 
 msgid ""
 "Provides contextual links to perform actions related to elements on a page."
 msgstr ""
+"Provides contextual links to perform actions related to elements on a page."
 
 msgid "Provides discussion forums."
-msgstr ""
+msgstr "Provides discussion forums."
 
 msgid "List (text)"
-msgstr ""
+msgstr "List (text)"
 
 msgid "ReadyState: !readyState"
-msgstr ""
+msgstr "ReadyState: !readyState"
 
 msgid "This field stores a number in the database as an integer."
-msgstr ""
+msgstr "This field stores a number in the database as an integer."
 
 msgid "This field stores a number in the database in a fixed decimal format."
-msgstr ""
+msgstr "This field stores a number in the database in a fixed decimal format."
 
 msgid "This field stores a number in the database in a floating point format."
 msgstr ""
+"This field stores a number in the database in a floating point format."
 
 msgid ""
 "The minimum value that should be allowed in this field. Leave blank for no "
 "minimum."
 msgstr ""
+"The minimum value that should be allowed in this field. Leave blank for no "
+"minimum."
 
 msgid ""
 "The maximum value that should be allowed in this field. Leave blank for no "
 "maximum."
 msgstr ""
+"The maximum value that should be allowed in this field. Leave blank for no "
+"maximum."
 
 msgid ""
 "Define a string that should be prefixed to the value, like '$ ' or '&euro; "
 "'. Leave blank for none. Separate singular and plural values with a pipe "
 "('pound|pounds')."
 msgstr ""
+"Define a string that should be prefixed to the value, like '$ ' or '&euro; "
+"'. Leave blank for none. Separate singular and plural values with a pipe "
+"('pound|pounds')."
 
 msgid "Summary input"
-msgstr ""
+msgstr "Summary input"
 
 msgid ""
 "This allows authors to input an explicit summary, to be displayed instead of"
 " the automatically trimmed text when using the \"Summary or trimmed\" "
 "display type."
 msgstr ""
+"This allows authors to input an explicit summary, to be displayed instead of"
+" the automatically trimmed text when using the \"Summary or trimmed\" "
+"display type."
 
 msgid "Summary or trimmed"
-msgstr ""
+msgstr "Summary or trimmed"
 
 msgid "Text area with a summary"
-msgstr ""
+msgstr "Text area with a summary"
 
 msgid "Leave blank to use trimmed value of full text as the summary."
-msgstr ""
+msgstr "Leave blank to use trimmed value of full text as the summary."
 
 msgid "Hide summary"
-msgstr ""
+msgstr "Hide summary"
 
 msgid "Edit summary"
-msgstr ""
+msgstr "Edit summary"
 
 msgid "Edit field settings."
-msgstr ""
+msgstr "Edit field settings."
 
 msgid ""
 "These settings apply to the %field field everywhere it is used. These "
 "settings impact the way that data is stored in the database and cannot be "
 "changed once data has been created."
 msgstr ""
+"These settings apply to the %field field everywhere it is used. These "
+"settings impact the way that data is stored in the database and cannot be "
+"changed once data has been created."
 
 msgid "Updated field %label field settings."
-msgstr ""
+msgstr "Updated field %label field settings."
 
 msgid "Attempt to update field %label failed: %message."
-msgstr ""
+msgstr "Attempt to update field %label failed: %message."
 
 msgid "The field %field has been deleted from the %type content type."
-msgstr ""
+msgstr "The field %field has been deleted from the %type content type."
 
 msgid "There was a problem removing the %field from the %type content type."
-msgstr ""
+msgstr "There was a problem removing the %field from the %type content type."
 
 msgid "Required field"
-msgstr ""
+msgstr "Required field"
 
 msgid "The default value for this field, used when creating new content."
-msgstr ""
+msgstr "The default value for this field, used when creating new content."
 
 msgid "Saved %label configuration."
-msgstr ""
+msgstr "Saved %label configuration."
 
 msgid "This list shows all fields currently in use for easy reference."
-msgstr ""
+msgstr "This list shows all fields currently in use for easy reference."
 
 msgid "Manage display"
-msgstr ""
+msgstr "Manage display"
 
 msgid "Field UI"
-msgstr ""
+msgstr "Field UI"
 
 msgid "This field stores the ID of a file as an integer value."
-msgstr ""
+msgstr "This field stores the ID of a file as an integer value."
 
 msgid "Enable <em>Display</em> field"
-msgstr ""
+msgstr "Enable <em>Display</em> field"
 
 msgid ""
 "The display option allows users to choose if a file should be shown when "
 "viewing the content."
 msgstr ""
+"The display option allows users to choose if a file should be shown when "
+"viewing the content."
 
 msgid "Files displayed by default"
-msgstr ""
+msgstr "Files displayed by default"
 
 msgid "This setting only has an effect if the display option is enabled."
-msgstr ""
+msgstr "This setting only has an effect if the display option is enabled."
 
 msgid "Upload destination"
-msgstr ""
+msgstr "Upload destination"
 
 msgid ""
 "Select where the final files should be stored. Private file storage has "
 "significantly more overhead than public files, but allows restricted access "
 "to files within this field."
 msgstr ""
+"Select where the final files should be stored. Private file storage has "
+"significantly more overhead than public files, but allows restricted access "
+"to files within this field."
 
 msgid ""
 "Optional subdirectory within the upload destination where files will be "
 "stored. Do not include preceding or trailing slashes."
 msgstr ""
+"Optional subdirectory within the upload destination where files will be "
+"stored. Do not include preceding or trailing slashes."
 
 msgid ""
 "Enter a value like \"512\" (bytes), \"80 KB\" (kilobytes) or \"50 MB\" "
@@ -8701,89 +9064,102 @@ msgid ""
 "file sizes will be limited only by PHP's maximum post and file upload sizes "
 "(current limit <strong>%limit</strong>)."
 msgstr ""
+"Enter a value like \"512\" (bytes), \"80 KB\" (kilobytes) or \"50 MB\" "
+"(megabytes) in order to restrict the allowed file size. If left empty the "
+"file sizes will be limited only by PHP's maximum post and file upload sizes "
+"(current limit <strong>%limit</strong>)."
 
 msgid "Enable <em>Description</em> field"
-msgstr ""
+msgstr "Enable <em>Description</em> field"
 
 msgid ""
 "The description field allows users to enter a description about the uploaded"
 " file."
 msgstr ""
+"The description field allows users to enter a description about the uploaded"
+" file."
 
 msgid ""
 "The list of allowed extensions is not valid, be sure to exclude leading dots"
 " and to separate extensions with a comma or space."
 msgstr ""
+"The list of allowed extensions is not valid, be sure to exclude leading dots"
+" and to separate extensions with a comma or space."
 
 msgid "Generic file"
-msgstr ""
+msgstr "Generic file"
 
 msgid "Table of files"
-msgstr ""
+msgstr "Table of files"
 
 msgid "Add a new file"
-msgstr ""
+msgstr "Add a new file"
 
 msgid "Include file in display"
-msgstr ""
+msgstr "Include file in display"
 
 msgid "The description may be used as the label of the link to the file."
-msgstr ""
+msgstr "The description may be used as the label of the link to the file."
 
 msgid "All roles may use this format"
-msgstr ""
+msgstr "All roles may use this format"
 
 msgid "The text format ordering has been saved."
-msgstr ""
+msgstr "The text format ordering has been saved."
 
 msgid "Add text format"
-msgstr ""
+msgstr "Add text format"
 
 msgid "All roles for this text format must be enabled and cannot be changed."
-msgstr ""
+msgstr "All roles for this text format must be enabled and cannot be changed."
 
 msgid "Filter processing order"
-msgstr ""
+msgstr "Filter processing order"
 
 msgid "Text format names must be unique. A format named %name already exists."
 msgstr ""
+"Text format names must be unique. A format named %name already exists."
 
 msgid "Added text format %format."
-msgstr ""
+msgstr "Added text format %format."
 
 msgid "The text format %format has been updated."
-msgstr ""
+msgstr "The text format %format has been updated."
 
 msgid "Text formats"
-msgstr ""
+msgstr "Text formats"
 
 msgid "Choosing a text format"
-msgstr ""
+msgstr "Choosing a text format"
 
 msgid ""
 "Warning: This permission may have security implications depending on how the"
 " text format is configured."
 msgstr ""
+"Warning: This permission may have security implications depending on how the"
+" text format is configured."
 
 msgid ""
 "Convert line breaks into HTML (i.e. <code>&lt;br&gt;</code> and "
 "<code>&lt;p&gt;</code>)"
 msgstr ""
+"Convert line breaks into HTML (i.e. <code>&lt;br&gt;</code> and "
+"<code>&lt;p&gt;</code>)"
 
 msgid "Convert URLs into links"
-msgstr ""
+msgstr "Convert URLs into links"
 
 msgid "Correct faulty and chopped off HTML"
-msgstr ""
+msgstr "Correct faulty and chopped off HTML"
 
 msgid "Display any HTML as plain text"
-msgstr ""
+msgstr "Display any HTML as plain text"
 
 msgid "Display basic HTML help in long filter tips"
-msgstr ""
+msgstr "Display basic HTML help in long filter tips"
 
 msgid "Add rel=\"nofollow\" to all links"
-msgstr ""
+msgstr "Add rel=\"nofollow\" to all links"
 
 msgid ""
 "This site allows HTML content. While learning all of HTML may feel "
@@ -8791,21 +9167,25 @@ msgid ""
 " \"tags\" is very easy. This table provides examples for each tag that is "
 "enabled on this site."
 msgstr ""
+"This site allows HTML content. While learning all of HTML may feel "
+"intimidating, learning how to use a very small number of the most basic HTML"
+" \"tags\" is very easy. This table provides examples for each tag that is "
+"enabled on this site."
 
 msgid "Most unusual characters can be directly entered without any problems."
-msgstr ""
+msgstr "Most unusual characters can be directly entered without any problems."
 
 msgid "No HTML tags allowed."
-msgstr ""
+msgstr "No HTML tags allowed."
 
 msgid "The number of replies a topic must have to be considered \"hot\"."
-msgstr ""
+msgstr "The number of replies a topic must have to be considered \"hot\"."
 
 msgid "Starting a discussion"
-msgstr ""
+msgstr "Starting a discussion"
 
 msgid "Moving forum topics"
-msgstr ""
+msgstr "Moving forum topics"
 
 msgid ""
 "A forum topic (and all of its comments) may be moved between forums by "
@@ -8813,9 +9193,13 @@ msgid ""
 " topic between forums, the <em>Leave shadow copy</em> option creates a link "
 "in the original forum pointing to the new location."
 msgstr ""
+"A forum topic (and all of its comments) may be moved between forums by "
+"selecting a different forum while editing a forum topic. When moving a forum"
+" topic between forums, the <em>Leave shadow copy</em> option creates a link "
+"in the original forum pointing to the new location."
 
 msgid "Locking and disabling comments"
-msgstr ""
+msgstr "Locking and disabling comments"
 
 msgid ""
 "Selecting <em>Closed</em> under <em>Comment settings</em> while editing a "
@@ -8823,199 +9207,234 @@ msgid ""
 "<em>Hidden</em> under <em>Comment settings</em> while editing a forum topic "
 "will hide all existing comments on the thread, and prevent new ones."
 msgstr ""
+"Selecting <em>Closed</em> under <em>Comment settings</em> while editing a "
+"forum topic will lock (prevent new comments on) the thread. Selecting "
+"<em>Hidden</em> under <em>Comment settings</em> while editing a forum topic "
+"will hide all existing comments on the thread, and prevent new ones."
 
 msgid "Forums contain forum topics. Use containers to group related forums."
-msgstr ""
+msgstr "Forums contain forum topics. Use containers to group related forums."
 
 msgid "Use containers to group related forums."
-msgstr ""
+msgstr "Use containers to group related forums."
 
 msgid "A forum holds related forum topics."
-msgstr ""
+msgstr "A forum holds related forum topics."
 
 msgid "Add new @node_type"
-msgstr ""
+msgstr "Add new @node_type"
 
 msgid ""
 "The item %forum is a forum container, not a forum. Select one of the forums "
 "below instead."
 msgstr ""
+"The item %forum is a forum container, not a forum. Select one of the forums "
+"below instead."
 
 msgid "A <em>forum topic</em> starts a new discussion thread within a forum."
-msgstr ""
+msgstr "A <em>forum topic</em> starts a new discussion thread within a forum."
 
 msgid "Control forum hierarchy settings."
-msgstr ""
+msgstr "Control forum hierarchy settings."
 
 msgid "Forum navigation vocabulary"
-msgstr ""
+msgstr "Forum navigation vocabulary"
 
 msgid "Filters content in preparation for display."
-msgstr ""
+msgstr "Filters content in preparation for display."
 
 msgid "Follow these steps to set up and start using your website:"
-msgstr ""
+msgstr "Follow these steps to set up and start using your website:"
 
 msgid "Providing a help reference"
-msgstr ""
+msgstr "Providing a help reference"
 
 msgid "Image style name"
-msgstr ""
+msgstr "Image style name"
 
 msgid "Select a new effect"
-msgstr ""
+msgstr "Select a new effect"
 
 msgid "Select an effect to add."
-msgstr ""
+msgstr "Select an effect to add."
 
 msgid "The image effect was successfully applied."
-msgstr ""
+msgstr "The image effect was successfully applied."
 
 msgid "Style name"
-msgstr ""
+msgstr "Style name"
 
 msgid "Create new style"
-msgstr ""
+msgstr "Create new style"
 
 msgid "Style %name was created."
-msgstr ""
+msgstr "Style %name was created."
 
 msgid "Replacement style"
-msgstr ""
+msgstr "Replacement style"
 
 msgid "Optionally select a style before deleting %style"
-msgstr ""
+msgstr "Optionally select a style before deleting %style"
 
 msgid "Edit %label effect"
-msgstr ""
+msgstr "Edit %label effect"
 
 msgid "Add %label effect"
-msgstr ""
+msgstr "Add %label effect"
 
 msgid "Update effect"
-msgstr ""
+msgstr "Update effect"
 
 msgid ""
 "Are you sure you want to delete the @effect effect from the %style style?"
 msgstr ""
+"Are you sure you want to delete the @effect effect from the %style style?"
 
 msgid "The image effect %name has been deleted."
-msgstr ""
+msgstr "The image effect %name has been deleted."
 
 msgid "Width and height can not both be blank."
-msgstr ""
+msgstr "Width and height can not both be blank."
 
 msgid "The part of the image that will be retained during the crop."
-msgstr ""
+msgstr "The part of the image that will be retained during the crop."
 
 msgid ""
 "The background color to use for exposed areas of the image. Use web-style "
 "hex colors (#FFFFFF for white, #000000 for black). Leave blank for "
 "transparency on image types that support it."
 msgstr ""
+"The background color to use for exposed areas of the image. Use web-style "
+"hex colors (#FFFFFF for white, #000000 for black). Leave blank for "
+"transparency on image types that support it."
 
 msgid ""
 "There are currently no effects in this style. Add one by selecting an option"
 " below."
 msgstr ""
+"There are currently no effects in this style. Add one by selecting an option"
+" below."
 
 msgid "view actual size"
-msgstr ""
+msgstr "view actual size"
 
 msgid "Sample original image"
-msgstr ""
+msgstr "Sample original image"
 
 msgid "Sample modified image"
-msgstr ""
+msgstr "Sample modified image"
 
 msgid ""
 "Resizing will make images an exact set of dimensions. This may cause images "
 "to be stretched or shrunk disproportionately."
 msgstr ""
+"Resizing will make images an exact set of dimensions. This may cause images "
+"to be stretched or shrunk disproportionately."
 
 msgid ""
 "Scaling will maintain the aspect-ratio of the original image. If only a "
 "single dimension is specified, the other dimension will be calculated."
 msgstr ""
+"Scaling will maintain the aspect-ratio of the original image. If only a "
+"single dimension is specified, the other dimension will be calculated."
 
 msgid "Scale and crop"
-msgstr ""
+msgstr "Scale and crop"
 
 msgid ""
 "Scale and crop will maintain the aspect-ratio of the original image, then "
 "crop the larger dimension. This is most useful for creating perfectly square"
 " thumbnails without stretching the image."
 msgstr ""
+"Scale and crop will maintain the aspect-ratio of the original image, then "
+"crop the larger dimension. This is most useful for creating perfectly square"
+" thumbnails without stretching the image."
 
 msgid "Desaturate"
-msgstr ""
+msgstr "Desaturate"
 
 msgid "Desaturate converts an image to grayscale."
-msgstr ""
+msgstr "Desaturate converts an image to grayscale."
 
 msgid ""
 "Rotating an image may cause the dimensions of an image to increase to fit "
 "the diagonal."
 msgstr ""
+"Rotating an image may cause the dimensions of an image to increase to fit "
+"the diagonal."
 
 msgid ""
 "Image resize failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Image resize failed using the %toolkit toolkit on %path (%mimetype, "
+"%dimensions)"
 
 msgid ""
 "Image scale failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Image scale failed using the %toolkit toolkit on %path (%mimetype, "
+"%dimensions)"
 
 msgid ""
 "Image crop failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Image crop failed using the %toolkit toolkit on %path (%mimetype, "
+"%dimensions)"
 
 msgid ""
 "Image scale and crop failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Image scale and crop failed using the %toolkit toolkit on %path (%mimetype, "
+"%dimensions)"
 
 msgid ""
 "Image desaturate failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Image desaturate failed using the %toolkit toolkit on %path (%mimetype, "
+"%dimensions)"
 
 msgid ""
 "Image rotate failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Image rotate failed using the %toolkit toolkit on %path (%mimetype, "
+"%dimensions)"
 
 msgid "This field stores the ID of an image file as an integer value."
-msgstr ""
+msgstr "This field stores the ID of an image file as an integer value."
 
 msgid "If no image is uploaded, this image will be shown on display."
-msgstr ""
+msgstr "If no image is uploaded, this image will be shown on display."
 
 msgid "Minimum image resolution"
-msgstr ""
+msgstr "Minimum image resolution"
 
 msgid "Enable <em>Alt</em> field"
-msgstr ""
+msgstr "Enable <em>Alt</em> field"
 
 msgid "Enable <em>Title</em> field"
-msgstr ""
+msgstr "Enable <em>Title</em> field"
 
 msgid ""
 "The title attribute is used as a tooltip when the mouse hovers over the "
 "image."
 msgstr ""
+"The title attribute is used as a tooltip when the mouse hovers over the "
+"image."
 
 msgid "Preview image style"
-msgstr ""
+msgstr "Preview image style"
 
 msgid "no preview"
-msgstr ""
+msgstr "no preview"
 
 msgid "The preview image will be shown while editing the content."
-msgstr ""
+msgstr "The preview image will be shown while editing the content."
 
 msgid ""
 "Image styles commonly provide thumbnail sizes by scaling and cropping "
@@ -9023,171 +9442,188 @@ msgid ""
 "an image is displayed with a style, a new file is created and the original "
 "image is left unchanged."
 msgstr ""
+"Image styles commonly provide thumbnail sizes by scaling and cropping "
+"images, but can also add various effects before an image is displayed. When "
+"an image is displayed with a style, a new file is created and the original "
+"image is left unchanged."
 
 msgid "Administer image styles"
-msgstr ""
+msgstr "Administer image styles"
 
 msgid "No defined styles"
-msgstr ""
+msgstr "No defined styles"
 
 msgid "Image generation in progress. Try again shortly."
-msgstr ""
+msgstr "Image generation in progress. Try again shortly."
 
 msgid "Error generating image."
-msgstr ""
+msgstr "Error generating image."
 
 msgid "Unable to generate the derived image located at %path."
-msgstr ""
+msgstr "Unable to generate the derived image located at %path."
 
 msgid "Failed to create style directory: %directory"
-msgstr ""
+msgstr "Failed to create style directory: %directory"
 
 msgid ""
 "Cached image file %destination already exists. There may be an issue with "
 "your rewrite configuration."
 msgstr ""
+"Cached image file %destination already exists. There may be an issue with "
+"your rewrite configuration."
 
 msgid "Edit image effect"
-msgstr ""
+msgstr "Edit image effect"
 
 msgid "Delete image effect"
-msgstr ""
+msgstr "Delete image effect"
 
 msgid "Add image effect"
-msgstr ""
+msgstr "Add image effect"
 
 msgid "Detection method"
-msgstr ""
+msgstr "Detection method"
 
 msgid "Part of the URL that determines language"
-msgstr ""
+msgstr "Part of the URL that determines language"
 
 msgid "Request/session parameter"
-msgstr ""
+msgstr "Request/session parameter"
 
 msgid ""
 "Name of the request/session parameter used to determine the desired "
 "language."
 msgstr ""
+"Name of the request/session parameter used to determine the desired "
+"language."
 
 msgid "Date type"
-msgstr ""
+msgstr "Date type"
 
 msgid ""
 "Determine the language from a request/session parameter. Example: "
 "\"http://example.com?language=de\" sets language to German based on the use "
 "of \"de\" within the \"language\" parameter."
 msgstr ""
+"Determine the language from a request/session parameter. Example: "
+"\"http://example.com?language=de\" sets language to German based on the use "
+"of \"de\" within the \"language\" parameter."
 
 msgid "Administer languages"
-msgstr ""
+msgstr "Administer languages"
 
 msgid ""
 "Order of language detection methods for content. If a version of content is "
 "available in the detected language, it will be displayed."
 msgstr ""
+"Order of language detection methods for content. If a version of content is "
+"available in the detected language, it will be displayed."
 
 msgid "Follow the user's language preference."
-msgstr ""
+msgstr "Follow the user's language preference."
 
 msgid "Language switcher (@type)"
-msgstr ""
+msgstr "Language switcher (@type)"
 
 msgid "Detection and selection"
-msgstr ""
+msgstr "Detection and selection"
 
 msgid "URL language detection configuration"
-msgstr ""
+msgstr "URL language detection configuration"
 
 msgid "Session language detection configuration"
-msgstr ""
+msgstr "Session language detection configuration"
 
 msgctxt "Long month name"
 msgid "January"
-msgstr ""
+msgstr "January"
 
 msgctxt "Long month name"
 msgid "February"
-msgstr ""
+msgstr "February"
 
 msgctxt "Long month name"
 msgid "March"
-msgstr ""
+msgstr "March"
 
 msgctxt "Long month name"
 msgid "April"
-msgstr ""
+msgstr "April"
 
 msgctxt "Long month name"
 msgid "May"
-msgstr ""
+msgstr "May"
 
 msgctxt "Long month name"
 msgid "June"
-msgstr ""
+msgstr "June"
 
 msgctxt "Long month name"
 msgid "July"
-msgstr ""
+msgstr "July"
 
 msgctxt "Long month name"
 msgid "August"
-msgstr ""
+msgstr "August"
 
 msgctxt "Long month name"
 msgid "October"
-msgstr ""
+msgstr "October"
 
 msgctxt "Long month name"
 msgid "November"
-msgstr ""
+msgstr "November"
 
 msgctxt "Long month name"
 msgid "December"
-msgstr ""
+msgstr "December"
 
 msgid "The text to be used for this link in the menu."
-msgstr ""
+msgstr "The text to be used for this link in the menu."
 
 msgid "Menu links that are not enabled will not be listed in any menu."
-msgstr ""
+msgstr "Menu links that are not enabled will not be listed in any menu."
 
 msgid ""
 "If selected and this menu link has children, the menu will always appear "
 "expanded."
 msgstr ""
+"If selected and this menu link has children, the menu will always appear "
+"expanded."
 
 msgid "Parent link"
-msgstr ""
+msgstr "Parent link"
 
 msgid "Add to shortcuts"
-msgstr ""
+msgstr "Add to shortcuts"
 
 msgid "Add effect"
-msgstr ""
+msgstr "Add effect"
 
 msgid "Image styles"
-msgstr ""
+msgstr "Image styles"
 
 msgid ""
 "Configure styles that can be used for resizing or adjusting images on "
 "display."
 msgstr ""
+"Configure styles that can be used for resizing or adjusting images on "
+"display."
 
 msgid "Filter translatable strings"
-msgstr ""
+msgstr "Filter translatable strings"
 
 msgid "The menu link %title has been deleted."
-msgstr ""
+msgstr "The menu link %title has been deleted."
 
 msgid "Are you sure you want to reset the link %item to its default values?"
-msgstr ""
+msgstr "Are you sure you want to reset the link %item to its default values?"
 
 msgid "The menu link was reset to its default settings."
-msgstr ""
+msgstr "The menu link was reset to its default settings."
 
 msgid "Deleted custom menu %title and all its menu links."
-msgstr ""
+msgstr "Deleted custom menu %title and all its menu links."
 
 msgid ""
 "<strong>Warning:</strong> There is currently 1 menu link in %title. It will "
@@ -9196,122 +9632,137 @@ msgid_plural ""
 "<strong>Warning:</strong> There are currently @count menu links in %title. "
 "They will be deleted (system-defined links will be reset)."
 msgstr[0] ""
+"<strong>Warning:</strong> There is currently 1 menu link in %title. It will "
+"be deleted (system-defined items will be reset)."
 msgstr[1] ""
+"<strong>Warning:</strong> There are currently @count menu links in %title. "
+"They will be deleted (system-defined links will be reset)."
 
 msgid "Managing menus"
-msgstr ""
+msgstr "Managing menus"
 
 msgid "Administer menus and menu items"
-msgstr ""
+msgstr "Administer menus and menu items"
 
 msgid "Provide a menu link"
-msgstr ""
+msgstr "Provide a menu link"
 
 msgid "Available menus"
-msgstr ""
+msgstr "Available menus"
 
 msgid "The menus available to place links in for this content type."
-msgstr ""
+msgstr "The menus available to place links in for this content type."
 
 msgid "Default parent item"
-msgstr ""
+msgstr "Default parent item"
 
 msgid ""
 "Choose the menu item to be the default parent for a new link in the content "
 "authoring form."
 msgstr ""
+"Choose the menu item to be the default parent for a new link in the content "
+"authoring form."
 
 msgid "Edit menu link"
-msgstr ""
+msgstr "Edit menu link"
 
 msgid "Reset menu link"
-msgstr ""
+msgstr "Reset menu link"
 
 msgid "Delete menu link"
-msgstr ""
+msgstr "Delete menu link"
 
 msgid "Preview before submitting"
-msgstr ""
+msgstr "Preview before submitting"
 
 msgid ""
 "This text will be displayed at the top of the page when creating or editing "
 "content of this type."
 msgstr ""
+"This text will be displayed at the top of the page when creating or editing "
+"content of this type."
 
 msgid ""
 "Users with the <em>Administer content</em> permission will be able to "
 "override these options."
 msgstr ""
+"Users with the <em>Administer content</em> permission will be able to "
+"override these options."
 
 msgid "Author username and publish date will be displayed."
-msgstr ""
+msgstr "Author username and publish date will be displayed."
 
 msgid "Invalid machine-readable name. Enter a name other than %invalid."
-msgstr ""
+msgstr "Invalid machine-readable name. Enter a name other than %invalid."
 
 msgid "Publish selected content"
-msgstr ""
+msgstr "Publish selected content"
 
 msgid "Unpublish selected content"
-msgstr ""
+msgstr "Unpublish selected content"
 
 msgid "Promote selected content to front page"
-msgstr ""
+msgstr "Promote selected content to front page"
 
 msgid "Demote selected content from front page"
-msgstr ""
+msgstr "Demote selected content from front page"
 
 msgid "Make selected content sticky"
-msgstr ""
+msgstr "Make selected content sticky"
 
 msgid "Make selected content not sticky"
-msgstr ""
+msgstr "Make selected content not sticky"
 
 msgid "Are you sure you want to delete this item?"
 msgid_plural "Are you sure you want to delete these items?"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Are you sure you want to delete this item?"
+msgstr[1] "Are you sure you want to delete these items?"
 
 msgid "<em>Edit @type</em> @title"
-msgstr ""
+msgstr "<em>Edit @type</em> @title"
 
 msgid "Tokens related to individual content items, or \"nodes\"."
-msgstr ""
+msgstr "Tokens related to individual content items, or \"nodes\"."
 
 msgid "The unique ID of the content item, or \"node\"."
-msgstr ""
+msgstr "The unique ID of the content item, or \"node\"."
 
 msgid "The main body text of the node."
-msgstr ""
+msgstr "The main body text of the node."
 
 msgid "The summary of the node's main body text."
-msgstr ""
+msgstr "The summary of the node's main body text."
 
 msgid "Creating content"
-msgstr ""
+msgstr "Creating content"
 
 msgid "Creating custom content types"
-msgstr ""
+msgstr "Creating custom content types"
 
 msgid "Administering content"
-msgstr ""
+msgstr "Administering content"
 
 msgid "Creating revisions"
-msgstr ""
+msgstr "Creating revisions"
 
 msgid ""
 "The Node module also enables you to create multiple versions of any content,"
 " and revert to older versions using the <em>Revision information</em> "
 "settings."
 msgstr ""
+"The Node module also enables you to create multiple versions of any content,"
+" and revert to older versions using the <em>Revision information</em> "
+"settings."
 
 msgid "User permissions"
-msgstr ""
+msgstr "User permissions"
 
 msgid ""
 "Individual content types can have different fields, behaviors, and "
 "permissions assigned to them."
 msgstr ""
+"Individual content types can have different fields, behaviors, and "
+"permissions assigned to them."
 
 msgid ""
 "Content items can be displayed using different view modes: Teaser, Full "
@@ -9319,186 +9770,203 @@ msgid ""
 "typically used in lists of multiple content items. <em>Full content</em> is "
 "typically used when the content is displayed on its own page."
 msgstr ""
+"Content items can be displayed using different view modes: Teaser, Full "
+"content, Print, RSS, etc. <em>Teaser</em> is a short format that is "
+"typically used in lists of multiple content items. <em>Full content</em> is "
+"typically used when the content is displayed on its own page."
 
 msgid ""
 "Here, you can define which fields are shown and hidden when %type content is"
 " displayed in each view mode, and define how the fields are displayed in "
 "each view mode."
 msgstr ""
+"Here, you can define which fields are shown and hidden when %type content is"
+" displayed in each view mode, and define how the fields are displayed in "
+"each view mode."
 
 msgid "Administer content types"
-msgstr ""
+msgstr "Administer content types"
 
 msgid ""
 "Warning: Give to trusted roles only; this permission has security "
 "implications."
 msgstr ""
+"Warning: Give to trusted roles only; this permission has security "
+"implications."
 
 msgid "View published content"
-msgstr ""
+msgstr "View published content"
 
 msgid "Bypass content access control"
-msgstr ""
+msgstr "Bypass content access control"
 
 msgid "View own unpublished content"
-msgstr ""
+msgstr "View own unpublished content"
 
 msgid "Content is sticky at top of lists"
-msgstr ""
+msgstr "Content is sticky at top of lists"
 
 msgid "Content is promoted to the front page"
-msgstr ""
+msgstr "Content is promoted to the front page"
 
 msgid "No front page content has been created yet."
-msgstr ""
+msgstr "No front page content has been created yet."
 
 msgid "Change the author of content"
-msgstr ""
+msgstr "Change the author of content"
 
 msgid "Unpublish content containing keyword(s)"
-msgstr ""
+msgstr "Unpublish content containing keyword(s)"
 
 msgid ""
 "The content will be unpublished if it contains any of the phrases above. Use"
 " a case-sensitive, comma-separated list of phrases. Example: funny, bungee "
 "jumping, \"Company, Inc.\""
 msgstr ""
+"The content will be unpublished if it contains any of the phrases above. Use"
+" a case-sensitive, comma-separated list of phrases. Example: funny, bungee "
+"jumping, \"Company, Inc.\""
 
 msgid "One permission in use"
 msgid_plural "@count permissions in use"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "One permission in use"
+msgstr[1] "@count permissions in use"
 
 msgid "Don't display post information"
-msgstr ""
+msgstr "Don't display post information"
 
 msgid "Creating aliases"
-msgstr ""
+msgstr "Creating aliases"
 
 msgid "Managing aliases"
-msgstr ""
+msgstr "Managing aliases"
 
 msgid ""
 "An alias defines a different name for an existing URL path - for example, "
 "the alias 'about' for the URL path 'node/1'. A URL path can have multiple "
 "aliases."
 msgstr ""
+"An alias defines a different name for an existing URL path - for example, "
+"the alias 'about' for the URL path 'node/1'. A URL path can have multiple "
+"aliases."
 
 msgid "Administer URL aliases"
-msgstr ""
+msgstr "Administer URL aliases"
 
 msgid "Create and edit URL aliases"
-msgstr ""
+msgstr "Create and edit URL aliases"
 
 msgid "The alias is already in use."
-msgstr ""
+msgstr "The alias is already in use."
 
 msgid "Searched %type for %keys."
-msgstr ""
+msgstr "Searched %type for %keys."
 
 msgid "Administer search"
-msgstr ""
+msgstr "Administer search"
 
 msgid "Use search"
-msgstr ""
+msgstr "Use search"
 
 msgid "Choose a set of shortcuts to use"
-msgstr ""
+msgstr "Choose a set of shortcuts to use"
 
 msgid "Choose a set of shortcuts for this user"
-msgstr ""
+msgstr "Choose a set of shortcuts for this user"
 
 msgid ""
 "%user is now using a new shortcut set called %set_name. You can edit it from"
 " this page."
 msgstr ""
+"%user is now using a new shortcut set called %set_name. You can edit it from"
+" this page."
 
 msgid "You are now using the %set_name shortcut set."
-msgstr ""
+msgstr "You are now using the %set_name shortcut set."
 
 msgid "%user is now using the %set_name shortcut set."
-msgstr ""
+msgstr "%user is now using the %set_name shortcut set."
 
 msgid "Change set"
-msgstr ""
+msgstr "Change set"
 
 msgid "The shortcut set has been updated."
-msgstr ""
+msgstr "The shortcut set has been updated."
 
 msgid "The name of the shortcut."
-msgstr ""
+msgstr "The name of the shortcut."
 
 msgid "The shortcut %link has been updated."
-msgstr ""
+msgstr "The shortcut %link has been updated."
 
 msgid "Added a shortcut for %title."
-msgstr ""
+msgstr "Added a shortcut for %title."
 
 msgid "The shortcut %title has been deleted."
-msgstr ""
+msgstr "The shortcut %title has been deleted."
 
 msgid "Unable to add a shortcut for %title."
-msgstr ""
+msgstr "Unable to add a shortcut for %title."
 
 msgid "Adding and removing shortcuts"
-msgstr ""
+msgstr "Adding and removing shortcuts"
 
 msgid "Displaying shortcuts"
-msgstr ""
+msgstr "Displaying shortcuts"
 
 msgid "Administer shortcuts"
-msgstr ""
+msgstr "Administer shortcuts"
 
 msgid "Revision log message"
-msgstr ""
+msgstr "Revision log message"
 
 msgid "Make content unsticky"
-msgstr ""
+msgstr "Make content unsticky"
 
 msgid "Promote content to front page"
-msgstr ""
+msgstr "Promote content to front page"
 
 msgid "Save content"
-msgstr ""
+msgstr "Save content"
 
 msgid "Unpublish content"
-msgstr ""
+msgstr "Unpublish content"
 
 msgid "Find and manage content."
-msgstr ""
+msgstr "Find and manage content."
 
 msgid "Recent content"
-msgstr ""
+msgstr "Recent content"
 
 msgid "Node Access Permissions"
-msgstr ""
+msgstr "Node Access Permissions"
 
 msgid "Add to %shortcut_set shortcuts"
-msgstr ""
+msgstr "Add to %shortcut_set shortcuts"
 
 msgid "Use advanced search"
-msgstr ""
+msgstr "Use advanced search"
 
 msgid "Remove from %shortcut_set shortcuts"
-msgstr ""
+msgstr "Remove from %shortcut_set shortcuts"
 
 msgid "Remove from shortcuts"
-msgstr ""
+msgstr "Remove from shortcuts"
 
 msgid "Add shortcut"
-msgstr ""
+msgstr "Add shortcut"
 
 msgid "GSS negotiate"
-msgstr ""
+msgstr "GSS negotiate"
 
 msgid "NTLM"
-msgstr ""
+msgstr "NTLM"
 
 msgid "Any safe"
-msgstr ""
+msgstr "Any safe"
 
 msgid "Running tests"
-msgstr ""
+msgstr "Running tests"
 
 msgid ""
 "After the tests run, a message will be displayed next to each test group "
@@ -9510,70 +9978,88 @@ msgid ""
 " exceptions will be indicated in red or pink rows. You can then use these "
 "results to refine your code and tests, until all tests pass."
 msgstr ""
+"After the tests run, a message will be displayed next to each test group "
+"indicating whether tests within it passed, failed, or had exceptions. A pass"
+" means that the test returned the expected results, while fail means that it"
+" did not. An exception normally indicates an error outside of the test, such"
+" as a PHP warning or notice. If there were failures or exceptions, the "
+"results will be expanded to show details, and the tests that had failures or"
+" exceptions will be indicated in red or pink rows. You can then use these "
+"results to refine your code and tests, until all tests pass."
 
 msgid "Administer tests"
-msgstr ""
+msgstr "Administer tests"
 
 msgid "The test run finished in @elapsed."
-msgstr ""
+msgstr "The test run finished in @elapsed."
 
 msgid ""
 "Use the <em>Clean environment</em> button to clean-up temporary files and "
 "tables."
 msgstr ""
+"Use the <em>Clean environment</em> button to clean-up temporary files and "
+"tables."
 
 msgid "PHP open_basedir restriction"
-msgstr ""
+msgstr "PHP open_basedir restriction"
 
 msgid "Displaying popular content"
-msgstr ""
+msgstr "Displaying popular content"
 
 msgid "Page view counter"
-msgstr ""
+msgstr "Page view counter"
 
 msgid "Administer statistics"
-msgstr ""
+msgstr "Administer statistics"
 
 msgid "View content hits"
-msgstr ""
+msgstr "View content hits"
 
 msgid "Logging for UNIX, Linux, and Mac OS X"
-msgstr ""
+msgstr "Logging for UNIX, Linux, and Mac OS X"
 
 msgid "Logging for Microsoft Windows"
-msgstr ""
+msgstr "Logging for Microsoft Windows"
 
 msgid ""
 "On Microsoft Windows, messages are always sent to the Event Log using the "
 "code <code>LOG_USER</code>."
 msgstr ""
+"On Microsoft Windows, messages are always sent to the Event Log using the "
+"code <code>LOG_USER</code>."
 
 msgid "Syslog facility"
-msgstr ""
+msgstr "Syslog facility"
 
 msgid ""
 "Depending on the system configuration, Syslog and other logging tools use "
 "this code to identify or filter messages from within the entire system log."
 msgstr ""
+"Depending on the system configuration, Syslog and other logging tools use "
+"this code to identify or filter messages from within the entire system log."
 
 msgid ""
 "The image %file could not be rotated because the imagerotate() function is "
 "not available in this PHP installation."
 msgstr ""
+"The image %file could not be rotated because the imagerotate() function is "
+"not available in this PHP installation."
 
 msgid "default theme"
-msgstr ""
+msgstr "default theme"
 
 msgid ""
 "Choose \"Default theme\" to always use the same theme as the rest of the "
 "site."
 msgstr ""
+"Choose \"Default theme\" to always use the same theme as the rest of the "
+"site."
 
 msgid "Use the administration theme when editing or creating content"
-msgstr ""
+msgstr "Use the administration theme when editing or creating content"
 
 msgid "The %theme theme was not found."
-msgstr ""
+msgstr "The %theme theme was not found."
 
 msgid ""
 "Please note that the administration theme is still set to the %admin_theme "
@@ -9581,242 +10067,267 @@ msgid ""
 "administrative sections of the site, however, will show the selected "
 "%selected_theme theme by default."
 msgstr ""
+"Please note that the administration theme is still set to the %admin_theme "
+"theme; consequently, the theme on this page remains unchanged. All non-"
+"administrative sections of the site, however, will show the selected "
+"%selected_theme theme by default."
 
 msgid "%theme is now the default theme."
-msgstr ""
+msgstr "%theme is now the default theme."
 
 msgid "User verification status in comments"
-msgstr ""
+msgstr "User verification status in comments"
 
 msgid ""
 "These settings only exist for the themes based on the %engine theme engine."
 msgstr ""
+"These settings only exist for the themes based on the %engine theme engine."
 
 msgid "The custom logo path is invalid."
-msgstr ""
+msgstr "The custom logo path is invalid."
 
 msgid "The custom favicon path is invalid."
-msgstr ""
+msgstr "The custom favicon path is invalid."
 
 msgid "Would you like to continue with the above?"
-msgstr ""
+msgstr "Would you like to continue with the above?"
 
 msgid "Enter a valid IP address."
-msgstr ""
+msgstr "Enter a valid IP address."
 
 msgid "The IP address %ip was deleted."
-msgstr ""
+msgstr "The IP address %ip was deleted."
 
 msgid "How this is used depends on your site's theme."
-msgstr ""
+msgstr "How this is used depends on your site's theme."
 
 msgid ""
 "This page is displayed when the requested document is denied to the current "
 "user. Leave blank to display a generic \"access denied\" page."
 msgstr ""
+"This page is displayed when the requested document is denied to the current "
+"user. Leave blank to display a generic \"access denied\" page."
 
 msgid ""
 "This page is displayed when no other content matches the requested document."
 " Leave blank to display a generic \"page not found\" page."
 msgstr ""
+"This page is displayed when no other content matches the requested document."
+" Leave blank to display a generic \"page not found\" page."
 
 msgid "Errors and warnings"
-msgstr ""
+msgstr "Errors and warnings"
 
 msgid "Public file system path"
-msgstr ""
+msgstr "Public file system path"
 
 msgid "Private file system path"
-msgstr ""
+msgstr "Private file system path"
 
 msgid ""
 "A local file system path where temporary files will be stored. This "
 "directory should not be accessible over the web."
 msgstr ""
+"A local file system path where temporary files will be stored. This "
+"directory should not be accessible over the web."
 
 msgid "Default download method"
-msgstr ""
+msgstr "Default download method"
 
 msgid ""
 "This setting is used as the preferred download method. The use of public "
 "files is more efficient, but does not provide any access control."
 msgstr ""
+"This setting is used as the preferred download method. The use of public "
+"files is more efficient, but does not provide any access control."
 
 msgid "Description of your site, included in each feed."
-msgstr ""
+msgstr "Description of your site, included in each feed."
 
 msgid "Time zones"
-msgstr ""
+msgstr "Time zones"
 
 msgid "Only applied if users may set their own time zone."
-msgstr ""
+msgstr "Only applied if users may set their own time zone."
 
 msgid "Time zone for new users"
-msgstr ""
+msgstr "Time zone for new users"
 
 msgid "Put site into maintenance mode"
-msgstr ""
+msgstr "Put site into maintenance mode"
 
 msgid "Displayed as %date"
-msgstr ""
+msgstr "Displayed as %date"
 
 msgid "Save format"
-msgstr ""
+msgstr "Save format"
 
 msgid "Custom date format updated."
-msgstr ""
+msgstr "Custom date format updated."
 
 msgid "Custom date format added."
-msgstr ""
+msgstr "Custom date format added."
 
 msgid "Available actions:"
-msgstr ""
+msgstr "Available actions:"
 
 msgid "Create an advanced action"
-msgstr ""
+msgstr "Create an advanced action"
 
 msgid "Deleted %ip"
-msgstr ""
+msgstr "Deleted %ip"
 
 msgid "You must enable the @required module to install @module."
 msgid_plural "You must enable the @required modules to install @module."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "You must enable the @required module to install @module."
+msgstr[1] "You must enable the @required modules to install @module."
 
 msgid "Tokens for site-wide settings and other global information."
-msgstr ""
+msgstr "Tokens for site-wide settings and other global information."
 
 msgid "Tokens related to times and dates."
-msgstr ""
+msgstr "Tokens related to times and dates."
 
 msgid "Tokens related to uploaded files."
-msgstr ""
+msgstr "Tokens related to uploaded files."
 
 msgid "The URL of the site's front page without the protocol."
-msgstr ""
+msgstr "The URL of the site's front page without the protocol."
 
 msgid "A date in 'short' format. (%date)"
-msgstr ""
+msgstr "A date in 'short' format. (%date)"
 
 msgid "A date in 'medium' format. (%date)"
-msgstr ""
+msgstr "A date in 'medium' format. (%date)"
 
 msgid "A date in 'long' format. (%date)"
-msgstr ""
+msgstr "A date in 'long' format. (%date)"
 
 msgid "A date in UNIX timestamp format (%date)"
-msgstr ""
+msgstr "A date in UNIX timestamp format (%date)"
 
 msgid "Managing modules"
-msgstr ""
+msgstr "Managing modules"
 
 msgid "Managing themes"
-msgstr ""
+msgstr "Managing themes"
 
 msgid "Configuring basic site settings"
-msgstr ""
+msgstr "Configuring basic site settings"
 
 msgid "Administer modules"
-msgstr ""
+msgstr "Administer modules"
 
 msgid "Administer site configuration"
-msgstr ""
+msgstr "Administer site configuration"
 
 msgid "Administer themes"
-msgstr ""
+msgstr "Administer themes"
 
 msgid "Administer actions"
-msgstr ""
+msgstr "Administer actions"
 
 msgid "Use the administration pages and help"
-msgstr ""
+msgstr "Use the administration pages and help"
 
 msgid "Use the site in maintenance mode"
-msgstr ""
+msgstr "Use the site in maintenance mode"
 
 msgid "View site reports"
-msgstr ""
+msgstr "View site reports"
 
 msgid "Public files"
-msgstr ""
+msgstr "Public files"
 
 msgid "Public local files served by the webserver."
-msgstr ""
+msgstr "Public local files served by the webserver."
 
 msgid "Private local files served by Drupal."
-msgstr ""
+msgstr "Private local files served by Drupal."
 
 msgid "Temporary files"
-msgstr ""
+msgstr "Temporary files"
 
 msgid "Temporary local files for upload and previews."
-msgstr ""
+msgstr "Temporary local files for upload and previews."
 
 msgid "Update modules"
-msgstr ""
+msgstr "Update modules"
 
 msgid "Update themes"
-msgstr ""
+msgstr "Update themes"
 
 msgid "SSH"
-msgstr ""
+msgstr "SSH"
 
 msgid ""
 "Your password is not saved in the database and is only used to establish a "
 "connection."
 msgstr ""
+"Your password is not saved in the database and is only used to establish a "
+"connection."
 
 msgid "Edit shortcuts"
-msgstr ""
+msgstr "Edit shortcuts"
 
 msgid "Clear all caches"
-msgstr ""
+msgstr "Clear all caches"
 
 msgid "Bandwidth optimization"
-msgstr ""
+msgstr "Bandwidth optimization"
 
 msgid "Allows users to manage customizable lists of shortcut links."
-msgstr ""
+msgstr "Allows users to manage customizable lists of shortcut links."
 
 msgid ""
 "The connection will be created between your web server and the machine "
 "hosting the web server files. In the vast majority of cases, this will be "
 "the same machine, and \"localhost\" is correct."
 msgstr ""
+"The connection will be created between your web server and the machine "
+"hosting the web server files. In the vast majority of cases, this will be "
+"the same machine, and \"localhost\" is correct."
 
 msgid ""
 "Select the desired local time and time zone. Dates and times throughout this"
 " site will be displayed using this time zone."
 msgstr ""
+"Select the desired local time and time zone. Dates and times throughout this"
+" site will be displayed using this time zone."
 
 msgid "The directory %directory does not exist and could not be created."
-msgstr ""
+msgstr "The directory %directory does not exist and could not be created."
 
 msgid ""
 "The directory %directory exists but is not writable and could not be made "
 "writable."
 msgstr ""
+"The directory %directory exists but is not writable and could not be made "
+"writable."
 
 msgid "Delete IP address"
-msgstr ""
+msgstr "Delete IP address"
 
 msgid "Edit date format"
-msgstr ""
+msgstr "Edit date format"
 
 msgid "%profile_name (%profile-%version)"
-msgstr ""
+msgstr "%profile_name (%profile-%version)"
 
 msgid "Tokens related to taxonomy terms."
-msgstr ""
+msgstr "Tokens related to taxonomy terms."
 
 msgid "Tokens related to taxonomy vocabularies."
-msgstr ""
+msgstr "Tokens related to taxonomy vocabularies."
 
 msgid ""
 "Taxonomy is for categorizing content. Terms are grouped into vocabularies. "
 "For example, a vocabulary called \"Fruit\" would contain the terms \"Apple\""
 " and \"Banana\"."
 msgstr ""
+"Taxonomy is for categorizing content. Terms are grouped into vocabularies. "
+"For example, a vocabulary called \"Fruit\" would contain the terms \"Apple\""
+" and \"Banana\"."
 
 msgid ""
 "You can reorganize the terms in %capital_name using their drag-and-drop "
@@ -9835,509 +10346,545 @@ msgstr ""
 "the terms in %capital_name using their drag-and-drop handles."
 
 msgid "Administer vocabularies and terms"
-msgstr ""
+msgstr "Administer vocabularies and terms"
 
 msgid "Tracking new and updated site content"
-msgstr ""
+msgstr "Tracking new and updated site content"
 
 msgid "Tracking user-specific content"
-msgstr ""
+msgstr "Tracking user-specific content"
 
 msgid "My recent content"
-msgstr ""
+msgstr "My recent content"
 
 msgid "Translating content"
-msgstr ""
+msgstr "Translating content"
 
 msgid "Installing updates"
-msgstr ""
+msgstr "Installing updates"
 
 msgid "Preparing to update your site"
-msgstr ""
+msgstr "Preparing to update your site"
 
 msgid "Installing %project"
-msgstr ""
+msgstr "Installing %project"
 
 msgid "Preparing to install"
-msgstr ""
+msgstr "Preparing to install"
 
 msgid "Error installing / updating"
-msgstr ""
+msgstr "Error installing / updating"
 
 msgid "Installed %project_name successfully"
-msgstr ""
+msgstr "Installed %project_name successfully"
 
 msgid ""
 "Update was completed successfully. Your site has been taken out of "
 "maintenance mode."
 msgstr ""
+"Update was completed successfully. Your site has been taken out of "
+"maintenance mode."
 
 msgid "Update was completed successfully."
-msgstr ""
+msgstr "Update was completed successfully."
 
 msgid "Update failed! See the log below for more information."
-msgstr ""
+msgstr "Update failed! See the log below for more information."
 
 msgid ""
 "Update failed! See the log below for more information. Your site is still in"
 " maintenance mode."
 msgstr ""
+"Update failed! See the log below for more information. Your site is still in"
+" maintenance mode."
 
 msgid ""
 "Installation was completed successfully. Your site has been taken out of "
 "maintenance mode."
 msgstr ""
+"Installation was completed successfully. Your site has been taken out of "
+"maintenance mode."
 
 msgid "Installation was completed successfully."
-msgstr ""
+msgstr "Installation was completed successfully."
 
 msgid "Installation failed! See the log below for more information."
-msgstr ""
+msgstr "Installation failed! See the log below for more information."
 
 msgid ""
 "Installation failed! See the log below for more information. Your site is "
 "still in maintenance mode."
 msgstr ""
+"Installation failed! See the log below for more information. Your site is "
+"still in maintenance mode."
 
 msgid "No available update data"
-msgstr ""
+msgstr "No available update data"
 
 msgid "Checking available update data"
-msgstr ""
+msgstr "Checking available update data"
 
 msgid "Trying to check available update data ..."
-msgstr ""
+msgstr "Trying to check available update data ..."
 
 msgid "Error checking available update data."
-msgstr ""
+msgstr "Error checking available update data."
 
 msgid "Checking available update data ..."
-msgstr ""
+msgstr "Checking available update data ..."
 
 msgid "Checked available update data for %title."
-msgstr ""
+msgstr "Checked available update data for %title."
 
 msgid "Failed to check available update data for %title."
-msgstr ""
+msgstr "Failed to check available update data for %title."
 
 msgid "An error occurred trying to get available update data."
-msgstr ""
+msgstr "An error occurred trying to get available update data."
 
 msgid "Checked available update data for one project."
 msgid_plural "Checked available update data for @count projects."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Checked available update data for one project."
+msgstr[1] "Checked available update data for @count projects."
 
 msgid "Failed to get available update data for one project."
 msgid_plural "Failed to get available update data for @count projects."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Failed to get available update data for one project."
+msgstr[1] "Failed to get available update data for @count projects."
 
 msgid "There was a problem getting update information. Try again later."
-msgstr ""
+msgstr "There was a problem getting update information. Try again later."
 
 msgid "(Theme)"
-msgstr ""
+msgstr "(Theme)"
 
 msgid "(Security update)"
-msgstr ""
+msgstr "(Security update)"
 
 msgid "(Unsupported)"
-msgstr ""
+msgstr "(Unsupported)"
 
 msgid "All of your projects are up to date."
-msgstr ""
+msgstr "All of your projects are up to date."
 
 msgid "Download these updates"
-msgstr ""
+msgstr "Download these updates"
 
 msgid "Manual updates required"
-msgstr ""
+msgstr "Manual updates required"
 
 msgid "You must select at least one project to update."
-msgstr ""
+msgstr "You must select at least one project to update."
 
 msgid "Downloading updates"
-msgstr ""
+msgstr "Downloading updates"
 
 msgid "Preparing to download selected updates"
-msgstr ""
+msgstr "Preparing to download selected updates"
 
 msgid "Downloading updates failed:"
-msgstr ""
+msgstr "Downloading updates failed:"
 
 msgid "Updates downloaded successfully."
-msgstr ""
+msgstr "Updates downloaded successfully."
 
 msgid "Fatal error trying to download."
-msgstr ""
+msgstr "Fatal error trying to download."
 
 msgid "Perform updates with site in maintenance mode (strongly recommended)"
-msgstr ""
+msgstr "Perform updates with site in maintenance mode (strongly recommended)"
 
 msgid "Install from a URL"
-msgstr ""
+msgstr "Install from a URL"
 
 msgid "For example: %url"
-msgstr ""
+msgstr "For example: %url"
 
 msgid "Upload a module or theme archive to install"
-msgstr ""
+msgstr "Upload a module or theme archive to install"
 
 msgid "For example: %filename from your local computer"
-msgstr ""
+msgstr "For example: %filename from your local computer"
 
 msgid "You must either provide a URL or upload an archive file to install."
-msgstr ""
+msgstr "You must either provide a URL or upload an archive file to install."
 
 msgid "Unable to retrieve Drupal project from %url."
-msgstr ""
+msgstr "Unable to retrieve Drupal project from %url."
 
 msgid "Provided archive contains no files."
-msgstr ""
+msgstr "Provided archive contains no files."
 
 msgid "Unable to determine %project name."
-msgstr ""
+msgstr "Unable to determine %project name."
 
 msgid "%project is already installed."
-msgstr ""
+msgstr "%project is already installed."
 
 msgid "Cannot extract %file, not a valid archive."
-msgstr ""
+msgstr "Cannot extract %file, not a valid archive."
 
 msgid "Downloading %project"
-msgstr ""
+msgstr "Downloading %project"
 
 msgid "Failed to download %project from %url"
-msgstr ""
+msgstr "Failed to download %project from %url"
 
 msgid "Includes:"
-msgstr ""
+msgstr "Includes:"
 
 msgid "Enabled: %includes"
-msgstr ""
+msgstr "Enabled: %includes"
 
 msgid "Disabled: %disabled"
-msgstr ""
+msgstr "Disabled: %disabled"
 
 msgid "Checking for available updates"
-msgstr ""
+msgstr "Checking for available updates"
 
 msgid ""
 "You can automatically install your missing updates using the Update manager:"
 msgstr ""
+"You can automatically install your missing updates using the Update manager:"
 
 msgid ""
 "The installed version of at least one of your modules or themes is no longer"
 " supported. Upgrading or disabling is strongly recommended. See the project "
 "homepage for more details."
 msgstr ""
+"The installed version of at least one of your modules or themes is no longer"
+" supported. Upgrading or disabling is strongly recommended. See the project "
+"homepage for more details."
 
 msgid "Ready to update"
-msgstr ""
+msgstr "Ready to update"
 
 msgid "Update manager"
-msgstr ""
+msgstr "Update manager"
 
 msgid ""
 "This role will be automatically assigned new permissions whenever a module "
 "is enabled. Changing this setting will not affect existing permissions."
 msgstr ""
+"This role will be automatically assigned new permissions whenever a module "
+"is enabled. Changing this setting will not affect existing permissions."
 
 msgid "Registration and cancellation"
-msgstr ""
+msgstr "Registration and cancellation"
 
 msgid "Maintenance mode"
-msgstr ""
+msgstr "Maintenance mode"
 
 msgid "No people available."
-msgstr ""
+msgstr "No people available."
 
 msgid "Logging and errors"
-msgstr ""
+msgstr "Logging and errors"
 
 msgid "Regional and language"
-msgstr ""
+msgstr "Regional and language"
 
 msgid "Search and metadata"
-msgstr ""
+msgstr "Search and metadata"
 
 msgid "Content authoring"
-msgstr ""
+msgstr "Content authoring"
 
 msgid "more information"
-msgstr ""
+msgstr "more information"
 
 msgid "Failed to get available update data."
-msgstr ""
+msgstr "Failed to get available update data."
 
 msgid "Enables tracking of recent content for users."
-msgstr ""
+msgstr "Enables tracking of recent content for users."
 
 msgid ""
 "Checks for available updates, and can securely install or update modules and"
 " themes via a web interface."
 msgstr ""
+"Checks for available updates, and can securely install or update modules and"
+" themes via a web interface."
 
 msgid "Who can register accounts?"
-msgstr ""
+msgstr "Who can register accounts?"
 
 msgid "Administrators only"
-msgstr ""
+msgstr "Administrators only"
 
 msgid "Visitors, but administrator approval is required"
-msgstr ""
+msgstr "Visitors, but administrator approval is required"
 
 msgid "When cancelling a user account"
-msgstr ""
+msgstr "When cancelling a user account"
 
 msgid "Select method for cancelling account"
-msgstr ""
+msgstr "Select method for cancelling account"
 
 msgid "Administer users"
-msgstr ""
+msgstr "Administer users"
 
 msgid "Welcome (new user created by administrator)"
-msgstr ""
+msgstr "Welcome (new user created by administrator)"
 
 msgid "Welcome (awaiting approval)"
-msgstr ""
+msgstr "Welcome (awaiting approval)"
 
 msgid "Welcome (no approval required)"
-msgstr ""
+msgstr "Welcome (no approval required)"
 
 msgid "Password recovery"
-msgstr ""
+msgstr "Password recovery"
 
 msgid "Account activation"
-msgstr ""
+msgstr "Account activation"
 
 msgid "Account cancellation confirmation"
-msgstr ""
+msgstr "Account cancellation confirmation"
 
 msgid "Account canceled"
-msgstr ""
+msgstr "Account canceled"
 
 msgid "The one-time login link you clicked is invalid."
-msgstr ""
+msgstr "The one-time login link you clicked is invalid."
 
 msgid ""
 "You have just used your one-time login link. It is no longer necessary to "
 "use this link to log in. Please change your password."
 msgstr ""
+"You have just used your one-time login link. It is no longer necessary to "
+"use this link to log in. Please change your password."
 
 msgid ""
 "<p>This is a one-time login for %user_name and will expire on "
 "%expiration_date.</p><p>Click on this button to log in to the site and "
 "change your password.</p>"
 msgstr ""
+"<p>This is a one-time login for %user_name and will expire on "
+"%expiration_date.</p><p>Click on this button to log in to the site and "
+"change your password.</p>"
 
 msgid ""
 "You have tried to use a one-time login link that has either been used or is "
 "no longer valid. Please request a new one using the form below."
 msgstr ""
+"You have tried to use a one-time login link that has either been used or is "
+"no longer valid. Please request a new one using the form below."
 
 msgid "When cancelling your account"
-msgstr ""
+msgstr "When cancelling your account"
 
 msgid "When cancelling the account"
-msgstr ""
+msgstr "When cancelling the account"
 
 msgid "Are you sure you want to cancel your account?"
-msgstr ""
+msgstr "Are you sure you want to cancel your account?"
 
 msgid "Are you sure you want to cancel the account %name?"
-msgstr ""
+msgstr "Are you sure you want to cancel the account %name?"
 
 msgid "Select the method to cancel the account above."
-msgstr ""
+msgstr "Select the method to cancel the account above."
 
 msgid ""
 "Your account will be blocked and you will no longer be able to log in. All "
 "of your content will be hidden from everyone but administrators."
 msgstr ""
+"Your account will be blocked and you will no longer be able to log in. All "
+"of your content will be hidden from everyone but administrators."
 
 msgid ""
 "Your account will be removed and all account information deleted. All of "
 "your content will be assigned to the %anonymous-name user."
 msgstr ""
+"Your account will be removed and all account information deleted. All of "
+"your content will be assigned to the %anonymous-name user."
 
 msgid ""
 "Your account will be removed and all account information deleted. All of "
 "your content will also be deleted."
 msgstr ""
+"Your account will be removed and all account information deleted. All of "
+"your content will also be deleted."
 
 msgid ""
 "You have tried to use an account cancellation link that has expired. Please "
 "request a new one using the form below."
 msgstr ""
+"You have tried to use an account cancellation link that has expired. Please "
+"request a new one using the form below."
 
 msgid "Sent account cancellation request to %name %email."
-msgstr ""
+msgstr "Sent account cancellation request to %name %email."
 
 msgid "Tokens related to individual user accounts."
-msgstr ""
+msgstr "Tokens related to individual user accounts."
 
 msgid "Tokens related to the currently logged in user."
-msgstr ""
+msgstr "Tokens related to the currently logged in user."
 
 msgid "Creating and managing users"
-msgstr ""
+msgstr "Creating and managing users"
 
 msgid ""
 "This form lets administrators configure how fields should be displayed when "
 "rendering a user profile page."
 msgstr ""
+"This form lets administrators configure how fields should be displayed when "
+"rendering a user profile page."
 
 msgid "Administer permissions"
-msgstr ""
+msgstr "Administer permissions"
 
 msgid "Change own username"
-msgstr ""
+msgstr "Change own username"
 
 msgid "Cancel own user account"
-msgstr ""
+msgstr "Cancel own user account"
 
 msgid "Cancelling account"
-msgstr ""
+msgstr "Cancelling account"
 
 msgid "Cancelling user account"
-msgstr ""
+msgstr "Cancelling user account"
 
 msgid "%name has been disabled."
-msgstr ""
+msgstr "%name has been disabled."
 
 msgid "Cancel the selected user accounts"
-msgstr ""
+msgstr "Cancel the selected user accounts"
 
 msgid "When cancelling these accounts"
-msgstr ""
+msgstr "When cancelling these accounts"
 
 msgid "Are you sure you want to cancel these user accounts?"
-msgstr ""
+msgstr "Are you sure you want to cancel these user accounts?"
 
 msgid "Cancel accounts"
-msgstr ""
+msgstr "Cancel accounts"
 
 msgid "Add lowercase letters"
-msgstr ""
+msgstr "Add lowercase letters"
 
 msgid "Add uppercase letters"
-msgstr ""
+msgstr "Add uppercase letters"
 
 msgid "Add numbers"
-msgstr ""
+msgstr "Add numbers"
 
 msgid "Add punctuation"
-msgstr ""
+msgstr "Add punctuation"
 
 msgid "Make it different from your username"
-msgstr ""
+msgstr "Make it different from your username"
 
 msgid "Weak"
-msgstr ""
+msgstr "Weak"
 
 msgid "Fair"
-msgstr ""
+msgstr "Fair"
 
 msgid "Blocked user: %name %email."
-msgstr ""
+msgstr "Blocked user: %name %email."
 
 msgid "Confirm account cancellation"
-msgstr ""
+msgstr "Confirm account cancellation"
 
 msgid "Minimal"
-msgstr ""
+msgstr "Minimal"
 
 msgid "Install with commonly used features pre-configured."
-msgstr ""
+msgstr "Install with commonly used features pre-configured."
 
 msgid "Flood control"
-msgstr ""
+msgstr "Flood control"
 
 msgid "Exposed"
-msgstr ""
+msgstr "Exposed"
 
 msgid "Remove this display"
-msgstr ""
+msgstr "Remove this display"
 
 msgid "Operator to use on all groups"
-msgstr ""
+msgstr "Operator to use on all groups"
 
 msgid ""
 "Either \"group 0 AND group 1 AND group 2\" or \"group 0 OR group 1 OR group "
 "2\", etc"
 msgstr ""
+"Either \"group 0 AND group 1 AND group 2\" or \"group 0 OR group 1 OR group "
+"2\", etc"
 
 msgid "Remove group @group"
-msgstr ""
+msgstr "Remove group @group"
 
 msgid "Default group"
-msgstr ""
+msgstr "Default group"
 
 msgid "Group @group"
-msgstr ""
+msgstr "Group @group"
 
 msgid "Ungroupable filters"
-msgstr ""
+msgstr "Ungroupable filters"
 
 msgid "Basic exposed form"
-msgstr ""
+msgstr "Basic exposed form"
 
 msgid "Input required"
-msgstr ""
+msgstr "Input required"
 
 msgid ""
 "An exposed form that only renders a view if the form contains user input."
 msgstr ""
+"An exposed form that only renders a view if the form contains user input."
 
 msgid "Display all items"
-msgstr ""
+msgstr "Display all items"
 
 msgid "Display a specified number of items"
-msgstr ""
+msgstr "Display a specified number of items"
 
 msgid "Display a limited number items that this view might find."
-msgstr ""
+msgstr "Display a limited number items that this view might find."
 
 msgid "Paged output, full pager"
-msgstr ""
+msgstr "Paged output, full pager"
 
 msgid "Paged output, full Drupal style"
-msgstr ""
+msgstr "Paged output, full Drupal style"
 
 msgid "Paged output, mini pager"
-msgstr ""
+msgstr "Paged output, mini pager"
 
 msgid "Name (raw)"
-msgstr ""
+msgstr "Name (raw)"
 
 msgid "Provide markup text for the area."
-msgstr ""
+msgstr "Provide markup text for the area."
 
 msgid "Machine Name"
-msgstr ""
+msgstr "Machine Name"
 
 msgid "Change the machine name of this display."
-msgstr ""
+msgstr "Change the machine name of this display."
 
 msgid "Change settings for this pager type."
-msgstr ""
+msgstr "Change settings for this pager type."
 
 msgid "Allow grouping and aggregation (calculation) of fields."
-msgstr ""
+msgstr "Allow grouping and aggregation (calculation) of fields."
 
 msgid "Exposed form style"
-msgstr ""
+msgstr "Exposed form style"
 
 msgid "Select the kind of exposed filter to use."
-msgstr ""
+msgstr "Select the kind of exposed filter to use."
 
 msgid "Exposed form settings for this exposed form style."
-msgstr ""
+msgstr "Exposed form settings for this exposed form style."
 
 msgid "The machine name of this display"
-msgstr ""
+msgstr "The machine name of this display"
 
 msgid ""
 "If enabled, some fields may become unavailable. All fields that are selected"
@@ -10346,113 +10893,118 @@ msgid ""
 "them. For example, you can group nodes on title and count the number of nids"
 " in order to get a list of duplicate titles."
 msgstr ""
+"If enabled, some fields may become unavailable. All fields that are selected"
+" for grouping will be collapsed to one record per distinct value. Other "
+"fields which are selected for aggregation will have the function run on "
+"them. For example, you can group nodes on title and count the number of nids"
+" in order to get a list of duplicate titles."
 
 msgid "Exposed Form"
-msgstr ""
+msgstr "Exposed Form"
 
 msgid "Exposed form options"
-msgstr ""
+msgstr "Exposed form options"
 
 msgid "Pager options"
-msgstr ""
+msgstr "Pager options"
 
 msgid "Display id should be unique."
-msgstr ""
+msgstr "Display id should be unique."
 
 msgid "Include reset button"
-msgstr ""
+msgstr "Include reset button"
 
 msgid "Reset button label"
-msgstr ""
+msgstr "Reset button label"
 
 msgid "Text to display in the reset button of the exposed form."
-msgstr ""
+msgstr "Text to display in the reset button of the exposed form."
 
 msgid "Exposed sorts label"
-msgstr ""
+msgstr "Exposed sorts label"
 
 msgid "Select any filter and click on Apply to see results"
-msgstr ""
+msgstr "Select any filter and click on Apply to see results"
 
 msgid "Image style"
-msgstr ""
+msgstr "Image style"
 
 msgid "Use tags to group articles on similar topics into categories."
-msgstr ""
+msgstr "Use tags to group articles on similar topics into categories."
 
 msgid "An administrator created an account for you at [site:name]"
-msgstr ""
+msgstr "An administrator created an account for you at [site:name]"
 
 msgid "Find and manage people interacting with your site."
-msgstr ""
+msgstr "Find and manage people interacting with your site."
 
 msgid "Entity ID"
-msgstr ""
+msgstr "Entity ID"
 
 msgid "Contact forms"
-msgstr ""
+msgstr "Contact forms"
 
 msgid "Text on demand"
-msgstr ""
+msgstr "Text on demand"
 
 msgid "Exposed options"
-msgstr ""
+msgstr "Exposed options"
 
 msgid "Items per page label"
-msgstr ""
+msgstr "Items per page label"
 
 msgid "Exposed items per page options"
-msgstr ""
+msgstr "Exposed items per page options"
 
 msgid "Expose Offset"
-msgstr ""
+msgstr "Expose Offset"
 
 msgid "Offset label"
-msgstr ""
+msgstr "Offset label"
 
 msgid "Mini pager, @count item, skip @skip"
 msgid_plural "Mini pager, @count items, skip @skip"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Mini pager, @count item, skip @skip"
+msgstr[1] "Mini pager, @count items, skip @skip"
 
 msgid "Mini pager, @count item"
 msgid_plural "Mini pager, @count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Mini pager, @count item"
+msgstr[1] "Mini pager, @count items"
 
 msgid "All items, skip @skip"
-msgstr ""
+msgstr "All items, skip @skip"
 
 msgid "All items"
-msgstr ""
+msgstr "All items"
 
 msgid "@count item, skip @skip"
 msgid_plural "@count items, skip @skip"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count item, skip @skip"
+msgstr[1] "@count items, skip @skip"
 
 msgid "@count item"
 msgid_plural "@count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count item"
+msgstr[1] "@count items"
 
 msgid "Group results together"
-msgstr ""
+msgstr "Group results together"
 
 msgid "Unlock"
-msgstr ""
+msgstr "Unlock"
 
 msgid "Bundle ID"
-msgstr ""
+msgstr "Bundle ID"
 
 msgid "Add custom block"
-msgstr ""
+msgstr "Add custom block"
 
 msgid "Internet"
-msgstr ""
+msgstr "Internet"
 
 msgid "Alt"
-msgstr ""
+msgstr "Alt"
 
 msgid ""
 "1 pending update (@number_applied to be applied, @number_incompatible "
@@ -10461,118 +11013,132 @@ msgid_plural ""
 "@count pending updates (@number_applied to be applied, @number_incompatible "
 "skipped)"
 msgstr[0] ""
+"1 pending update (@number_applied to be applied, @number_incompatible "
+"skipped)"
 msgstr[1] ""
+"@count pending updates (@number_applied to be applied, @number_incompatible "
+"skipped)"
 
 msgid "Author textfield"
-msgstr ""
+msgstr "Author textfield"
 
 msgid "Error messages to display"
-msgstr ""
+msgstr "Error messages to display"
 
 msgid ""
 "It is recommended that sites running on production environments do not "
 "display any errors."
 msgstr ""
+"It is recommended that sites running on production environments do not "
+"display any errors."
 
 msgid "Cannot open %file_path"
-msgstr ""
+msgstr "Cannot open %file_path"
 
 msgid "Current password"
-msgstr ""
+msgstr "Current password"
 
 msgid ""
 "Your current password is missing or incorrect; it's required to change the "
 "%name."
 msgstr ""
+"Your current password is missing or incorrect; it's required to change the "
+"%name."
 
 msgid "Terminology"
-msgstr ""
+msgstr "Terminology"
 
 msgid "Last login timestamp"
-msgstr ""
+msgstr "Last login timestamp"
 
 msgid "Forum settings"
-msgstr ""
+msgstr "Forum settings"
 
 msgid "Maximize"
-msgstr ""
+msgstr "Maximize"
 
 msgid "Update preview"
-msgstr ""
+msgstr "Update preview"
 
 msgid "No media available."
-msgstr ""
+msgstr "No media available."
 
 msgid "Administer media"
-msgstr ""
+msgstr "Administer media"
 
 msgid "View media"
-msgstr ""
+msgstr "View media"
 
 msgid "Remove block"
-msgstr ""
+msgstr "Remove block"
 
 msgid "all languages"
-msgstr ""
+msgstr "all languages"
 
 msgid "%module module installed."
-msgstr ""
+msgstr "%module module installed."
 
 msgid "@node_type comment"
-msgstr ""
+msgstr "@node_type comment"
 
 msgid "Administer text formats and filters"
-msgstr ""
+msgstr "Administer text formats and filters"
 
 msgid "@type language detection"
-msgstr ""
+msgstr "@type language detection"
 
 msgid "Use the detected interface language."
-msgstr ""
+msgstr "Use the detected interface language."
 
 msgid ""
 "The new set is created by copying items from your default shortcut set."
 msgstr ""
+"The new set is created by copying items from your default shortcut set."
 
 msgid "The new set is created by copying items from the %default set."
-msgstr ""
+msgstr "The new set is created by copying items from the %default set."
 
 msgid "You are currently using the %set-name shortcut set."
-msgstr ""
+msgstr "You are currently using the %set-name shortcut set."
 
 msgid "Create new set"
-msgstr ""
+msgstr "Create new set"
 
 msgid ""
 "The %set_name shortcut set has been created. You can edit it from this page."
 msgstr ""
+"The %set_name shortcut set has been created. You can edit it from this page."
 
 msgid "Updated set name to %set-name."
-msgstr ""
+msgstr "Updated set name to %set-name."
 
 msgid ""
 "If you have chosen this shortcut set as the default for some or all users, "
 "they may also be affected by deleting it."
 msgstr ""
+"If you have chosen this shortcut set as the default for some or all users, "
+"they may also be affected by deleting it."
 
 msgid "1 user has chosen or been assigned to this shortcut set."
 msgid_plural "@count users have chosen or been assigned to this shortcut set."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 user has chosen or been assigned to this shortcut set."
+msgstr[1] "@count users have chosen or been assigned to this shortcut set."
 
 msgid "Administering shortcuts"
-msgstr ""
+msgstr "Administering shortcuts"
 
 msgid "Choosing shortcut sets"
-msgstr ""
+msgstr "Choosing shortcut sets"
 
 msgid ""
 "Users with permission to switch shortcut sets can choose a shortcut set to "
 "use from the Shortcuts tab of their user account page."
 msgstr ""
+"Users with permission to switch shortcut sets can choose a shortcut set to "
+"use from the Shortcuts tab of their user account page."
 
 msgid "Edit current shortcut set"
-msgstr ""
+msgstr "Edit current shortcut set"
 
 msgid ""
 "Editing the current shortcut set will affect other users if that set has "
@@ -10580,323 +11146,353 @@ msgid ""
 "set\" permission along with this permission will grant permission to edit "
 "any shortcut set."
 msgstr ""
+"Editing the current shortcut set will affect other users if that set has "
+"been assigned to or selected by other users. Granting \"Select any shortcut "
+"set\" permission along with this permission will grant permission to edit "
+"any shortcut set."
 
 msgid "Select any shortcut set"
-msgstr ""
+msgstr "Select any shortcut set"
 
 msgid ""
 "From all shortcut sets, select one to be own active set. Without this "
 "permission, an administrator selects shortcut sets for users."
 msgstr ""
+"From all shortcut sets, select one to be own active set. Without this "
+"permission, an administrator selects shortcut sets for users."
 
 msgid "Add shortcut set"
-msgstr ""
+msgstr "Add shortcut set"
 
 msgid "Edit set name"
-msgstr ""
+msgstr "Edit set name"
 
 msgid "Delete shortcut set"
-msgstr ""
+msgstr "Delete shortcut set"
 
 msgid "@remote could not be saved to @path."
-msgstr ""
+msgstr "@remote could not be saved to @path."
 
 msgid "Database support"
-msgstr ""
+msgstr "Database support"
 
 msgid "Cache type"
-msgstr ""
+msgstr "Cache type"
 
 msgid "Is not empty (NOT NULL)"
-msgstr ""
+msgstr "Is not empty (NOT NULL)"
 
 msgid ""
 "Display %display has set node/% as path. This will not produce what you "
 "want. If you want to have multiple versions of the node view, use panels."
 msgstr ""
+"Display %display has set node/% as path. This will not produce what you "
+"want. If you want to have multiple versions of the node view, use panels."
 
 msgid "Use absolute link (begins with \"http://\")"
-msgstr ""
+msgstr "Use absolute link (begins with \"http://\")"
 
 msgid "Output machine name"
-msgstr ""
+msgstr "Output machine name"
 
 msgid "Change the CSS class name(s) that will be added to this display."
-msgstr ""
+msgstr "Change the CSS class name(s) that will be added to this display."
 
 msgid "CSS classes must be alphanumeric or dashes only."
-msgstr ""
+msgstr "CSS classes must be alphanumeric or dashes only."
 
 msgid ""
 "Set between which values the user can choose when determining the items per "
 "page. Separated by comma."
 msgstr ""
+"Set between which values the user can choose when determining the items per "
+"page. Separated by comma."
 
 msgid "Update @name"
-msgstr ""
+msgstr "Update @name"
 
 msgid "Link field"
-msgstr ""
+msgstr "Link field"
 
 msgid "Attachment before"
-msgstr ""
+msgstr "Attachment before"
 
 msgid "Attachment after"
-msgstr ""
+msgstr "Attachment after"
 
 msgid "Feed icon"
-msgstr ""
+msgstr "Feed icon"
 
 msgid "Cache configuration"
-msgstr ""
+msgstr "Cache configuration"
 
 msgid "Editing"
-msgstr ""
+msgstr "Editing"
 
 msgid "The date the comment was most recently updated."
-msgstr ""
+msgstr "The date the comment was most recently updated."
 
 msgid "Comment posted: %subject."
-msgstr ""
+msgstr "Comment posted: %subject."
 
 msgid ""
 "This field has been disabled because you do not have sufficient permissions "
 "to edit it."
 msgstr ""
+"This field has been disabled because you do not have sufficient permissions "
+"to edit it."
 
 msgid ""
 "View, edit and delete all content regardless of permission restrictions."
 msgstr ""
+"View, edit and delete all content regardless of permission restrictions."
 
 msgid "Syslog format"
-msgstr ""
+msgstr "Syslog format"
 
 msgid "A date in 'time-since' format. (%date)"
-msgstr ""
+msgstr "A date in 'time-since' format. (%date)"
 
 msgid "The location of the file relative to Drupal root."
-msgstr ""
+msgstr "The location of the file relative to Drupal root."
 
 msgid "Your modules have been downloaded and updated."
-msgstr ""
+msgstr "Your modules have been downloaded and updated."
 
 msgid ""
 "The selected file %filename cannot be uploaded. Only files with the "
 "following extensions are allowed: %extensions."
 msgstr ""
+"The selected file %filename cannot be uploaded. Only files with the "
+"following extensions are allowed: %extensions."
 
 msgid "Bartik"
-msgstr ""
+msgstr "Bartik"
 
 msgid "Highlighted"
-msgstr ""
+msgstr "Highlighted"
 
 msgid "Main background"
-msgstr ""
+msgstr "Main background"
 
 msgid "Sidebar background"
-msgstr ""
+msgstr "Sidebar background"
 
 msgid "Current page"
-msgstr ""
+msgstr "Current page"
 
 msgid "Configure user accounts."
-msgstr ""
+msgstr "Configure user accounts."
 
 msgid "Add and modify shortcut sets."
-msgstr ""
+msgstr "Add and modify shortcut sets."
 
 msgid "Overview of fields on all entity types."
-msgstr ""
+msgstr "Overview of fields on all entity types."
 
 msgid "GD library PNG support"
-msgstr ""
+msgstr "GD library PNG support"
 
 msgid "Translation update status"
-msgstr ""
+msgstr "Translation update status"
 
 msgid "Filter modules"
-msgstr ""
+msgstr "Filter modules"
 
 msgid "Field API to add fields to entities like nodes and users."
-msgstr ""
+msgstr "Field API to add fields to entities like nodes and users."
 
 msgid "Collapse"
-msgstr ""
+msgstr "Collapse"
 
 msgid "Sidebar borders"
-msgstr ""
+msgstr "Sidebar borders"
 
 msgid "Footer background"
-msgstr ""
+msgstr "Footer background"
 
 msgid "Plum"
-msgstr ""
+msgstr "Plum"
 
 msgid "Site logo"
-msgstr ""
+msgstr "Site logo"
 
 msgid "Title link"
-msgstr ""
+msgstr "Title link"
 
 msgid ""
 "A space-separated list of HTML tags allowed in the content of feed items. "
 "Disallowed tags are stripped from the content."
 msgstr ""
+"A space-separated list of HTML tags allowed in the content of feed items. "
+"Disallowed tags are stripped from the content."
 
 msgid "%field cannot contain any markup."
-msgstr ""
+msgstr "%field cannot contain any markup."
 
 msgid ""
 "These options control the display settings for the %name theme. When your "
 "site is displayed using this theme, these settings will be used."
 msgstr ""
+"These options control the display settings for the %name theme. When your "
+"site is displayed using this theme, these settings will be used."
 
 msgid "Administer software updates"
-msgstr ""
+msgstr "Administer software updates"
 
 msgid "@required_name (Missing)"
-msgstr ""
+msgstr "@required_name (Missing)"
 
 msgid "@required_name (Version @compatibility required)"
-msgstr ""
+msgstr "@required_name (Version @compatibility required)"
 
 msgid "@name requires at least PHP @version."
-msgstr ""
+msgstr "@name requires at least PHP @version."
 
 msgid "Unresolved dependency"
-msgstr ""
+msgstr "Unresolved dependency"
 
 msgid "@name requires this module."
-msgstr ""
+msgstr "@name requires this module."
 
 msgid ""
 "@name requires this module and version. Currently using @required_name "
 "version @version"
 msgstr ""
+"@name requires this module and version. Currently using @required_name "
+"version @version"
 
 msgid "Previous page"
-msgstr ""
+msgstr "Previous page"
 
 msgid "Fetch settings"
-msgstr ""
+msgstr "Fetch settings"
 
 msgid "Site details"
-msgstr ""
+msgstr "Site details"
 
 msgid "The email address %mail is not valid."
-msgstr ""
+msgstr "The email address %mail is not valid."
 
 msgid "Add media"
-msgstr ""
+msgstr "Add media"
 
 msgid "Interfaces"
-msgstr ""
+msgstr "Interfaces"
 
 msgid "Title and slogan"
-msgstr ""
+msgstr "Title and slogan"
 
 msgid "Firehouse"
-msgstr ""
+msgstr "Firehouse"
 
 msgid "Ice"
-msgstr ""
+msgstr "Ice"
 
 msgid ""
 "The database table prefix you have entered, %prefix, is invalid. The table "
 "prefix can only contain alphanumeric characters, periods, or underscores."
 msgstr ""
+"The database table prefix you have entered, %prefix, is invalid. The table "
+"prefix can only contain alphanumeric characters, periods, or underscores."
 
 msgid "Default settings file"
-msgstr ""
+msgstr "Default settings file"
 
 msgid "The default settings file does not exist."
-msgstr ""
+msgstr "The default settings file does not exist."
 
 msgid ""
 "The @drupal installer requires that the %default-file file not be modified "
 "in any way from the original download."
 msgstr ""
+"The @drupal installer requires that the %default-file file not be modified "
+"in any way from the original download."
 
 msgid "Show row weights"
-msgstr ""
+msgstr "Show row weights"
 
 msgid "Hide row weights"
-msgstr ""
+msgstr "Hide row weights"
 
 msgid "%name: the value may be no less than %min."
-msgstr ""
+msgstr "%name: the value may be no less than %min."
 
 msgid "%name: the value may be no greater than %max."
-msgstr ""
+msgstr "%name: the value may be no greater than %max."
 
 msgid "Custom display settings"
-msgstr ""
+msgstr "Custom display settings"
 
 msgid ""
 "Separate extensions with a space or comma and do not include the leading "
 "dot."
 msgstr ""
+"Separate extensions with a space or comma and do not include the leading "
+"dot."
 
 msgid "Node module element"
-msgstr ""
+msgstr "Node module element"
 
 msgid "not yet assigned"
-msgstr ""
+msgstr "not yet assigned"
 
 msgid "not yet created"
-msgstr ""
+msgstr "not yet created"
 
 msgid "Edit permissions"
-msgstr ""
+msgstr "Edit permissions"
 
 msgid "None (original image)"
-msgstr ""
+msgstr "None (original image)"
 
 msgid "Row class"
-msgstr ""
+msgstr "Row class"
 
 msgid "Latest version"
-msgstr ""
+msgstr "Latest version"
 
 msgid "The URL of the account edit page."
-msgstr ""
+msgstr "The URL of the account edit page."
 
 msgid "Edit translations"
-msgstr ""
+msgstr "Edit translations"
 
 msgid "- Use default -"
-msgstr ""
+msgstr "- Use default -"
 
 msgid "Query type"
-msgstr ""
+msgstr "Query type"
 
 msgid "Search pages"
-msgstr ""
+msgstr "Search pages"
 
 msgid "Add search page"
-msgstr ""
+msgstr "Add search page"
 
 msgid "Redirect path"
-msgstr ""
+msgstr "Redirect path"
 
 msgid "Unknown content type"
-msgstr ""
+msgstr "Unknown content type"
 
 msgid "Drupal Upgrade"
-msgstr ""
+msgstr "Drupal Upgrade"
 
 msgid "Summary options"
-msgstr ""
+msgstr "Summary options"
 
 msgid "Never (manually)"
-msgstr ""
+msgstr "Never (manually)"
 
 msgid ""
 "The data could not be saved because the destination %destination is invalid."
 " This may be caused by improper use of file_save_data() or a missing stream "
 "wrapper."
 msgstr ""
+"The data could not be saved because the destination %destination is invalid."
+" This may be caused by improper use of file_save_data() or a missing stream "
+"wrapper."
 
 msgid ""
 "Failed to connect to your database server. The server reports the following "
@@ -10905,407 +11501,458 @@ msgid ""
 " you entered the correct username and password?</li><li>Have you entered the"
 " correct database hostname?</li></ul>"
 msgstr ""
+"Failed to connect to your database server. The server reports the following "
+"message: %error.<ul><li>Is the database server running?</li><li>Does the "
+"database exist, and have you entered the correct database name?</li><li>Have"
+" you entered the correct username and password?</li><li>Have you entered the"
+" correct database hostname?</li></ul>"
 
 msgid "Exit block region demonstration"
-msgstr ""
+msgstr "Exit block region demonstration"
 
 msgid "Database log messages to keep"
-msgstr ""
+msgstr "Database log messages to keep"
 
 msgid ""
 "Define a string that should be suffixed to the value, like ' m', ' kb/s'. "
 "Leave blank for none. Separate singular and plural values with a pipe "
 "('pound|pounds')."
 msgstr ""
+"Define a string that should be suffixed to the value, like ' m', ' kb/s'. "
+"Leave blank for none. Separate singular and plural values with a pipe "
+"('pound|pounds')."
 
 msgid "Thousand marker"
-msgstr ""
+msgstr "Thousand marker"
 
 msgid "Display prefix and suffix."
-msgstr ""
+msgstr "Display prefix and suffix."
 
 msgid "Display with prefix and suffix."
-msgstr ""
+msgstr "Display with prefix and suffix."
 
 msgid "- Select a value -"
-msgstr ""
+msgstr "- Select a value -"
 
 msgid "Trim length"
-msgstr ""
+msgstr "Trim length"
 
 msgid "No field is displayed."
-msgstr ""
+msgstr "No field is displayed."
 
 msgid "No field is hidden."
-msgstr ""
+msgstr "No field is hidden."
 
 msgid "Format settings:"
-msgstr ""
+msgstr "Format settings:"
 
 msgid ""
 "Text formats are presented on content editing pages in the order defined on "
 "this page. The first format available to a user will be selected by default."
 msgstr ""
+"Text formats are presented on content editing pages in the order defined on "
+"this page. The first format available to a user will be selected by default."
 
 msgid "Link image to"
-msgstr ""
+msgstr "Link image to"
 
 msgid "Image style: @style"
-msgstr ""
+msgstr "Image style: @style"
 
 msgid "Linked to content"
-msgstr ""
+msgstr "Linked to content"
 
 msgid "Linked to file"
-msgstr ""
+msgstr "Linked to file"
 
 msgid "Shown when hovering over the menu link."
-msgstr ""
+msgstr "Shown when hovering over the menu link."
 
 msgid ""
 "Format: %time. The date format is YYYY-MM-DD and %timezone is the time zone "
 "offset from UTC. Leave blank to use the time of form submission."
 msgstr ""
+"Format: %time. The date format is YYYY-MM-DD and %timezone is the time zone "
+"offset from UTC. Leave blank to use the time of form submission."
 
 msgid "Syslog identity"
-msgstr ""
+msgstr "Syslog identity"
 
 msgid ""
 "A string that will be prepended to every message logged to Syslog. If you "
 "have multiple sites logging to the same Syslog log file, a unique identity "
 "per site makes it easy to tell the log entries apart."
 msgstr ""
+"A string that will be prepended to every message logged to Syslog. If you "
+"have multiple sites logging to the same Syslog log file, a unique identity "
+"per site makes it easy to tell the log entries apart."
 
 msgid "Error pages"
-msgstr ""
+msgstr "Error pages"
 
 msgid "Run cron every"
-msgstr ""
+msgstr "Run cron every"
 
 msgid "Weight for added term"
-msgstr ""
+msgstr "Weight for added term"
 
 msgid ""
 "Minimal profile for running tests. Includes absolutely required modules "
 "only."
 msgstr ""
+"Minimal profile for running tests. Includes absolutely required modules "
+"only."
 
 msgid "Administrative name"
-msgstr ""
+msgstr "Administrative name"
 
 msgid "Saint Martin"
-msgstr ""
+msgstr "Saint Martin"
 
 msgid "Invalid merge query: no conditions"
-msgstr ""
+msgstr "Invalid merge query: no conditions"
 
 msgid "Weight for @block block"
-msgstr ""
+msgstr "Weight for @block block"
 
 msgid "Region for @block block"
-msgstr ""
+msgstr "Region for @block block"
 
 msgid "Post comments"
-msgstr ""
+msgstr "Post comments"
 
 msgid "Skip comment approval"
-msgstr ""
+msgstr "Skip comment approval"
 
 msgid "Are you sure you want to disable the text format %format?"
-msgstr ""
+msgstr "Are you sure you want to disable the text format %format?"
 
 msgid ""
 "Disabled text formats are completely removed from the administrative "
 "interface, and any content stored with that format will not be displayed. "
 "This action cannot be undone."
 msgstr ""
+"Disabled text formats are completely removed from the administrative "
+"interface, and any content stored with that format will not be displayed. "
+"This action cannot be undone."
 
 msgid "Disabled text format %format."
-msgstr ""
+msgstr "Disabled text format %format."
 
 msgid "Text Formats"
-msgstr ""
+msgstr "Text Formats"
 
 msgid "Disable text format"
-msgstr ""
+msgstr "Disable text format"
 
 msgid "Comment type"
-msgstr ""
+msgstr "Comment type"
 
 msgid "Bulk update"
-msgstr ""
+msgstr "Bulk update"
 
 msgid "Search page"
-msgstr ""
+msgstr "Search page"
 
 msgid "View mode"
-msgstr ""
+msgstr "View mode"
 
 msgid "UUID"
-msgstr ""
+msgstr "UUID"
 
 msgid "Subscribe to @title"
-msgstr ""
+msgstr "Subscribe to @title"
 
 msgid "Back to site"
-msgstr ""
+msgstr "Back to site"
 
 msgid "Configuration files"
-msgstr ""
+msgstr "Configuration files"
 
 msgid "@module"
-msgstr ""
+msgstr "@module"
 
 msgid "User interface for the Field API."
-msgstr ""
+msgstr "User interface for the Field API."
 
 msgid "Hot topic, new comments"
-msgstr ""
+msgstr "Hot topic, new comments"
 
 msgid "Hot topic"
-msgstr ""
+msgstr "Hot topic"
 
 msgid "Normal topic"
-msgstr ""
+msgstr "Normal topic"
 
 msgid "Closed topic"
-msgstr ""
+msgstr "Closed topic"
 
 msgid "Configure @module permissions"
-msgstr ""
+msgstr "Configure @module permissions"
 
 msgid "Install new module or theme"
-msgstr ""
+msgstr "Install new module or theme"
 
 msgid "Install new theme"
-msgstr ""
+msgstr "Install new theme"
 
 msgid "Nothing"
-msgstr ""
+msgstr "Nothing"
 
 msgid "Update @title"
-msgstr ""
+msgstr "Update @title"
 
 msgid ""
 "A unique machine-readable name. Can only contain lowercase letters, numbers,"
 " and underscores."
 msgstr ""
+"A unique machine-readable name. Can only contain lowercase letters, numbers,"
+" and underscores."
 
 msgid "The machine-readable name must contain unique characters."
-msgstr ""
+msgstr "The machine-readable name must contain unique characters."
 
 msgid ""
 "The machine-readable name must contain only lowercase letters, numbers, and "
 "hyphens."
 msgstr ""
+"The machine-readable name must contain only lowercase letters, numbers, and "
+"hyphens."
 
 msgid "The machine-readable name is already in use. It must be unique."
-msgstr ""
+msgstr "The machine-readable name is already in use. It must be unique."
 
 msgid "Weight for @title"
-msgstr ""
+msgstr "Weight for @title"
 
 msgid "Weight for row @number"
-msgstr ""
+msgstr "Weight for row @number"
 
 msgid "Label display for @title"
-msgstr ""
+msgstr "Label display for @title"
 
 msgid "Formatter for @title"
-msgstr ""
+msgstr "Formatter for @title"
 
 msgid "Parents for @title"
-msgstr ""
+msgstr "Parents for @title"
 
 msgid ""
 "There is data for this field in the database. The field settings can no "
 "longer be changed."
 msgstr ""
+"There is data for this field in the database. The field settings can no "
+"longer be changed."
 
 msgid "Weight for new file"
-msgstr ""
+msgstr "Weight for new file"
 
 msgid "Choose a file"
-msgstr ""
+msgstr "Choose a file"
 
 msgid "Weight for new effect"
-msgstr ""
+msgstr "Weight for new effect"
 
 msgid "Enable @title menu link"
-msgstr ""
+msgstr "Enable @title menu link"
 
 msgid ""
 "A unique name to construct the URL for the menu. It must only contain "
 "lowercase letters, numbers and hyphens."
 msgstr ""
+"A unique name to construct the URL for the menu. It must only contain "
+"lowercase letters, numbers and hyphens."
 
 msgid "Schema version"
-msgstr ""
+msgstr "Schema version"
 
 msgid "Number of servings"
-msgstr ""
+msgstr "Number of servings"
 
 msgid "Theme name"
-msgstr ""
+msgstr "Theme name"
 
 msgid "URL fallback"
-msgstr ""
+msgstr "URL fallback"
 
 msgid "Use an already detected language for URLs if none is found."
-msgstr ""
+msgstr "Use an already detected language for URLs if none is found."
 
 msgid "%type_name: Create new content"
-msgstr ""
+msgstr "%type_name: Create new content"
 
 msgid "%type_name: Edit own content"
-msgstr ""
+msgstr "%type_name: Edit own content"
 
 msgid "%type_name: Edit any content"
-msgstr ""
+msgstr "%type_name: Edit any content"
 
 msgid "%type_name: Delete own content"
-msgstr ""
+msgstr "%type_name: Delete own content"
 
 msgid "%type_name: Delete any content"
-msgstr ""
+msgstr "%type_name: Delete any content"
 
 msgid "New object was not saved, no error provided"
-msgstr ""
+msgstr "New object was not saved, no error provided"
 
 msgid "The published status of a comment. (0 = Published, 1 = Not Published)"
-msgstr ""
+msgstr "The published status of a comment. (0 = Published, 1 = Not Published)"
 
 msgid "The comment author's name."
-msgstr ""
+msgstr "The comment author's name."
 
 msgid "Next steps"
-msgstr ""
+msgstr "Next steps"
 
 msgid "@driver_name settings"
-msgstr ""
+msgstr "@driver_name settings"
 
 msgid "SQLite"
-msgstr ""
+msgstr "SQLite"
 
 msgid "Database file"
-msgstr ""
+msgstr "Database file"
 
 msgid ""
 "The absolute path to the file where @drupal data will be stored. This must "
 "be writable by the web server and should exist outside of the web root."
 msgstr ""
+"The absolute path to the file where @drupal data will be stored. This must "
+"be writable by the web server and should exist outside of the web root."
 
 msgid "No fields are present yet."
-msgstr ""
+msgstr "No fields are present yet."
 
 msgctxt "Font weight"
 msgid "Strong"
-msgstr ""
+msgstr "Strong"
 
 msgid "Enable newly added modules"
-msgstr ""
+msgstr "Enable newly added modules"
 
 msgid "View the administration theme"
-msgstr ""
+msgstr "View the administration theme"
 
 msgid "Indexed %count content items for tracking."
-msgstr ""
+msgstr "Indexed %count content items for tracking."
 
 msgid "Release notes for @project_title"
-msgstr ""
+msgstr "Release notes for @project_title"
 
 msgid "The role settings have been updated."
-msgstr ""
+msgstr "The role settings have been updated."
 
 msgid "Disable the account and keep its content."
-msgstr ""
+msgstr "Disable the account and keep its content."
 
 msgid "Disable the account and unpublish its content."
-msgstr ""
+msgstr "Disable the account and unpublish its content."
 
 msgid ""
 "Delete the account and make its content belong to the %anonymous-name user."
 msgstr ""
+"Delete the account and make its content belong to the %anonymous-name user."
 
 msgid "Delete the account and its content."
-msgstr ""
+msgstr "Delete the account and its content."
 
 msgid "Drupal system listing compatible test"
-msgstr ""
+msgstr "Drupal system listing compatible test"
 
 msgid "Support module for testing the drupal_system_listing function."
-msgstr ""
+msgstr "Support module for testing the drupal_system_listing function."
 
 msgid "Fixed value"
-msgstr ""
+msgstr "Fixed value"
 
 msgid "String settings"
-msgstr ""
+msgstr "String settings"
 
 msgid "Use field label instead of the \"On value\" as label"
-msgstr ""
+msgstr "Use field label instead of the \"On value\" as label"
 
 msgid "List (integer)"
-msgstr ""
+msgstr "List (integer)"
 
 msgid ""
 "This field stores integer values from a list of allowed 'value => label' "
 "pairs, i.e. 'Lifetime in days': 1 => 1 day, 7 => 1 week, 31 => 1 month."
 msgstr ""
+"This field stores integer values from a list of allowed 'value => label' "
+"pairs, i.e. 'Lifetime in days': 1 => 1 day, 7 => 1 week, 31 => 1 month."
 
 msgid "List (float)"
-msgstr ""
+msgstr "List (float)"
 
 msgid ""
 "This field stores float values from a list of allowed 'value => label' "
 "pairs, i.e. 'Fraction': 0 => 0, .25 => 1/4, .75 => 3/4, 1 => 1."
 msgstr ""
+"This field stores float values from a list of allowed 'value => label' "
+"pairs, i.e. 'Fraction': 0 => 0, .25 => 1/4, .75 => 3/4, 1 => 1."
 
 msgid ""
 "This field stores text values from a list of allowed 'value => label' pairs,"
 " i.e. 'US States': IL => Illinois, IA => Iowa, IN => Indiana."
 msgstr ""
+"This field stores text values from a list of allowed 'value => label' pairs,"
+" i.e. 'US States': IL => Illinois, IA => Iowa, IN => Indiana."
 
 msgid ""
 "The possible values this field can contain. Enter one value per line, in the"
 " format key|label."
 msgstr ""
+"The possible values this field can contain. Enter one value per line, in the"
+" format key|label."
 
 msgid ""
 "The key is the stored value, and must be numeric. The label will be used in "
 "displayed values and edit forms."
 msgstr ""
+"The key is the stored value, and must be numeric. The label will be used in "
+"displayed values and edit forms."
 
 msgid ""
 "The label is optional: if a line contains a single number, it will be used "
 "as key and label."
 msgstr ""
+"The label is optional: if a line contains a single number, it will be used "
+"as key and label."
 
 msgid ""
 "Lists of labels are also accepted (one label per line), only if the field "
 "does not hold any values yet. Numeric keys will be automatically generated "
 "from the positions in the list."
 msgstr ""
+"Lists of labels are also accepted (one label per line), only if the field "
+"does not hold any values yet. Numeric keys will be automatically generated "
+"from the positions in the list."
 
 msgid ""
 "The key is the stored value. The label will be used in displayed values and "
 "edit forms."
 msgstr ""
+"The key is the stored value. The label will be used in displayed values and "
+"edit forms."
 
 msgid ""
 "The label is optional: if a line contains a single string, it will be used "
 "as key and label."
 msgstr ""
+"The label is optional: if a line contains a single string, it will be used "
+"as key and label."
 
 msgid "Allowed values list: invalid input."
-msgstr ""
+msgstr "Allowed values list: invalid input."
 
 msgid ""
 "Allowed values list: some values are being removed while currently in use."
 msgstr ""
+"Allowed values list: some values are being removed while currently in use."
 
 msgid "The entity type."
-msgstr ""
+msgstr "The entity type."
 
 msgid "Center left"
 msgstr "Centre left"
@@ -11314,287 +11961,330 @@ msgid "Center right"
 msgstr "Centre right"
 
 msgid "Unable to parse info file: %info_file."
-msgstr ""
+msgstr "Unable to parse info file: %info_file."
 
 msgid "Custom blocks"
-msgstr ""
+msgstr "Custom blocks"
 
 msgid "HTML element"
-msgstr ""
+msgstr "HTML element"
 
 msgid "Label HTML element"
-msgstr ""
+msgstr "Label HTML element"
 
 msgid "Place a colon after the label"
-msgstr ""
+msgstr "Place a colon after the label"
 
 msgid "Wrapper HTML element"
-msgstr ""
+msgstr "Wrapper HTML element"
 
 msgid "Wrapper class"
-msgstr ""
+msgstr "Wrapper class"
 
 msgid "Add default classes"
-msgstr ""
+msgstr "Add default classes"
 
 msgid ""
 "Use default Views classes to identify the field, field label and field "
 "content."
 msgstr ""
+"Use default Views classes to identify the field, field label and field "
+"content."
 
 msgid "Use absolute path"
-msgstr ""
+msgstr "Use absolute path"
 
 msgid "Rel Text"
-msgstr ""
+msgstr "Rel Text"
 
 msgid ""
 "Include Rel attribute for use in lightbox2 or other javascript utility."
 msgstr ""
+"Include Rel attribute for use in lightbox2 or other javascript utility."
 
 msgid "Preserve certain tags"
-msgstr ""
+msgstr "Preserve certain tags"
 
 msgid "Specify validation criteria"
-msgstr ""
+msgstr "Specify validation criteria"
 
 msgid "Representative sort order"
-msgstr ""
+msgstr "Representative sort order"
 
 msgid "Hash"
-msgstr ""
+msgstr "Hash"
 
 msgid "Administer settings."
-msgstr ""
+msgstr "Administer settings."
 
 msgid "Changed date"
-msgstr ""
+msgstr "Changed date"
 
 msgid "Asc"
-msgstr ""
+msgstr "Asc"
 
 msgid "View reports, updates, and errors."
-msgstr ""
+msgstr "View reports, updates, and errors."
 
 msgid "Reference for usage, configuration, and modules."
-msgstr ""
+msgstr "Reference for usage, configuration, and modules."
 
 msgid "Database system version"
-msgstr ""
+msgstr "Database system version"
 
 msgid "Database system"
-msgstr ""
+msgstr "Database system"
 
 msgid "Install new module"
-msgstr ""
+msgstr "Install new module"
 
 msgid "Uninstall @module module"
-msgstr ""
+msgstr "Uninstall @module module"
 
 msgid ""
 "List the tags that need to be preserved during the stripping process. "
 "example &quot;&lt;p&gt; &lt;br&gt;&quot; which will preserve all p and br "
 "elements"
 msgstr ""
+"List the tags that need to be preserved during the stripping process. "
+"example &quot;&lt;p&gt; &lt;br&gt;&quot; which will preserve all p and br "
+"elements"
 
 msgid "Format plural"
-msgstr ""
+msgstr "Format plural"
 
 msgid "If checked, special handling will be used for plurality."
-msgstr ""
+msgstr "If checked, special handling will be used for plurality."
 
 msgid "Singular form"
-msgstr ""
+msgstr "Singular form"
 
 msgid "Plural form"
-msgstr ""
+msgstr "Plural form"
 
 msgid ""
 "Text to use for the plural form, @count will be replaced with the value."
 msgstr ""
+"Text to use for the plural form, @count will be replaced with the value."
 
 msgid ""
 "A unique machine-readable name for this View. It must only contain lowercase"
 " letters, numbers, and underscores."
 msgstr ""
+"A unique machine-readable name for this View. It must only contain lowercase"
+" letters, numbers, and underscores."
 
 msgid "Weight for @display"
-msgstr ""
+msgstr "Weight for @display"
 
 msgid ""
 "This title will be displayed on the views edit page instead of the default "
 "one. This might be useful if you have the same item twice."
 msgstr ""
+"This title will be displayed on the views edit page instead of the default "
+"one. This might be useful if you have the same item twice."
 
 msgid "The unique ID of the aggregator item."
-msgstr ""
+msgstr "The unique ID of the aggregator item."
 
 msgid "The guid of the original imported item."
-msgstr ""
+msgstr "The guid of the original imported item."
 
 msgid "Date and time of when the comment was created."
-msgstr ""
+msgstr "Date and time of when the comment was created."
 
 msgid "Date and time of when the comment was last updated."
-msgstr ""
+msgstr "Date and time of when the comment was last updated."
 
 msgid "Whether the comment is approved (or still in the moderation queue)."
-msgstr ""
+msgstr "Whether the comment is approved (or still in the moderation queue)."
 
 msgid "Last comment CID"
-msgstr ""
+msgstr "Last comment CID"
 
 msgid "Last Comment"
-msgstr ""
+msgstr "Last Comment"
 
 msgid ""
 "Some roles lack permission to access content, but display %display has no "
 "access control."
 msgstr ""
+"Some roles lack permission to access content, but display %display has no "
+"access control."
 
 msgid "The extension of the file."
-msgstr ""
+msgstr "The extension of the file."
 
 msgid "File Usage"
-msgstr ""
+msgstr "File Usage"
 
 msgid ""
 "A file that is associated with this node, usually because it is in a field "
 "on the node."
 msgstr ""
+"A file that is associated with this node, usually because it is in a field "
+"on the node."
 
 msgid ""
 "A user that is associated with this file, usually because this file is in a "
 "field on the user."
 msgstr ""
+"A user that is associated with this file, usually because this file is in a "
+"field on the user."
 
 msgid ""
 "A file that is associated with this user, usually because it is in a field "
 "on the user."
 msgstr ""
+"A file that is associated with this user, usually because it is in a field "
+"on the user."
 
 msgid ""
 "A comment that is associated with this file, usually because this file is in"
 " a field on the comment."
 msgstr ""
+"A comment that is associated with this file, usually because this file is in"
+" a field on the comment."
 
 msgid ""
 "A file that is associated with this comment, usually because it is in a "
 "field on the comment."
 msgstr ""
+"A file that is associated with this comment, usually because it is in a "
+"field on the comment."
 
 msgid ""
 "A taxonomy term that is associated with this file, usually because this file"
 " is in a field on the taxonomy term."
 msgstr ""
+"A taxonomy term that is associated with this file, usually because this file"
+" is in a field on the taxonomy term."
 
 msgid ""
 "A file that is associated with this taxonomy term, usually because it is in "
 "a field on the taxonomy term."
 msgstr ""
+"A file that is associated with this taxonomy term, usually because it is in "
+"a field on the taxonomy term."
 
 msgid "The module managing this file relationship."
-msgstr ""
+msgstr "The module managing this file relationship."
 
 msgid "The type of entity that is related to the file."
-msgstr ""
+msgstr "The type of entity that is related to the file."
 
 msgid "The number of times the file is used by this entity."
-msgstr ""
+msgstr "The number of times the file is used by this entity."
 
 msgid ""
 "Used by Style: Table to determine the actual column to click sort the field "
 "on. The default is usually fine."
 msgstr ""
+"Used by Style: Table to determine the actual column to click sort the field "
+"on. The default is usually fine."
 
 msgid "Group column"
-msgstr ""
+msgstr "Group column"
 
 msgid ""
 "Select the column of this field to apply the grouping function selected "
 "above."
 msgstr ""
+"Select the column of this field to apply the grouping function selected "
+"above."
 
 msgid "Group columns (additional)"
-msgstr ""
+msgstr "Group columns (additional)"
 
 msgid ""
 "Select any additional columns of this field to include in the query and to "
 "group on."
 msgstr ""
+"Select any additional columns of this field to include in the query and to "
+"group on."
 
 msgid "Display download path instead of file storage URI"
-msgstr ""
+msgstr "Display download path instead of file storage URI"
 
 msgid "The machine name for the vocabulary the term belongs to."
-msgstr ""
+msgstr "The machine name for the vocabulary the term belongs to."
 
 msgid "Display error message"
-msgstr ""
+msgstr "Display error message"
 
 msgid "Comment or document this display."
-msgstr ""
+msgstr "Comment or document this display."
 
 msgid "Query settings"
-msgstr ""
+msgstr "Query settings"
 
 msgid "Allow to set some advanced settings for the query plugin"
-msgstr ""
+msgstr "Allow to set some advanced settings for the query plugin"
 
 msgid "The name and the description of this display"
-msgstr ""
+msgstr "The name and the description of this display"
 
 msgid "Query options"
-msgstr ""
+msgstr "Query options"
 
 msgid "Display name must be letters, numbers, or underscores only."
-msgstr ""
+msgstr "Display name must be letters, numbers, or underscores only."
 
 msgid ""
 "Should this display inherit its paging values from the parent display to "
 "which it is attached?"
 msgstr ""
+"Should this display inherit its paging values from the parent display to "
+"which it is attached?"
 
 msgid ""
 "Should this display render the pager values? This is only meaningful if "
 "inheriting a pager."
 msgstr ""
+"Should this display render the pager values? This is only meaningful if "
+"inheriting a pager."
 
 msgid ""
 "This will appear as the name of this block in administer >> structure >> "
 "blocks."
 msgstr ""
+"This will appear as the name of this block in administer >> structure >> "
+"blocks."
 
 msgid ""
 "Text to display instead of results until the user selects and applies an "
 "exposed filter."
 msgstr ""
+"Text to display instead of results until the user selects and applies an "
+"exposed filter."
 
 msgid "Include all items option"
-msgstr ""
+msgstr "Include all items option"
 
 msgid "All items label"
-msgstr ""
+msgstr "All items label"
 
 msgid "Disable SQL rewriting"
-msgstr ""
+msgstr "Disable SQL rewriting"
 
 msgid "The class to provide on each row."
-msgstr ""
+msgstr "The class to provide on each row."
 
 msgid ""
 "You may use field tokens from as per the \"Replacement patterns\" used in "
 "\"Rewrite the output of this field\" for all fields."
 msgstr ""
+"You may use field tokens from as per the \"Replacement patterns\" used in "
+"\"Rewrite the output of this field\" for all fields."
 
 msgid "The class to provide on the wrapper, outside the list."
-msgstr ""
+msgstr "The class to provide on the wrapper, outside the list."
 
 msgid "List class"
-msgstr ""
+msgstr "List class"
 
 msgid "The class to provide on the list element itself."
-msgstr ""
+msgstr "The class to provide on the list element itself."
 
 msgid ""
 "Define the base path for links in this summary\n"
@@ -11603,595 +12293,659 @@ msgid ""
 "        is empty, views will use the first path found as the base path,\n"
 "        in page displays, or / if no path could be found."
 msgstr ""
+"Define the base path for links in this summary\n"
+"        view, i.e. http://example.com/<strong>your_view_path/archive</strong>.\n"
+"        Do not include beginning and ending forward slash. If this value\n"
+"        is empty, views will use the first path found as the base path,\n"
+"        in page displays, or / if no path could be found."
 
 msgid "Content access"
-msgstr ""
+msgstr "Content access"
 
 msgctxt "ampm"
 msgid "am"
-msgstr ""
+msgstr "am"
 
 msgctxt "ampm"
 msgid "pm"
-msgstr ""
+msgstr "pm"
 
 msgid "Sticky status"
-msgstr ""
+msgstr "Sticky status"
 
 msgid "RSS category"
-msgstr ""
+msgstr "RSS category"
 
 msgid "RSS enclosure"
-msgstr ""
+msgstr "RSS enclosure"
 
 msgid "Paste your configuration here"
-msgstr ""
+msgstr "Paste your configuration here"
 
 msgid "Import configuration"
-msgstr ""
+msgstr "Import configuration"
 
 msgid "5 minute"
-msgstr ""
+msgstr "5 minute"
 
 msgid "15 minute"
-msgstr ""
+msgstr "15 minute"
 
 msgid "URL to image"
-msgstr ""
+msgstr "URL to image"
 
 msgid "Content revisions"
-msgstr ""
+msgstr "Content revisions"
 
 msgid "%time hence"
-msgstr ""
+msgstr "%time hence"
 
 msgid "Language selection"
-msgstr ""
+msgstr "Language selection"
 
 msgid "Delete all translations"
-msgstr ""
+msgstr "Delete all translations"
 
 msgid "No Access"
-msgstr ""
+msgstr "No Access"
 
 msgid "Search page path"
-msgstr ""
+msgstr "Search page path"
 
 msgid "Many to one"
-msgstr ""
+msgstr "Many to one"
 
 msgid "All Day"
-msgstr ""
+msgstr "All Day"
 
 msgid "Upscale"
-msgstr ""
+msgstr "Upscale"
 
 msgid "Logo settings"
-msgstr ""
+msgstr "Logo settings"
 
 msgid "Delete field."
-msgstr ""
+msgstr "Delete field."
 
 msgid "No results behavior"
-msgstr ""
+msgstr "No results behavior"
 
 msgid "Edit @section"
-msgstr ""
+msgstr "Edit @section"
 
 msgid "View to insert"
-msgstr ""
+msgstr "View to insert"
 
 msgid "The view to insert into this area."
-msgstr ""
+msgstr "The view to insert into this area."
 
 msgid "Inherit contextual filters"
-msgstr ""
+msgstr "Inherit contextual filters"
 
 msgid ""
 "If checked, this view will receive the same contextual filters as its "
 "parent."
 msgstr ""
+"If checked, this view will receive the same contextual filters as its "
+"parent."
 
 msgid "Recursion detected in view @view display @display."
-msgstr ""
+msgstr "Recursion detected in view @view display @display."
 
 msgid "When the filter value is <em>NOT</em> in the URL"
-msgstr ""
+msgstr "When the filter value is <em>NOT</em> in the URL"
 
 msgid "Exception value"
-msgstr ""
+msgstr "Exception value"
 
 msgid "If this value is received, the filter will be ignored; i.e, \"all values\""
 msgstr ""
+"If this value is received, the filter will be ignored; i.e, \"all values\""
 
 msgid "When the filter value <em>IS</em> in the URL or a default is provided"
-msgstr ""
+msgstr "When the filter value <em>IS</em> in the URL or a default is provided"
 
 msgid "Provide title"
-msgstr ""
+msgstr "Provide title"
 
 msgid "Custom block"
-msgstr ""
+msgstr "Custom block"
 
 msgid "Action to take if filter value does not validate"
-msgstr ""
+msgstr "Action to take if filter value does not validate"
 
 msgid "Display all results for the specified field"
-msgstr ""
+msgstr "Display all results for the specified field"
 
 msgid "Provide default value"
-msgstr ""
+msgstr "Provide default value"
 
 msgid "Show \"Page not found\""
-msgstr ""
+msgstr "Show \"Page not found\""
 
 msgid "Display a summary"
-msgstr ""
+msgstr "Display a summary"
 
 msgid "Display contents of \"No results found\""
-msgstr ""
+msgstr "Display contents of \"No results found\""
 
 msgid "Skip default argument for view URL"
-msgstr ""
+msgstr "Skip default argument for view URL"
 
 msgid ""
 "Select whether to include this default argument when constructing the URL "
 "for this view. Skipping default arguments is useful e.g. in the case of "
 "feeds."
 msgstr ""
+"Select whether to include this default argument when constructing the URL "
+"for this view. Skipping default arguments is useful e.g. in the case of "
+"feeds."
 
 msgid "Number of records"
-msgstr ""
+msgstr "Number of records"
 
 msgctxt "Sort order"
 msgid "Default sort"
-msgstr ""
+msgstr "Default sort"
 
 msgctxt "Sort order"
 msgid "Date"
-msgstr ""
+msgstr "Date"
 
 msgctxt "Sort order"
 msgid "Numerical"
-msgstr ""
+msgstr "Numerical"
 
 msgid ""
 "If selected, users can enter multiple values in the form of 1+2+3 (for OR) "
 "or 1,2,3 (for AND)."
 msgstr ""
+"If selected, users can enter multiple values in the form of 1+2+3 (for OR) "
+"or 1,2,3 (for AND)."
 
 msgid ""
 "If selected, multiple instances of this filter can work together, as though "
 "multiple values were supplied to the same filter. This setting is not "
 "compatible with the \"Reduce duplicates\" setting."
 msgstr ""
+"If selected, multiple instances of this filter can work together, as though "
+"multiple values were supplied to the same filter. This setting is not "
+"compatible with the \"Reduce duplicates\" setting."
 
 msgid ""
 "If selected, the numbers entered for the filter will be excluded rather than"
 " limiting the view."
 msgstr ""
+"If selected, the numbers entered for the filter will be excluded rather than"
+" limiting the view."
 
 msgid ""
 "Glossary mode applies a limit to the number of characters used in the filter"
 " value, which allows the summary view to act as a glossary."
 msgstr ""
+"Glossary mode applies a limit to the number of characters used in the filter"
+" value, which allows the summary view to act as a glossary."
 
 msgid ""
 "How many characters of the filter value to filter against. If set to 1, all "
 "fields starting with the first letter in the filter value would be matched."
 msgstr ""
+"How many characters of the filter value to filter against. If set to 1, all "
+"fields starting with the first letter in the filter value would be matched."
 
 msgid ""
 "When printing the title and summary, how to transform the case of the filter"
 " value."
 msgstr ""
+"When printing the title and summary, how to transform the case of the filter"
+" value."
 
 msgctxt "Sort order"
 msgid "Alphabetical"
-msgstr ""
+msgstr "Alphabetical"
 
 msgid "Create a label"
-msgstr ""
+msgstr "Create a label"
 
 msgid ""
 "Enable to load this field as hidden. Often used to group fields, or to use "
 "as token in another field."
 msgstr ""
+"Enable to load this field as hidden. Often used to group fields, or to use "
+"as token in another field."
 
 msgid "Choose the HTML element to wrap around this field, e.g. H1, H2, etc."
-msgstr ""
+msgstr "Choose the HTML element to wrap around this field, e.g. H1, H2, etc."
 
 msgid "Create a CSS class"
-msgstr ""
+msgstr "Create a CSS class"
 
 msgid "Choose the HTML element to wrap around this label, e.g. H1, H2, etc."
-msgstr ""
+msgstr "Choose the HTML element to wrap around this label, e.g. H1, H2, etc."
 
 msgid "Rewrite results"
-msgstr ""
+msgstr "Rewrite results"
 
 msgid "Replace spaces with dashes"
-msgstr ""
+msgstr "Replace spaces with dashes"
 
 msgid "External server URL"
-msgstr ""
+msgstr "External server URL"
 
 msgid ""
 "Links to an external server using a full URL: e.g. 'http://www.example.com' "
 "or 'www.example.com'."
 msgstr ""
+"Links to an external server using a full URL: e.g. 'http://www.example.com' "
+"or 'www.example.com'."
 
 msgid "Convert newlines to HTML &lt;br&gt; tags"
-msgstr ""
+msgstr "Convert newlines to HTML &lt;br&gt; tags"
 
 msgid "No results text"
-msgstr ""
+msgstr "No results text"
 
 msgid ""
 "Enable to display the \"no results text\" if the field contains the number "
 "0."
 msgstr ""
+"Enable to display the \"no results text\" if the field contains the number "
+"0."
 
 msgid "Time hence"
-msgstr ""
+msgstr "Time hence"
 
 msgid "Time hence (with \"hence\" appended)"
-msgstr ""
+msgstr "Time hence (with \"hence\" appended)"
 
 msgid "Time span (future dates have \"-\" prepended)"
-msgstr ""
+msgstr "Time span (future dates have \"-\" prepended)"
 
 msgid "Time span (past dates have \"-\" prepended)"
-msgstr ""
+msgstr "Time span (past dates have \"-\" prepended)"
 
 msgid ""
 "How should the serialized data be displayed. You can choose a custom "
 "array/object key or a print_r on the full output."
 msgstr ""
+"How should the serialized data be displayed. You can choose a custom "
+"array/object key or a print_r on the full output."
 
 msgid "Full data (unserialized)"
-msgstr ""
+msgstr "Full data (unserialized)"
 
 msgid "A certain key"
-msgstr ""
+msgstr "A certain key"
 
 msgid "Which key should be displayed"
-msgstr ""
+msgstr "Which key should be displayed"
 
 msgid "You have to enter a key if you want to display a key of the data."
-msgstr ""
+msgstr "You have to enter a key if you want to display a key of the data."
 
 msgid "How many different units to display in the string."
-msgstr ""
+msgstr "How many different units to display in the string."
 
 msgid "This filter is not exposed. Expose it to allow the users to change it."
 msgstr ""
+"This filter is not exposed. Expose it to allow the users to change it."
 
 msgid "Expose filter"
-msgstr ""
+msgstr "Expose filter"
 
 msgid ""
 "This filter is exposed. If you hide it, users will not be able to change it."
 msgstr ""
+"This filter is exposed. If you hide it, users will not be able to change it."
 
 msgid "Hide filter"
-msgstr ""
+msgstr "Hide filter"
 
 msgid "Expose operator"
-msgstr ""
+msgstr "Expose operator"
 
 msgid "Allow the user to choose the operator."
-msgstr ""
+msgstr "Allow the user to choose the operator."
 
 msgid "Allow multiple selections"
-msgstr ""
+msgstr "Allow multiple selections"
 
 msgid "Enable to allow users to select multiple items."
-msgstr ""
+msgstr "Enable to allow users to select multiple items."
 
 msgid "Remember the last selection"
-msgstr ""
+msgstr "Remember the last selection"
 
 msgid "Enable to remember the last selection made by the user."
-msgstr ""
+msgstr "Enable to remember the last selection made by the user."
 
 msgid "You must select a value unless this is an non-required exposed filter."
 msgstr ""
+"You must select a value unless this is an non-required exposed filter."
 
 msgid "Enable to hide items that do not contain this relationship"
-msgstr ""
+msgstr "Enable to hide items that do not contain this relationship"
 
 msgid "This sort is not exposed. Expose it to allow the users to change it."
-msgstr ""
+msgstr "This sort is not exposed. Expose it to allow the users to change it."
 
 msgid "Expose sort"
-msgstr ""
+msgstr "Expose sort"
 
 msgid ""
 "This sort is exposed. If you hide it, users will not be able to change it."
 msgstr ""
+"This sort is exposed. If you hide it, users will not be able to change it."
 
 msgid "Hide sort"
-msgstr ""
+msgstr "Hide sort"
 
 msgid "Provide description"
-msgstr ""
+msgstr "Provide description"
 
 msgid "Update \"@title\" choice"
-msgstr ""
+msgstr "Update \"@title\" choice"
 
 msgid "Update \"@title\" choice (@number)"
-msgstr ""
+msgstr "Update \"@title\" choice (@number)"
 
 msgid "Auto preview"
-msgstr ""
+msgstr "Auto preview"
 
 msgid "Preview with contextual filters:"
-msgstr ""
+msgstr "Preview with contextual filters:"
 
 msgid "Separate contextual filter values with a \"/\". For example, %example."
-msgstr ""
+msgstr "Separate contextual filter values with a \"/\". For example, %example."
 
 msgid ":"
-msgstr ""
+msgstr ":"
 
 msgid "Apply and continue"
-msgstr ""
+msgstr "Apply and continue"
 
 msgid "@current of @total"
-msgstr ""
+msgstr "@current of @total"
 
 msgid "All displays (except overridden)"
-msgstr ""
+msgstr "All displays (except overridden)"
 
 msgid "All displays"
-msgstr ""
+msgstr "All displays"
 
 msgid "This @display_type (override)"
-msgstr ""
+msgstr "This @display_type (override)"
 
 msgid "Create new filter group"
-msgstr ""
+msgstr "Create new filter group"
 
 msgid "No filters have been added."
-msgstr ""
+msgstr "No filters have been added."
 
 msgid "Drag to add filters."
-msgstr ""
+msgstr "Drag to add filters."
 
 msgid "Add and configure @types"
-msgstr ""
+msgstr "Add and configure @types"
 
 msgid "Configure @type: @item"
-msgstr ""
+msgstr "Configure @type: @item"
 
 msgid "Always show advanced display settings"
-msgstr ""
+msgstr "Always show advanced display settings"
 
 msgid "Label for \"Any\" value on non-required single-select exposed filters"
-msgstr ""
+msgstr "Label for \"Any\" value on non-required single-select exposed filters"
 
 msgid "Live preview settings"
-msgstr ""
+msgstr "Live preview settings"
 
 msgid "Automatically update preview on changes"
-msgstr ""
+msgstr "Automatically update preview on changes"
 
 msgid "Show information and statistics about the view during live preview"
-msgstr ""
+msgstr "Show information and statistics about the view during live preview"
 
 msgid "Above the preview"
-msgstr ""
+msgstr "Above the preview"
 
 msgid "Below the preview"
-msgstr ""
+msgstr "Below the preview"
 
 msgid "Show the SQL query"
-msgstr ""
+msgstr "Show the SQL query"
 
 msgid "Show performance statistics"
-msgstr ""
+msgstr "Show performance statistics"
 
 msgid "Display"
 msgid_plural "Displays"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Display"
+msgstr[1] "Displays"
 
 msgid "Unformatted list"
-msgstr ""
+msgstr "Unformatted list"
 
 msgid "Contextual filters"
-msgstr ""
+msgstr "Contextual filters"
 
 msgid "contextual filters"
-msgstr ""
+msgstr "contextual filters"
 
 msgid "Contextual filter"
-msgstr ""
+msgstr "Contextual filter"
 
 msgid "contextual filter"
-msgstr ""
+msgstr "contextual filter"
 
 msgid "filter criteria"
-msgstr ""
+msgstr "filter criteria"
 
 msgid "Filter criterion"
-msgstr ""
+msgstr "Filter criterion"
 
 msgid "filter criterion"
-msgstr ""
+msgstr "filter criterion"
 
 msgid "no results behavior"
-msgstr ""
+msgstr "no results behavior"
 
 msgid "The node ID."
-msgstr ""
+msgstr "The node ID."
 
 msgid "The content title."
-msgstr ""
+msgstr "The content title."
 
 msgid "The date the content was posted."
-msgstr ""
+msgstr "The date the content was posted."
 
 msgid "Filters out unpublished content if the current user cannot view it."
-msgstr ""
+msgstr "Filters out unpublished content if the current user cannot view it."
 
 msgid "Whether or not the content is sticky."
-msgstr ""
+msgstr "Whether or not the content is sticky."
 
 msgid ""
 "Whether or not the content is sticky. To list sticky content first, set this"
 " to descending."
 msgstr ""
+"Whether or not the content is sticky. To list sticky content first, set this"
+" to descending."
 
 msgid "Relate content to the user who created it."
-msgstr ""
+msgstr "Relate content to the user who created it."
 
 msgid "User has a revision"
-msgstr ""
+msgstr "User has a revision"
 
 msgid "All nodes where a certain user has a revision"
-msgstr ""
+msgstr "All nodes where a certain user has a revision"
 
 msgid "Content revision is a history of changes to content."
-msgstr ""
+msgstr "Content revision is a history of changes to content."
 
 msgid "Relate a content revision to the user who created the revision."
-msgstr ""
+msgstr "Relate a content revision to the user who created the revision."
 
 msgid "Get the actual content from a content revision."
-msgstr ""
+msgstr "Get the actual content from a content revision."
 
 msgid "Provide a simple link to delete the content revision."
-msgstr ""
+msgstr "Provide a simple link to delete the content revision."
 
 msgid ""
 "Filter for content by view access. <strong>Not necessary if you are using "
 "node as your base table.</strong>"
 msgstr ""
+"Filter for content by view access. <strong>Not necessary if you are using "
+"node as your base table.</strong>"
 
 msgid "Show a marker if the content is new or updated."
-msgstr ""
+msgstr "Show a marker if the content is new or updated."
 
 msgid "Show only content that is new or updated."
-msgstr ""
+msgstr "Show only content that is new or updated."
 
 msgid "Display the content with standard node view."
-msgstr ""
+msgstr "Display the content with standard node view."
 
 msgid "Content ID from URL"
-msgstr ""
+msgstr "Content ID from URL"
 
 msgid ""
 "Content that is associated with this file, usually because this file is in a"
 " field on the content."
 msgstr ""
+"Content that is associated with this file, usually because this file is in a"
+" field on the content."
 
 msgid ""
 "Allows the \"depth\" for Taxonomy: Term ID (with depth) to be modified via "
 "an additional contextual filter value."
 msgstr ""
+"Allows the \"depth\" for Taxonomy: Term ID (with depth) to be modified via "
+"an additional contextual filter value."
 
 msgid "Content authored"
-msgstr ""
+msgstr "Content authored"
 
 msgid ""
 "Relate content to the user who created it. This relationship will create one"
 " record for each content item created by the user."
 msgstr ""
+"Relate content to the user who created it. This relationship will create one"
+" record for each content item created by the user."
 
 msgid ""
 "Allow a contextual filter value to be ignored. The query will not be altered"
 " by this contextual filter value. Can be used when contextual filter values "
 "come from the URL, and a part of the URL needs to be ignored."
 msgstr ""
+"Allow a contextual filter value to be ignored. The query will not be altered"
+" by this contextual filter value. Can be used when contextual filter values "
+"come from the URL, and a part of the URL needs to be ignored."
 
 msgid "View area"
-msgstr ""
+msgstr "View area"
 
 msgid "Insert a view inside an area."
-msgstr ""
+msgstr "Insert a view inside an area."
 
 msgid "Enable to override this field's links."
-msgstr ""
+msgstr "Enable to override this field's links."
 
 msgid "Use field template"
-msgstr ""
+msgstr "Use field template"
 
 msgid ""
 "Checking this option will cause the group Display Type and Separator values "
 "to be ignored."
 msgstr ""
+"Checking this option will cause the group Display Type and Separator values "
+"to be ignored."
 
 msgid "Multiple field settings"
-msgstr ""
+msgstr "Multiple field settings"
 
 msgid "Display all values in the same row"
-msgstr ""
+msgstr "Display all values in the same row"
 
 msgid "Display @count value(s)"
-msgstr ""
+msgstr "Display @count value(s)"
 
 msgid "Raw @column"
-msgstr ""
+msgstr "Raw @column"
 
 msgid "Link this field to the original piece of content"
-msgstr ""
+msgstr "Link this field to the original piece of content"
 
 msgid ""
 "Enable this option to output an absolute link. Required if you want to use "
 "the path as a link destination (as in \"output this field as a link\" "
 "above)."
 msgstr ""
+"Enable this option to output an absolute link. Required if you want to use "
+"the path as a link destination (as in \"output this field as a link\" "
+"above)."
 
 msgid "Access operation to check"
-msgstr ""
+msgstr "Access operation to check"
 
 msgid ""
 "If selected, users can enter multiple values in the form of 1+2+3. Due to "
 "the number of JOINs it would require, AND will be treated as OR with this "
 "filter."
 msgstr ""
+"If selected, users can enter multiple values in the form of 1+2+3. Due to "
+"the number of JOINs it would require, AND will be treated as OR with this "
+"filter."
 
 msgid "Load default filter from term page"
-msgstr ""
+msgstr "Load default filter from term page"
 
 msgid "Transform dashes in URL to spaces in term name filter values"
-msgstr ""
+msgstr "Transform dashes in URL to spaces in term name filter values"
 
 msgid ""
 "Note: you do not have permission to modify this. If you change the default "
 "filter type, this setting will be lost and you will NOT be able to get it "
 "back."
 msgstr ""
+"Note: you do not have permission to modify this. If you change the default "
+"filter type, this setting will be lost and you will NOT be able to get it "
+"back."
 
 msgid "Change the way content is formatted."
-msgstr ""
+msgstr "Change the way content is formatted."
 
 msgid "Change settings for this format"
-msgstr ""
+msgstr "Change settings for this format"
 
 msgid "Change the way each row in the view is styled."
-msgstr ""
+msgstr "Change the way each row in the view is styled."
 
 msgid "Hide attachments in summary"
-msgstr ""
+msgstr "Hide attachments in summary"
 
 msgid ""
 "Change whether or not to display attachments when displaying a contextual "
 "filter summary."
 msgstr ""
+"Change whether or not to display attachments when displaying a contextual "
+"filter summary."
 
 msgid "Hide attachments when displaying a contextual filter summary"
-msgstr ""
+msgstr "Hide attachments when displaying a contextual filter summary"
 
 msgid "Attachment position"
-msgstr ""
+msgstr "Attachment position"
 
 msgid ""
 "Should this display inherit its contextual filter values from the parent "
 "display to which it is attached?"
 msgstr ""
+"Should this display inherit its contextual filter values from the parent "
+"display to which it is attached?"
 
 msgid ""
 "This view will be displayed by visiting this path on your site. It is "
@@ -12199,180 +12953,192 @@ msgid ""
 "\"path/%/%/rss.xml\", putting one % in the path for each contextual filter "
 "you have defined in the view."
 msgstr ""
+"This view will be displayed by visiting this path on your site. It is "
+"recommended that the path be something like \"path/%/%/feed\" or "
+"\"path/%/%/rss.xml\", putting one % in the path for each contextual filter "
+"you have defined in the view."
 
 msgid ""
 "Display @display is set to use a menu but the menu link text is not set."
 msgstr ""
+"Display @display is set to use a menu but the menu link text is not set."
 
 msgid ""
 "Display @display is set to use a parent menu but the parent menu link text "
 "is not set."
 msgstr ""
+"Display @display is set to use a parent menu but the parent menu link text "
+"is not set."
 
 msgid "@count item, skip @skip"
 msgid_plural "Paged, @count items, skip @skip"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count item, skip @skip"
+msgstr[1] "Paged, @count items, skip @skip"
 
 msgid "@count item"
 msgid_plural "Paged, @count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count item"
+msgstr[1] "Paged, @count items"
 
 msgid "Create a page"
-msgstr ""
+msgstr "Create a page"
 
 msgid "Create a menu link"
-msgstr ""
+msgstr "Create a menu link"
 
 msgid "Include an RSS feed"
-msgstr ""
+msgstr "Include an RSS feed"
 
 msgid "Feed path"
-msgstr ""
+msgstr "Feed path"
 
 msgid "Feed row style"
-msgstr ""
+msgstr "Feed row style"
 
 msgid "Create a block"
-msgstr ""
+msgstr "Create a block"
 
 msgid "of fields"
-msgstr ""
+msgstr "of fields"
 
 msgid "of type"
-msgstr ""
+msgstr "of type"
 
 msgid "tagged with"
-msgstr ""
+msgstr "tagged with"
 
 msgid "teasers"
-msgstr ""
+msgstr "teasers"
 
 msgid "full posts"
-msgstr ""
+msgstr "full posts"
 
 msgid "titles"
-msgstr ""
+msgstr "titles"
 
 msgid "titles (linked)"
-msgstr ""
+msgstr "titles (linked)"
 
 msgid "Sorts"
-msgstr ""
+msgstr "Sorts"
 
 msgid "Hide view"
-msgstr ""
+msgstr "Hide view"
 
 msgid "@group (historical data)"
-msgstr ""
+msgstr "@group (historical data)"
 
 msgid "Use path alias"
-msgstr ""
+msgstr "Use path alias"
 
 msgid "Field mappings"
-msgstr ""
+msgstr "Field mappings"
 
 msgid "Cooking time"
-msgstr ""
+msgstr "Cooking time"
 
 msgid "View any unpublished content"
-msgstr ""
+msgstr "View any unpublished content"
 
 msgid "Relative default value"
-msgstr ""
+msgstr "Relative default value"
 
 msgid "The comment UUID."
-msgstr ""
+msgstr "The comment UUID."
 
 msgid "The file UUID."
-msgstr ""
+msgstr "The file UUID."
 
 msgid "The term UUID."
-msgstr ""
+msgstr "The term UUID."
 
 msgid "The user UUID."
-msgstr ""
+msgstr "The user UUID."
 
 msgid "Field item"
-msgstr ""
+msgstr "Field item"
 
 msgid "Edit shortcut set"
-msgstr ""
+msgstr "Edit shortcut set"
 
 msgid "Appearance settings"
-msgstr ""
+msgstr "Appearance settings"
 
 msgid "Delete translation"
-msgstr ""
+msgstr "Delete translation"
 
 msgid "Unsorted"
-msgstr ""
+msgstr "Unsorted"
 
 msgid "Changes to the style have been saved."
-msgstr ""
+msgstr "Changes to the style have been saved."
 
 msgid "Media query"
-msgstr ""
+msgstr "Media query"
 
 msgid "Aggregation type"
-msgstr ""
+msgstr "Aggregation type"
 
 msgid "Mapping type"
-msgstr ""
+msgstr "Mapping type"
 
 msgid "Create media"
-msgstr ""
+msgstr "Create media"
 
 msgid "Use replacement tokens from the first row"
-msgstr ""
+msgstr "Use replacement tokens from the first row"
 
 msgid "Allow multiple filter values to work together"
-msgstr ""
+msgstr "Allow multiple filter values to work together"
 
 msgid "Customize field HTML"
-msgstr ""
+msgstr "Customize field HTML"
 
 msgid ""
 "You may use token substitutions from the rewriting section in this class."
 msgstr ""
+"You may use token substitutions from the rewriting section in this class."
 
 msgid "Customize label HTML"
-msgstr ""
+msgstr "Customize label HTML"
 
 msgid "Customize field and label wrapper HTML"
-msgstr ""
+msgstr "Customize field and label wrapper HTML"
 
 msgid ""
 "Choose the HTML element to wrap around this field and label, e.g. H1, H2, "
 "etc. This may not be used if the field and label are not rendered together, "
 "such as with a table."
 msgstr ""
+"Choose the HTML element to wrap around this field and label, e.g. H1, H2, "
+"etc. This may not be used if the field and label are not rendered together, "
+"such as with a table."
 
 msgid "Remove whitespace"
-msgstr ""
+msgstr "Remove whitespace"
 
 msgid "Hide rewriting if empty"
-msgstr ""
+msgstr "Hide rewriting if empty"
 
 msgid "Do not display rewritten content if this field is empty."
-msgstr ""
+msgstr "Do not display rewritten content if this field is empty."
 
 msgid "Thousands marker"
-msgstr ""
+msgstr "Thousands marker"
 
 msgid "Expose this filter to visitors, to allow them to change it"
-msgstr ""
+msgstr "Expose this filter to visitors, to allow them to change it"
 
 msgid "Subquery namespace"
-msgstr ""
+msgstr "Subquery namespace"
 
 msgid ""
 "Advanced. Enter a namespace for the subquery used by this relationship."
 msgstr ""
+"Advanced. Enter a namespace for the subquery used by this relationship."
 
 msgid "Representative view"
-msgstr ""
+msgstr "Representative view"
 
 msgid ""
 "Advanced. Use another view to generate the relationship subquery. This "
@@ -12380,407 +13146,453 @@ msgid ""
 " the sort options above are ignored. Your view must have the ID of its base "
 "as its only field, and should have some kind of sorting."
 msgstr ""
+"Advanced. Use another view to generate the relationship subquery. This "
+"allows you to use filtering and more than one sort. If you pick a view here,"
+" the sort options above are ignored. Your view must have the ID of its base "
+"as its only field, and should have some kind of sorting."
 
 msgid ""
 "Will re-generate the subquery for this relationship every time the view is "
 "run, instead of only when these options are saved. Use for testing if you "
 "are making changes elsewhere. WARNING: seriously impairs performance."
 msgstr ""
+"Will re-generate the subquery for this relationship every time the view is "
+"run, instead of only when these options are saved. Use for testing if you "
+"are making changes elsewhere. WARNING: seriously impairs performance."
 
 msgid "Expose this sort to visitors, to allow them to change it"
-msgstr ""
+msgstr "Expose this sort to visitors, to allow them to change it"
 
 msgid "This display is disabled."
-msgstr ""
+msgstr "This display is disabled."
 
 msgid ""
 "Error: Display @display refers to a plugin named '@plugin', but that plugin "
 "is not available."
 msgstr ""
+"Error: Display @display refers to a plugin named '@plugin', but that plugin "
+"is not available."
 
 msgid "Aggregation settings"
-msgstr ""
+msgstr "Aggregation settings"
 
 msgid "Display extenders"
-msgstr ""
+msgstr "Display extenders"
 
 msgid "Select extensions of the views interface."
-msgstr ""
+msgstr "Select extensions of the views interface."
 
 msgid ""
 "You have configured display %display with a path which is an path alias as "
 "well. This might lead to unwanted effects so better use an internal path."
 msgstr ""
+"You have configured display %display with a path which is an path alias as "
+"well. This might lead to unwanted effects so better use an internal path."
 
 msgid "Configure aggregation settings for @type %item"
-msgstr ""
+msgstr "Configure aggregation settings for @type %item"
 
 msgid "Select the aggregation function to use on this field."
-msgstr ""
+msgstr "Select the aggregation function to use on this field."
 
 msgid "Empty display extender"
-msgstr ""
+msgstr "Empty display extender"
 
 msgid "Raw value from URL"
-msgstr ""
+msgstr "Raw value from URL"
 
 msgid "Apply (all displays)"
-msgstr ""
+msgstr "Apply (all displays)"
 
 msgid "Apply (this display)"
-msgstr ""
+msgstr "Apply (this display)"
 
 msgid "The date of the most recent new content on the feed."
-msgstr ""
+msgstr "The date of the most recent new content on the feed."
 
 msgid "This is an alias of @group: @field."
-msgstr ""
+msgstr "This is an alias of @group: @field."
 
 msgid "@label:delta"
-msgstr ""
+msgstr "@label:delta"
 
 msgid "Delta - Appears in: @bundles."
-msgstr ""
+msgstr "Delta - Appears in: @bundles."
 
 msgid "User who uploaded"
-msgstr ""
+msgstr "User who uploaded"
 
 msgid "Taxonomy term chosen from autocomplete or select widget."
-msgstr ""
+msgstr "Taxonomy term chosen from autocomplete or select widget."
 
 msgid "Representative node"
-msgstr ""
+msgstr "Representative node"
 
 msgid ""
 "Obtains a single representative node for each term, according to a chosen "
 "sort criterion."
 msgstr ""
+"Obtains a single representative node for each term, according to a chosen "
+"sort criterion."
 
 msgid "Content with term"
-msgstr ""
+msgstr "Content with term"
 
 msgid "Relate all content tagged with a term."
-msgstr ""
+msgstr "Relate all content tagged with a term."
 
 msgid "Has taxonomy term ID"
-msgstr ""
+msgstr "Has taxonomy term ID"
 
 msgid "Display content if it has the selected taxonomy terms."
-msgstr ""
+msgstr "Display content if it has the selected taxonomy terms."
 
 msgid "Has taxonomy term"
-msgstr ""
+msgstr "Has taxonomy term"
 
 msgid "Taxonomy terms on node"
-msgstr ""
+msgstr "Taxonomy terms on node"
 
 msgid "All taxonomy terms"
-msgstr ""
+msgstr "All taxonomy terms"
 
 msgid ""
 "Display content if it has the selected taxonomy terms, or children of the "
 "selected terms. Due to additional complexity, this has fewer options than "
 "the versions without depth."
 msgstr ""
+"Display content if it has the selected taxonomy terms, or children of the "
+"selected terms. Due to additional complexity, this has fewer options than "
+"the versions without depth."
 
 msgid "Has taxonomy term ID (with depth)"
-msgstr ""
+msgstr "Has taxonomy term ID (with depth)"
 
 msgid "Has taxonomy terms (with depth)"
-msgstr ""
+msgstr "Has taxonomy terms (with depth)"
 
 msgid "Has taxonomy term ID depth modifier"
-msgstr ""
+msgstr "Has taxonomy term ID depth modifier"
 
 msgid "@entity using @field"
-msgstr ""
+msgstr "@entity using @field"
 
 msgid "Taxonomy term ID from URL"
-msgstr ""
+msgstr "Taxonomy term ID from URL"
 
 msgid ""
 "Obtains a single representative node for each user, according to a chosen "
 "sort criterion."
 msgstr ""
+"Obtains a single representative node for each user, according to a chosen "
+"sort criterion."
 
 msgid ""
 "Display an icon representing the file type, instead of the MIME text (such "
 "as \"image/jpeg\")"
 msgstr ""
+"Display an icon representing the file type, instead of the MIME text (such "
+"as \"image/jpeg\")"
 
 msgid ""
 "Load default filter from node page, that's good for related taxonomy blocks"
 msgstr ""
+"Load default filter from node page, that's good for related taxonomy blocks"
 
 msgid "Path component"
-msgstr ""
+msgstr "Path component"
 
 msgid ""
 "The numbering starts from 1, e.g. on the page admin/structure/types, the 3rd"
 " path component is \"types\"."
 msgstr ""
+"The numbering starts from 1, e.g. on the page admin/structure/types, the 3rd"
+" path component is \"types\"."
 
 msgid "Use aggregation"
-msgstr ""
+msgstr "Use aggregation"
 
 msgid "Display title may not be empty."
-msgstr ""
+msgstr "Display title may not be empty."
 
 msgid "When the filter value is <em>NOT</em> available"
-msgstr ""
+msgstr "When the filter value is <em>NOT</em> available"
 
 msgid "When the filter value <em>IS</em> available or a default is provided"
-msgstr ""
+msgstr "When the filter value <em>IS</em> available or a default is provided"
 
 msgid ""
 "This display does not have a source for contextual filters, so no contextual"
 " filter value will be available unless you select 'Provide default'."
 msgstr ""
+"This display does not have a source for contextual filters, so no contextual"
+" filter value will be available unless you select 'Provide default'."
 
 msgid "Query Comment"
-msgstr ""
+msgstr "Query Comment"
 
 msgid ""
 "If set, this comment will be embedded in the query and passed to the SQL "
 "server. This can be helpful for logging or debugging."
 msgstr ""
+"If set, this comment will be embedded in the query and passed to the SQL "
+"server. This can be helpful for logging or debugging."
 
 msgid "Count DISTINCT"
-msgstr ""
+msgstr "Count DISTINCT"
 
 msgid "Provide default field wrapper elements"
-msgstr ""
+msgstr "Provide default field wrapper elements"
 
 msgid ""
 "Inline fields will be displayed next to each other rather than one after "
 "another. Note that some fields will ignore this if they are block elements, "
 "particularly body fields and other formatted HTML."
 msgstr ""
+"Inline fields will be displayed next to each other rather than one after "
+"another. Note that some fields will ignore this if they are block elements, "
+"particularly body fields and other formatted HTML."
 
 msgid "Show the empty text in the table"
-msgstr ""
+msgstr "Show the empty text in the table"
 
 msgid "The block could not be saved."
-msgstr ""
+msgstr "The block could not be saved."
 
 msgid "Datetime"
-msgstr ""
+msgstr "Datetime"
 
 msgid "Language (fr, en, ...)"
-msgstr ""
+msgstr "Language (fr, en, ...)"
 
 msgid "Link attributes"
-msgstr ""
+msgstr "Link attributes"
 
 msgid "Max age"
-msgstr ""
+msgstr "Max age"
 
 msgid "Last Cron Run"
-msgstr ""
+msgstr "Last Cron Run"
 
 msgid "The user ID."
-msgstr ""
+msgstr "The user ID."
 
 msgid "Latest revision"
-msgstr ""
+msgstr "Latest revision"
 
 msgid "Responsive image"
-msgstr ""
+msgstr "Responsive image"
 
 msgid "The field that is going to be used as the RSS item title for each row."
 msgstr ""
+"The field that is going to be used as the RSS item title for each row."
 
 msgid ""
 "The field that is going to be used as the RSS item link for each row. This "
 "must be a drupal relative path."
 msgstr ""
+"The field that is going to be used as the RSS item link for each row. This "
+"must be a drupal relative path."
 
 msgid ""
 "The field that is going to be used as the RSS item description for each row."
 msgstr ""
+"The field that is going to be used as the RSS item description for each row."
 
 msgid "Creator field"
-msgstr ""
+msgstr "Creator field"
 
 msgid ""
 "The field that is going to be used as the RSS item creator for each row."
 msgstr ""
+"The field that is going to be used as the RSS item creator for each row."
 
 msgid "Publication date field"
-msgstr ""
+msgstr "Publication date field"
 
 msgid ""
 "Row style plugin requires specifying which views fields to use for RSS item."
 msgstr ""
+"Row style plugin requires specifying which views fields to use for RSS item."
 
 msgid "Unique watchdog event ID."
-msgstr ""
+msgstr "Unique watchdog event ID."
 
 msgid ""
 "The severity level of the event; ranges from 0 (Emergency) to 7 (Debug)."
 msgstr ""
+"The severity level of the event; ranges from 0 (Emergency) to 7 (Debug)."
 
 msgid "Logo image"
-msgstr ""
+msgstr "Logo image"
 
 msgid "Curaçao"
-msgstr ""
+msgstr "Curaçao"
 
 msgid "Réunion"
-msgstr ""
+msgstr "Réunion"
 
 msgid "Sint Maarten"
-msgstr ""
+msgstr "Sint Maarten"
 
 msgid "Manage view modes"
-msgstr ""
+msgstr "Manage view modes"
 
 msgid "JavaScript settings"
-msgstr ""
+msgstr "JavaScript settings"
 
 msgid "Entity Reference"
-msgstr ""
+msgstr "Entity Reference"
 
 msgid "An autocomplete text field."
-msgstr ""
+msgstr "An autocomplete text field."
 
 msgid "Display the label of the referenced entities."
-msgstr ""
+msgstr "Display the label of the referenced entities."
 
 msgid "Rendered entity"
-msgstr ""
+msgstr "Rendered entity"
 
 msgid "Display the referenced entities rendered by entity_view()."
-msgstr ""
+msgstr "Display the referenced entities rendered by entity_view()."
 
 msgid "Link label to the referenced entity"
-msgstr ""
+msgstr "Link label to the referenced entity"
 
 msgid "Link to the referenced entity"
-msgstr ""
+msgstr "Link to the referenced entity"
 
 msgid "Rendered as @mode"
-msgstr ""
+msgstr "Rendered as @mode"
 
 msgid "Language types"
-msgstr ""
+msgstr "Language types"
 
 msgid "Add view mode"
-msgstr ""
+msgstr "Add view mode"
 
 msgid "@group: @field"
-msgstr ""
+msgstr "@group: @field"
 
 msgid "@group (historical data): @field"
-msgstr ""
+msgstr "@group (historical data): @field"
 
 msgid "Edit view mode"
-msgstr ""
+msgstr "Edit view mode"
 
 msgid "Default date"
-msgstr ""
+msgstr "Default date"
 
 msgid "Default end date"
-msgstr ""
+msgstr "Default end date"
 
 msgid "Time increments"
-msgstr ""
+msgstr "Time increments"
 
 msgid "10 minute"
-msgstr ""
+msgstr "10 minute"
 
 msgid "30 minute"
-msgstr ""
+msgstr "30 minute"
 
 msgid "Text of the auto-reply message."
-msgstr ""
+msgstr "Text of the auto-reply message."
 
 msgid "Entity reference"
-msgstr ""
+msgstr "Entity reference"
 
 msgid "@name field is required."
-msgstr ""
+msgstr "@name field is required."
 
 msgid "Fields pending deletion"
-msgstr ""
+msgstr "Fields pending deletion"
 
 msgid "No translatable fields"
-msgstr ""
+msgstr "No translatable fields"
 
 msgid "Translations of %label"
-msgstr ""
+msgstr "Translations of %label"
 
 msgid "This translation is published"
-msgstr ""
+msgstr "This translation is published"
 
 msgid "Are you sure you want to delete the @language translation of %label?"
-msgstr ""
+msgstr "Are you sure you want to delete the @language translation of %label?"
 
 msgid "Shown"
-msgstr ""
+msgstr "Shown"
 
 msgid "Translate any entity"
-msgstr ""
+msgstr "Translate any entity"
 
 msgid "Hide empty columns"
-msgstr ""
+msgstr "Hide empty columns"
 
 msgid ""
 "The node ID of the node a user created or commented on. You must use an "
 "argument or filter on UID or you will get misleading results using this "
 "field."
 msgstr ""
+"The node ID of the node a user created or commented on. You must use an "
+"argument or filter on UID or you will get misleading results using this "
+"field."
 
 msgid ""
 "The user ID of a user who touched the node (either created or commented on "
 "it)."
 msgstr ""
+"The user ID of a user who touched the node (either created or commented on "
+"it)."
 
 msgid ""
 "The date the node was last updated or commented on. You must use an argument"
 " or filter on UID or you will get misleading results using this field."
 msgstr ""
+"The date the node was last updated or commented on. You must use an argument"
+" or filter on UID or you will get misleading results using this field."
 
 msgid "Entity types"
-msgstr ""
+msgstr "Entity types"
 
 msgid "Change handler"
-msgstr ""
+msgstr "Change handler"
 
 msgid "Autocomplete (Tags style)"
-msgstr ""
+msgstr "Autocomplete (Tags style)"
 
 msgid "Mail system"
-msgstr ""
+msgstr "Mail system"
 
 msgid "Hide empty column"
-msgstr ""
+msgstr "Hide empty column"
 
 msgid "Restrict images to this site"
-msgstr ""
+msgstr "Restrict images to this site"
 
 msgid ""
 "Disallows usage of &lt;img&gt; tag sources that are not hosted on this site "
 "by replacing them with a placeholder image."
 msgstr ""
+"Disallows usage of &lt;img&gt; tag sources that are not hosted on this site "
+"by replacing them with a placeholder image."
 
 msgid "Maximum dimensions"
-msgstr ""
+msgstr "Maximum dimensions"
 
 msgid "Fallback image style"
-msgstr ""
+msgstr "Fallback image style"
 
 msgid "Wide"
-msgstr ""
+msgstr "Wide"
 
 msgid "The operator is invalid on filter: @filter."
-msgstr ""
+msgstr "The operator is invalid on filter: @filter."
 
 msgid "No valid values found on filter: @filter."
-msgstr ""
+msgstr "No valid values found on filter: @filter."
 
 msgid "The value @value is not an array for @operator on filter: @filter"
-msgstr ""
+msgstr "The value @value is not an array for @operator on filter: @filter"
 
 msgid ""
 "If not checked, fields that are not configured to customize their HTML "
@@ -12789,177 +13601,200 @@ msgid ""
 "view provides by default, at the cost of making it more difficult to apply "
 "CSS."
 msgstr ""
+"If not checked, fields that are not configured to customize their HTML "
+"elements will get no wrappers at all for their field, label and field + "
+"label wrappers. You can use this to quickly reduce the amount of markup the "
+"view provides by default, at the cost of making it more difficult to apply "
+"CSS."
 
 msgid "@label (@column)"
-msgstr ""
+msgstr "@label (@column)"
 
 msgid "banned IP addresses"
-msgstr ""
+msgstr "banned IP addresses"
 
 msgid "The IP address %ip has been banned."
-msgstr ""
+msgstr "The IP address %ip has been banned."
 
 msgid "CKEditor settings"
-msgstr ""
+msgstr "CKEditor settings"
 
 msgid "The field name."
-msgstr ""
+msgstr "The field name."
 
 msgid "Validate options"
-msgstr ""
+msgstr "Validate options"
 
 msgid "Whether the user is active or blocked."
-msgstr ""
+msgstr "Whether the user is active or blocked."
 
 msgid "Views query"
-msgstr ""
+msgstr "Views query"
 
 msgid ""
 "The throbber display does not show the status of uploads but takes up less "
 "space. The progress bar is helpful for monitoring progress on large uploads."
 msgstr ""
+"The throbber display does not show the status of uploads but takes up less "
+"space. The progress bar is helpful for monitoring progress on large uploads."
 
 msgid "Leave this blank to delete both the existing username and password."
-msgstr ""
+msgstr "Leave this blank to delete both the existing username and password."
 
 msgid "To change the password, enter the new password here."
-msgstr ""
+msgstr "To change the password, enter the new password here."
 
 msgid ""
 "HTTP authentication credentials must include a username in addition to a "
 "password."
 msgstr ""
+"HTTP authentication credentials must include a username in addition to a "
+"password."
 
 msgid ""
 "Cron takes care of running periodic tasks like checking for updates and "
 "indexing content for search."
 msgstr ""
+"Cron takes care of running periodic tasks like checking for updates and "
+"indexing content for search."
 
 msgid "User name and password"
-msgstr ""
+msgstr "User name and password"
 
 msgid "User module account form elements."
-msgstr ""
+msgstr "User module account form elements."
 
 msgid "Manage form display"
-msgstr ""
+msgstr "Manage form display"
 
 msgid ""
 "A Drupal path or external URL the more link will point to. Note that this "
 "will override the link display setting above."
 msgstr ""
+"A Drupal path or external URL the more link will point to. Note that this "
+"will override the link display setting above."
 
 msgid "<em>Alt</em> field required"
-msgstr ""
+msgstr "<em>Alt</em> field required"
 
 msgid "<em>Title</em> field required"
-msgstr ""
+msgstr "<em>Title</em> field required"
 
 msgid "Link to entity"
-msgstr ""
+msgstr "Link to entity"
 
 msgid "Bypass access checks"
-msgstr ""
+msgstr "Bypass access checks"
 
 msgid "Media type"
-msgstr ""
+msgstr "Media type"
 
 msgid "@view : @display"
-msgstr ""
+msgstr "@view : @display"
 
 msgid "View: @view - Display: @display"
-msgstr ""
+msgstr "View: @view - Display: @display"
 
 msgid "Transform the case"
-msgstr ""
+msgstr "Transform the case"
 
 msgid ""
 "If \"Custom\", see <a href=\"http://us.php.net/manual/en/function.date.php\""
 " target=\"_blank\">the PHP docs</a> for date formats. Otherwise, enter the "
 "number of different time units to display, which defaults to 2."
 msgstr ""
+"If \"Custom\", see <a href=\"http://us.php.net/manual/en/function.date.php\""
+" target=\"_blank\">the PHP docs</a> for date formats. Otherwise, enter the "
+"number of different time units to display, which defaults to 2."
 
 msgid "Representative sort criteria"
-msgstr ""
+msgstr "Representative sort criteria"
 
 msgid ""
 "The sort criteria is applied to the data brought in by the relationship to "
 "determine how a representative item is obtained for each row. For example, "
 "to show the most recent node for each user, pick 'Content: Updated date'."
 msgstr ""
+"The sort criteria is applied to the data brought in by the relationship to "
+"determine how a representative item is obtained for each row. For example, "
+"to show the most recent node for each user, pick 'Content: Updated date'."
 
 msgid "The ordering to use for the sort criteria selected above."
-msgstr ""
+msgstr "The ordering to use for the sort criteria selected above."
 
 msgid "Revert to default"
-msgstr ""
+msgstr "Revert to default"
 
 msgid "No fields have been used in views yet."
-msgstr ""
+msgstr "No fields have been used in views yet."
 
 msgid "Provide a simple link to approve the comment."
-msgstr ""
+msgstr "Provide a simple link to approve the comment."
 
 msgid "Author uid"
-msgstr ""
+msgstr "Author uid"
 
 msgid "Relate each @entity with a @field set to the file."
-msgstr ""
+msgstr "Relate each @entity with a @field set to the file."
 
 msgid "Relate each @entity with a @field set to the image."
-msgstr ""
+msgstr "Relate each @entity with a @field set to the image."
 
 msgid "The tid of a taxonomy term."
-msgstr ""
+msgstr "The tid of a taxonomy term."
 
 msgid "The user permissions."
-msgstr ""
+msgstr "The user permissions."
 
 msgid "First and last only"
-msgstr ""
+msgstr "First and last only"
 
 msgid "Multiple-value handling"
-msgstr ""
+msgstr "Multiple-value handling"
 
 msgid "Filter to items that share all terms"
-msgstr ""
+msgstr "Filter to items that share all terms"
 
 msgid "Filter to items that share any term"
-msgstr ""
+msgstr "Filter to items that share any term"
 
 msgid "Use a pager"
-msgstr ""
+msgstr "Use a pager"
 
 msgid "Logo path"
-msgstr ""
+msgstr "Logo path"
 
 msgid ""
 "@module (<span class=\"admin-missing\">incompatible with</span> this version"
 " of Drupal core)"
 msgstr ""
+"@module (<span class=\"admin-missing\">incompatible with</span> this version"
+" of Drupal core)"
 
 msgid "Responsive"
-msgstr ""
+msgstr "Responsive"
 
 msgid "Tokens related to views."
-msgstr ""
+msgstr "Tokens related to views."
 
 msgid "The description of the view."
-msgstr ""
+msgstr "The description of the view."
 
 msgid "The title of current display of the view."
-msgstr ""
+msgstr "The title of current display of the view."
 
 msgid "The URL of the view."
-msgstr ""
+msgstr "The URL of the view."
 
 msgid "-Select-"
-msgstr ""
+msgstr "-Select-"
 
 msgid ""
 "Text to place as \"title\" text which most browsers display as a tooltip "
 "when hovering over the link."
 msgstr ""
+"Text to place as \"title\" text which most browsers display as a tooltip "
+"when hovering over the link."
 
 msgid ""
 "Enable to hide this field if it is empty. Note that the field label or "
@@ -12967,914 +13802,1009 @@ msgid ""
 "row style settings for empty fields. To hide rewritten content, check the "
 "\"Hide rewriting if empty\" checkbox."
 msgstr ""
+"Enable to hide this field if it is empty. Note that the field label or "
+"rewritten output may still be displayed. To hide labels, check the style or "
+"row style settings for empty fields. To hide rewritten content, check the "
+"\"Hide rewriting if empty\" checkbox."
 
 msgid "Apostrophe"
-msgstr ""
+msgstr "Apostrophe"
 
 msgid "Date in the form of CCYYMMDD."
-msgstr ""
+msgstr "Date in the form of CCYYMMDD."
 
 msgid "Date in the form of YYYYMM."
-msgstr ""
+msgstr "Date in the form of YYYYMM."
 
 msgid "Date in the form of YYYY."
-msgstr ""
+msgstr "Date in the form of YYYY."
 
 msgid "Date in the form of MM (01 - 12)."
-msgstr ""
+msgstr "Date in the form of MM (01 - 12)."
 
 msgid "Date value"
-msgstr ""
+msgstr "Date value"
 
 msgid "Full HTML"
-msgstr ""
+msgstr "Full HTML"
 
 msgid "View modes"
-msgstr ""
+msgstr "View modes"
 
 msgid "Date in the form of DD (01 - 31)."
-msgstr ""
+msgstr "Date in the form of DD (01 - 31)."
 
 msgid "Date in the form of WW (01 - 53)."
-msgstr ""
+msgstr "Date in the form of WW (01 - 53)."
 
 msgid ""
 "If you need more fields than the uid add the comment: author relationship"
 msgstr ""
+"If you need more fields than the uid add the comment: author relationship"
 
 msgid "Last comment uid"
-msgstr ""
+msgstr "Last comment uid"
 
 msgid ""
 "The user authoring the content. If you need more fields than the uid add the"
 " content: author relationship"
 msgstr ""
+"The user authoring the content. If you need more fields than the uid add the"
+" content: author relationship"
 
 msgid "Convert spaces in term names to hyphens"
-msgstr ""
+msgstr "Convert spaces in term names to hyphens"
 
 msgid "Use rendered output to group rows"
-msgstr ""
+msgstr "Use rendered output to group rows"
 
 msgid ""
 "If enabled the rendered output of the grouping field is used to group the "
 "rows."
 msgstr ""
+"If enabled the rendered output of the grouping field is used to group the "
+"rows."
 
 msgid "Block count"
-msgstr ""
+msgstr "Block count"
 
 msgid "Limit to vocabulary"
-msgstr ""
+msgstr "Limit to vocabulary"
 
 msgid ""
 "You may use HTML code in this field. The following tokens are supported:"
 msgstr ""
+"You may use HTML code in this field. The following tokens are supported:"
 
 msgid "Result summary"
-msgstr ""
+msgstr "Result summary"
 
 msgid "Shows result summary, for example the items per page."
-msgstr ""
+msgstr "Shows result summary, for example the items per page."
 
 msgid "Use site default RSS settings"
-msgstr ""
+msgstr "Use site default RSS settings"
 
 msgid "Display list value as human readable"
-msgstr ""
+msgstr "Display list value as human readable"
 
 msgid "Displays the link in contextual links"
-msgstr ""
+msgstr "Displays the link in contextual links"
 
 msgid "Grouping field Nr.@number"
-msgstr ""
+msgstr "Grouping field Nr.@number"
 
 msgid "Response status code"
-msgstr ""
+msgstr "Response status code"
 
 msgid "Callback function"
-msgstr ""
+msgstr "Callback function"
 
 msgid ""
 "Your search used too many AND/OR expressions. Only the first @count terms "
 "were included in this search."
 msgstr ""
+"Your search used too many AND/OR expressions. Only the first @count terms "
+"were included in this search."
 
 msgid "Other…"
-msgstr ""
+msgstr "Other…"
 
 msgid "The selected selection handler is broken."
-msgstr ""
+msgstr "The selected selection handler is broken."
 
 msgid "Performance settings"
-msgstr ""
+msgstr "Performance settings"
 
 msgid "Display field as machine name."
-msgstr ""
+msgstr "Display field as machine name."
 
 msgid "Provide a display which can be embedded using the views api."
-msgstr ""
+msgstr "Provide a display which can be embedded using the views api."
 
 msgid "Only has the 'authenticated user' role"
-msgstr ""
+msgstr "Only has the 'authenticated user' role"
 
 msgid "Has roles in addition to 'authenticated user'"
-msgstr ""
+msgstr "Has roles in addition to 'authenticated user'"
 
 msgid "Remove tags from rendered output"
-msgstr ""
+msgstr "Remove tags from rendered output"
 
 msgid "Fields to be included as contextual links."
-msgstr ""
+msgstr "Fields to be included as contextual links."
 
 msgid "Include destination"
-msgstr ""
+msgstr "Include destination"
 
 msgid ""
 "Include a \"destination\" parameter in the link to return the user to the "
 "original view upon completing the contextual action."
 msgstr ""
+"Include a \"destination\" parameter in the link to return the user to the "
+"original view upon completing the contextual action."
 
 msgid "Contextual Links"
-msgstr ""
+msgstr "Contextual Links"
 
 msgid "Display fields in a contextual links menu."
-msgstr ""
+msgstr "Display fields in a contextual links menu."
 
 msgid "Upload directory"
-msgstr ""
+msgstr "Upload directory"
 
 msgid "The file %file could not be saved because the upload did not complete."
 msgstr ""
+"The file %file could not be saved because the upload did not complete."
 
 msgid "Authentication provider"
-msgstr ""
+msgstr "Authentication provider"
 
 msgid "Allowed values function"
-msgstr ""
+msgstr "Allowed values function"
 
 msgid "Select media"
-msgstr ""
+msgstr "Select media"
 
 msgid "Third party settings"
-msgstr ""
+msgstr "Third party settings"
 
 msgid "Date/time format"
-msgstr ""
+msgstr "Date/time format"
 
 msgid "Enable translation"
-msgstr ""
+msgstr "Enable translation"
 
 msgid "Drupal Version"
-msgstr ""
+msgstr "Drupal Version"
 
 msgid "This field supports tokens."
-msgstr ""
+msgstr "This field supports tokens."
 
 msgid "Twig"
-msgstr ""
+msgstr "Twig"
 
 msgid "Search score"
-msgstr ""
+msgstr "Search score"
 
 msgid "Add transition"
-msgstr ""
+msgstr "Add transition"
 
 msgid "There was a problem creating field %label: @message"
-msgstr ""
+msgstr "There was a problem creating field %label: @message"
 
 msgid "No content selected."
-msgstr ""
+msgstr "No content selected."
 
 msgid ""
 "A list field (@field_name) with existing data cannot have its keys changed."
 msgstr ""
+"A list field (@field_name) with existing data cannot have its keys changed."
 
 msgid ""
 "A unique machine-readable name containing letters, numbers, and underscores."
 msgstr ""
+"A unique machine-readable name containing letters, numbers, and underscores."
 
 msgid ""
 "If no image is uploaded, this image will be shown on display and will "
 "override the field's default image."
 msgstr ""
+"If no image is uploaded, this image will be shown on display and will "
+"override the field's default image."
 
 msgid "The menu name. Primary key."
-msgstr ""
+msgstr "The menu name. Primary key."
 
 msgid "The human-readable name of the menu."
-msgstr ""
+msgstr "The human-readable name of the menu."
 
 msgid "A description of the menu"
-msgstr ""
+msgstr "A description of the menu"
 
 msgid ""
 "The menu name. All links with the same menu name (such as 'navigation') are "
 "part of the same menu."
 msgstr ""
+"The menu name. All links with the same menu name (such as 'navigation') are "
+"part of the same menu."
 
 msgid "The menu link ID (mlid) is the integer primary key."
-msgstr ""
+msgstr "The menu link ID (mlid) is the integer primary key."
 
 msgid "The name of the module that generated this link."
-msgstr ""
+msgstr "The name of the module that generated this link."
 
 msgid "Bulk operation"
-msgstr ""
+msgstr "Bulk operation"
 
 msgid "View used to select the entities"
-msgstr ""
+msgstr "View used to select the entities"
 
 msgid ""
 "Choose the view and display that select the entities that can be "
 "referenced.<br />Only views with a display of type \"Entity Reference\" are "
 "eligible."
 msgstr ""
+"Choose the view and display that select the entities that can be "
+"referenced.<br />Only views with a display of type \"Entity Reference\" are "
+"eligible."
 
 msgid "Views: Filter by an entity reference view"
-msgstr ""
+msgstr "Views: Filter by an entity reference view"
 
 msgid "Entity Reference Source"
-msgstr ""
+msgstr "Entity Reference Source"
 
 msgid "Entity Reference list"
-msgstr ""
+msgstr "Entity Reference list"
 
 msgid ""
 "Display \"@display\" needs a selected search fields to work properly. See "
 "the settings for the Entity Reference list format."
 msgstr ""
+"Display \"@display\" needs a selected search fields to work properly. See "
+"the settings for the Entity Reference list format."
 
 msgid ""
 "Display \"@display\" uses field %field as search field, but the field is no "
 "longer present. See the settings for the Entity Reference list format."
 msgstr ""
+"Display \"@display\" uses field %field as search field, but the field is no "
+"longer present. See the settings for the Entity Reference list format."
 
 msgid ""
 "<strong>Note:</strong> In 'Entity Reference' displays, all fields will be "
 "displayed inline unless an explicit selection of inline fields is made here."
 msgstr ""
+"<strong>Note:</strong> In 'Entity Reference' displays, all fields will be "
+"displayed inline unless an explicit selection of inline fields is made here."
 
 msgid ""
 "Select the field(s) that will be searched when using the autocomplete "
 "widget."
 msgstr ""
+"Select the field(s) that will be searched when using the autocomplete "
+"widget."
 
 msgid "Public files directory"
-msgstr ""
+msgstr "Public files directory"
 
 msgid "Temporary files directory"
-msgstr ""
+msgstr "Temporary files directory"
 
 msgid "Private files directory"
-msgstr ""
+msgstr "Private files directory"
 
 msgid "Comment Statistics"
-msgstr ""
+msgstr "Comment Statistics"
 
 msgid "You have unsaved changes"
-msgstr ""
+msgstr "You have unsaved changes"
 
 msgid "Loading…"
-msgstr ""
+msgstr "Loading…"
 
 msgid "Use site name"
-msgstr ""
+msgstr "Use site name"
 
 msgid "Use site slogan"
-msgstr ""
+msgstr "Use site slogan"
 
 msgid "File status"
-msgstr ""
+msgstr "File status"
 
 msgid "Reduce"
-msgstr ""
+msgstr "Reduce"
 
 msgid "Easy"
-msgstr ""
+msgstr "Easy"
 
 msgid "Breakpoint"
-msgstr ""
+msgstr "Breakpoint"
 
 msgid "Needs to be updated"
-msgstr ""
+msgstr "Needs to be updated"
 
 msgid "Does not need to be updated"
-msgstr ""
+msgstr "Does not need to be updated"
 
 msgid "Edit comment @subject"
-msgstr ""
+msgstr "Edit comment @subject"
 
 msgid ""
 "Only this translation is published. You must publish at least one more "
 "translation to unpublish this one."
 msgstr ""
+"Only this translation is published. You must publish at least one more "
+"translation to unpublish this one."
 
 msgid "Time interval"
-msgstr ""
+msgstr "Time interval"
 
 msgid "Used in views"
-msgstr ""
+msgstr "Used in views"
 
 msgid "Display \"Access Denied\""
-msgstr ""
+msgstr "Display \"Access Denied\""
 
 msgid "Timezone to be used for date output."
-msgstr ""
+msgstr "Timezone to be used for date output."
 
 msgid "- Default site/user timezone -"
-msgstr ""
+msgstr "- Default site/user timezone -"
 
 msgid ""
 "Grouped filters allow a choice between predefined operator|value pairs."
 msgstr ""
+"Grouped filters allow a choice between predefined operator|value pairs."
 
 msgid "Filter type to expose"
-msgstr ""
+msgstr "Filter type to expose"
 
 msgid "Single filter"
-msgstr ""
+msgstr "Single filter"
 
 msgid "Grouped filters"
-msgstr ""
+msgstr "Grouped filters"
 
 msgid "Language type"
-msgstr ""
+msgstr "Language type"
 
 msgid "No book content available."
-msgstr ""
+msgstr "No book content available."
 
 msgid "Default translation"
-msgstr ""
+msgstr "Default translation"
 
 msgid "Views plugins"
-msgstr ""
+msgstr "Views plugins"
 
 msgid "Translation for @language"
-msgstr ""
+msgstr "Translation for @language"
 
 msgid "Last page"
-msgstr ""
+msgstr "Last page"
 
 msgid "Export options"
-msgstr ""
+msgstr "Export options"
 
 msgid "Hide description"
-msgstr ""
+msgstr "Hide description"
 
 msgid ""
 "Remember exposed selection only for the selected user role(s). If you select"
 " no roles, the exposed data will never be stored."
 msgstr ""
+"Remember exposed selection only for the selected user role(s). If you select"
+" no roles, the exposed data will never be stored."
 
 msgid ""
 "Select which kind of widget will be used to render the group of filters"
 msgstr ""
+"Select which kind of widget will be used to render the group of filters"
 
 msgid "grouped"
-msgstr ""
+msgstr "grouped"
 
 msgid "Choose fields to combine for filtering"
-msgstr ""
+msgstr "Choose fields to combine for filtering"
 
 msgid "This filter doesn't work for very special field handlers."
-msgstr ""
+msgstr "This filter doesn't work for very special field handlers."
 
 msgid "You have to add some fields to be able to use this filter."
-msgstr ""
+msgstr "You have to add some fields to be able to use this filter."
 
 msgid "@entity types"
-msgstr ""
+msgstr "@entity types"
 
 msgid "There is no lock on view %name to break."
-msgstr ""
+msgstr "There is no lock on view %name to break."
 
 msgid "&lt;Any&gt;"
-msgstr ""
+msgstr "&lt;Any&gt;"
 
 msgid "There are no enabled views."
-msgstr ""
+msgstr "There are no enabled views."
 
 msgid "Display fields as RSS items."
-msgstr ""
+msgstr "Display fields as RSS items."
 
 msgid "- No value -"
-msgstr ""
+msgstr "- No value -"
 
 msgid "Provide a simple link to the revision."
-msgstr ""
+msgstr "Provide a simple link to the revision."
 
 msgid "The ID of the entity that is related to the file."
-msgstr ""
+msgstr "The ID of the entity that is related to the file."
 
 msgid "The raw numeric user ID."
-msgstr ""
+msgstr "The raw numeric user ID."
 
 msgid "Unfiltered text"
-msgstr ""
+msgstr "Unfiltered text"
 
 msgid ""
 "Add unrestricted, custom text or markup. This is similar to the custom text "
 "field."
 msgstr ""
+"Add unrestricted, custom text or markup. This is similar to the custom text "
+"field."
 
 msgid "Combine fields filter"
-msgstr ""
+msgstr "Combine fields filter"
 
 msgid "Column used for click sorting"
-msgstr ""
+msgstr "Column used for click sorting"
 
 msgid "Use path alias instead of internal path."
-msgstr ""
+msgstr "Use path alias instead of internal path."
 
 msgid "Length of time in seconds raw query results should be cached."
-msgstr ""
+msgstr "Length of time in seconds raw query results should be cached."
 
 msgid "Length of time in seconds rendered HTML output should be cached."
-msgstr ""
+msgstr "Length of time in seconds rendered HTML output should be cached."
 
 msgid "Custom time values must be numeric."
-msgstr ""
+msgstr "Custom time values must be numeric."
 
 msgid "Change whether or not to display contextual links for this view."
-msgstr ""
+msgstr "Change whether or not to display contextual links for this view."
 
 msgid "Display 'more' link only if there is more content"
-msgstr ""
+msgstr "Display 'more' link only if there is more content"
 
 msgid ""
 "Exposed filters in block displays require \"Use AJAX\" to be set to work "
 "correctly."
 msgstr ""
+"Exposed filters in block displays require \"Use AJAX\" to be set to work "
+"correctly."
 
 msgid "Number of pager links visible"
-msgstr ""
+msgstr "Number of pager links visible"
 
 msgid "Specify the number of links to pages to display in the pager."
-msgstr ""
+msgstr "Specify the number of links to pages to display in the pager."
 
 msgid "Query Tags"
-msgstr ""
+msgstr "Query Tags"
 
 msgid ""
 "If set, these tags will be appended to the query and can be used to identify"
 " the query in a module. This can be helpful for altering queries."
 msgstr ""
+"If set, these tags will be appended to the query and can be used to identify"
+" the query in a module. This can be helpful for altering queries."
 
 msgid ""
 "The query tags may only contain lower-case alphabetical characters and "
 "underscores."
 msgstr ""
+"The query tags may only contain lower-case alphabetical characters and "
+"underscores."
 
 msgid ""
 "The field that is going to be used as the RSS item pubDate for each row. It "
 "needs to be in RFC 2822 format."
 msgstr ""
+"The field that is going to be used as the RSS item pubDate for each row. It "
+"needs to be in RFC 2822 format."
 
 msgid "GUID settings"
-msgstr ""
+msgstr "GUID settings"
 
 msgid "GUID field"
-msgstr ""
+msgstr "GUID field"
 
 msgid "The globally unique identifier of the RSS item."
-msgstr ""
+msgstr "The globally unique identifier of the RSS item."
 
 msgid "GUID is permalink"
-msgstr ""
+msgstr "GUID is permalink"
 
 msgid "The RSS item GUID is a permalink."
-msgstr ""
+msgstr "The RSS item GUID is a permalink."
 
 msgid "Add views row classes"
-msgstr ""
+msgstr "Add views row classes"
 
 msgid "Force using fields"
-msgstr ""
+msgstr "Force using fields"
 
 msgid ""
 "If neither the row nor the style plugin supports fields, this field allows "
 "to enable them, so you can for example use groupby."
 msgstr ""
+"If neither the row nor the style plugin supports fields, this field allows "
+"to enable them, so you can for example use groupby."
 
 msgid "File storage"
-msgstr ""
+msgstr "File storage"
 
 msgid ""
 "A flexible, recolorable theme with many regions and a responsive, mobile-"
 "first layout."
 msgstr ""
+"A flexible, recolorable theme with many regions and a responsive, mobile-"
+"first layout."
 
 msgid "Enter 0 for no limit."
-msgstr ""
+msgstr "Enter 0 for no limit."
 
 msgid "Entity label"
-msgstr ""
+msgstr "Entity label"
 
 msgid "The @type %title has been deleted."
-msgstr ""
+msgstr "The @type %title has been deleted."
 
 msgid "The URL %url is not valid."
-msgstr ""
+msgstr "The URL %url is not valid."
 
 msgid "All messages, with backtrace information"
-msgstr ""
+msgstr "All messages, with backtrace information"
 
 msgid "The views entity selection mode requires a view."
-msgstr ""
+msgstr "The views entity selection mode requires a view."
 
 msgid "The connection protocol %backend does not exist."
-msgstr ""
+msgstr "The connection protocol %backend does not exist."
 
 msgid "Unknown (@langcode)"
-msgstr ""
+msgstr "Unknown (@langcode)"
 
 msgid ""
 "The file %file could not be saved because it exceeds %maxsize, the maximum "
 "allowed size for uploads."
 msgstr ""
+"The file %file could not be saved because it exceeds %maxsize, the maximum "
+"allowed size for uploads."
 
 msgid ""
 "The file could not be uploaded because the destination %destination is "
 "invalid."
 msgstr ""
+"The file could not be uploaded because the destination %destination is "
+"invalid."
 
 msgid "The file %path was not deleted because it does not exist."
-msgstr ""
+msgstr "The file %path was not deleted because it does not exist."
 
 msgid "%name field is not in the right format."
-msgstr ""
+msgstr "%name field is not in the right format."
 
 msgid "%name is not a valid number."
-msgstr ""
+msgstr "%name is not a valid number."
 
 msgid "%name must be a valid color."
-msgstr ""
+msgstr "%name must be a valid color."
 
 msgid "Theme hook %hook not found."
-msgstr ""
+msgstr "Theme hook %hook not found."
 
 msgid "…"
-msgstr ""
+msgstr "…"
 
 msgid "Table @name already exists."
-msgstr ""
+msgstr "Table @name already exists."
 
 msgid "Cannot rename @table to @table_new: table @table doesn't exist."
-msgstr ""
+msgstr "Cannot rename @table to @table_new: table @table doesn't exist."
 
 msgid "Cannot rename @table to @table_new: table @table_new already exists."
-msgstr ""
+msgstr "Cannot rename @table to @table_new: table @table_new already exists."
 
 msgid "Cannot add field @table.@field: table doesn't exist."
-msgstr ""
+msgstr "Cannot add field @table.@field: table doesn't exist."
 
 msgid "Cannot add field @table.@field: field already exists."
-msgstr ""
+msgstr "Cannot add field @table.@field: field already exists."
 
 msgid "Cannot set default value of field @table.@field: field doesn't exist."
-msgstr ""
+msgstr "Cannot set default value of field @table.@field: field doesn't exist."
 
 msgid ""
 "Cannot remove default value of field @table.@field: field doesn't exist."
 msgstr ""
+"Cannot remove default value of field @table.@field: field doesn't exist."
 
 msgid "Cannot add primary key to table @table: table doesn't exist."
-msgstr ""
+msgstr "Cannot add primary key to table @table: table doesn't exist."
 
 msgid "Cannot add primary key to table @table: primary key already exists."
-msgstr ""
+msgstr "Cannot add primary key to table @table: primary key already exists."
 
 msgid "Cannot add unique key @name to table @table: table doesn't exist."
-msgstr ""
+msgstr "Cannot add unique key @name to table @table: table doesn't exist."
 
 msgid ""
 "Cannot add unique key @name to table @table: unique key already exists."
 msgstr ""
+"Cannot add unique key @name to table @table: unique key already exists."
 
 msgid "Cannot add index @name to table @table: table doesn't exist."
-msgstr ""
+msgstr "Cannot add index @name to table @table: table doesn't exist."
 
 msgid "Cannot add index @name to table @table: index already exists."
-msgstr ""
+msgstr "Cannot add index @name to table @table: index already exists."
 
 msgid ""
 "Cannot change the definition of field @table.@name: field doesn't exist."
 msgstr ""
+"Cannot change the definition of field @table.@name: field doesn't exist."
 
 msgid ""
 "Cannot rename field @table.@name to @name_new: target field already exists."
 msgstr ""
+"Cannot rename field @table.@name to @name_new: target field already exists."
 
 msgid "Boolean value"
-msgstr ""
+msgstr "Boolean value"
 
 msgid "The referenced entity"
-msgstr ""
+msgstr "The referenced entity"
 
 msgid "Integer value"
-msgstr ""
+msgstr "Integer value"
 
 msgid "Language object"
-msgstr ""
+msgstr "Language object"
 
 msgid "Text value"
-msgstr ""
+msgstr "Text value"
 
 msgid ""
 "A unique label for this advanced action. This label will be displayed in the"
 " interface of modules that integrate with actions."
 msgstr ""
+"A unique label for this advanced action. This label will be displayed in the"
+" interface of modules that integrate with actions."
 
 msgid "Aggregator refresh"
-msgstr ""
+msgstr "Aggregator refresh"
 
 msgid "The feed from %site seems to be broken because of error \"%error\"."
-msgstr ""
+msgstr "The feed from %site seems to be broken because of error \"%error\"."
 
 msgid "This IP address is already banned."
-msgstr ""
+msgstr "This IP address is already banned."
 
 msgid "You may not ban your own IP address."
-msgstr ""
+msgstr "You may not ban your own IP address."
 
 msgid "Banning IP addresses"
-msgstr ""
+msgstr "Banning IP addresses"
 
 msgid ""
 "IP addresses listed here are banned from your site. Banned addresses are "
 "completely forbidden from accessing the site and instead see a brief message"
 " explaining the situation."
 msgstr ""
+"IP addresses listed here are banned from your site. Banned addresses are "
+"completely forbidden from accessing the site and instead see a brief message"
+" explaining the situation."
 
 msgid "Ban IP addresses"
-msgstr ""
+msgstr "Ban IP addresses"
 
 msgid "IP address bans"
-msgstr ""
+msgstr "IP address bans"
 
 msgid "Perform tasks on specific events triggered within the system."
-msgstr ""
+msgstr "Perform tasks on specific events triggered within the system."
 
 msgid "List additional actions"
-msgstr ""
+msgstr "List additional actions"
 
 msgid "Enables banning of IP addresses."
-msgstr ""
+msgstr "Enables banning of IP addresses."
 
 msgid "You must enter a valid hexadecimal color value for %name."
-msgstr ""
+msgstr "You must enter a valid hexadecimal color value for %name."
 
 msgid "Database Logging"
-msgstr ""
+msgstr "Database Logging"
 
 msgid "Trim link text length"
-msgstr ""
+msgstr "Trim link text length"
 
 msgid "Leave blank to allow unlimited link text lengths."
-msgstr ""
+msgstr "Leave blank to allow unlimited link text lengths."
 
 msgid "URL only"
-msgstr ""
+msgstr "URL only"
 
 msgid "Show URL as plain text"
-msgstr ""
+msgstr "Show URL as plain text"
 
 msgid "Add rel=\"nofollow\" to links"
-msgstr ""
+msgstr "Add rel=\"nofollow\" to links"
 
 msgid "Link text trimmed to @limit characters"
-msgstr ""
+msgstr "Link text trimmed to @limit characters"
 
 msgid "Link text not trimmed"
-msgstr ""
+msgstr "Link text not trimmed"
 
 msgid "Show URL only as plain-text"
-msgstr ""
+msgstr "Show URL only as plain-text"
 
 msgid "Show URL only"
-msgstr ""
+msgstr "Show URL only"
 
 msgid "Add rel=\"@rel\""
-msgstr ""
+msgstr "Add rel=\"@rel\""
 
 msgid "Thin space"
-msgstr ""
+msgstr "Thin space"
 
 msgid "Processed text"
-msgstr ""
+msgstr "Processed text"
 
 msgid "Re-use existing field: you need to provide a label."
-msgstr ""
+msgstr "Re-use existing field: you need to provide a label."
 
 msgid ""
 "The specified file %file could not be copied because the destination is "
 "invalid. More information is available in the system log."
 msgstr ""
+"The specified file %file could not be copied because the destination is "
+"invalid. More information is available in the system log."
 
 msgid ""
 "The specified file %file could not be moved because the destination is "
 "invalid. More information is available in the system log."
 msgstr ""
+"The specified file %file could not be moved because the destination is "
+"invalid. More information is available in the system log."
 
 msgid ""
 "The data could not be saved because the destination is invalid. More "
 "information is available in the system log."
 msgstr ""
+"The data could not be saved because the destination is invalid. More "
+"information is available in the system log."
 
 msgid ""
 "File %file (%realpath) could not be copied because the destination "
 "%destination is invalid. This is often caused by improper use of file_copy()"
 " or a missing stream wrapper."
 msgstr ""
+"File %file (%realpath) could not be copied because the destination "
+"%destination is invalid. This is often caused by improper use of file_copy()"
+" or a missing stream wrapper."
 
 msgid ""
 "File %file could not be copied because the destination %destination is "
 "invalid. This is often caused by improper use of file_copy() or a missing "
 "stream wrapper."
 msgstr ""
+"File %file could not be copied because the destination %destination is "
+"invalid. This is often caused by improper use of file_copy() or a missing "
+"stream wrapper."
 
 msgid ""
 "File %file (%realpath) could not be moved because the destination "
 "%destination is invalid. This may be caused by improper use of file_move() "
 "or a missing stream wrapper."
 msgstr ""
+"File %file (%realpath) could not be moved because the destination "
+"%destination is invalid. This may be caused by improper use of file_move() "
+"or a missing stream wrapper."
 
 msgid ""
 "File %file could not be moved because the destination %destination is "
 "invalid. This may be caused by improper use of file_move() or a missing "
 "stream wrapper."
 msgstr ""
+"File %file could not be moved because the destination %destination is "
+"invalid. This may be caused by improper use of file_move() or a missing "
+"stream wrapper."
 
 msgid ""
 "Did not delete temporary file \"%path\" during garbage collection because it"
 " is in use by the following modules: %modules."
 msgstr ""
+"Did not delete temporary file \"%path\" during garbage collection because it"
+" is in use by the following modules: %modules."
 
 msgid "Are you sure you want to delete the forum %label?"
-msgstr ""
+msgstr "Are you sure you want to delete the forum %label?"
 
 msgid "Edit style %name"
-msgstr ""
+msgstr "Edit style %name"
 
 msgid "Error generating image, missing source file."
-msgstr ""
+msgstr "Error generating image, missing source file."
 
 msgid "Set @title as default"
-msgstr ""
+msgstr "Set @title as default"
 
 msgid "Custom language..."
-msgstr ""
+msgstr "Custom language..."
 
 msgid ""
 "Fill in the language details and save the language with <em>Add custom "
 "language</em>."
 msgstr ""
+"Fill in the language details and save the language with <em>Add custom "
+"language</em>."
 
 msgid "The language %language (%langcode) already exists."
-msgstr ""
+msgstr "The language %language (%langcode) already exists."
 
 msgid "Use the <em>Add language</em> button to save a predefined language."
-msgstr ""
+msgstr "Use the <em>Add language</em> button to save a predefined language."
 
 msgid "The language %language has been created and can now be used."
-msgstr ""
+msgstr "The language %language has been created and can now be used."
 
 msgid "The %language (%langcode) language has been removed."
-msgstr ""
+msgstr "The %language (%langcode) language has been removed."
 
 msgid "Path prefix configuration"
-msgstr ""
+msgstr "Path prefix configuration"
 
 msgid "Domain configuration"
-msgstr ""
+msgstr "Domain configuration"
 
 msgid "%language (%langcode) path prefix (Default language)"
-msgstr ""
+msgstr "%language (%langcode) path prefix (Default language)"
 
 msgid "%language (%langcode) path prefix"
-msgstr ""
+msgstr "%language (%langcode) path prefix"
 
 msgid "%language (%langcode) domain"
-msgstr ""
+msgstr "%language (%langcode) domain"
 
 msgid "The prefix may not contain a slash."
-msgstr ""
+msgstr "The prefix may not contain a slash."
 
 msgid "The prefix for %language, %value, is not unique."
-msgstr ""
+msgstr "The prefix for %language, %value, is not unique."
 
 msgid "The domain for %language, %value, is not unique."
-msgstr ""
+msgstr "The domain for %language, %value, is not unique."
 
 msgid "Existing languages"
-msgstr ""
+msgstr "Existing languages"
 
 msgid "Add a new mapping"
-msgstr ""
+msgstr "Add a new mapping"
 
 msgid "Browser language code"
-msgstr ""
+msgstr "Browser language code"
 
 msgid "Browser language codes must be unique."
-msgstr ""
+msgstr "Browser language codes must be unique."
 
 msgid ""
 "Browser language codes can only contain lowercase letters and a hyphen(-)."
 msgstr ""
+"Browser language codes can only contain lowercase letters and a hyphen(-)."
 
 msgid "Are you sure you want to delete %browser_langcode?"
-msgstr ""
+msgstr "Are you sure you want to delete %browser_langcode?"
 
 msgid ""
 "Add a language to be supported by your site. If your desired language is not"
 " available, pick <em>Custom language...</em> at the end and provide a "
 "language code and other details manually."
 msgstr ""
+"Add a language to be supported by your site. If your desired language is not"
+" available, pick <em>Custom language...</em> at the end and provide a "
+"language code and other details manually."
 
 msgid "- @name -"
-msgstr ""
+msgstr "- @name -"
 
 msgid "Language from the URL (Path prefix or domain)."
-msgstr ""
+msgstr "Language from the URL (Path prefix or domain)."
 
 msgid "Language from a request/session parameter."
-msgstr ""
+msgstr "Language from a request/session parameter."
 
 msgid "Language from the browser's language settings."
-msgstr ""
+msgstr "Language from the browser's language settings."
 
 msgid "Account administration pages"
-msgstr ""
+msgstr "Account administration pages"
 
 msgid "Account administration pages language setting."
-msgstr ""
+msgstr "Account administration pages language setting."
 
 msgid "The %language (%langcode) language has been created."
-msgstr ""
+msgstr "The %language (%langcode) language has been created."
 
 msgid "The %language (%langcode) language has been updated."
-msgstr ""
+msgstr "The %language (%langcode) language has been updated."
 
 msgid "Browser language detection configuration"
-msgstr ""
+msgstr "Browser language detection configuration"
 
 msgid "A Gettext Portable Object file."
-msgstr ""
+msgstr "A Gettext Portable Object file."
 
 msgid "Treat imported strings as custom translations"
-msgstr ""
+msgstr "Treat imported strings as custom translations"
 
 msgid "Overwrite non-customized translations"
-msgstr ""
+msgstr "Overwrite non-customized translations"
 
 msgid "Overwrite existing customized translations"
-msgstr ""
+msgstr "Overwrite existing customized translations"
 
 msgid "No language available. The export will only contain source strings."
-msgstr ""
+msgstr "No language available. The export will only contain source strings."
 
 msgid "@count disallowed HTML string(s) in files: @files."
-msgstr ""
+msgstr "@count disallowed HTML string(s) in files: @files."
 
 msgid "In Context"
-msgstr ""
+msgstr "In Context"
 
 msgid "First plural form"
 msgid_plural "@count. plural form"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "First plural form"
+msgstr[1] "@count. plural form"
 
 msgid "Interface translation"
-msgstr ""
+msgstr "Interface translation"
 
 msgid "@translated/@total (@ratio%)"
-msgstr ""
+msgstr "@translated/@total (@ratio%)"
 
 msgid "not applicable"
-msgstr ""
+msgstr "not applicable"
 
 msgid "Enable interface translation to English"
-msgstr ""
+msgstr "Enable interface translation to English"
 
 msgid "Interface translations directory"
-msgstr ""
+msgstr "Interface translations directory"
 
 msgid ""
 "Removed JavaScript translation file for the language %language because no "
 "translations currently exist for that language."
 msgstr ""
+"Removed JavaScript translation file for the language %language because no "
+"translations currently exist for that language."
 
 msgid ""
 "Import of string \"%string\" was skipped because of disallowed or malformed "
 "HTML."
 msgstr ""
+"Import of string \"%string\" was skipped because of disallowed or malformed "
+"HTML."
 
 msgid "logged in users only"
-msgstr ""
+msgstr "logged in users only"
 
 msgid "Author's preferred language"
-msgstr ""
+msgstr "Author's preferred language"
 
 msgid ""
 "%type is used by 1 piece of content on your site. You can not remove this "
@@ -13883,66 +14813,78 @@ msgid_plural ""
 "%type is used by @count pieces of content on your site. You may not remove "
 "%type until you have removed all of the %type content."
 msgstr[0] ""
+"%type is used by 1 piece of content on your site. You can not remove this "
+"content type until you have removed all of the %type content."
 msgstr[1] ""
+"%type is used by @count pieces of content on your site. You may not remove "
+"%type until you have removed all of the %type content."
 
 msgid "The language code of the language the node is written in."
-msgstr ""
+msgstr "The language code of the language the node is written in."
 
 msgid ""
 "Query tagged for node access but there is no node table, specify the "
 "base_table using meta data."
 msgstr ""
+"Query tagged for node access but there is no node table, specify the "
+"base_table using meta data."
 
 msgid "Briefly describe the changes you have made."
-msgstr ""
+msgstr "Briefly describe the changes you have made."
 
 msgid "@name format: @date"
-msgstr ""
+msgstr "@name format: @date"
 
 msgid "Non-customized translation"
-msgstr ""
+msgstr "Non-customized translation"
 
 msgid "Customized translation"
-msgstr ""
+msgstr "Customized translation"
 
 msgid "Translation type"
-msgstr ""
+msgstr "Translation type"
 
 msgid "Include non-customized translations"
-msgstr ""
+msgstr "Include non-customized translations"
 
 msgid "Include customized translations"
-msgstr ""
+msgstr "Include customized translations"
 
 msgid "Include untranslated text"
-msgstr ""
+msgstr "Include untranslated text"
 
 msgid "The strings have been saved."
-msgstr ""
+msgstr "The strings have been saved."
 
 msgid ""
 "A path alias set for a specific language will always be used when displaying"
 " this page in that language, and takes precedence over path aliases set as "
 "<em>- None -</em>."
 msgstr ""
+"A path alias set for a specific language will always be used when displaying"
+" this page in that language, and takes precedence over path aliases set as "
+"<em>- None -</em>."
 
 msgid "Use the default shortcut icon supplied by the theme"
-msgstr ""
+msgstr "Use the default shortcut icon supplied by the theme"
 
 msgid ""
 "Examples: <code>@implicit-public-file</code> (for a file in the public "
 "filesystem), <code>@explicit-file</code>, or <code>@local-file</code>."
 msgstr ""
+"Examples: <code>@implicit-public-file</code> (for a file in the public "
+"filesystem), <code>@explicit-file</code>, or <code>@local-file</code>."
 
 msgid "Message to display when in maintenance mode"
-msgstr ""
+msgstr "Message to display when in maintenance mode"
 
 msgid "This theme requires the base theme @base_theme to operate correctly."
-msgstr ""
+msgstr "This theme requires the base theme @base_theme to operate correctly."
 
 msgid ""
 "This theme requires the theme engine @theme_engine to operate correctly."
 msgstr ""
+"This theme requires the theme engine @theme_engine to operate correctly."
 
 msgid ""
 "Use maintenance mode when making major updates, particularly if the updates "
@@ -13950,93 +14892,106 @@ msgid ""
 "importing or exporting content, modifying a theme, modifying content types, "
 "and making backups."
 msgstr ""
+"Use maintenance mode when making major updates, particularly if the updates "
+"could disrupt visitors or the update process. Examples include upgrading, "
+"importing or exporting content, modifying a theme, modifying content types, "
+"and making backups."
 
 msgid "A language object."
-msgstr ""
+msgstr "A language object."
 
 msgid "All kind of entities, e.g. nodes, comments or users."
-msgstr ""
+msgstr "All kind of entities, e.g. nodes, comments or users."
 
 msgid "An entity field containing a boolean value."
-msgstr ""
+msgstr "An entity field containing a boolean value."
 
 msgid "An entity field referencing a language."
-msgstr ""
+msgstr "An entity field referencing a language."
 
 msgid "An entity field containing an entity reference."
-msgstr ""
+msgstr "An entity field containing an entity reference."
 
 msgid ""
 "The directory %file is not protected from modifications and poses a security"
 " risk. You must change the directory's permissions to be non-writable."
 msgstr ""
+"The directory %file is not protected from modifications and poses a security"
+" risk. You must change the directory's permissions to be non-writable."
 
 msgid "Configuration directories"
-msgstr ""
+msgstr "Configuration directories"
 
 msgid "Apply pending updates"
-msgstr ""
+msgstr "Apply pending updates"
 
 msgid ""
 "Translation is not supported if language is always one of: @locked_languages"
 msgstr ""
+"Translation is not supported if language is always one of: @locked_languages"
 
 msgid "HTTP request to @url failed with error: @error."
-msgstr ""
+msgstr "HTTP request to @url failed with error: @error."
 
 msgid "Update Manager"
-msgstr ""
+msgstr "Update Manager"
 
 msgid ""
 "The name for this role. Example: \"Moderator\", \"Editorial board\", \"Site "
 "architect\"."
 msgstr ""
+"The name for this role. Example: \"Moderator\", \"Editorial board\", \"Site "
+"architect\"."
 
 msgid "User module 'member for' view element."
-msgstr ""
+msgstr "User module 'member for' view element."
 
 msgid ""
 "This is also assumed to be the primary language of this account's profile "
 "information."
 msgstr ""
+"This is also assumed to be the primary language of this account's profile "
+"information."
 
 msgid "Administration pages language"
-msgstr ""
+msgstr "Administration pages language"
 
 msgid ""
 "Build a custom site without pre-configured functionality. Suitable for "
 "advanced users."
 msgstr ""
+"Build a custom site without pre-configured functionality. Suitable for "
+"advanced users."
 
 msgid "Header background top"
-msgstr ""
+msgstr "Header background top"
 
 msgid "Header background bottom"
-msgstr ""
+msgstr "Header background bottom"
 
 msgid "Site's default language (@lang_name)"
-msgstr ""
+msgstr "Site's default language (@lang_name)"
 
 msgid "Installation profile"
-msgstr ""
+msgstr "Installation profile"
 
 msgid "Selected language"
-msgstr ""
+msgstr "Selected language"
 
 msgid "Expose sort order"
-msgstr ""
+msgstr "Expose sort order"
 
 msgid "Use a custom %field_name"
-msgstr ""
+msgstr "Use a custom %field_name"
 
 msgid "Validation settings"
-msgstr ""
+msgstr "Validation settings"
 
 msgid "Language Code"
-msgstr ""
+msgstr "Language Code"
 
 msgid "@dir can not be opened"
-msgstr ""
+msgstr "@dir can not be opened"
 
 msgid ""
 "Breakpoints can be organized into groups. Modules and themes should use "
@@ -14048,89 +15003,103 @@ msgstr ""
 "purposes, such as breakpoints for layouts or breakpoints for image sizing."
 
 msgid "Parent permalink"
-msgstr ""
+msgstr "Parent permalink"
 
 msgid "Save and manage fields"
-msgstr ""
+msgstr "Save and manage fields"
 
 msgid "Image removed."
-msgstr ""
+msgstr "Image removed."
 
 msgid ""
 "This image has been removed. For security reasons, only images from the "
 "local domain are allowed."
 msgstr ""
+"This image has been removed. For security reasons, only images from the "
+"local domain are allowed."
 
 msgid "Only images hosted on this site may be used in &lt;img&gt; tags."
-msgstr ""
+msgstr "Only images hosted on this site may be used in &lt;img&gt; tags."
 
 msgid ""
 "An error occurred trying to check available interface translation updates."
 msgstr ""
+"An error occurred trying to check available interface translation updates."
 
 msgid "Checked available interface translation updates for one project."
 msgid_plural ""
 "Checked available interface translation updates for @count projects."
-msgstr[0] ""
+msgstr[0] "Checked available interface translation updates for one project."
 msgstr[1] ""
+"Checked available interface translation updates for @count projects."
 
 msgid ""
 "Optionally, specify a relative URL to display as the front page. Leave blank"
 " to display the default front page."
 msgstr ""
+"Optionally, specify a relative URL to display as the front page. Leave blank"
+" to display the default front page."
 
 msgid "Vocabulary language"
-msgstr ""
+msgstr "Vocabulary language"
 
 msgid "The role machine-name of the role."
-msgstr ""
+msgstr "The role machine-name of the role."
 
 msgid "The base table used for this view."
-msgstr ""
+msgstr "The base table used for this view."
 
 msgid "The base field used for this view."
-msgstr ""
+msgstr "The base field used for this view."
 
 msgid ""
 "The total amount of results returned from the view. The current display will"
 " be used."
 msgstr ""
+"The total amount of results returned from the view. The current display will"
+" be used."
 
 msgid "The number of items per page."
-msgstr ""
+msgstr "The number of items per page."
 
 msgid "The current page of results the view is on."
-msgstr ""
+msgstr "The current page of results the view is on."
 
 msgid "The total page count."
-msgstr ""
+msgstr "The total page count."
 
 msgid ""
 "Override the default view title for this view. This is useful to display an "
 "alternative title when a view is empty."
 msgstr ""
+"Override the default view title for this view. This is useful to display an "
+"alternative title when a view is empty."
 
 msgid "Overridden title"
-msgstr ""
+msgstr "Overridden title"
 
 msgid "Tracker - User"
-msgstr ""
+msgstr "Tracker - User"
 
 msgid ""
 "Whether or not the node is published. You must use an argument or filter on "
 "UID or you will get misleading results using this field."
 msgstr ""
+"Whether or not the node is published. You must use an argument or filter on "
+"UID or you will get misleading results using this field."
 
 msgid "The translation authoring username %name does not exist."
-msgstr ""
+msgstr "The translation authoring username %name does not exist."
 
 msgid "You have to specify a valid translation authoring date."
-msgstr ""
+msgstr "You have to specify a valid translation authoring date."
 
 msgid ""
 "Database %database not found. The server reports the following message when "
 "attempting to create the database: %error."
 msgstr ""
+"Database %database not found. The server reports the following message when "
+"attempting to create the database: %error."
 
 msgid ""
 "Failed to connect to your database server. The server reports the following "
@@ -14140,80 +15109,88 @@ msgid ""
 "name?</li><li>Have you entered the correct username and "
 "password?</li><li>Have you entered the correct database hostname?</li></ul>"
 msgstr ""
+"Failed to connect to your database server. The server reports the following "
+"message: %error.<ul><li>Is the database server running?</li><li>Does the "
+"database exist or does the database user have sufficient privileges to "
+"create the database?</li><li>Have you entered the correct database "
+"name?</li><li>Have you entered the correct username and "
+"password?</li><li>Have you entered the correct database hostname?</li></ul>"
 
 msgid "Install another module"
-msgstr ""
+msgstr "Install another module"
 
 msgid "Are you sure you want to unblock %ip?"
-msgstr ""
+msgstr "Are you sure you want to unblock %ip?"
 
 msgid "Import all"
-msgstr ""
+msgstr "Import all"
 
 msgid "Another request may be synchronizing configuration already."
-msgstr ""
+msgstr "Another request may be synchronizing configuration already."
 
 msgid "The configuration was imported successfully."
-msgstr ""
+msgstr "The configuration was imported successfully."
 
 msgid "@count new"
 msgid_plural "@count new"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count new"
+msgstr[1] "@count new"
 
 msgid "@count changed"
 msgid_plural "@count changed"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count changed"
+msgstr[1] "@count changed"
 
 msgid "@count removed"
 msgid_plural "@count removed"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count removed"
+msgstr[1] "@count removed"
 
 msgid "Synchronize configuration"
-msgstr ""
+msgstr "Synchronize configuration"
 
 msgid "Flag other translations as outdated"
-msgstr ""
+msgstr "Flag other translations as outdated"
 
 msgid "Do not flag other translations as outdated"
-msgstr ""
+msgstr "Do not flag other translations as outdated"
 
 msgid "Example: 'Hero image' or 'Author image'."
-msgstr ""
+msgstr "Example: 'Hero image' or 'Author image'."
 
 msgid "Breakpoint group"
-msgstr ""
+msgstr "Breakpoint group"
 
 msgid "Select an image style for this breakpoint."
-msgstr ""
+msgstr "Select an image style for this breakpoint."
 
 msgid "Base field"
-msgstr ""
+msgstr "Base field"
 
 msgid "Manage customized lists of content."
-msgstr ""
+msgstr "Manage customized lists of content."
 
 msgid "Add and enable modules to extend site functionality."
-msgstr ""
+msgstr "Add and enable modules to extend site functionality."
 
 msgid "User account actions"
-msgstr ""
+msgstr "User account actions"
 
 msgid "View profile"
-msgstr ""
+msgstr "View profile"
 
 msgid ""
 "Provides an image formatter and breakpoint mappings to output responsive "
 "images using the HTML5 picture tag."
 msgstr ""
+"Provides an image formatter and breakpoint mappings to output responsive "
+"images using the HTML5 picture tag."
 
 msgid "Administrative interface for Views."
-msgstr ""
+msgstr "Administrative interface for Views."
 
 msgid "Access @method on %label resource"
-msgstr ""
+msgstr "Access @method on %label resource"
 
 msgid ""
 "By default SimpleTest will clear the results after they have been viewed on "
@@ -14224,18 +15201,25 @@ msgid ""
 "the results the first time. Additionally, some modules may provide more "
 "analysis or features that require this setting to be disabled."
 msgstr ""
+"By default SimpleTest will clear the results after they have been viewed on "
+"the results page, but in some cases it may be useful to leave the results in"
+" the database. The results can then be viewed at "
+"<em>admin/config/development/testing/results/[test_id]</em>. The test ID can"
+" be found in the database, simpletest table, or kept track of when viewing "
+"the results the first time. Additionally, some modules may provide more "
+"analysis or features that require this setting to be disabled."
 
 msgid "Displayed as %date_format"
-msgstr ""
+msgstr "Displayed as %date_format"
 
 msgid "Enabling translation"
-msgstr ""
+msgstr "Enabling translation"
 
 msgid "Create %language translation of %title"
-msgstr ""
+msgstr "Create %language translation of %title"
 
 msgid "Source language: @language"
-msgstr ""
+msgstr "Source language: @language"
 
 msgid ""
 "If you made a significant change, which means the other translations should "
@@ -14243,304 +15227,319 @@ msgid ""
 "will not change any other property of them, like whether they are published "
 "or not."
 msgstr ""
+"If you made a significant change, which means the other translations should "
+"be updated, you can flag all translations of this content as outdated. This "
+"will not change any other property of them, like whether they are published "
+"or not."
 
 msgid ""
 "When this option is checked, this translation needs to be updated. Uncheck "
 "when the translation is up to date again."
 msgstr ""
+"When this option is checked, this translation needs to be updated. Uncheck "
+"when the translation is up to date again."
 
 msgid "Source language set to: %language"
-msgstr ""
+msgstr "Source language set to: %language"
 
 msgid "This will delete all the translations of %label."
-msgstr ""
+msgstr "This will delete all the translations of %label."
 
 msgid "No path is set"
-msgstr ""
+msgstr "No path is set"
 
 msgid "@type: @field"
-msgstr ""
+msgstr "@type: @field"
 
 msgid "View differences"
-msgstr ""
+msgstr "View differences"
 
 msgid "Menu language"
-msgstr ""
+msgstr "Menu language"
 
 msgid "Block types"
-msgstr ""
+msgstr "Block types"
 
 msgid "@field_name"
-msgstr ""
+msgstr "@field_name"
 
 msgid "Access in-place editing"
-msgstr ""
+msgstr "Access in-place editing"
 
 msgid "Updated the %field-name field through in-place editing."
-msgstr ""
+msgstr "Updated the %field-name field through in-place editing."
 
 msgid "No item selected."
-msgstr ""
+msgstr "No item selected."
 
 msgid "Modified timestamp"
-msgstr ""
+msgstr "Modified timestamp"
 
 msgid "Are you sure you want to delete the @entity-type %label?"
-msgstr ""
+msgstr "Are you sure you want to delete the @entity-type %label?"
 
 msgid "The @entity-type %label has been deleted."
-msgstr ""
+msgstr "The @entity-type %label has been deleted."
 
 msgid "Edit %label"
-msgstr ""
+msgstr "Edit %label"
 
 msgid "Add @bundle"
-msgstr ""
+msgstr "Add @bundle"
 
 msgid "Reference type"
-msgstr ""
+msgstr "Reference type"
 
 msgid "Delete state"
-msgstr ""
+msgstr "Delete state"
 
 msgid "South Sudan"
-msgstr ""
+msgstr "South Sudan"
 
 msgid "Custom output for TRUE"
-msgstr ""
+msgstr "Custom output for TRUE"
 
 msgid "Custom output for FALSE"
-msgstr ""
+msgstr "Custom output for FALSE"
 
 msgid ""
 "Thank you for applying for an account. Your account is currently pending "
 "approval by the site administrator.<br />In the meantime, a welcome message "
 "with further instructions has been sent to your email address."
 msgstr ""
+"Thank you for applying for an account. Your account is currently pending "
+"approval by the site administrator.<br />In the meantime, a welcome message "
+"with further instructions has been sent to your email address."
 
 msgid ""
 "An unrecoverable error has occurred. You can find the error message below. "
 "It is advised to copy it to the clipboard for reference."
 msgstr ""
+"An unrecoverable error has occurred. You can find the error message below. "
+"It is advised to copy it to the clipboard for reference."
 
 msgid "Place block"
-msgstr ""
+msgstr "Place block"
 
 msgid "Port number"
-msgstr ""
+msgstr "Port number"
 
 msgid "Revision timestamp"
-msgstr ""
+msgstr "Revision timestamp"
 
 msgid "Administer account settings"
-msgstr ""
+msgstr "Administer account settings"
 
 msgid "Entity language"
-msgstr ""
+msgstr "Entity language"
 
 msgid "Hide empty"
-msgstr ""
+msgstr "Hide empty"
 
 msgid "Quick Edit"
-msgstr ""
+msgstr "Quick Edit"
 
 msgid "Revision Log message"
-msgstr ""
+msgstr "Revision Log message"
 
 msgid "The translation set id for this node"
-msgstr ""
+msgstr "The translation set id for this node"
 
 msgid "Registered timestamp"
-msgstr ""
+msgstr "Registered timestamp"
 
 msgid "Signature format"
-msgstr ""
+msgstr "Signature format"
 
 msgid "Init"
-msgstr ""
+msgstr "Init"
 
 msgid "Update form"
-msgstr ""
+msgstr "Update form"
 
 msgid "HTTP Basic Authentication"
-msgstr ""
+msgstr "HTTP Basic Authentication"
 
 msgid "Storage settings"
-msgstr ""
+msgstr "Storage settings"
 
 msgid "File added"
-msgstr ""
+msgstr "File added"
 
 msgid "File removed"
-msgstr ""
+msgstr "File removed"
 
 msgid "Translate configuration"
-msgstr ""
+msgstr "Translate configuration"
 
 msgid "Translations directory"
-msgstr ""
+msgstr "Translations directory"
 
 msgid "The translations directory does not exist."
-msgstr ""
+msgstr "The translations directory does not exist."
 
 msgid "The translations directory is not readable."
-msgstr ""
+msgstr "The translations directory is not readable."
 
 msgid "The translations directory is not writable."
-msgstr ""
+msgstr "The translations directory is not writable."
 
 msgid "The translations directory is writable."
-msgstr ""
+msgstr "The translations directory is writable."
 
 msgid "The translation server is offline."
-msgstr ""
+msgstr "The translation server is offline."
 
 msgid "The translation server is online."
-msgstr ""
+msgstr "The translation server is online."
 
 msgid "The %language translation is not available."
-msgstr ""
+msgstr "The %language translation is not available."
 
 msgid "The %language translation is available."
-msgstr ""
+msgstr "The %language translation is available."
 
 msgid "The %language translation could not be downloaded."
-msgstr ""
+msgstr "The %language translation could not be downloaded."
 
 msgid "Not blank"
-msgstr ""
+msgstr "Not blank"
 
 msgid "You have unsaved changes."
-msgstr ""
+msgstr "You have unsaved changes."
 
 msgid "Allows users to apply an action to one or more items."
-msgstr ""
+msgstr "Allows users to apply an action to one or more items."
 
 msgid ""
 "A unique name for this action. It must only contain lowercase letters, "
 "numbers and underscores."
 msgstr ""
+"A unique name for this action. It must only contain lowercase letters, "
+"numbers and underscores."
 
 msgid "All actions, except selected"
-msgstr ""
+msgstr "All actions, except selected"
 
 msgid "Only selected actions"
-msgstr ""
+msgstr "Only selected actions"
 
 msgid "Selected actions"
-msgstr ""
+msgstr "Selected actions"
 
 msgid "%action was applied to @count item."
 msgid_plural "%action was applied to @count items."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%action was applied to @count item."
+msgstr[1] "%action was applied to @count items."
 
 msgid "The feed language code."
-msgstr ""
+msgstr "The feed language code."
 
 msgid "Time when this feed was queued for refresh, 0 if not queued."
-msgstr ""
+msgstr "Time when this feed was queued for refresh, 0 if not queued."
 
 msgid "The link of the feed."
-msgstr ""
+msgstr "The link of the feed."
 
 msgid "Calculated hash of the feed data, used for validating cache."
-msgstr ""
+msgstr "Calculated hash of the feed data, used for validating cache."
 
 msgid "Etag"
-msgstr ""
+msgstr "Etag"
 
 msgid "The ID of the aggregator feed."
-msgstr ""
+msgstr "The ID of the aggregator feed."
 
 msgid "The title of the feed item."
-msgstr ""
+msgstr "The title of the feed item."
 
 msgid "The feed item language code."
-msgstr ""
+msgstr "The feed item language code."
 
 msgid "The link of the feed item."
-msgstr ""
+msgstr "The link of the feed item."
 
 msgid "The author of the feed item."
-msgstr ""
+msgstr "The author of the feed item."
 
 msgid "The body of the feed item."
-msgstr ""
+msgstr "The body of the feed item."
 
 msgid "Posted date of the feed item, as a Unix timestamp."
-msgstr ""
+msgstr "Posted date of the feed item, as a Unix timestamp."
 
 msgid "Failed to download OPML file due to \"%error\"."
-msgstr ""
+msgstr "Failed to download OPML file due to \"%error\"."
 
 msgid "Edit custom block %label"
-msgstr ""
+msgstr "Edit custom block %label"
 
 msgid "Custom block types"
-msgstr ""
+msgstr "Custom block types"
 
 msgid "Add custom block type"
-msgstr ""
+msgstr "Add custom block type"
 
 msgid "@type %info has been created."
-msgstr ""
+msgstr "@type %info has been created."
 
 msgid "@type %info has been updated."
-msgstr ""
+msgstr "@type %info has been updated."
 
 msgid "@type: added %info."
-msgstr ""
+msgstr "@type: added %info."
 
 msgid "@type: updated %info."
-msgstr ""
+msgstr "@type: updated %info."
 
 msgid "The custom block ID."
-msgstr ""
+msgstr "The custom block ID."
 
 msgid "The custom block UUID."
-msgstr ""
+msgstr "The custom block UUID."
 
 msgid "The comment language code."
-msgstr ""
+msgstr "The comment language code."
 
 msgid "The block type."
-msgstr ""
+msgstr "The block type."
 
 msgid ""
 "Provide a label for this block type to help identify it in the "
 "administration pages."
 msgstr ""
+"Provide a label for this block type to help identify it in the "
+"administration pages."
 
 msgid "Enter a description for this block type."
-msgstr ""
+msgstr "Enter a description for this block type."
 
 msgid "Create a new revision by default for this block type."
-msgstr ""
+msgstr "Create a new revision by default for this block type."
 
 msgid "Custom block type %label has been updated."
-msgstr ""
+msgstr "Custom block type %label has been updated."
 
 msgid "Delete forum"
-msgstr ""
+msgstr "Delete forum"
 
 msgid "User-defined shortcuts"
-msgstr ""
+msgstr "User-defined shortcuts"
 
 msgid "Vertical orientation"
-msgstr ""
+msgstr "Vertical orientation"
 
 msgid "Tray orientation changed to @orientation."
-msgstr ""
+msgstr "Tray orientation changed to @orientation."
 
 msgid "opened"
-msgstr ""
+msgstr "opened"
 
 msgid "Custom block type %label has been added."
-msgstr ""
+msgstr "Custom block type %label has been added."
 
 msgid "Add %type custom block"
-msgstr ""
+msgstr "Add %type custom block"
 
 msgid ""
 "%label is used by 1 custom block on your site. You can not remove this block"
@@ -14549,333 +15548,367 @@ msgid_plural ""
 "%label is used by @count custom blocks on your site. You may not remove "
 "%label until you have removed all of the %label custom blocks."
 msgstr[0] ""
+"%label is used by 1 custom block on your site. You can not remove this block"
+" type until you have removed all of the %label blocks."
 msgstr[1] ""
+"%label is used by @count custom blocks on your site. You may not remove "
+"%label until you have removed all of the %label custom blocks."
 
 msgid "Output the block in this view mode."
-msgstr ""
+msgstr "Output the block in this view mode."
 
 msgid "Select the region where this block should be displayed."
-msgstr ""
+msgstr "Select the region where this block should be displayed."
 
 msgid "- Create a new book -"
-msgstr ""
+msgstr "- Create a new book -"
 
 msgid "Edit order and titles"
-msgstr ""
+msgstr "Edit order and titles"
 
 msgid "Toolbar configuration"
-msgstr ""
+msgstr "Toolbar configuration"
 
 msgid "Available buttons"
-msgstr ""
+msgstr "Available buttons"
 
 msgid "Active toolbar"
-msgstr ""
+msgstr "Active toolbar"
 
 msgid "No styles configured"
-msgstr ""
+msgstr "No styles configured"
 
 msgid "@count styles configured"
-msgstr ""
+msgstr "@count styles configured"
 
 msgid "Button separator"
-msgstr ""
+msgstr "Button separator"
 
 msgid "The provided list of styles is syntactically incorrect."
-msgstr ""
+msgstr "The provided list of styles is syntactically incorrect."
 
 msgid "You must configure the selected text editor."
-msgstr ""
+msgstr "You must configure the selected text editor."
 
 msgid "Approved status"
-msgstr ""
+msgstr "Approved status"
 
 msgid "Approved comment status"
-msgstr ""
+msgstr "Approved comment status"
 
 msgid "Link to approve comment"
-msgstr ""
+msgstr "Link to approve comment"
 
 msgid "Link to reply-to comment"
-msgstr ""
+msgstr "Link to reply-to comment"
 
 msgid "The parent comment ID if this is a reply to a comment."
-msgstr ""
+msgstr "The parent comment ID if this is a reply to a comment."
 
 msgid "The user ID of the comment author."
-msgstr ""
+msgstr "The user ID of the comment author."
 
 msgid "The comment author's home page address."
-msgstr ""
+msgstr "The comment author's home page address."
 
 msgid "The comment author's hostname."
-msgstr ""
+msgstr "The comment author's hostname."
 
 msgid "The time that the comment was created."
-msgstr ""
+msgstr "The time that the comment was created."
 
 msgid "The time that the comment was last edited."
-msgstr ""
+msgstr "The time that the comment was last edited."
 
 msgid "Thread place"
-msgstr ""
+msgstr "Thread place"
 
 msgid ""
 "The alphadecimal representation of the comment's place in a thread, "
 "consisting of a base 36 string prefixed by an integer indicating its length."
 msgstr ""
+"The alphadecimal representation of the comment's place in a thread, "
+"consisting of a base 36 string prefixed by an integer indicating its length."
 
 msgid "View changes of @config_file"
-msgstr ""
+msgstr "View changes of @config_file"
 
 msgid "Send copy to sender"
-msgstr ""
+msgstr "Send copy to sender"
 
 msgid "Contact module form element."
-msgstr ""
+msgstr "Contact module form element."
 
 msgid "Selected user"
-msgstr ""
+msgstr "Selected user"
 
 msgid "The name of the person that is sending the contact message."
-msgstr ""
+msgstr "The name of the person that is sending the contact message."
 
 msgid "Whether to send a copy of the message to the sender."
-msgstr ""
+msgstr "Whether to send a copy of the message to the sender."
 
 msgid "The ID of the recipient user for personal contact messages."
-msgstr ""
+msgstr "The ID of the recipient user for personal contact messages."
 
 msgid "@action @title configuration options"
-msgstr ""
+msgstr "@action @title configuration options"
 
 msgid "Tabbing is no longer constrained by the Contextual module."
-msgstr ""
+msgstr "Tabbing is no longer constrained by the Contextual module."
 
 msgid ""
 "Tabbing is constrained to a set of @contextualsCount and the edit mode "
 "toggle."
 msgstr ""
+"Tabbing is constrained to a set of @contextualsCount and the edit mode "
+"toggle."
 
 msgid "Press the esc key to exit."
-msgstr ""
+msgstr "Press the esc key to exit."
 
 msgid "@count contextual link"
 msgid_plural "@count contextual links"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count contextual link"
+msgstr[1] "@count contextual links"
 
 msgid "No contextual ids specified."
-msgstr ""
+msgstr "No contextual ids specified."
 
 msgid "Create and store date values."
-msgstr ""
+msgstr "Create and store date values."
 
 msgid "Choose the type of date to create."
-msgstr ""
+msgstr "Choose the type of date to create."
 
 msgid "Date only"
-msgstr ""
+msgstr "Date only"
 
 msgid "Set a default value for this date."
-msgstr ""
+msgstr "Set a default value for this date."
 
 msgid ""
 "The %field date is required. Please enter a date in the format %format."
 msgstr ""
+"The %field date is required. Please enter a date in the format %format."
 
 msgid "The %field date is invalid. Please enter a date in the format %format."
 msgstr ""
+"The %field date is invalid. Please enter a date in the format %format."
 
 msgid "AM/PM"
-msgstr ""
+msgstr "AM/PM"
 
 msgid "The %field date is required."
-msgstr ""
+msgstr "The %field date is required."
 
 msgid "The %field date is invalid."
-msgstr ""
+msgstr "The %field date is invalid."
 
 msgid "Format: %format. Leave blank to use the time of form submission."
-msgstr ""
+msgstr "Format: %format. Leave blank to use the time of form submission."
 
 msgid ""
 "Choose a format for displaying the date. Be sure to set a format appropriate"
 " for the field, i.e. omitting time for a field that only has a date."
 msgstr ""
+"Choose a format for displaying the date. Be sure to set a format appropriate"
+" for the field, i.e. omitting time for a field that only has a date."
 
 msgid "Format: @display"
-msgstr ""
+msgstr "Format: @display"
 
 msgid "Date part order"
-msgstr ""
+msgstr "Date part order"
 
 msgid "Month/Day/Year"
-msgstr ""
+msgstr "Month/Day/Year"
 
 msgid "Day/Month/Year"
-msgstr ""
+msgstr "Day/Month/Year"
 
 msgid "Year/Month/Day"
-msgstr ""
+msgstr "Year/Month/Day"
 
 msgid "Time type"
-msgstr ""
+msgstr "Time type"
 
 msgid "24 hour time"
-msgstr ""
+msgstr "24 hour time"
 
 msgid "12 hour time"
-msgstr ""
+msgstr "12 hour time"
 
 msgid "Text editor"
-msgstr ""
+msgstr "Text editor"
 
 msgid ""
 "This option is disabled because no modules that provide a text editor are "
 "currently enabled."
 msgstr ""
+"This option is disabled because no modules that provide a text editor are "
+"currently enabled."
 
 msgid ""
 "Text that will be shown inside the field until a value is entered. This hint"
 " is usually a sample value or a brief description of the expected format."
 msgstr ""
+"Text that will be shown inside the field until a value is entered. This hint"
+" is usually a sample value or a brief description of the expected format."
 
 msgid "Type of item to reference"
-msgstr ""
+msgstr "Type of item to reference"
 
 msgid "Reference method"
-msgstr ""
+msgstr "Reference method"
 
 msgid "@entity_type selection"
-msgstr ""
+msgstr "@entity_type selection"
 
 msgid "There are no entities matching \"%value\"."
-msgstr ""
+msgstr "There are no entities matching \"%value\"."
 
 msgid ""
 "Many entities are called %value. Specify the one you want by appending the "
 "id in parentheses, like \"@value (@id)\"."
 msgstr ""
+"Many entities are called %value. Specify the one you want by appending the "
+"id in parentheses, like \"@value (@id)\"."
 
 msgid ""
 "Multiple entities match this reference; \"%multiple\". Specify the one you "
 "want by appending the id in parentheses, like \"@value (@id)\"."
 msgstr ""
+"Multiple entities match this reference; \"%multiple\". Specify the one you "
+"want by appending the id in parentheses, like \"@value (@id)\"."
 
 msgid ""
 "Select the method used to collect autocomplete suggestions. Note that "
 "<em>Contains</em> can cause performance issues on sites with thousands of "
 "entities."
 msgstr ""
+"Select the method used to collect autocomplete suggestions. Note that "
+"<em>Contains</em> can cause performance issues on sites with thousands of "
+"entities."
 
 msgid ""
 "If checked, field api classes will be added by field templates. This is not "
 "recommended unless your CSS depends upon these classes. If not checked, "
 "template will not be used."
 msgstr ""
+"If checked, field api classes will be added by field templates. This is not "
+"recommended unless your CSS depends upon these classes. If not checked, "
+"template will not be used."
 
 msgid "%entity_label: Administer fields"
-msgstr ""
+msgstr "%entity_label: Administer fields"
 
 msgid "%entity_label: Administer display"
-msgstr ""
+msgstr "%entity_label: Administer display"
 
 msgid "Allowed number of values"
-msgstr ""
+msgstr "Allowed number of values"
 
 msgid "Number of values is required."
-msgstr ""
+msgstr "Number of values is required."
 
 msgid ""
 "Field %field can only hold @max values but there were @count uploaded. The "
 "following files have been omitted as a result: %list."
 msgstr ""
+"Field %field can only hold @max values but there were @count uploaded. The "
+"following files have been omitted as a result: %list."
 
 msgid "Unlimited number of files can be uploaded to this field."
-msgstr ""
+msgstr "Unlimited number of files can be uploaded to this field."
 
 msgid "The file ID."
-msgstr ""
+msgstr "The file ID."
 
 msgid "The file language code."
-msgstr ""
+msgstr "The file language code."
 
 msgid "The user ID of the file."
-msgstr ""
+msgstr "The user ID of the file."
 
 msgid "Name of the file with no path components."
-msgstr ""
+msgstr "Name of the file with no path components."
 
 msgid "The URI to access the file (either local or remote)."
-msgstr ""
+msgstr "The URI to access the file (either local or remote)."
 
 msgid "The time that the node was created."
-msgstr ""
+msgstr "The time that the node was created."
 
 msgid "Detect if tar is part of the extension"
-msgstr ""
+msgstr "Detect if tar is part of the extension"
 
 msgid "This format is shown when no other formats are available"
-msgstr ""
+msgstr "This format is shown when no other formats are available"
 
 msgid ""
 "Based on the text editor configuration, these tags have automatically been "
 "added: <strong>@tag-list</strong>."
 msgstr ""
+"Based on the text editor configuration, these tags have automatically been "
+"added: <strong>@tag-list</strong>."
 
 msgid "Forum content"
-msgstr ""
+msgstr "Forum content"
 
 msgid "The content ID of the forum index entry."
-msgstr ""
+msgstr "The content ID of the forum index entry."
 
 msgid "1 new post<span class=\"visually-hidden\"> in forum %title</span>"
 msgid_plural ""
 "@count new posts<span class=\"visually-hidden\"> in forum %title</span>"
-msgstr[0] ""
+msgstr[0] "1 new post<span class=\"visually-hidden\"> in forum %title</span>"
 msgstr[1] ""
+"@count new posts<span class=\"visually-hidden\"> in forum %title</span>"
 
 msgid "The user ID of the author of the current revision."
-msgstr ""
+msgstr "The user ID of the author of the current revision."
 
 msgid "Displaying link text"
-msgstr ""
+msgstr "Displaying link text"
 
 msgid "1 new post<span class=\"visually-hidden\"> in topic %title</span>"
 msgid_plural ""
 "@count new posts<span class=\"visually-hidden\"> in topic %title</span>"
-msgstr[0] ""
+msgstr[0] "1 new post<span class=\"visually-hidden\"> in topic %title</span>"
 msgstr[1] ""
+"@count new posts<span class=\"visually-hidden\"> in topic %title</span>"
 
 msgid "The forum %label and all sub-forums have been deleted."
-msgstr ""
+msgstr "The forum %label and all sub-forums have been deleted."
 
 msgid "forum: deleted %label and all its sub-forums."
-msgstr ""
+msgstr "forum: deleted %label and all its sub-forums."
 
 msgid ""
 "Source image at %source_image_path not found while trying to generate "
 "derivative image at %derivative_path."
 msgstr ""
+"Source image at %source_image_path not found while trying to generate "
+"derivative image at %derivative_path."
 
 msgid "Alternative image text, for the image's 'alt' attribute."
-msgstr ""
+msgstr "Alternative image text, for the image's 'alt' attribute."
 
 msgid "Image title text, for the image's 'title' attribute."
-msgstr ""
+msgstr "Image title text, for the image's 'title' attribute."
 
 msgid "The width of the image in pixels."
-msgstr ""
+msgstr "The width of the image in pixels."
 
 msgid "The height of the image in pixels."
-msgstr ""
+msgstr "The height of the image in pixels."
 
 msgid "Custom language settings"
-msgstr ""
+msgstr "Custom language settings"
 
 msgid "Settings successfully updated."
-msgstr ""
+msgstr "Settings successfully updated."
 
 msgid ""
 "Change language settings for <em>content types</em>, <em>taxonomy "
@@ -14883,73 +15916,86 @@ msgid ""
 " your site. By default, language settings hide the language selector and the"
 " language is the site's default language."
 msgstr ""
+"Change language settings for <em>content types</em>, <em>taxonomy "
+"vocabularies</em>, <em>user profiles</em>, or any other supported element on"
+" your site. By default, language settings hide the language selector and the"
+" language is the site's default language."
 
 msgid "Show language selector on create and edit pages"
-msgstr ""
+msgstr "Show language selector on create and edit pages"
 
 msgid ""
 "Select languages to enforce. If none are selected, all languages will be "
 "allowed."
 msgstr ""
+"Select languages to enforce. If none are selected, all languages will be "
+"allowed."
 
 msgid "The language is not @languages."
-msgstr ""
+msgstr "The language is not @languages."
 
 msgid "The language is @languages."
-msgstr ""
+msgstr "The language is @languages."
 
 msgid ""
 "Stores a URL string, optional varchar link text, and optional blob of "
 "attributes to assemble a link."
 msgstr ""
+"Stores a URL string, optional varchar link text, and optional blob of "
+"attributes to assemble a link."
 
 msgid "Allow link text"
-msgstr ""
+msgstr "Allow link text"
 
 msgid "Placeholder for URL"
-msgstr ""
+msgstr "Placeholder for URL"
 
 msgid "Placeholder for link text"
-msgstr ""
+msgstr "Placeholder for link text"
 
 msgid "Nothing to check."
-msgstr ""
+msgstr "Nothing to check."
 
 msgid "Importing translation for %project."
-msgstr ""
+msgstr "Importing translation for %project."
 
 msgid "Translation file not found: @uri."
-msgstr ""
+msgstr "Translation file not found: @uri."
 
 msgid "Unable to download translation file @uri."
-msgstr ""
+msgstr "Unable to download translation file @uri."
 
 msgid "One translation files could not be checked. See the log for details."
 msgid_plural ""
 "@count translation files could not be checked. See the log for details."
 msgstr[0] ""
+"One translation files could not be checked. See the log for details."
 msgstr[1] ""
+"@count translation files could not be checked. See the log for details."
 
 msgid "Updating configuration translations"
-msgstr ""
+msgstr "Updating configuration translations"
 
 msgid "Error updating configuration translations"
-msgstr ""
+msgstr "Error updating configuration translations"
 
 msgid "No configuration objects have been updated."
-msgstr ""
+msgstr "No configuration objects have been updated."
 
 msgid "Unable to import translations file: @file"
-msgstr ""
+msgstr "Unable to import translations file: @file"
 
 msgid ""
 "Translations imported: %number added, %update updated, %delete removed."
 msgstr ""
+"Translations imported: %number added, %update updated, %delete removed."
 
 msgid ""
 "The configuration was successfully updated. %number configuration objects "
 "updated."
 msgstr ""
+"The configuration was successfully updated. %number configuration objects "
+"updated."
 
 msgid ""
 "One translation string was skipped because of disallowed or malformed HTML. "
@@ -14958,245 +16004,260 @@ msgid_plural ""
 "@count translation strings were skipped because of disallowed or malformed "
 "HTML. See the log for details."
 msgstr[0] ""
+"One translation string was skipped because of disallowed or malformed HTML. "
+"See the log for details."
 msgstr[1] ""
+"@count translation strings were skipped because of disallowed or malformed "
+"HTML. See the log for details."
 
 msgid "Checking translations"
-msgstr ""
+msgstr "Checking translations"
 
 msgid "Error checking translation updates."
-msgstr ""
+msgstr "Error checking translation updates."
 
 msgid "Updating translations"
-msgstr ""
+msgstr "Updating translations"
 
 msgid "Error importing translation files"
-msgstr ""
+msgstr "Error importing translation files"
 
 msgid "Updating translations."
-msgstr ""
+msgstr "Updating translations."
 
 msgid "All translations up to date."
-msgstr ""
+msgstr "All translations up to date."
 
 msgid "Select a language to update."
-msgstr ""
+msgstr "Select a language to update."
 
 msgid "File not found at %remote_path nor at %local_path"
-msgstr ""
+msgstr "File not found at %remote_path nor at %local_path"
 
 msgid "File not found at %local_path"
-msgstr ""
+msgstr "File not found at %local_path"
 
 msgid "Translation file location could not be determined."
-msgstr ""
+msgstr "Translation file location could not be determined."
 
 msgid "Missing translations for:"
-msgstr ""
+msgstr "Missing translations for:"
 
 msgid "Missing translations for one project"
 msgid_plural "Missing translations for @count projects"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Missing translations for one project"
+msgstr[1] "Missing translations for @count projects"
 
 msgid ""
 "A local file system path where interface translation files will be stored."
 msgstr ""
+"A local file system path where interface translation files will be stored."
 
 msgid "Updates available"
-msgstr ""
+msgstr "Updates available"
 
 msgid "Missing translations"
-msgstr ""
+msgstr "Missing translations"
 
 msgid "Translation source"
-msgstr ""
+msgstr "Translation source"
 
 msgid "Drupal translation server and local files"
-msgstr ""
+msgstr "Drupal translation server and local files"
 
 msgid "Local files only"
-msgstr ""
+msgstr "Local files only"
 
 msgid "The source of translation files for automatic interface translation."
-msgstr ""
+msgstr "The source of translation files for automatic interface translation."
 
 msgid "Don't overwrite existing translations."
-msgstr ""
+msgstr "Don't overwrite existing translations."
 
 msgid ""
 "Only overwrite imported translations, customized translations are kept."
 msgstr ""
+"Only overwrite imported translations, customized translations are kept."
 
 msgid "Overwrite existing translations."
-msgstr ""
+msgstr "Overwrite existing translations."
 
 msgid ""
 "How to treat existing translations when automatically updating the interface"
 " translations."
 msgstr ""
+"How to treat existing translations when automatically updating the interface"
+" translations."
 
 msgid "Edit menu %label"
-msgstr ""
+msgstr "Edit menu %label"
 
 msgid "Add menu link"
-msgstr ""
+msgstr "Add menu link"
 
 msgid "Administrative summary"
-msgstr ""
+msgstr "Administrative summary"
 
 msgid "Menu %label has been updated."
-msgstr ""
+msgstr "Menu %label has been updated."
 
 msgid "Menu %label has been added."
-msgstr ""
+msgstr "Menu %label has been added."
 
 msgid "The menu link has been saved."
-msgstr ""
+msgstr "The menu link has been saved."
 
 msgid "Published status or admin user"
-msgstr ""
+msgstr "Published status or admin user"
 
 msgid "Promoted to front page status"
-msgstr ""
+msgstr "Promoted to front page status"
 
 msgid "Node operations bulk form"
-msgstr ""
+msgstr "Node operations bulk form"
 
 msgid "Add a form element that lets you run operations on multiple nodes."
-msgstr ""
+msgstr "Add a form element that lets you run operations on multiple nodes."
 
 msgid "Empty Node Frontpage behavior"
-msgstr ""
+msgstr "Empty Node Frontpage behavior"
 
 msgid "Provides a link to the node add overview page."
-msgstr ""
+msgstr "Provides a link to the node add overview page."
 
 msgid "Link to revision"
-msgstr ""
+msgstr "Link to revision"
 
 msgid "Link to revert revision"
-msgstr ""
+msgstr "Link to revert revision"
 
 msgid "Link to delete revision"
-msgstr ""
+msgstr "Link to delete revision"
 
 msgid "Access the Content overview page"
-msgstr ""
+msgstr "Access the Content overview page"
 
 msgid "View all revisions"
-msgstr ""
+msgstr "View all revisions"
 
 msgid "Revert all revisions"
-msgstr ""
+msgstr "Revert all revisions"
 
 msgid "%type_name: View revisions"
-msgstr ""
+msgstr "%type_name: View revisions"
 
 msgid "%type_name: Revert revisions"
-msgstr ""
+msgstr "%type_name: Revert revisions"
 
 msgid "%type_name: Delete revisions"
-msgstr ""
+msgstr "%type_name: Delete revisions"
 
 msgid "Promotion options"
-msgstr ""
+msgstr "Promotion options"
 
 msgid "Read more<span class=\"visually-hidden\"> about @title</span>"
-msgstr ""
+msgstr "Read more<span class=\"visually-hidden\"> about @title</span>"
 
 msgid "The node revision ID."
-msgstr ""
+msgstr "The node revision ID."
 
 msgid "The time that the node was last edited."
-msgstr ""
+msgstr "The time that the node was last edited."
 
 msgid "The time that the current revision was created."
-msgstr ""
+msgstr "The time that the current revision was created."
 
 msgid "Checked translation for %project."
-msgstr ""
+msgstr "Checked translation for %project."
 
 msgid "Downloaded translation for %project."
-msgstr ""
+msgstr "Downloaded translation for %project."
 
 msgid "Imported translation for %project."
-msgstr ""
+msgstr "Imported translation for %project."
 
 msgid "Importing translation file: %filename (@percent%)."
-msgstr ""
+msgstr "Importing translation file: %filename (@percent%)."
 
 msgid "Translations imported."
-msgstr ""
+msgstr "Translations imported."
 
 msgid ""
 "The configuration was successfully updated. There are %number configuration "
 "objects updated."
 msgstr ""
+"The configuration was successfully updated. There are %number configuration "
+"objects updated."
 
 msgid "Source string (@language)"
-msgstr ""
+msgstr "Source string (@language)"
 
 msgid "Built-in English"
-msgstr ""
+msgstr "Built-in English"
 
 msgid "Translated string (@language)"
-msgstr ""
+msgstr "Translated string (@language)"
 
 msgid "The node bundle is @bundles or @last"
-msgstr ""
+msgstr "The node bundle is @bundles or @last"
 
 msgid "The node bundle is @bundle"
-msgstr ""
+msgstr "The node bundle is @bundle"
 
 msgid "Float value"
-msgstr ""
+msgstr "Float value"
 
 msgid "An entity field containing a path alias and related data."
-msgstr ""
+msgstr "An entity field containing a path alias and related data."
 
 msgid "Path id"
-msgstr ""
+msgstr "Path id"
 
 msgid "Log entry with ID @id was not found"
-msgstr ""
+msgstr "Log entry with ID @id was not found"
 
 msgid "Created entity %type with ID %id."
-msgstr ""
+msgstr "Created entity %type with ID %id."
 
 msgid "Updated entity %type with ID %id."
-msgstr ""
+msgstr "Updated entity %type with ID %id."
 
 msgid "Deleted entity %type with ID %id."
-msgstr ""
+msgstr "Deleted entity %type with ID %id."
 
 msgid "Raw output"
-msgstr ""
+msgstr "Raw output"
 
 msgid "You have no fields. Add some to your view."
-msgstr ""
+msgstr "You have no fields. Add some to your view."
 
 msgid ""
 "The machine-readable name must contain only letters, numbers, dashes and "
 "underscores."
 msgstr ""
+"The machine-readable name must contain only letters, numbers, dashes and "
+"underscores."
 
 msgid "Accepted request formats"
-msgstr ""
+msgstr "Accepted request formats"
 
 msgid ""
 "Request formats that will be allowed in responses. If none are selected all "
 "formats will be allowed."
 msgstr ""
+"Request formats that will be allowed in responses. If none are selected all "
+"formats will be allowed."
 
 msgid "The new set label is required."
-msgstr ""
+msgstr "The new set label is required."
 
 msgid "Enter test name…"
-msgstr ""
+msgstr "Enter test name…"
 
 msgid ""
 "Enter at least 3 characters of the test name or description to filter by."
 msgstr ""
+"Enter at least 3 characters of the test name or description to filter by."
 
 msgid ""
 "On UNIX, Linux, and Mac OS X, you will find the configuration in the file "
@@ -15208,303 +16269,341 @@ msgid ""
 "or <em>rsyslog.conf</em>, see the <em>syslog.conf</em> or "
 "<em>rsyslog.conf</em> manual page on your command line."
 msgstr ""
+"On UNIX, Linux, and Mac OS X, you will find the configuration in the file "
+"<em>/etc/syslog.conf</em>, or in <em>/etc/rsyslog.conf</em> or in the "
+"directory <em>/etc/rsyslog.d</em>. These files define the routing "
+"configuration. Messages can be flagged with the codes "
+"<code>LOG_LOCAL0</code> through <code>LOG_LOCAL7</code>. For information on "
+"Syslog facilities, severity levels, and how to set up <em>syslog.conf</em> "
+"or <em>rsyslog.conf</em>, see the <em>syslog.conf</em> or "
+"<em>rsyslog.conf</em> manual page on your command line."
 
 msgid "Any data"
-msgstr ""
+msgstr "Any data"
 
 msgid "An entity field containing a UUID."
-msgstr ""
+msgstr "An entity field containing a UUID."
 
 msgid "@zone"
-msgstr ""
+msgstr "@zone"
 
 msgid "Failed to fetch file due to error \"%error\""
-msgstr ""
+msgstr "Failed to fetch file due to error \"%error\""
 
 msgid ""
 "The update.php script is accessible to everyone without authentication "
 "check, which is a security risk. You must change the @settings_name value in"
 " your settings.php back to FALSE."
 msgstr ""
+"The update.php script is accessible to everyone without authentication "
+"check, which is a security risk. You must change the @settings_name value in"
+" your settings.php back to FALSE."
 
 msgid "Name of the date format"
-msgstr ""
+msgstr "Name of the date format"
 
 msgid "@toolkit settings"
-msgstr ""
+msgstr "@toolkit settings"
 
 msgid "Update this item"
-msgstr ""
+msgstr "Update this item"
 
 msgid "This value should not be null."
-msgstr ""
+msgstr "This value should not be null."
 
 msgid "This value should be %limit or more."
-msgstr ""
+msgstr "This value should be %limit or more."
 
 msgid "The term ID."
-msgstr ""
+msgstr "The term ID."
 
 msgid "The term language code."
-msgstr ""
+msgstr "The term language code."
 
 msgid "Term Parents"
-msgstr ""
+msgstr "Term Parents"
 
 msgid "The parents of this term."
-msgstr ""
+msgstr "The parents of this term."
 
 msgid "Create referenced entities if they don't already exist"
-msgstr ""
+msgstr "Create referenced entities if they don't already exist"
 
 msgid "Telephone number"
-msgstr ""
+msgstr "Telephone number"
 
 msgid "This field stores a telephone number in the database."
-msgstr ""
+msgstr "This field stores a telephone number in the database."
 
 msgid "Link using text: @title"
-msgstr ""
+msgstr "Link using text: @title"
 
 msgid "Link using provided telephone number."
-msgstr ""
+msgstr "Link using provided telephone number."
 
 msgid "Translatable elements"
-msgstr ""
+msgstr "Translatable elements"
 
 msgid ""
 "At least one field needs to be translatable to enable %bundle for "
 "translation."
 msgstr ""
+"At least one field needs to be translatable to enable %bundle for "
+"translation."
 
 msgid "<strong>@language_name (Original language)</strong>"
-msgstr ""
+msgstr "<strong>@language_name (Original language)</strong>"
 
 msgid "Administer translation settings"
-msgstr ""
+msgstr "Administer translation settings"
 
 msgid "Create translations"
-msgstr ""
+msgstr "Create translations"
 
 msgid "Delete translations"
-msgstr ""
+msgstr "Delete translations"
 
 msgid "Translate %bundle_label @entity_label"
-msgstr ""
+msgstr "Translate %bundle_label @entity_label"
 
 msgid "Translate @entity_label"
-msgstr ""
+msgstr "Translate @entity_label"
 
 msgid ""
 "\"Show language selector\" is not compatible with translating content that "
 "has default language: %choice. Either do not hide the language selector or "
 "pick a specific language."
 msgstr ""
+"\"Show language selector\" is not compatible with translating content that "
+"has default language: %choice. Either do not hide the language selector or "
+"pick a specific language."
 
 msgid ""
 "An unpublished translation will not be visible without translation "
 "permissions."
 msgstr ""
+"An unpublished translation will not be visible without translation "
+"permissions."
 
 msgid "%archive_file does not contain any .info.yml files."
-msgstr ""
+msgstr "%archive_file does not contain any .info.yml files."
 
 msgid ""
 "<p>This is a one-time login for %user_name.</p><p>Click on this button to "
 "log in to the site and change your password.</p>"
 msgstr ""
+"<p>This is a one-time login for %user_name.</p><p>Click on this button to "
+"log in to the site and change your password.</p>"
 
 msgid "Provides access to the user data service."
-msgstr ""
+msgstr "Provides access to the user data service."
 
 msgid "Add a form element that lets you run operations on multiple users."
-msgstr ""
+msgstr "Add a form element that lets you run operations on multiple users."
 
 msgid "User module form element."
-msgstr ""
+msgstr "User module form element."
 
 msgid "System module form element."
-msgstr ""
+msgstr "System module form element."
 
 msgid "Login attempt failed from %ip."
-msgstr ""
+msgstr "Login attempt failed from %ip."
 
 msgid "Cancel user"
-msgstr ""
+msgstr "Cancel user"
 
 msgid "Enable password strength indicator"
-msgstr ""
+msgstr "Enable password strength indicator"
 
 msgid "Admin (user awaiting approval)"
-msgstr ""
+msgstr "Admin (user awaiting approval)"
 
 msgid "Role %label has been updated."
-msgstr ""
+msgstr "Role %label has been updated."
 
 msgid "Role %label has been added."
-msgstr ""
+msgstr "Role %label has been added."
 
 msgid "The user language code."
-msgstr ""
+msgstr "The user language code."
 
 msgid "The time that the user last accessed the site."
-msgstr ""
+msgstr "The time that the user last accessed the site."
 
 msgid "The time that the user last logged in."
-msgstr ""
+msgstr "The time that the user last logged in."
 
 msgid "The email address used for initial account creation."
-msgstr ""
+msgstr "The email address used for initial account creation."
 
 msgid "The roles the user has."
-msgstr ""
+msgstr "The roles the user has."
 
 msgid "Update the user %name"
-msgstr ""
+msgstr "Update the user %name"
 
 msgid "The module which sets this user data."
-msgstr ""
+msgstr "The module which sets this user data."
 
 msgid "The name of the data key."
-msgstr ""
+msgstr "The name of the data key."
 
 msgid "The label of the view."
-msgstr ""
+msgstr "The label of the view."
 
 msgid "The machine-readable ID of the view."
-msgstr ""
+msgstr "The machine-readable ID of the view."
 
 msgid "Dropbutton"
-msgstr ""
+msgstr "Dropbutton"
 
 msgid "Display fields in a dropbutton."
-msgstr ""
+msgstr "Display fields in a dropbutton."
 
 msgid "Rendered entity - @label"
-msgstr ""
+msgstr "Rendered entity - @label"
 
 msgid "Displays a rendered @label entity in an area."
-msgstr ""
+msgstr "Displays a rendered @label entity in an area."
 
 msgid "Display the @label"
-msgstr ""
+msgstr "Display the @label"
 
 msgid "Available global token replacements"
-msgstr ""
+msgstr "Available global token replacements"
 
 msgid ""
 "Override the title of this view when it is empty. The available global "
 "tokens below can be used here."
 msgstr ""
+"Override the title of this view when it is empty. The available global "
+"tokens below can be used here."
 
 msgid "Administrative comment"
-msgstr ""
+msgstr "Administrative comment"
 
 msgid "Machine name of the display"
-msgstr ""
+msgstr "Machine name of the display"
 
 msgid ""
 "This description will only be seen within the administrative interface and "
 "can be used to document this display."
 msgstr ""
+"This description will only be seen within the administrative interface and "
+"can be used to document this display."
 
 msgid "CSS class name(s)"
-msgstr ""
+msgstr "CSS class name(s)"
 
 msgid "Show contextual links on this view."
-msgstr ""
+msgstr "Show contextual links on this view."
 
 msgid "Show contextual links"
-msgstr ""
+msgstr "Show contextual links"
 
 msgid ""
 "In the menu, the heavier links will sink and the lighter links will be "
 "positioned nearer the top."
 msgstr ""
+"In the menu, the heavier links will sink and the lighter links will be "
+"positioned nearer the top."
 
 msgid ""
 "If the parent menu item is a tab, enter the weight of the tab. Heavier tabs "
 "will sink and the lighter tabs will be positioned nearer to the first menu "
 "item."
 msgstr ""
+"If the parent menu item is a tab, enter the weight of the tab. Heavier tabs "
+"will sink and the lighter tabs will be positioned nearer to the first menu "
+"item."
 
 msgid "Allow people to choose the sort order"
-msgstr ""
+msgstr "Allow people to choose the sort order"
 
 msgid ""
 "If sort order is not exposed, the sort criteria settings for each sort will "
 "determine its order."
 msgstr ""
+"If sort order is not exposed, the sort criteria settings for each sort will "
+"determine its order."
 
 msgid "Label for ascending sort"
-msgstr ""
+msgstr "Label for ascending sort"
 
 msgid "Label for descending sort"
-msgstr ""
+msgstr "Label for descending sort"
 
 msgid "Toolbar items"
-msgstr ""
+msgstr "Toolbar items"
 
 msgid "Edit user account"
-msgstr ""
+msgstr "Edit user account"
 
 msgid "End tour"
-msgstr ""
+msgstr "End tour"
 
 msgid "Override the output of this field with custom text"
-msgstr ""
+msgstr "Override the output of this field with custom text"
 
 msgid "Output this field as a custom link"
-msgstr ""
+msgstr "Output this field as a custom link"
 
 msgid "Trim this field to a maximum number of characters"
-msgstr ""
+msgstr "Trim this field to a maximum number of characters"
 
 msgid "More link label"
-msgstr ""
+msgstr "More link label"
 
 msgid "You may use the \"Replacement patterns\" above."
-msgstr ""
+msgstr "You may use the \"Replacement patterns\" above."
 
 msgid ""
 "An HTML corrector will be run to ensure HTML tags are properly closed after "
 "trimming."
 msgstr ""
+"An HTML corrector will be run to ensure HTML tags are properly closed after "
+"trimming."
 
 msgid "Fields to be included as links."
-msgstr ""
+msgstr "Fields to be included as links."
 
 msgid ""
 "Include a \"destination\" parameter in the link to return the user to the "
 "original view upon completing the link action."
 msgstr ""
+"Include a \"destination\" parameter in the link to return the user to the "
+"original view upon completing the link action."
 
 msgid "First page link text"
-msgstr ""
+msgstr "First page link text"
 
 msgid "Last page link text"
-msgstr ""
+msgstr "Last page link text"
 
 msgid "Offset (number of items to skip)"
-msgstr ""
+msgstr "Offset (number of items to skip)"
 
 msgid ""
 "For example, set this to 3 and the first 3 items will not be displayed."
 msgstr ""
+"For example, set this to 3 and the first 3 items will not be displayed."
 
 msgid "Pager link labels"
-msgstr ""
+msgstr "Pager link labels"
 
 msgid "Previous page link text"
-msgstr ""
+msgstr "Previous page link text"
 
 msgid "Next page link text"
-msgstr ""
+msgstr "Next page link text"
 
 msgid ""
 "Insert a list of integer numeric values separated by commas: e.g: 10, 20, "
 "50, 100"
 msgstr ""
+"Insert a list of integer numeric values separated by commas: e.g: 10, 20, "
+"50, 100"
 
 msgid ""
 "WARNING: Disabling SQL rewriting means that node access security is "
@@ -15512,375 +16611,388 @@ msgid ""
 " your view is misconfigured. Use this option only if you understand and "
 "accept this security risk."
 msgstr ""
+"WARNING: Disabling SQL rewriting means that node access security is "
+"disabled. This may allow users to see data they should not be able to see if"
+" your view is misconfigured. Use this option only if you understand and "
+"accept this security risk."
 
 msgid "No view mode selected"
-msgstr ""
+msgstr "No view mode selected"
 
 msgid "Caption for the table"
-msgstr ""
+msgstr "Caption for the table"
 
 msgid "Table details"
-msgstr ""
+msgstr "Table details"
 
 msgid "Summary title"
-msgstr ""
+msgstr "Summary title"
 
 msgid "Table description"
-msgstr ""
+msgstr "Table description"
 
 msgid "Provide additional details about the table to increase accessibility."
-msgstr ""
+msgstr "Provide additional details about the table to increase accessibility."
 
 msgid "Enable @display_title"
-msgstr ""
+msgstr "Enable @display_title"
 
 msgid "Delete @display_title"
-msgstr ""
+msgstr "Delete @display_title"
 
 msgid "Undo delete of @display_title"
-msgstr ""
+msgstr "Undo delete of @display_title"
 
 msgid "Disable @display_title"
-msgstr ""
+msgstr "Disable @display_title"
 
 msgid "Edit view name/description"
-msgstr ""
+msgstr "Edit view name/description"
 
 msgid "Analyze view"
-msgstr ""
+msgstr "Analyze view"
 
 msgid "Reorder displays"
-msgstr ""
+msgstr "Reorder displays"
 
 msgid "Revert view"
-msgstr ""
+msgstr "Revert view"
 
 msgid "Add <span class=\"visually-hidden\">@type</span>"
-msgstr ""
+msgstr "Add <span class=\"visually-hidden\">@type</span>"
 
 msgid "And/Or Rearrange <span class=\"visually-hidden\">filter criteria</span>"
-msgstr ""
+msgstr "And/Or Rearrange <span class=\"visually-hidden\">filter criteria</span>"
 
 msgid "Rearrange <span class=\"visually-hidden\">@type</span>"
-msgstr ""
+msgstr "Rearrange <span class=\"visually-hidden\">@type</span>"
 
 msgid "This display has one or more validation errors."
-msgstr ""
+msgstr "This display has one or more validation errors."
 
 msgid "There are no disabled views."
-msgstr ""
+msgstr "There are no disabled views."
 
 msgid "[@time ms] @query"
-msgstr ""
+msgstr "[@time ms] @query"
 
 msgid "Do you want to break the lock on view %name?"
-msgstr ""
+msgstr "Do you want to break the lock on view %name?"
 
 msgid "View language"
-msgstr ""
+msgstr "View language"
 
 msgid "Language of labels and other textual elements in this view."
-msgstr ""
+msgstr "Language of labels and other textual elements in this view."
 
 msgid "No displays available."
-msgstr ""
+msgstr "No displays available."
 
 msgid "Last saved"
-msgstr ""
+msgstr "Last saved"
 
 msgid "Not saved yet"
-msgstr ""
+msgstr "Not saved yet"
 
 msgid "Hard"
-msgstr ""
+msgstr "Hard"
 
 msgid "Book Page"
-msgstr ""
+msgstr "Book Page"
 
 msgid "Aggregator feed item"
-msgstr ""
+msgstr "Aggregator feed item"
 
 msgid "Default parser for RSS, Atom and RDF feeds."
-msgstr ""
+msgstr "Default parser for RSS, Atom and RDF feeds."
 
 msgid "Custom Block"
-msgstr ""
+msgstr "Custom Block"
 
 msgid "CKEditor core"
-msgstr ""
+msgstr "CKEditor core"
 
 msgid "Styles dropdown"
-msgstr ""
+msgstr "Styles dropdown"
 
 msgid "Comment selection"
-msgstr ""
+msgstr "Comment selection"
 
 msgid "My Editor"
-msgstr ""
+msgstr "My Editor"
 
 msgid "Entity display"
-msgstr ""
+msgstr "Entity display"
 
 msgid "Display the ID of the referenced entities."
-msgstr ""
+msgstr "Display the ID of the referenced entities."
 
 msgid "Selects referenceable entities for an entity reference field."
-msgstr ""
+msgstr "Selects referenceable entities for an entity reference field."
 
 msgid "Entity Reference inline fields"
-msgstr ""
+msgstr "Entity Reference inline fields"
 
 msgid "Returns results as a PHP array of labels and rendered rows."
-msgstr ""
+msgstr "Returns results as a PHP array of labels and rendered rows."
 
 msgid "File selection"
-msgstr ""
+msgstr "File selection"
 
 msgid "Separate link text and URL"
-msgstr ""
+msgstr "Separate link text and URL"
 
 msgid "Node Bundle"
-msgstr ""
+msgstr "Node Bundle"
 
 msgid "Node selection"
-msgstr ""
+msgstr "Node selection"
 
 msgid "Watchdog database log"
-msgstr ""
+msgstr "Watchdog database log"
 
 msgid "REST export"
-msgstr ""
+msgstr "REST export"
 
 msgid "Create a REST export resource."
-msgstr ""
+msgstr "Create a REST export resource."
 
 msgid "Use entities as row data."
-msgstr ""
+msgstr "Use entities as row data."
 
 msgid "Use fields as row data."
-msgstr ""
+msgstr "Use fields as row data."
 
 msgid "Serializer"
-msgstr ""
+msgstr "Serializer"
 
 msgid "Serializes views row data using the Serializer component."
-msgstr ""
+msgstr "Serializes views row data using the Serializer component."
 
 msgid "Tar"
-msgstr ""
+msgstr "Tar"
 
 msgid "Handles .tar files."
-msgstr ""
+msgstr "Handles .tar files."
 
 msgid "Handles zip files."
-msgstr ""
+msgstr "Handles zip files."
 
 msgid "Taxonomy Term selection"
-msgstr ""
+msgstr "Taxonomy Term selection"
 
 msgid "Display reference to taxonomy term in RSS."
-msgstr ""
+msgstr "Display reference to taxonomy term in RSS."
 
 msgid "Telephone link"
-msgstr ""
+msgstr "Telephone link"
 
 msgid "User selection"
-msgstr ""
+msgstr "User selection"
 
 msgid "Views Exposed Filter Block"
-msgstr ""
+msgstr "Views Exposed Filter Block"
 
 msgid " - Basic validation - "
-msgstr ""
+msgstr " - Basic validation - "
 
 msgid "A simple pager containing previous and next links."
-msgstr ""
+msgstr "A simple pager containing previous and next links."
 
 msgid "Display all items that this view might find."
-msgstr ""
+msgstr "Display all items that this view might find."
 
 msgid "Displays rows as HTML list."
-msgstr ""
+msgstr "Displays rows as HTML list."
 
 msgid "Language detection and selection"
-msgstr ""
+msgstr "Language detection and selection"
 
 msgid "Toolkit"
-msgstr ""
+msgstr "Toolkit"
 
 msgid "Configuration Translation"
-msgstr ""
+msgstr "Configuration Translation"
 
 msgid "- empty image -"
-msgstr ""
+msgstr "- empty image -"
 
 msgid "Field formatters"
-msgstr ""
+msgstr "Field formatters"
 
 msgid ""
 "If enabled, access permissions for rendering the entity are not checked."
 msgstr ""
+"If enabled, access permissions for rendering the entity are not checked."
 
 msgid "The directory %translations_directory exists."
-msgstr ""
+msgstr "The directory %translations_directory exists."
 
 msgid "MySQL, MariaDB, Percona Server, or equivalent"
-msgstr ""
+msgstr "MySQL, MariaDB, Percona Server, or equivalent"
 
 msgid "The referenced language"
-msgstr ""
+msgstr "The referenced language"
 
 msgid "Language reference"
-msgstr ""
+msgstr "Language reference"
 
 msgid "URI value"
-msgstr ""
+msgstr "URI value"
 
 msgid "An entity field containing a URI."
-msgstr ""
+msgstr "An entity field containing a URI."
 
 msgid "Caribbean Netherlands"
-msgstr ""
+msgstr "Caribbean Netherlands"
 
 msgid "Cocos [Keeling] Islands"
-msgstr ""
+msgstr "Cocos [Keeling] Islands"
 
 msgid "Congo - Kinshasa"
-msgstr ""
+msgstr "Congo - Kinshasa"
 
 msgid "Congo - Brazzaville"
-msgstr ""
+msgstr "Congo - Brazzaville"
 
 msgid "Côte d’Ivoire"
-msgstr ""
+msgstr "Côte d’Ivoire"
 
 msgid "Clipperton Island"
-msgstr ""
+msgstr "Clipperton Island"
 
 msgid "Ceuta and Melilla"
-msgstr ""
+msgstr "Ceuta and Melilla"
 
 msgid "Hong Kong SAR China"
-msgstr ""
+msgstr "Hong Kong SAR China"
 
 msgid "Canary Islands"
-msgstr ""
+msgstr "Canary Islands"
 
 msgid "Myanmar [Burma]"
-msgstr ""
+msgstr "Myanmar [Burma]"
 
 msgid "Macau SAR China"
-msgstr ""
+msgstr "Macau SAR China"
 
 msgid "Palestinian Territories"
-msgstr ""
+msgstr "Palestinian Territories"
 
 msgid "Outlying Oceania"
-msgstr ""
+msgstr "Outlying Oceania"
 
 msgid "São Tomé and Príncipe"
-msgstr ""
+msgstr "São Tomé and Príncipe"
 
 msgid "U.S. Outlying Islands"
-msgstr ""
+msgstr "U.S. Outlying Islands"
 
 msgid "Time span in seconds"
-msgstr ""
+msgstr "Time span in seconds"
 
 msgid "Using simple actions"
-msgstr ""
+msgstr "Using simple actions"
 
 msgid "Shortcut set"
-msgstr ""
+msgstr "Shortcut set"
 
 msgid "Entity form display"
-msgstr ""
+msgstr "Entity form display"
 
 msgid "WYSIWYG editing for rich text fields using CKEditor."
-msgstr ""
+msgstr "WYSIWYG editing for rich text fields using CKEditor."
 
 msgid "Creating and configuring advanced actions"
-msgstr ""
+msgstr "Creating and configuring advanced actions"
 
 msgid ""
 "A unique name for this block instance. Must be alpha-numeric and underscore "
 "separated."
 msgstr ""
+"A unique name for this block instance. Must be alpha-numeric and underscore "
+"separated."
 
 msgid "Filter by block name"
-msgstr ""
+msgstr "Filter by block name"
 
 msgid "Allow settings in the block configuration"
-msgstr ""
+msgstr "Allow settings in the block configuration"
 
 msgid "Items per block"
-msgstr ""
+msgstr "Items per block"
 
 msgid "@count (default setting)"
-msgstr ""
+msgstr "@count (default setting)"
 
 msgid "Enabling CKEditor for individual text formats"
-msgstr ""
+msgstr "Enabling CKEditor for individual text formats"
 
 msgid "Configuring the toolbar"
-msgstr ""
+msgstr "Configuring the toolbar"
 
 msgid "Formatting content"
-msgstr ""
+msgstr "Formatting content"
 
 msgid "Toggling between formatted text and HTML source"
-msgstr ""
+msgstr "Toggling between formatted text and HTML source"
 
 msgid "Uploads disabled"
-msgstr ""
+msgstr "Uploads disabled"
 
 msgid "Uploads enabled, max size: @size @dimensions"
-msgstr ""
+msgstr "Uploads enabled, max size: @size @dimensions"
 
 msgid "Edit Image"
-msgstr ""
+msgstr "Edit Image"
 
 msgid "Drupal link"
-msgstr ""
+msgstr "Drupal link"
 
 msgid "CKEditor plugin settings"
-msgstr ""
+msgstr "CKEditor plugin settings"
 
 msgid ""
 "Could not extract the contents of the tar file. The error message is "
 "<em>@message</em>"
 msgstr ""
+"Could not extract the contents of the tar file. The error message is "
+"<em>@message</em>"
 
 msgid "Discard changes?"
-msgstr ""
+msgstr "Discard changes?"
 
 msgid "Enable image uploads"
-msgstr ""
+msgstr "Enable image uploads"
 
 msgid "Storage: @name"
-msgstr ""
+msgstr "Storage: @name"
 
 msgid ""
 "A directory relative to Drupal's files directory where uploaded images will "
 "be stored."
 msgstr ""
+"A directory relative to Drupal's files directory where uploaded images will "
+"be stored."
 
 msgid ""
 "If this is left empty, then the file size will be limited by the PHP maximum"
 " upload size of @size."
 msgstr ""
+"If this is left empty, then the file size will be limited by the PHP maximum"
+" upload size of @size."
 
 msgid "Images larger than these dimensions will be scaled down."
-msgstr ""
+msgstr "Images larger than these dimensions will be scaled down."
 
 msgid "Installing text editors"
-msgstr ""
+msgstr "Installing text editors"
 
 msgid "Enabling a text editor for a text format"
-msgstr ""
+msgstr "Enabling a text editor for a text format"
 
 msgid "Configuring a text editor"
-msgstr ""
+msgstr "Configuring a text editor"
 
 msgid ""
 "Once a text editor is associated with a text format, you can configure it by"
@@ -15890,69 +17002,77 @@ msgid ""
 "and they often insert HTML tags into the field source. For details, see the "
 "help page of the specific text editor."
 msgstr ""
+"Once a text editor is associated with a text format, you can configure it by"
+" clicking on the <em>Configure</em> link for this format. Depending on the "
+"specific text editor, you can configure it for example by adding buttons to "
+"its toolbar. Typically these buttons provide formatting or editing tools, "
+"and they often insert HTML tags into the field source. For details, see the "
+"help page of the specific text editor."
 
 msgid "Using different text editors and formats"
-msgstr ""
+msgstr "Using different text editors and formats"
 
 msgid "Placeholder: @placeholder"
-msgstr ""
+msgstr "Placeholder: @placeholder"
 
 msgid "No placeholder"
-msgstr ""
+msgstr "No placeholder"
 
 msgid "Add, edit, and delete custom display modes."
-msgstr ""
+msgstr "Add, edit, and delete custom display modes."
 
 msgid "Add form mode"
-msgstr ""
+msgstr "Add form mode"
 
 msgid "Edit form mode"
-msgstr ""
+msgstr "Edit form mode"
 
 msgid "Choose view mode entity type"
-msgstr ""
+msgstr "Choose view mode entity type"
 
 msgid "Choose form mode entity type"
-msgstr ""
+msgstr "Choose form mode entity type"
 
 msgid "Saved the %label @entity-type."
-msgstr ""
+msgstr "Saved the %label @entity-type."
 
 msgid "Autocomplete matching: @match_operator"
-msgstr ""
+msgstr "Autocomplete matching: @match_operator"
 
 msgid "The referenced entity (%type: %id) does not exist."
-msgstr ""
+msgstr "The referenced entity (%type: %id) does not exist."
 
 msgctxt "Sort order"
 msgid "Order"
-msgstr ""
+msgstr "Order"
 
 msgid "%entity_label: Administer form display"
-msgstr ""
+msgstr "%entity_label: Administer form display"
 
 msgid "Plugin for @title"
-msgstr ""
+msgstr "Plugin for @title"
 
 msgid "@type (module: @module)"
-msgstr ""
+msgstr "@type (module: @module)"
 
 msgid "Widget settings:"
-msgstr ""
+msgstr "Widget settings:"
 
 msgid "The label of the entity that is related to the file."
-msgstr ""
+msgstr "The label of the entity that is related to the file."
 
 msgid "Access the Files overview page"
-msgstr ""
+msgstr "Access the Files overview page"
 
 msgid "Progress indicator: @progress_indicator"
-msgstr ""
+msgstr "Progress indicator: @progress_indicator"
 
 msgid ""
 "The %filter filter is missing, and will be removed once this format is "
 "saved."
 msgstr ""
+"The %filter filter is missing, and will be removed once this format is "
+"saved."
 
 msgid ""
 "Lines and paragraphs are automatically recognized. The &lt;br /&gt; line "
@@ -15960,42 +17080,49 @@ msgid ""
 "automatically. If paragraphs are not recognized simply add a couple of blank"
 " lines."
 msgstr ""
+"Lines and paragraphs are automatically recognized. The &lt;br /&gt; line "
+"break, &lt;p&gt; paragraph and &lt;/p&gt; close paragraph tags are inserted "
+"automatically. If paragraphs are not recognized simply add a couple of blank"
+" lines."
 
 msgid "Missing filter. All text is removed"
-msgstr ""
+msgstr "Missing filter. All text is removed"
 
 msgid "Missing filter plugin: %filter."
-msgstr ""
+msgstr "Missing filter plugin: %filter."
 
 msgid "Provides a fallback for missing filters. Do not use."
-msgstr ""
+msgstr "Provides a fallback for missing filters. Do not use."
 
 msgid "Updated @type %term."
-msgstr ""
+msgstr "Updated @type %term."
 
 msgid "Add image style"
-msgstr ""
+msgstr "Add image style"
 
 msgid "Preview image style: @style"
-msgstr ""
+msgstr "Preview image style: @style"
 
 msgid ""
 "Deleting a language will remove all interface translations associated with "
 "it, and content in this language will be set to be language neutral. This "
 "action cannot be undone."
 msgstr ""
+"Deleting a language will remove all interface translations associated with "
+"it, and content in this language will be set to be language neutral. This "
+"action cannot be undone."
 
 msgid "No placeholders"
-msgstr ""
+msgstr "No placeholders"
 
 msgid "Title placeholder: @placeholder_title"
-msgstr ""
+msgstr "Title placeholder: @placeholder_title"
 
 msgid "URL placeholder: @placeholder_url"
-msgstr ""
+msgstr "URL placeholder: @placeholder_url"
 
 msgid "Note that importing large .po files may take several minutes."
-msgstr ""
+msgstr "Note that importing large .po files may take several minutes."
 
 msgid ""
 "Content items can be edited using different form modes. Here, you can define"
@@ -16003,25 +17130,33 @@ msgid ""
 " mode, and define how the field form widgets are displayed in each form "
 "mode."
 msgstr ""
+"Content items can be edited using different form modes. Here, you can define"
+" which fields are shown and hidden when %type content is edited in each form"
+" mode, and define how the field form widgets are displayed in each form "
+"mode."
 
 msgid "Edit %label content type"
-msgstr ""
+msgstr "Edit %label content type"
 
 msgid ""
 "The content has either been modified by another user, or you have already "
 "submitted modifications. As a result, your changes cannot be saved."
 msgstr ""
+"The content has either been modified by another user, or you have already "
+"submitted modifications. As a result, your changes cannot be saved."
 
 msgid "Use field label: @display_label"
-msgstr ""
+msgstr "Use field label: @display_label"
 
 msgid "Provides a row plugin to display search results."
-msgstr ""
+msgstr "Provides a row plugin to display search results."
 
 msgid ""
 "More information about setting up scheduled tasks can be found by <a "
 "href=\"@url\">reading the cron tutorial on drupal.org</a>."
 msgstr ""
+"More information about setting up scheduled tasks can be found by <a "
+"href=\"@url\">reading the cron tutorial on drupal.org</a>."
 
 msgid ""
 "A local file system path where public files will be stored. This directory "
@@ -16029,64 +17164,75 @@ msgid ""
 " Drupal installation directory and be accessible over the web. This must be "
 "changed in settings.php"
 msgstr ""
+"A local file system path where public files will be stored. This directory "
+"must exist and be writable by Drupal. This directory must be relative to the"
+" Drupal installation directory and be accessible over the web. This must be "
+"changed in settings.php"
 
 msgid "%name: the telephone number may not be longer than @max characters."
-msgstr ""
+msgstr "%name: the telephone number may not be longer than @max characters."
 
 msgid "%name: the text may not be longer than @max characters."
-msgstr ""
+msgstr "%name: the text may not be longer than @max characters."
 
 msgid "Summary rows"
-msgstr ""
+msgstr "Summary rows"
 
 msgid ""
 "This form lets administrators add and edit fields for storing user data."
 msgstr ""
+"This form lets administrators add and edit fields for storing user data."
 
 msgid ""
 "This form lets administrators configure how form fields should be displayed "
 "when editing a user profile."
 msgstr ""
+"This form lets administrators configure how form fields should be displayed "
+"when editing a user profile."
 
 msgid ""
 "Alter the HTTP response status code used by this view, mostly helpful for "
 "empty results."
 msgstr ""
+"Alter the HTTP response status code used by this view, mostly helpful for "
+"empty results."
 
 msgid "HTTP status code"
-msgstr ""
+msgstr "HTTP status code"
 
 msgid "Always display the more link"
-msgstr ""
+msgstr "Always display the more link"
 
 msgid ""
 "Check this to display the more link even if there are no more items to "
 "display."
 msgstr ""
+"Check this to display the more link even if there are no more items to "
+"display."
 
 msgid "Make entity label a link to entity page."
-msgstr ""
+msgstr "Make entity label a link to entity page."
 
 msgid "Configure language support for content."
-msgstr ""
+msgstr "Configure language support for content."
 
 msgid "Managing and displaying link fields"
-msgstr ""
+msgstr "Managing and displaying link fields"
 
 msgid "Adding link text"
-msgstr ""
+msgstr "Adding link text"
 
 msgid "Display modes"
-msgstr ""
+msgstr "Display modes"
 
 msgid "Manage custom view modes."
-msgstr ""
+msgstr "Manage custom view modes."
 
 msgid "Configure what displays are available for your content and forms."
-msgstr ""
+msgstr "Configure what displays are available for your content and forms."
 
 msgid "Allows the creation of custom blocks through the user interface."
-msgstr ""
+msgstr "Allows the creation of custom blocks through the user interface."
 
 msgid ""
 "You must add some additional fields to this display before using this field."
@@ -16094,36 +17240,43 @@ msgid ""
 "Note that due to rendering order, you cannot use fields that come after this"
 " field; if you need a field not listed here, rearrange your fields."
 msgstr ""
+"You must add some additional fields to this display before using this field."
+" These fields may be marked as <em>Exclude from display</em> if you prefer. "
+"Note that due to rendering order, you cannot use fields that come after this"
+" field; if you need a field not listed here, rearrange your fields."
 
 msgid "Automatic width"
-msgstr ""
+msgstr "Automatic width"
 
 msgid "Default column classes"
-msgstr ""
+msgstr "Default column classes"
 
 msgid "Custom column class"
-msgstr ""
+msgstr "Custom column class"
 
 msgid "Additional classes to provide on each column. Separated by a space."
-msgstr ""
+msgstr "Additional classes to provide on each column. Separated by a space."
 
 msgid "Default row classes"
-msgstr ""
+msgstr "Default row classes"
 
 msgid ""
 "Adds the default views row classes like views-row, row-1 and clearfix to the"
 " output. You can use this to quickly reduce the amount of markup the view "
 "provides by default, at the cost of making it more difficult to apply CSS."
 msgstr ""
+"Adds the default views row classes like views-row, row-1 and clearfix to the"
+" output. You can use this to quickly reduce the amount of markup the view "
+"provides by default, at the cost of making it more difficult to apply CSS."
 
 msgid "Custom row class"
-msgstr ""
+msgstr "Custom row class"
 
 msgid "Additional classes to provide on each row. Separated by a space."
-msgstr ""
+msgstr "Additional classes to provide on each row. Separated by a space."
 
 msgid "Default wizard"
-msgstr ""
+msgstr "Default wizard"
 
 msgid ""
 "All Views-generated queries will include the name of the views and display "
@@ -16131,701 +17284,722 @@ msgid ""
 "makes identifying Views queries in database server logs simpler, but should "
 "only be used when troubleshooting."
 msgstr ""
+"All Views-generated queries will include the name of the views and display "
+"'view-name:display-name' as a string at the end of the SELECT clause. This "
+"makes identifying Views queries in database server logs simpler, but should "
+"only be used when troubleshooting."
 
 msgid "Selected:"
-msgstr ""
+msgstr "Selected:"
 
 msgctxt "Validation"
 msgid "Allowed values"
-msgstr ""
+msgstr "Allowed values"
 
 msgid "You must select at least %limit choice."
 msgid_plural "You must select at least %limit choices."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "You must select at least %limit choice."
+msgstr[1] "You must select at least %limit choices."
 
 msgid "You must select at most %limit choice."
 msgid_plural "You must select at most %limit choices."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "You must select at most %limit choice."
+msgstr[1] "You must select at most %limit choices."
 
 msgctxt "Validation"
 msgid "Bundle"
-msgstr ""
+msgstr "Bundle"
 
 msgid "The entity must be of bundle %bundle."
-msgstr ""
+msgstr "The entity must be of bundle %bundle."
 
 msgctxt "Validation"
 msgid "Complex data"
-msgstr ""
+msgstr "Complex data"
 
 msgctxt "Validation"
 msgid "Count"
-msgstr ""
+msgstr "Count"
 
 msgid "This collection should contain %limit element or more."
 msgid_plural "This collection should contain %limit elements or more."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "This collection should contain %limit element or more."
+msgstr[1] "This collection should contain %limit elements or more."
 
 msgid "This collection should contain %limit element or less."
 msgid_plural "This collection should contain %limit elements or less."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "This collection should contain %limit element or less."
+msgstr[1] "This collection should contain %limit elements or less."
 
 msgid "This collection should contain exactly %limit element."
 msgid_plural "This collection should contain exactly %limit elements."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "This collection should contain exactly %limit element."
+msgstr[1] "This collection should contain exactly %limit elements."
 
 msgctxt "Validation"
 msgid "Entity type"
-msgstr ""
+msgstr "Entity type"
 
 msgid "The entity must be of type %type."
-msgstr ""
+msgstr "The entity must be of type %type."
 
 msgctxt "Validation"
 msgid "Length"
-msgstr ""
+msgstr "Length"
 
 msgid "This value is too long. It should have %limit character or less."
 msgid_plural ""
 "This value is too long. It should have %limit characters or less."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "This value is too long. It should have %limit character or less."
+msgstr[1] "This value is too long. It should have %limit characters or less."
 
 msgid "This value is too short. It should have %limit character or more."
 msgid_plural ""
 "This value is too short. It should have %limit characters or more."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "This value is too short. It should have %limit character or more."
+msgstr[1] "This value is too short. It should have %limit characters or more."
 
 msgid "This value should have exactly %limit character."
 msgid_plural "This value should have exactly %limit characters."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "This value should have exactly %limit character."
+msgstr[1] "This value should have exactly %limit characters."
 
 msgctxt "Validation"
 msgid "Primitive type"
-msgstr ""
+msgstr "Primitive type"
 
 msgid "This value should be of the correct primitive type."
-msgstr ""
+msgstr "This value should be of the correct primitive type."
 
 msgctxt "Validation"
 msgid "Range"
-msgstr ""
+msgstr "Range"
 
 msgid "This value should be %limit or less."
-msgstr ""
+msgstr "This value should be %limit or less."
 
 msgctxt "Validation"
 msgid "Entity Reference valid reference"
-msgstr ""
+msgstr "Entity Reference valid reference"
 
 msgctxt "Validation"
 msgid "User name"
-msgstr ""
+msgstr "User name"
 
 msgctxt "Validation"
 msgid "User name unique"
-msgstr ""
+msgstr "User name unique"
 
 msgid "%name must be higher than or equal to %min."
-msgstr ""
+msgstr "%name must be higher than or equal to %min."
 
 msgid "%name must be lower than or equal to %max."
-msgstr ""
+msgstr "%name must be lower than or equal to %max."
 
 msgctxt "Validation"
 msgid "Entity changed"
-msgstr ""
+msgstr "Entity changed"
 
 msgid "Select the feed that should be displayed"
-msgstr ""
+msgstr "Select the feed that should be displayed"
 
 msgid "Creating and managing custom block types"
-msgstr ""
+msgstr "Creating and managing custom block types"
 
 msgid "The custom block language code."
-msgstr ""
+msgstr "The custom block language code."
 
 msgid "The time that the custom block was last edited."
-msgstr ""
+msgstr "The time that the custom block was last edited."
 
 msgid "Block category"
-msgstr ""
+msgstr "Block category"
 
 msgid "Hide block if the view output is empty"
-msgstr ""
+msgstr "Hide block if the view output is empty"
 
 msgid "Block empty settings"
-msgstr ""
+msgstr "Block empty settings"
 
 msgid "Hide block if no result/empty text"
-msgstr ""
+msgstr "Hide block if no result/empty text"
 
 msgid ""
 "Hide the block if there is no result and no empty text and no header/footer "
 "which is shown on empty result"
 msgstr ""
+"Hide the block if there is no result and no empty text and no header/footer "
+"which is shown on empty result"
 
 msgid "Enter caption here"
-msgstr ""
+msgstr "Enter caption here"
 
 msgid "Drupal image caption widget"
-msgstr ""
+msgstr "Drupal image caption widget"
 
 msgid "The number of comments posted on an entity."
-msgstr ""
+msgstr "The number of comments posted on an entity."
 
 msgid ""
 "The number of comments posted on an entity since the reader last viewed it."
 msgstr ""
+"The number of comments posted on an entity since the reader last viewed it."
 
 msgid "The entity the comment was posted to."
-msgstr ""
+msgstr "The entity the comment was posted to."
 
 msgid "The @entity_type to which the comment is a reply to."
-msgstr ""
+msgstr "The @entity_type to which the comment is a reply to."
 
 msgid "The number of comments an entity has."
-msgstr ""
+msgstr "The number of comments an entity has."
 
 msgid "Display the last comment of an entity"
-msgstr ""
+msgstr "Display the last comment of an entity"
 
 msgid "The last comment of an entity."
-msgstr ""
+msgstr "The last comment of an entity."
 
 msgid "The entity type to which the comment is a reply to."
-msgstr ""
+msgstr "The entity type to which the comment is a reply to."
 
 msgid ""
 "Display nodes only if a user posted the @entity_type or commented on the "
 "@entity_type."
 msgstr ""
+"Display nodes only if a user posted the @entity_type or commented on the "
+"@entity_type."
 
 msgid "Comments of the @entity_type using field: @field_name"
-msgstr ""
+msgstr "Comments of the @entity_type using field: @field_name"
 
 msgid "Edit comment %title"
-msgstr ""
+msgstr "Edit comment %title"
 
 msgid "The ID of the entity of which this comment is a reply."
-msgstr ""
+msgstr "The ID of the entity of which this comment is a reply."
 
 msgid "The entity type to which this comment is attached."
-msgstr ""
+msgstr "The entity type to which this comment is attached."
 
 msgid "Comment field name"
-msgstr ""
+msgstr "Comment field name"
 
 msgid "The field name through which this comment was added."
-msgstr ""
+msgstr "The field name through which this comment was added."
 
 msgid "The time that the last comment was created."
-msgstr ""
+msgstr "The time that the last comment was created."
 
 msgid "The name of the user posting the last comment."
-msgstr ""
+msgstr "The name of the user posting the last comment."
 
 msgid "The number of comments."
-msgstr ""
+msgstr "The number of comments."
 
 msgid ""
 "This field manages configuration and presentation of comments on an entity."
 msgstr ""
+"This field manages configuration and presentation of comments on an entity."
 
 msgid "Comment list"
-msgstr ""
+msgstr "Comment list"
 
 msgid "Select source language"
-msgstr ""
+msgstr "Select source language"
 
 msgid "Computed date"
-msgstr ""
+msgstr "Computed date"
 
 msgid "The computed DateTime object."
-msgstr ""
+msgstr "The computed DateTime object."
 
 msgid "Log entries"
-msgstr ""
+msgstr "Log entries"
 
 msgid "Contains a list of log entries."
-msgstr ""
+msgstr "Contains a list of log entries."
 
 msgid "The user on which the log entry as written."
-msgstr ""
+msgstr "The user on which the log entry as written."
 
 msgid "The actual message of the log entry."
-msgstr ""
+msgstr "The actual message of the log entry."
 
 msgid "The variables of the log entry in a serialized format."
-msgstr ""
+msgstr "The variables of the log entry in a serialized format."
 
 msgid "Operation links for the event."
-msgstr ""
+msgstr "Operation links for the event."
 
 msgid "URL of the previous page."
-msgstr ""
+msgstr "URL of the previous page."
 
 msgid "Date when the event occurred."
-msgstr ""
+msgstr "Date when the event occurred."
 
 msgid "Replace variables"
-msgstr ""
+msgstr "Replace variables"
 
 msgid "One file only."
 msgid_plural "Maximum @count files."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "One file only."
+msgstr[1] "Maximum @count files."
 
 msgid "Last comment ID"
-msgstr ""
+msgstr "Last comment ID"
 
 msgid "WID"
-msgstr ""
+msgstr "WID"
 
 msgid "Block layout"
-msgstr ""
+msgstr "Block layout"
 
 msgid "Content language and translation"
-msgstr ""
+msgstr "Content language and translation"
 
 msgid "Configure language and translation support for content."
-msgstr ""
+msgstr "Configure language and translation support for content."
 
 msgid "Adding attributes to links"
-msgstr ""
+msgstr "Adding attributes to links"
 
 msgid "Validating URLs"
-msgstr ""
+msgstr "Validating URLs"
 
 msgid "Number (decimal)"
-msgstr ""
+msgstr "Number (decimal)"
 
 msgid "Number (float)"
-msgstr ""
+msgstr "Number (float)"
 
 msgid "Number (integer)"
-msgstr ""
+msgstr "Number (integer)"
 
 msgid "Alias for @id"
-msgstr ""
+msgstr "Alias for @id"
 
 msgid "Raw output for @id"
-msgstr ""
+msgstr "Raw output for @id"
 
 msgid "The date the term was last updated."
-msgstr ""
+msgstr "The date the term was last updated."
 
 msgid "The time that the term was last edited."
-msgstr ""
+msgstr "The time that the term was last edited."
 
 msgid "Managing and displaying telephone fields"
-msgstr ""
+msgstr "Managing and displaying telephone fields"
 
 msgid "Displaying telephone numbers as links"
-msgstr ""
+msgstr "Displaying telephone numbers as links"
 
 msgid "The user account %name cannot be canceled."
-msgstr ""
+msgstr "The user account %name cannot be canceled."
 
 msgid "Default actions"
-msgstr ""
+msgstr "Default actions"
 
 msgid "Grouping @id"
-msgstr ""
+msgstr "Grouping @id"
 
 msgid "Columns for @field"
-msgstr ""
+msgstr "Columns for @field"
 
 msgid "Sortable for @field"
-msgstr ""
+msgstr "Sortable for @field"
 
 msgid "Default sort order for @field"
-msgstr ""
+msgstr "Default sort order for @field"
 
 msgid "Default sort for @field"
-msgstr ""
+msgstr "Default sort for @field"
 
 msgid "Alignment for @field"
-msgstr ""
+msgstr "Alignment for @field"
 
 msgid "Separator for @field"
-msgstr ""
+msgstr "Separator for @field"
 
 msgid "Hide empty column for @field"
-msgstr ""
+msgstr "Hide empty column for @field"
 
 msgid "Responsive setting for @field"
-msgstr ""
+msgstr "Responsive setting for @field"
 
 msgid "No default sort"
-msgstr ""
+msgstr "No default sort"
 
 msgid "Page display settings"
-msgstr ""
+msgstr "Page display settings"
 
 msgid "Block display settings"
-msgstr ""
+msgstr "Block display settings"
 
 msgid "Always show the master (default) display"
-msgstr ""
+msgstr "Always show the master (default) display"
 
 msgid "Allow embedded displays"
-msgstr ""
+msgstr "Allow embedded displays"
 
 msgid "Embedded displays can be used in code via views_embed_view()."
-msgstr ""
+msgstr "Embedded displays can be used in code via views_embed_view()."
 
 msgid "Show SQL query"
-msgstr ""
+msgstr "Show SQL query"
 
 msgid "Remove @title"
-msgstr ""
+msgstr "Remove @title"
 
 msgid "Weight for @id"
-msgstr ""
+msgstr "Weight for @id"
 
 msgid "Group for @id"
-msgstr ""
+msgstr "Group for @id"
 
 msgid "Remove @id"
-msgstr ""
+msgstr "Remove @id"
 
 msgid "PHP date format"
-msgstr ""
+msgstr "PHP date format"
 
 msgid "@group: @title"
-msgstr ""
+msgstr "@group: @title"
 
 msgid "Media types"
-msgstr ""
+msgstr "Media types"
 
 msgid "Not fully protected"
-msgstr ""
+msgstr "Not fully protected"
 
 msgid ""
 "Could not load the form for <q>@field-label</q>, either due to a website "
 "problem or a network connection problem.<br>Please try again."
 msgstr ""
+"Could not load the form for <q>@field-label</q>, either due to a website "
+"problem or a network connection problem.<br>Please try again."
 
 msgid "Reset your password"
-msgstr ""
+msgstr "Reset your password"
 
 msgid "Number of new comments"
-msgstr ""
+msgstr "Number of new comments"
 
 msgid "Button divider"
-msgstr ""
+msgstr "Button divider"
 
 msgid "CKEditor toolbar and button configuration."
-msgstr ""
+msgstr "CKEditor toolbar and button configuration."
 
 msgid "Hide group names"
-msgstr ""
+msgstr "Hide group names"
 
 msgid "Show group names"
-msgstr ""
+msgstr "Show group names"
 
 msgid "Press the down arrow key to create a new row."
-msgstr ""
+msgstr "Press the down arrow key to create a new row."
 
 msgid "@name @type."
-msgstr ""
+msgstr "@name @type."
 
 msgid "Press the down arrow key to activate."
-msgstr ""
+msgstr "Press the down arrow key to activate."
 
 msgid "This is the last group. Move the button forward to create a new group."
 msgstr ""
+"This is the last group. Move the button forward to create a new group."
 
 msgid "The \"@name\" button is currently enabled."
-msgstr ""
+msgstr "The \"@name\" button is currently enabled."
 
 msgid "Use the keyboard arrow keys to change the position of this button."
-msgstr ""
+msgstr "Use the keyboard arrow keys to change the position of this button."
 
 msgid "Press the up arrow key on the top row to disable the button."
-msgstr ""
+msgstr "Press the up arrow key on the top row to disable the button."
 
 msgid "The \"@name\" button is currently disabled."
-msgstr ""
+msgstr "The \"@name\" button is currently disabled."
 
 msgid "Use the down arrow key to move this button into the active toolbar."
-msgstr ""
+msgstr "Use the down arrow key to move this button into the active toolbar."
 
 msgid "This @name is currently enabled."
-msgstr ""
+msgstr "This @name is currently enabled."
 
 msgid "Use the keyboard arrow keys to change the position of this separator."
-msgstr ""
+msgstr "Use the keyboard arrow keys to change the position of this separator."
 
 msgid "Separators are used to visually split individual buttons."
-msgstr ""
+msgstr "Separators are used to visually split individual buttons."
 
 msgid "This @name is currently disabled."
-msgstr ""
+msgstr "This @name is currently disabled."
 
 msgid "Use the down arrow key to move this separator into the active toolbar."
 msgstr ""
+"Use the down arrow key to move this separator into the active toolbar."
 
 msgid "You may add multiple separators to each button group."
-msgstr ""
+msgstr "You may add multiple separators to each button group."
 
 msgid "Please provide a name for the button group."
-msgstr ""
+msgstr "Please provide a name for the button group."
 
 msgid "Button group name"
-msgstr ""
+msgstr "Button group name"
 
 msgid "Place a button to create a new button group."
-msgstr ""
+msgstr "Place a button to create a new button group."
 
 msgid "Add a CKEditor button group to the end of this row."
-msgstr ""
+msgstr "Add a CKEditor button group to the end of this row."
 
 msgid "Simple configuration"
-msgstr ""
+msgstr "Simple configuration"
 
 msgid "Configuration type"
-msgstr ""
+msgstr "Configuration type"
 
 msgid "Here is your configuration:"
-msgstr ""
+msgstr "Here is your configuration:"
 
 msgid "Are you sure you want to update the %name @type?"
-msgstr ""
+msgstr "Are you sure you want to update the %name @type?"
 
 msgid "Enter block, theme or category"
-msgstr ""
+msgstr "Enter block, theme or category"
 
 msgid "Enter a part of the block, theme or category to filter by."
-msgstr ""
+msgstr "Enter a part of the block, theme or category to filter by."
 
 msgid "Translations for %label"
-msgstr ""
+msgstr "Translations for %label"
 
 msgid "@language (original)"
-msgstr ""
+msgstr "@language (original)"
 
 msgid "Enter label"
-msgstr ""
+msgstr "Enter label"
 
 msgid "Enter a part of the label or description to filter by."
-msgstr ""
+msgstr "Enter a part of the label or description to filter by."
 
 msgid "Enter field or @bundle"
-msgstr ""
+msgstr "Enter field or @bundle"
 
 msgid "Successfully saved @language translation."
-msgstr ""
+msgstr "Successfully saved @language translation."
 
 msgid "Successfully updated @language translation."
-msgstr ""
+msgstr "Successfully updated @language translation."
 
 msgid "(Empty)"
-msgstr ""
+msgstr "(Empty)"
 
 msgid "Feed channel"
-msgstr ""
+msgstr "Feed channel"
 
 msgid "About text formats"
-msgstr ""
+msgstr "About text formats"
 
 msgid "The image style %name has been flushed."
-msgstr ""
+msgstr "The image style %name has been flushed."
 
 msgid "Image to be shown if no image is uploaded."
-msgstr ""
+msgstr "Image to be shown if no image is uploaded."
 
 msgid "Action title"
-msgstr ""
+msgstr "Action title"
 
 msgid "- Restricted access -"
-msgstr ""
+msgstr "- Restricted access -"
 
 msgid "Workflow type"
-msgstr ""
+msgstr "Workflow type"
 
 msgid "Display block title"
-msgstr ""
+msgstr "Display block title"
 
 msgid "List of items"
-msgstr ""
+msgstr "List of items"
 
 msgid "The ID of the feed item."
-msgstr ""
+msgstr "The ID of the feed item."
 
 msgid "Placing and moving blocks"
-msgstr ""
+msgstr "Placing and moving blocks"
 
 msgid "Demonstrating block regions for a theme"
-msgstr ""
+msgstr "Demonstrating block regions for a theme"
 
 msgid "Toggling between different themes"
-msgstr ""
+msgstr "Toggling between different themes"
 
 msgid "Configuring block settings"
-msgstr ""
+msgstr "Configuring block settings"
 
 msgid ""
 "You can control the visibility of a block by restricting it to specific "
 "pages, content types, and/or roles by setting the appropriate options under "
 "<em>Visibility settings</em> of the block configuration."
 msgstr ""
+"You can control the visibility of a block by restricting it to specific "
+"pages, content types, and/or roles by setting the appropriate options under "
+"<em>Visibility settings</em> of the block configuration."
 
 msgid "Adding custom blocks"
-msgstr ""
+msgstr "Adding custom blocks"
 
 msgid "Pager ID: @id"
-msgstr ""
+msgstr "Pager ID: @id"
 
 msgid "The email of the person that is sending the contact message."
-msgstr ""
+msgstr "The email of the person that is sending the contact message."
 
 msgid "Managing and displaying file fields"
-msgstr ""
+msgstr "Managing and displaying file fields"
 
 msgid "Allowing file extensions"
-msgstr ""
+msgstr "Allowing file extensions"
 
 msgid "Restricting the maximum file size"
-msgstr ""
+msgstr "Restricting the maximum file size"
 
 msgid "Displaying files and descriptions"
-msgstr ""
+msgstr "Displaying files and descriptions"
 
 msgid "The log entry explaining the changes in this revision."
-msgstr ""
+msgstr "The log entry explaining the changes in this revision."
 
 msgid "At least one authentication provider must be defined for resource @id"
-msgstr ""
+msgstr "At least one authentication provider must be defined for resource @id"
 
 msgid "Custom block ID"
-msgstr ""
+msgstr "Custom block ID"
 
 msgid "File usage"
-msgstr ""
+msgstr "File usage"
 
 msgid "Configuration translation"
-msgstr ""
+msgstr "Configuration translation"
 
 msgid "Translate the configuration."
-msgstr ""
+msgstr "Translate the configuration."
 
 msgid "@label fields"
-msgstr ""
+msgstr "@label fields"
 
 msgid "The uninstall process removes all data related to a module."
-msgstr ""
+msgstr "The uninstall process removes all data related to a module."
 
 msgid "At least one format must be defined for resource @id"
-msgstr ""
+msgstr "At least one format must be defined for resource @id"
 
 msgid "The ID of the shortcut."
-msgstr ""
+msgstr "The ID of the shortcut."
 
 msgid "The UUID of the shortcut."
-msgstr ""
+msgstr "The UUID of the shortcut."
 
 msgid "The bundle of the shortcut."
-msgstr ""
+msgstr "The bundle of the shortcut."
 
 msgid "Route name"
-msgstr ""
+msgstr "Route name"
 
 msgid "The language code of the shortcut."
-msgstr ""
+msgstr "The language code of the shortcut."
 
 msgid "Rebuild access"
-msgstr ""
+msgstr "Rebuild access"
 
 msgid "Taxonomy term ID"
-msgstr ""
+msgstr "Taxonomy term ID"
 
 msgid "Taxonomy term name"
-msgstr ""
+msgstr "Taxonomy term name"
 
 msgid "The name of this user."
-msgstr ""
+msgstr "The name of this user."
 
 msgid "The email of this user."
-msgstr ""
+msgstr "The email of this user."
 
 msgid "The timezone of this user."
-msgstr ""
+msgstr "The timezone of this user."
 
 msgid "The time that the user was created."
-msgstr ""
+msgstr "The time that the user was created."
 
 msgid "Adding functionality to administrative pages"
-msgstr ""
+msgstr "Adding functionality to administrative pages"
 
 msgid "Validate @label"
-msgstr ""
+msgstr "Validate @label"
 
 msgid "Validate user has access to the %name"
-msgstr ""
+msgstr "Validate user has access to the %name"
 
 msgid "Multiple arguments"
-msgstr ""
+msgstr "Multiple arguments"
 
 msgid "Single ID"
-msgstr ""
+msgstr "Single ID"
 
 msgid "One or more IDs separated by , or +"
-msgstr ""
+msgstr "One or more IDs separated by , or +"
 
 msgid "Tag based"
-msgstr ""
+msgstr "Tag based"
 
 msgid ""
 "Tag based caching of data. Caches will persist until any related cache tags "
 "are invalidated."
 msgstr ""
+"Tag based caching of data. Caches will persist until any related cache tags "
+"are invalidated."
 
 msgid "Name and description"
-msgstr ""
+msgstr "Name and description"
 
 msgid "Administrative tags"
-msgstr ""
+msgstr "Administrative tags"
 
 msgid "Enter a comma-separated list of words to describe your view."
-msgstr ""
+msgstr "Enter a comma-separated list of words to describe your view."
 
 msgid "The aggregator feed UUID."
-msgstr ""
+msgstr "The aggregator feed UUID."
 
 msgid "simple configuration"
-msgstr ""
+msgstr "simple configuration"
 
 msgid "The date the file created."
-msgstr ""
+msgstr "The date the file created."
 
 msgid "The timestamp that the file was created."
-msgstr ""
+msgstr "The timestamp that the file was created."
 
 msgid "The timestamp that the file was last changed."
-msgstr ""
+msgstr "The timestamp that the file was last changed."
 
 msgid "Language based on a selected language."
-msgstr ""
+msgstr "Language based on a selected language."
 
 msgid ""
 "Menu links with lower weights are displayed before links with higher "
 "weights."
 msgstr ""
+"Menu links with lower weights are displayed before links with higher "
+"weights."
 
 msgid "The name of the user role."
-msgstr ""
+msgstr "The name of the user role."
 
 msgid "Influence"
-msgstr ""
+msgstr "Influence"
 
 msgid ""
 "Influence is a numeric multiplier used in ordering search results. A higher "
@@ -16833,64 +18007,68 @@ msgid ""
 "zero means the factor is ignored. Changing these numbers does not require "
 "the search index to be rebuilt. Changes take effect immediately."
 msgstr ""
+"Influence is a numeric multiplier used in ordering search results. A higher "
+"number means the corresponding factor has more influence on search results; "
+"zero means the factor is ignored. Changing these numbers does not require "
+"the search index to be rebuilt. Changes take effect immediately."
 
 msgid "Search page type"
-msgstr ""
+msgstr "Search page type"
 
 msgid "- Choose page type -"
-msgstr ""
+msgstr "- Choose page type -"
 
 msgid "No search pages have been configured."
-msgstr ""
+msgstr "No search pages have been configured."
 
 msgid "You must select the new search page type."
-msgstr ""
+msgstr "You must select the new search page type."
 
 msgid "Edit %label search page"
-msgstr ""
+msgstr "Edit %label search page"
 
 msgid "The %label search page has been enabled."
-msgstr ""
+msgstr "The %label search page has been enabled."
 
 msgid "The %label search page has been disabled."
-msgstr ""
+msgstr "The %label search page has been disabled."
 
 msgid "The %label search page has been added."
-msgstr ""
+msgstr "The %label search page has been added."
 
 msgid "Save search page"
-msgstr ""
+msgstr "Save search page"
 
 msgid "The %label search page has been updated."
-msgstr ""
+msgstr "The %label search page has been updated."
 
 msgid "The label for this search page."
-msgstr ""
+msgstr "The label for this search page."
 
 msgid "The search page path must be unique."
-msgstr ""
+msgstr "The search page path must be unique."
 
 msgid "Managing and displaying text fields"
-msgstr ""
+msgstr "Managing and displaying text fields"
 
 msgid "Creating short text fields"
-msgstr ""
+msgstr "Creating short text fields"
 
 msgid "Creating long text fields"
-msgstr ""
+msgstr "Creating long text fields"
 
 msgid "Trimming the text length"
-msgstr ""
+msgstr "Trimming the text length"
 
 msgid "Displaying summaries instead of trimmed text"
-msgstr ""
+msgstr "Displaying summaries instead of trimmed text"
 
 msgid "Using text formats and editors"
-msgstr ""
+msgstr "Using text formats and editors"
 
 msgctxt "Text alignment"
 msgid "Left"
-msgstr ""
+msgstr "Left"
 
 msgctxt "Text alignment"
 msgid "Center"
@@ -16898,16 +18076,16 @@ msgstr "Centre"
 
 msgctxt "Text alignment"
 msgid "Right"
-msgstr ""
+msgstr "Right"
 
 msgid "%name: may not be longer than @max characters."
-msgstr ""
+msgstr "%name: may not be longer than @max characters."
 
 msgid "<abbr title=\"Outline Processor Markup Language\">OPML</abbr> integration"
-msgstr ""
+msgstr "<abbr title=\"Outline Processor Markup Language\">OPML</abbr> integration"
 
 msgid "Resolution multiplier"
-msgstr ""
+msgstr "Resolution multiplier"
 
 msgid ""
 "Resolution multipliers are a measure of the viewport's device resolution, "
@@ -16917,42 +18095,56 @@ msgid ""
 "multipliers of 1, 1.5, and 2; when defining breakpoints, modules and themes "
 "can define which multipliers apply to each breakpoint."
 msgstr ""
+"Resolution multipliers are a measure of the viewport's device resolution, "
+"defined to be the ratio between the physical pixel size of the active device"
+" and the <a href=\"http://en.wikipedia.org/wiki/Device_independent_pixel"
+"\">device-independent pixel</a> size. The Breakpoint module defines "
+"multipliers of 1, 1.5, and 2; when defining breakpoints, modules and themes "
+"can define which multipliers apply to each breakpoint."
 
 msgid "Defining breakpoints and breakpoint groups"
-msgstr ""
+msgstr "Defining breakpoints and breakpoint groups"
 
 msgid ""
 "Modules and themes can use the API provided by the Breakpoint module to "
 "define breakpoints and breakpoint groups, and to assign resolution "
 "multipliers to breakpoints."
 msgstr ""
+"Modules and themes can use the API provided by the Breakpoint module to "
+"define breakpoints and breakpoint groups, and to assign resolution "
+"multipliers to breakpoints."
 
 msgctxt "Validation"
 msgid "Comment author name"
-msgstr ""
+msgstr "Comment author name"
 
 msgid ""
 "Changing the text format to %text_format will permanently remove content "
 "that is not allowed in that text format.<br><br>Save your changes before "
 "switching the text format to avoid losing data."
 msgstr ""
+"Changing the text format to %text_format will permanently remove content "
+"that is not allowed in that text format.<br><br>Save your changes before "
+"switching the text format to avoid losing data."
 
 msgid "Change text format?"
-msgstr ""
+msgstr "Change text format?"
 
 msgid "Managing and displaying entity reference fields"
-msgstr ""
+msgstr "Managing and displaying entity reference fields"
 
 msgid "Selecting reference type"
-msgstr ""
+msgstr "Selecting reference type"
 
 msgid ""
 "In the field settings you can select which entity type you want to create a "
 "reference to."
 msgstr ""
+"In the field settings you can select which entity type you want to create a "
+"reference to."
 
 msgid "Filtering and sorting reference fields"
-msgstr ""
+msgstr "Filtering and sorting reference fields"
 
 msgid ""
 "Depending on the chosen entity type, additional filtering and sorting "
@@ -16960,1277 +18152,1303 @@ msgid ""
 "the field settings. For example, the list of users can be filtered by role "
 "and sorted by name or ID."
 msgstr ""
+"Depending on the chosen entity type, additional filtering and sorting "
+"options are available for the list of entities that can be referred to, in "
+"the field settings. For example, the list of users can be filtered by role "
+"and sorted by name or ID."
 
 msgid "Displaying a reference"
-msgstr ""
+msgstr "Displaying a reference"
 
 msgid "Managing text formats"
-msgstr ""
+msgstr "Managing text formats"
 
 msgid "Assigning roles to text formats"
-msgstr ""
+msgstr "Assigning roles to text formats"
 
 msgid "Selecting filters"
-msgstr ""
+msgstr "Selecting filters"
 
 msgid "The keywords to search for."
-msgstr ""
+msgstr "The keywords to search for."
 
 msgid "Choosing list field type"
-msgstr ""
+msgstr "Choosing list field type"
 
 msgid "Simpletest site directory"
-msgstr ""
+msgstr "Simpletest site directory"
 
 msgid "The vocabulary to which the term is assigned."
-msgstr ""
+msgstr "The vocabulary to which the term is assigned."
 
 msgid "Promo image"
-msgstr ""
+msgstr "Promo image"
 
 msgid "Missing profile parameter."
-msgstr ""
+msgstr "Missing profile parameter."
 
 msgid "Timestamp value"
-msgstr ""
+msgstr "Timestamp value"
 
 msgid "An entity field containing a UNIX timestamp value."
-msgstr ""
+msgstr "An entity field containing a UNIX timestamp value."
 
 msgid "Default PHP mailer"
-msgstr ""
+msgstr "Default PHP mailer"
 
 msgid "Sends the message as plain text, using PHP's native mail() function."
-msgstr ""
+msgstr "Sends the message as plain text, using PHP's native mail() function."
 
 msgid "Mail collector"
-msgstr ""
+msgstr "Mail collector"
 
 msgid ""
 "Does not send the message, but stores it in Drupal within the state system. "
 "Used for testing."
 msgstr ""
+"Does not send the message, but stores it in Drupal within the state system. "
+"Used for testing."
 
 msgid "Synchronizing configuration"
-msgstr ""
+msgstr "Synchronizing configuration"
 
 msgid "Starting configuration synchronization."
-msgstr ""
+msgstr "Starting configuration synchronization."
 
 msgid "Configuration synchronization has encountered an error."
-msgstr ""
+msgstr "Configuration synchronization has encountered an error."
 
 msgid "Nothing to export."
-msgstr ""
+msgstr "Nothing to export."
 
 msgid "Administer responsive images"
-msgstr ""
+msgstr "Administer responsive images"
 
 msgid "Return to site content"
-msgstr ""
+msgstr "Return to site content"
 
 msgid "Entity view display"
-msgstr ""
+msgstr "Entity view display"
 
 msgid "Defines a field type for telephone numbers."
-msgstr ""
+msgstr "Defines a field type for telephone numbers."
 
 msgid ""
 "Defined on the Appearance or Theme Settings page. You do not have the "
 "appropriate permissions to change the site logo."
 msgstr ""
+"Defined on the Appearance or Theme Settings page. You do not have the "
+"appropriate permissions to change the site logo."
 
 msgid ""
 "Defined on the Site Information page. You do not have the appropriate "
 "permissions to change the site logo."
 msgstr ""
+"Defined on the Site Information page. You do not have the appropriate "
+"permissions to change the site logo."
 
 msgid "Toggle branding elements"
-msgstr ""
+msgstr "Toggle branding elements"
 
 msgid ""
 "Choose which branding elements you want to show in this block instance."
 msgstr ""
+"Choose which branding elements you want to show in this block instance."
 
 msgid "Rendering language"
-msgstr ""
+msgstr "Rendering language"
 
 msgid ""
 "Form build-id mismatch detected while attempting to store a form in the "
 "cache."
 msgstr ""
+"Form build-id mismatch detected while attempting to store a form in the "
+"cache."
 
 msgid "Deleted and replaced configuration \"@name\""
-msgstr ""
+msgstr "Deleted and replaced configuration \"@name\""
 
 msgid "Update target \"@name\" is missing."
-msgstr ""
+msgstr "Update target \"@name\" is missing."
 
 msgid "%name: The integer must be larger or equal to %min."
-msgstr ""
+msgstr "%name: The integer must be larger or equal to %min."
 
 msgid "Size of URI field"
-msgstr ""
+msgstr "Size of URI field"
 
 msgid "URI field"
-msgstr ""
+msgstr "URI field"
 
 msgid "Are you sure you want to delete all items from the feed %feed?"
-msgstr ""
+msgstr "Are you sure you want to delete all items from the feed %feed?"
 
 msgid "The news items from %site have been deleted."
-msgstr ""
+msgstr "The news items from %site have been deleted."
 
 msgid "A brief description of your block."
-msgstr ""
+msgstr "A brief description of your block."
 
 msgid "Completed @current step of @total."
-msgstr ""
+msgstr "Completed @current step of @total."
 
 msgid "The configuration synchronization failed validation."
-msgstr ""
+msgstr "The configuration synchronization failed validation."
 
 msgid "Allowed link type"
-msgstr ""
+msgstr "Allowed link type"
 
 msgid "Internal links only"
-msgstr ""
+msgstr "Internal links only"
 
 msgid "Both internal and external links"
-msgstr ""
+msgstr "Both internal and external links"
 
 msgid "Translating individual strings"
-msgstr ""
+msgstr "Translating individual strings"
 
 msgid "Format ID."
-msgstr ""
+msgstr "Format ID."
 
 msgid "(this translation)"
-msgstr ""
+msgstr "(this translation)"
 
 msgid "(all translations)"
-msgstr ""
+msgstr "(all translations)"
 
 msgid "Search is currently disabled"
-msgstr ""
+msgstr "Search is currently disabled"
 
 msgid "No screenshot"
-msgstr ""
+msgstr "No screenshot"
 
 msgid "Configuration deletions"
-msgstr ""
+msgstr "Configuration deletions"
 
 msgid "The listed configuration will be deleted."
-msgstr ""
+msgstr "The listed configuration will be deleted."
 
 msgid "User's roles"
-msgstr ""
+msgstr "User's roles"
 
 msgid "One or more names separated by , or +"
-msgstr ""
+msgstr "One or more names separated by , or +"
 
 msgid "If none are selected, all are allowed."
-msgstr ""
+msgstr "If none are selected, all are allowed."
 
 msgid "Missing row plugin"
-msgstr ""
+msgstr "Missing row plugin"
 
 msgid "Tab options"
-msgstr ""
+msgstr "Tab options"
 
 msgid "Enable menu link"
-msgstr ""
+msgstr "Enable menu link"
 
 msgid "Allowed HTML"
-msgstr ""
+msgstr "Allowed HTML"
 
 msgid "Providing module"
-msgstr ""
+msgstr "Providing module"
 
 msgid "@label entities"
-msgstr ""
+msgstr "@label entities"
 
 msgid "Synchronizing configuration: @op @name in @collection."
-msgstr ""
+msgstr "Synchronizing configuration: @op @name in @collection."
 
 msgctxt "Entity type group"
 msgid "Content"
-msgstr ""
+msgstr "Content"
 
 msgctxt "Entity type group"
 msgid "Other"
-msgstr ""
+msgstr "Other"
 
 msgctxt "Entity type group"
 msgid "Configuration"
-msgstr ""
+msgstr "Configuration"
 
 msgid "Action ID"
-msgstr ""
+msgstr "Action ID"
 
 msgid "Action configuration"
-msgstr ""
+msgstr "Action configuration"
 
 msgid "Action description"
-msgstr ""
+msgstr "Action description"
 
 msgid "The feed ID."
-msgstr ""
+msgstr "The feed ID."
 
 msgid "Refresh frequency in seconds."
-msgstr ""
+msgstr "Refresh frequency in seconds."
 
 msgid "Last-checked unix timestamp."
-msgstr ""
+msgstr "Last-checked unix timestamp."
 
 msgid "When the feed was last modified."
-msgstr ""
+msgstr "When the feed was last modified."
 
 msgid "The block numeric identifier."
-msgstr ""
+msgstr "The block numeric identifier."
 
 msgid "The module providing the block."
-msgstr ""
+msgstr "The module providing the block."
 
 msgid "The block's delta."
-msgstr ""
+msgstr "The block's delta."
 
 msgid "Pages list."
-msgstr ""
+msgstr "Pages list."
 
 msgid "Cache rule."
-msgstr ""
+msgstr "Cache rule."
 
 msgid "Admin title of the block/box."
-msgstr ""
+msgstr "Admin title of the block/box."
 
 msgid "The comment title."
-msgstr ""
+msgstr "The comment title."
 
 msgid "The {node}.type to which this comment is a reply."
-msgstr ""
+msgstr "The {node}.type to which this comment is a reply."
 
 msgid "The node type"
-msgstr ""
+msgstr "The node type"
 
 msgid "Primary Key: Unique category ID."
-msgstr ""
+msgstr "Primary Key: Unique category ID."
 
 msgid "Category name."
-msgstr ""
+msgstr "Category name."
 
 msgid "The category's weight."
-msgstr ""
+msgstr "The category's weight."
 
 msgid "Type (text, integer, ....)"
-msgstr ""
+msgstr "Type (text, integer, ....)"
 
 msgid "Global settings. Shared with every field instance."
-msgstr ""
+msgstr "Global settings. Shared with every field instance."
 
 msgid "DB storage"
-msgstr ""
+msgstr "DB storage"
 
 msgid "DB Columns"
-msgstr ""
+msgstr "DB Columns"
 
 msgid "The machine name of field."
-msgstr ""
+msgstr "The machine name of field."
 
 msgid "Weight."
-msgstr ""
+msgstr "Weight."
 
 msgid "A name to show."
-msgstr ""
+msgstr "A name to show."
 
 msgid "Widget type."
-msgstr ""
+msgstr "Widget type."
 
 msgid "A description of field."
-msgstr ""
+msgstr "A description of field."
 
 msgid "Module that implements widget."
-msgstr ""
+msgstr "Module that implements widget."
 
 msgid "Status of widget"
-msgstr ""
+msgstr "Status of widget"
 
 msgid "The module that provides the field."
-msgstr ""
+msgstr "The module that provides the field."
 
 msgid "Content type where this field is used."
-msgstr ""
+msgstr "Content type where this field is used."
 
 msgid "The published status of a file."
-msgstr ""
+msgstr "The published status of a file."
 
 msgid "The time that the file was added."
-msgstr ""
+msgstr "The time that the file was added."
 
 msgid "The Drupal files path."
-msgstr ""
+msgstr "The Drupal files path."
 
 msgid "TRUE if the files directory is public otherwise FALSE."
-msgstr ""
+msgstr "TRUE if the files directory is public otherwise FALSE."
 
 msgid "Machine name of the node type."
-msgstr ""
+msgstr "Machine name of the node type."
 
 msgid "Human name of the node type."
-msgstr ""
+msgstr "Human name of the node type."
 
 msgid "The module providing the node type."
-msgstr ""
+msgstr "The module providing the node type."
 
 msgid "Description of the node type."
-msgstr ""
+msgstr "Description of the node type."
 
 msgid "Help text for the node type."
-msgstr ""
+msgstr "Help text for the node type."
 
 msgid "Title label."
-msgstr ""
+msgstr "Title label."
 
 msgid "Body label."
-msgstr ""
+msgstr "Body label."
 
 msgid "Flag."
-msgstr ""
+msgstr "Flag."
 
 msgid "The original type."
-msgstr ""
+msgstr "The original type."
 
 msgid "Primary Key: Unique profile field ID."
-msgstr ""
+msgstr "Primary Key: Unique profile field ID."
 
 msgid "Title of the field shown to the end user."
-msgstr ""
+msgstr "Title of the field shown to the end user."
 
 msgid "Explanation of the field to end users."
-msgstr ""
+msgstr "Explanation of the field to end users."
 
 msgid "Type of form field."
-msgstr ""
+msgstr "Type of form field."
 
 msgid "The numeric identifier of the path alias."
-msgstr ""
+msgstr "The numeric identifier of the path alias."
 
 msgid "The name of the vocabulary."
-msgstr ""
+msgstr "The name of the vocabulary."
 
 msgid "The description of the vocabulary."
-msgstr ""
+msgstr "The description of the vocabulary."
 
 msgid "Menu selection requires the activation of Menu UI module."
-msgstr ""
+msgstr "Menu selection requires the activation of Menu UI module."
 
 msgid ""
 "Numeric placeholders may not be used. Please use plain placeholders (%)."
 msgstr ""
+"Numeric placeholders may not be used. Please use plain placeholders (%)."
 
 msgid "Route Name"
-msgstr ""
+msgstr "Route Name"
 
 msgid "Route Params"
-msgstr ""
+msgstr "Route Params"
 
 msgid "Param"
-msgstr ""
+msgstr "Param"
 
 msgid "Configuration dependencies"
-msgstr ""
+msgstr "Configuration dependencies"
 
 msgid "Theme dependencies"
-msgstr ""
+msgstr "Theme dependencies"
 
 msgid "Extension settings"
-msgstr ""
+msgstr "Extension settings"
 
 msgid "Action settings"
-msgstr ""
+msgstr "Action settings"
 
 msgid "Recursion limit for actions"
-msgstr ""
+msgstr "Recursion limit for actions"
 
 msgid "Redirect to URL configuration"
-msgstr ""
+msgstr "Redirect to URL configuration"
 
 msgid "Display a message to the user configuration"
-msgstr ""
+msgstr "Display a message to the user configuration"
 
 msgid "Bulk form"
-msgstr ""
+msgstr "Bulk form"
 
 msgid "Admin info"
-msgstr ""
+msgstr "Admin info"
 
 msgid "Block display options"
-msgstr ""
+msgstr "Block display options"
 
 msgid "Book settings"
-msgstr ""
+msgstr "Book settings"
 
 msgid "Button groups"
-msgstr ""
+msgstr "Button groups"
 
 msgid "Button group"
-msgstr ""
+msgstr "Button group"
 
 msgid "List of styles"
-msgstr ""
+msgstr "List of styles"
 
 msgid "Color theme settings"
-msgstr ""
+msgstr "Color theme settings"
 
 msgid "Palette settings"
-msgstr ""
+msgstr "Palette settings"
 
 msgid "Last comment date"
-msgstr ""
+msgstr "Last comment date"
 
 msgid "no caching"
-msgstr ""
+msgstr "no caching"
 
 msgid "Entity options"
-msgstr ""
+msgstr "Entity options"
 
 msgid "Translate @type_name"
-msgstr ""
+msgstr "Translate @type_name"
 
 msgid "Personal contact form enabled by default"
-msgstr ""
+msgstr "Personal contact form enabled by default"
 
 msgid "Content translation link"
-msgstr ""
+msgstr "Content translation link"
 
 msgid "Contextual link"
-msgstr ""
+msgstr "Contextual link"
 
 msgid "Delete form mode"
-msgstr ""
+msgstr "Delete form mode"
 
 msgid "Entity view mode settings"
-msgstr ""
+msgstr "Entity view mode settings"
 
 msgid "Target entity type"
-msgstr ""
+msgstr "Target entity type"
 
 msgid "Entity form mode settings"
-msgstr ""
+msgstr "Entity form mode settings"
 
 msgid "View or form mode machine name"
-msgstr ""
+msgstr "View or form mode machine name"
 
 msgid "Field display setting"
-msgstr ""
+msgstr "Field display setting"
 
 msgid "Text field display format settings"
-msgstr ""
+msgstr "Text field display format settings"
 
 msgid "Sort settings"
-msgstr ""
+msgstr "Sort settings"
 
 msgid "Entity reference rendered entity display format settings"
-msgstr ""
+msgstr "Entity reference rendered entity display format settings"
 
 msgid "Entity reference entity ID display format settings"
-msgstr ""
+msgstr "Entity reference entity ID display format settings"
 
 msgid "Entity reference label display format settings"
-msgstr ""
+msgstr "Entity reference label display format settings"
 
 msgid "Entity reference autocomplete (Tags style) display format settings"
-msgstr ""
+msgstr "Entity reference autocomplete (Tags style) display format settings"
 
 msgid "Entity reference autocomplete display format settings"
-msgstr ""
+msgstr "Entity reference autocomplete display format settings"
 
 msgid "Search field"
-msgstr ""
+msgstr "Search field"
 
 msgid "- Hidden - format settings"
-msgstr ""
+msgstr "- Hidden - format settings"
 
 msgid "Integer settings"
-msgstr ""
+msgstr "Integer settings"
 
 msgid "Decimal settings"
-msgstr ""
+msgstr "Decimal settings"
 
 msgid "Float settings"
-msgstr ""
+msgstr "Float settings"
 
 msgid "Number decimal display format settings"
-msgstr ""
+msgstr "Number decimal display format settings"
 
 msgid "Number unformatted display format settings"
-msgstr ""
+msgstr "Number unformatted display format settings"
 
 msgid "Number default display format settings"
-msgstr ""
+msgstr "Number default display format settings"
 
 msgid "Reverse entity reference"
-msgstr ""
+msgstr "Reverse entity reference"
 
 msgid "Field UI settings"
-msgstr ""
+msgstr "Field UI settings"
 
 msgid "Enable Description field"
-msgstr ""
+msgstr "Enable Description field"
 
 msgid "HAL"
-msgstr ""
+msgstr "HAL"
 
 msgid "Delete language"
-msgstr ""
+msgstr "Delete language"
 
 msgid "All language types"
-msgstr ""
+msgstr "All language types"
 
 msgid "Language detection methods"
-msgstr ""
+msgstr "Language detection methods"
 
 msgid "Interface Translation"
-msgstr ""
+msgstr "Interface Translation"
 
 msgid "Translate interface settings"
-msgstr ""
+msgstr "Translate interface settings"
 
 msgid "Cache strings"
-msgstr ""
+msgstr "Cache strings"
 
 msgid "Overwrite non customized translations"
-msgstr ""
+msgstr "Overwrite non customized translations"
 
 msgid "Menu UI"
-msgstr ""
+msgstr "Menu UI"
 
 msgid "Per-content type menu settings"
-msgstr ""
+msgstr "Per-content type menu settings"
 
 msgid "Menu machine name"
-msgstr ""
+msgstr "Menu machine name"
 
 msgid "Change the author of content configuration"
-msgstr ""
+msgstr "Change the author of content configuration"
 
 msgid "Save content configuration"
-msgstr ""
+msgstr "Save content configuration"
 
 msgid "Delete content configuration"
-msgstr ""
+msgstr "Delete content configuration"
 
 msgid "Node user ID"
-msgstr ""
+msgstr "Node user ID"
 
 msgid "Node path"
-msgstr ""
+msgstr "Node path"
 
 msgid "Link to a node revision"
-msgstr ""
+msgstr "Link to a node revision"
 
 msgid "List (integer) settings"
-msgstr ""
+msgstr "List (integer) settings"
 
 msgid "List (float) settings"
-msgstr ""
+msgstr "List (float) settings"
 
 msgid "List (text) settings"
-msgstr ""
+msgstr "List (text) settings"
 
 msgid "Options list default display settings"
-msgstr ""
+msgstr "Options list default display settings"
 
 msgid "Key format settings"
-msgstr ""
+msgstr "Key format settings"
 
 msgid "Single on/off checkbox format settings"
-msgstr ""
+msgstr "Single on/off checkbox format settings"
 
 msgid "Select list format settings"
-msgstr ""
+msgstr "Select list format settings"
 
 msgid "Responsive Image"
-msgstr ""
+msgstr "Responsive Image"
 
 msgid "RESTful Web Services"
-msgstr ""
+msgstr "RESTful Web Services"
 
 msgid "REST settings"
-msgstr ""
+msgstr "REST settings"
 
 msgid "GET method settings"
-msgstr ""
+msgstr "GET method settings"
 
 msgid "POST method settings"
-msgstr ""
+msgstr "POST method settings"
 
 msgid "PATCH method settings"
-msgstr ""
+msgstr "PATCH method settings"
 
 msgid "DELETE method settings"
-msgstr ""
+msgstr "DELETE method settings"
 
 msgid "Supported format"
-msgstr ""
+msgstr "Supported format"
 
 msgid "Supported authentication"
-msgstr ""
+msgstr "Supported authentication"
 
 msgid "REST display options"
-msgstr ""
+msgstr "REST display options"
 
 msgid "Field row"
-msgstr ""
+msgstr "Field row"
 
 msgid "Alias for ID"
-msgstr ""
+msgstr "Alias for ID"
 
 msgid "Raw output for ID"
-msgstr ""
+msgstr "Raw output for ID"
 
 msgid "Serialized output format"
-msgstr ""
+msgstr "Serialized output format"
 
 msgid "Configure search pages and search indexing options."
-msgstr ""
+msgstr "Configure search pages and search indexing options."
 
 msgid "Add new search page"
-msgstr ""
+msgstr "Add new search page"
 
 msgid "AND/OR combination limit"
-msgstr ""
+msgstr "AND/OR combination limit"
 
 msgid "Default search page"
-msgstr ""
+msgstr "Default search page"
 
 msgid "HTML tags weight"
-msgstr ""
+msgstr "HTML tags weight"
 
 msgid "Tag h1 weight"
-msgstr ""
+msgstr "Tag h1 weight"
 
 msgid "Tag h2 weight"
-msgstr ""
+msgstr "Tag h2 weight"
 
 msgid "Tag h3 weight"
-msgstr ""
+msgstr "Tag h3 weight"
 
 msgid "Tag h4 weight"
-msgstr ""
+msgstr "Tag h4 weight"
 
 msgid "Tag h5 weight"
-msgstr ""
+msgstr "Tag h5 weight"
 
 msgid "Tag h6 weight"
-msgstr ""
+msgstr "Tag h6 weight"
 
 msgid "Tag u weight"
-msgstr ""
+msgstr "Tag u weight"
 
 msgid "Tag b weight"
-msgstr ""
+msgstr "Tag b weight"
 
 msgid "Tag i weight"
-msgstr ""
+msgstr "Tag i weight"
 
 msgid "Tag strong weight"
-msgstr ""
+msgstr "Tag strong weight"
 
 msgid "Tag em weight"
-msgstr ""
+msgstr "Tag em weight"
 
 msgid "Tag a weight"
-msgstr ""
+msgstr "Tag a weight"
 
 msgid "Query key"
-msgstr ""
+msgstr "Query key"
 
 msgid "Source link"
-msgstr ""
+msgstr "Source link"
 
 msgid "Serialization"
-msgstr ""
+msgstr "Serialization"
 
 msgid "Shortcut settings"
-msgstr ""
+msgstr "Shortcut settings"
 
 msgid "Statistics settings"
-msgstr ""
+msgstr "Statistics settings"
 
 msgid "Syslog settings"
-msgstr ""
+msgstr "Syslog settings"
 
 msgid "Set as default theme"
-msgstr ""
+msgstr "Set as default theme"
 
 msgid "Site UUID"
-msgstr ""
+msgstr "Site UUID"
 
 msgid "Authorize settings"
-msgstr ""
+msgstr "Authorize settings"
 
 msgid "Default file transfer protocol"
-msgstr ""
+msgstr "Default file transfer protocol"
 
 msgid "Remind users at login if their time zone is not set"
-msgstr ""
+msgstr "Remind users at login if their time zone is not set"
 
 msgid "Logging settings"
-msgstr ""
+msgstr "Logging settings"
 
 msgid "CSS performance settings"
-msgstr ""
+msgstr "CSS performance settings"
 
 msgid "Compress CSS files"
-msgstr ""
+msgstr "Compress CSS files"
 
 msgid "Fast 404 settings"
-msgstr ""
+msgstr "Fast 404 settings"
 
 msgid "Fast 404 enabled"
-msgstr ""
+msgstr "Fast 404 enabled"
 
 msgid "Fast 404 page html"
-msgstr ""
+msgstr "Fast 404 page html"
 
 msgid "Theme global settings"
-msgstr ""
+msgstr "Theme global settings"
 
 msgid "Maintain index table"
-msgstr ""
+msgstr "Maintain index table"
 
 msgid "Override selector"
-msgstr ""
+msgstr "Override selector"
 
 msgid "Number of terms per page"
-msgstr ""
+msgstr "Number of terms per page"
 
 msgid "Taxonomy format settings"
-msgstr ""
+msgstr "Taxonomy format settings"
 
 msgid "Use taxonomy term path"
-msgstr ""
+msgstr "Use taxonomy term path"
 
 msgid "Taxonomy depth modifier"
-msgstr ""
+msgstr "Taxonomy depth modifier"
 
 msgid "Taxonomy language"
-msgstr ""
+msgstr "Taxonomy language"
 
 msgid "Taxonomy term ID with depth"
-msgstr ""
+msgstr "Taxonomy term ID with depth"
 
 msgid "Telephone link format settings"
-msgstr ""
+msgstr "Telephone link format settings"
 
 msgid "Telephone default format settings"
-msgstr ""
+msgstr "Telephone default format settings"
 
 msgid "Default summary length"
-msgstr ""
+msgstr "Default summary length"
 
 msgid "Text area (multiple rows) display format settings"
-msgstr ""
+msgstr "Text area (multiple rows) display format settings"
 
 msgid "Number of summary rows"
-msgstr ""
+msgstr "Number of summary rows"
 
 msgid "Route settings"
-msgstr ""
+msgstr "Route settings"
 
 msgid "Tracker settings"
-msgstr ""
+msgstr "Tracker settings"
 
 msgid "Cron index limit"
-msgstr ""
+msgstr "Cron index limit"
 
 msgid "User window"
-msgstr ""
+msgstr "User window"
 
 msgid "Default area"
-msgstr ""
+msgstr "Default area"
 
 msgid "The shown text of the area"
-msgstr ""
+msgstr "The shown text of the area"
 
 msgid "Provides guided tours."
-msgstr ""
+msgstr "Provides guided tours."
 
 msgid "Translates the built-in user interface."
-msgstr ""
+msgstr "Translates the built-in user interface."
 
 msgctxt "With components"
 msgid "Extend"
-msgstr ""
+msgstr "Extend"
 
 msgid "Text custom"
-msgstr ""
+msgstr "Text custom"
 
 msgid "The shown text of the result summary area"
-msgstr ""
+msgstr "The shown text of the result summary area"
 
 msgid "The title which will be overridden for the page"
-msgstr ""
+msgstr "The title which will be overridden for the page"
 
 msgid "Node Creation Time"
-msgstr ""
+msgstr "Node Creation Time"
 
 msgid "Node Update Time"
-msgstr ""
+msgstr "Node Update Time"
 
 msgid "Day Date"
-msgstr ""
+msgstr "Day Date"
 
 msgid "Formula"
-msgstr ""
+msgstr "Formula"
 
 msgid "Place Holder"
-msgstr ""
+msgstr "Place Holder"
 
 msgid "Formula Used"
-msgstr ""
+msgstr "Formula Used"
 
 msgid "Full Date"
-msgstr ""
+msgstr "Full Date"
 
 msgid "Group by Numeric"
-msgstr ""
+msgstr "Group by Numeric"
 
 msgid "Month Date"
-msgstr ""
+msgstr "Month Date"
 
 msgid "Week Date"
-msgstr ""
+msgstr "Week Date"
 
 msgid "Year Date"
-msgstr ""
+msgstr "Year Date"
 
 msgid "YearMonthDate"
-msgstr ""
+msgstr "YearMonthDate"
 
 msgid "Date Year month"
-msgstr ""
+msgstr "Date Year month"
 
 msgid "Basic validation"
-msgstr ""
+msgstr "Basic validation"
 
 msgid "Tag based caching"
-msgstr ""
+msgstr "Tag based caching"
 
 msgid "Time based caching"
-msgstr ""
+msgstr "Time based caching"
 
 msgid "Exposed form type"
-msgstr ""
+msgstr "Exposed form type"
 
 msgid "Row type"
-msgstr ""
+msgstr "Row type"
 
 msgid "Filter groups"
-msgstr ""
+msgstr "Filter groups"
 
 msgid "Display comment"
-msgstr ""
+msgstr "Display comment"
 
 msgid "Plugin ID"
-msgstr ""
+msgstr "Plugin ID"
 
 msgid "A unique ID per handler type"
-msgstr ""
+msgstr "A unique ID per handler type"
 
 msgid "A sql aggregation type"
-msgstr ""
+msgstr "A sql aggregation type"
 
 msgid "When the filter value is NOT available"
-msgstr ""
+msgstr "When the filter value is NOT available"
 
 msgid "Default argument options"
-msgstr ""
+msgstr "Default argument options"
 
 msgid "Convert newlines to HTML <br> tags"
-msgstr ""
+msgstr "Convert newlines to HTML <br> tags"
 
 msgid "SQL pager"
-msgstr ""
+msgstr "SQL pager"
 
 msgid "Grouping field number %i"
-msgstr ""
+msgstr "Grouping field number %i"
 
 msgid "Group items"
-msgstr ""
+msgstr "Group items"
 
 msgid "Group item"
-msgstr ""
+msgstr "Group item"
 
 msgid "Query comment"
-msgstr ""
+msgstr "Query comment"
 
 msgid "Default display options"
-msgstr ""
+msgstr "Default display options"
 
 msgid "Page display options"
-msgstr ""
+msgstr "Page display options"
 
 msgid "Attachment display options"
-msgstr ""
+msgstr "Attachment display options"
 
 msgid "Text on demand format"
-msgstr ""
+msgstr "Text on demand format"
 
 msgid "Default field"
-msgstr ""
+msgstr "Default field"
 
 msgid "Drop button"
-msgstr ""
+msgstr "Drop button"
 
 msgid "Default filter"
-msgstr ""
+msgstr "Default filter"
 
 msgid "Boolean string"
-msgstr ""
+msgstr "Boolean string"
 
 msgid "Group by numeric"
-msgstr ""
+msgstr "Group by numeric"
 
 msgid "IN operator"
-msgstr ""
+msgstr "IN operator"
 
 msgid "Reduce duplicate"
-msgstr ""
+msgstr "Reduce duplicate"
 
 msgid "Default pager"
-msgstr ""
+msgstr "Default pager"
 
 msgid "Groupwise max"
-msgstr ""
+msgstr "Groupwise max"
 
 msgid "Generate subquery each time view is run"
-msgstr ""
+msgstr "Generate subquery each time view is run"
 
 msgid "RSS field options"
-msgstr ""
+msgstr "RSS field options"
 
 msgid "Guid settings"
-msgstr ""
+msgstr "Guid settings"
 
 msgid "Display extender"
-msgstr ""
+msgstr "Display extender"
 
 msgid "Field rewrite elements"
-msgstr ""
+msgstr "Field rewrite elements"
 
 msgid "Display plugin"
-msgstr ""
+msgstr "Display plugin"
 
 msgid "Boolean sort"
-msgstr ""
+msgstr "Boolean sort"
 
 msgid "Date sort"
-msgstr ""
+msgstr "Date sort"
 
 msgid "Date sort expose settings"
-msgstr ""
+msgstr "Date sort expose settings"
 
 msgid "Custom row classes"
-msgstr ""
+msgstr "Custom row classes"
 
 msgid "Default views row classes"
-msgstr ""
+msgstr "Default views row classes"
 
 msgid "Custom column classes"
-msgstr ""
+msgstr "Custom column classes"
 
 msgid "Columns name"
-msgstr ""
+msgstr "Columns name"
 
 msgid "Columns info"
-msgstr ""
+msgstr "Columns info"
 
 msgid "Column info"
-msgstr ""
+msgstr "Column info"
 
 msgid "Preview view"
-msgstr ""
+msgstr "Preview view"
 
 msgid "Bartik settings"
-msgstr ""
+msgstr "Bartik settings"
 
 msgid "Seven settings"
-msgstr ""
+msgstr "Seven settings"
 
 msgid "Stark settings"
-msgstr ""
+msgstr "Stark settings"
 
 msgid "Visibility Conditions"
-msgstr ""
+msgstr "Visibility Conditions"
 
 msgid "Visibility Condition"
-msgstr ""
+msgstr "Visibility Condition"
 
 msgid "Context assignments"
-msgstr ""
+msgstr "Context assignments"
 
 msgid "Display variant"
-msgstr ""
+msgstr "Display variant"
 
 msgid "Requirements review"
-msgstr ""
+msgstr "Requirements review"
 
 msgid ""
 "Unable to send email. Contact the site administrator if the problem "
 "persists."
 msgstr ""
+"Unable to send email. Contact the site administrator if the problem "
+"persists."
 
 msgid "Error sending email (from %from to %to with reply-to %reply)."
-msgstr ""
+msgstr "Error sending email (from %from to %to with reply-to %reply)."
 
 msgid "The label for this display variant."
-msgstr ""
+msgstr "The label for this display variant."
 
 msgid "%name: the email address can not be longer than @max characters."
-msgstr ""
+msgstr "%name: the email address can not be longer than @max characters."
 
 msgid "An entity field containing an email value."
-msgstr ""
+msgstr "An entity field containing an email value."
 
 msgid ""
 "Automated emails, such as registration information, will be sent from this "
 "address. Use an address ending in your site's domain to help prevent these "
 "emails from being flagged as spam."
 msgstr ""
+"Automated emails, such as registration information, will be sent from this "
+"address. Use an address ending in your site's domain to help prevent these "
+"emails from being flagged as spam."
 
 msgid "Receive email notifications"
-msgstr ""
+msgstr "Receive email notifications"
 
 msgid "Send email configuration"
-msgstr ""
+msgstr "Send email configuration"
 
 msgid "<em>Either</em> upload a file or enter a URL."
-msgstr ""
+msgstr "<em>Either</em> upload a file or enter a URL."
 
 msgid "Show for the listed pages"
-msgstr ""
+msgstr "Show for the listed pages"
 
 msgid "Hide for the listed pages"
-msgstr ""
+msgstr "Hide for the listed pages"
 
 msgid "Duplicate @display_title"
-msgstr ""
+msgstr "Duplicate @display_title"
 
 msgid "Overriding default settings"
-msgstr ""
+msgstr "Overriding default settings"
 
 msgid ""
 "This page provides a list of all comment types on the site and allows you to"
 " manage the fields, form and display settings for each."
 msgstr ""
+"This page provides a list of all comment types on the site and allows you to"
+" manage the fields, form and display settings for each."
 
 msgid "Comment type %label has been updated."
-msgstr ""
+msgstr "Comment type %label has been updated."
 
 msgid "Comment type %label has been added."
-msgstr ""
+msgstr "Comment type %label has been added."
 
 msgid "The comment author's email address."
-msgstr ""
+msgstr "The comment author's email address."
 
 msgid "Comment Type"
-msgstr ""
+msgstr "Comment Type"
 
 msgid "The comment type."
-msgstr ""
+msgstr "The comment type."
 
 msgid ""
 "Example: 'webmaster@example.com' or 'sales@example.com,support@example.com' "
 ". To specify multiple recipients, separate each email address with a comma."
 msgstr ""
+"Example: 'webmaster@example.com' or 'sales@example.com,support@example.com' "
+". To specify multiple recipients, separate each email address with a comma."
 
 msgid "%recipient is an invalid email address."
-msgstr ""
+msgstr "%recipient is an invalid email address."
 
 msgctxt "Abbreviated month name"
 msgid "Jan"
-msgstr ""
+msgstr "Jan"
 
 msgctxt "Abbreviated month name"
 msgid "Feb"
-msgstr ""
+msgstr "Feb"
 
 msgctxt "Abbreviated month name"
 msgid "Mar"
-msgstr ""
+msgstr "Mar"
 
 msgctxt "Abbreviated month name"
 msgid "Apr"
-msgstr ""
+msgstr "Apr"
 
 msgctxt "Abbreviated month name"
 msgid "May"
-msgstr ""
+msgstr "May"
 
 msgctxt "Abbreviated month name"
 msgid "Jun"
-msgstr ""
+msgstr "Jun"
 
 msgctxt "Abbreviated month name"
 msgid "Jul"
-msgstr ""
+msgstr "Jul"
 
 msgctxt "Abbreviated month name"
 msgid "Aug"
-msgstr ""
+msgstr "Aug"
 
 msgctxt "Abbreviated month name"
 msgid "Sep"
-msgstr ""
+msgstr "Sep"
 
 msgctxt "Abbreviated month name"
 msgid "Oct"
-msgstr ""
+msgstr "Oct"
 
 msgctxt "Abbreviated month name"
 msgid "Nov"
-msgstr ""
+msgstr "Nov"
 
 msgctxt "Abbreviated month name"
 msgid "Dec"
-msgstr ""
+msgstr "Dec"
 
 msgctxt "Abbreviated weekday"
 msgid "Sun"
-msgstr ""
+msgstr "Sun"
 
 msgctxt "Abbreviated weekday"
 msgid "Mon"
-msgstr ""
+msgstr "Mon"
 
 msgctxt "Abbreviated weekday"
 msgid "Tue"
-msgstr ""
+msgstr "Tue"
 
 msgctxt "Abbreviated weekday"
 msgid "Wed"
-msgstr ""
+msgstr "Wed"
 
 msgctxt "Abbreviated weekday"
 msgid "Thu"
-msgstr ""
+msgstr "Thu"
 
 msgctxt "Abbreviated weekday"
 msgid "Fri"
-msgstr ""
+msgstr "Fri"
 
 msgctxt "Abbreviated weekday"
 msgid "Sat"
-msgstr ""
+msgstr "Sat"
 
 msgctxt "Abbreviated weekday"
 msgid "Su"
-msgstr ""
+msgstr "Su"
 
 msgctxt "Abbreviated weekday"
 msgid "Mo"
-msgstr ""
+msgstr "Mo"
 
 msgctxt "Abbreviated weekday"
 msgid "Tu"
-msgstr ""
+msgstr "Tu"
 
 msgctxt "Abbreviated weekday"
 msgid "We"
-msgstr ""
+msgstr "We"
 
 msgctxt "Abbreviated weekday"
 msgid "Th"
-msgstr ""
+msgstr "Th"
 
 msgctxt "Abbreviated weekday"
 msgid "Fr"
-msgstr ""
+msgstr "Fr"
 
 msgctxt "Abbreviated weekday"
 msgid "Sa"
-msgstr ""
+msgstr "Sa"
 
 msgctxt "Abbreviated 1 letter weekday Sunday"
 msgid "S"
-msgstr ""
+msgstr "S"
 
 msgctxt "Abbreviated 1 letter weekday Monday"
 msgid "M"
-msgstr ""
+msgstr "M"
 
 msgctxt "Abbreviated 1 letter weekday Tuesday"
 msgid "T"
-msgstr ""
+msgstr "T"
 
 msgctxt "Abbreviated 1 letter weekday Wednesday"
 msgid "W"
-msgstr ""
+msgstr "W"
 
 msgctxt "Abbreviated 1 letter weekday Thursday"
 msgid "T"
-msgstr ""
+msgstr "T"
 
 msgctxt "Abbreviated 1 letter weekday Friday"
 msgid "F"
-msgstr ""
+msgstr "F"
 
 msgctxt "Abbreviated 1 letter weekday Saturday"
 msgid "S"
-msgstr ""
+msgstr "S"
 
 msgid "Web page addresses and email addresses turn into links automatically."
-msgstr ""
+msgstr "Web page addresses and email addresses turn into links automatically."
 
 msgid "Configuring content languages"
-msgstr ""
+msgstr "Configuring content languages"
 
 msgid ""
 "<em>Selected language</em> allows you to specify the site's default language"
 " or a specific language as the fall-back language. This method should be "
 "listed last."
 msgstr ""
+"<em>Selected language</em> allows you to specify the site's default language"
+" or a specific language as the fall-back language. This method should be "
+"listed last."
 
 msgid "Comma-separated list of recipient email addresses."
-msgstr ""
+msgstr "Comma-separated list of recipient email addresses."
 
 msgid "Syndicate block"
-msgstr ""
+msgstr "Syndicate block"
 
 msgid "Use shortcuts"
-msgstr ""
+msgstr "Use shortcuts"
 
 msgid "Diff settings"
-msgstr ""
+msgstr "Diff settings"
 
 msgid "Branding block"
-msgstr ""
+msgstr "Branding block"
 
 msgid "Use site logo"
-msgstr ""
+msgstr "Use site logo"
 
 msgid "The current theme is not @theme"
-msgstr ""
+msgstr "The current theme is not @theme"
 
 msgid "The current theme is @theme"
-msgstr ""
+msgstr "The current theme is @theme"
 
 msgid "Request Path"
-msgstr ""
+msgstr "Request Path"
 
 msgid "Username or email address"
-msgstr ""
+msgstr "Username or email address"
 
 msgid "Email addresses to notify when updates are available"
-msgstr ""
+msgstr "Email addresses to notify when updates are available"
 
 msgid "%email is not a valid email address."
-msgstr ""
+msgstr "%email is not a valid email address."
 
 msgid "%emails are not valid email addresses."
-msgstr ""
+msgstr "%emails are not valid email addresses."
 
 msgid ""
 "A valid email address. All emails from the system will be sent to this "
@@ -18238,9 +19456,13 @@ msgid ""
 "wish to receive a new password or wish to receive certain news or "
 "notifications by email."
 msgstr ""
+"A valid email address. All emails from the system will be sent to this "
+"address. The email address is not made public and will only be used if you "
+"wish to receive a new password or wish to receive certain news or "
+"notifications by email."
 
 msgid "This account's preferred language for emails."
-msgstr ""
+msgstr "This account's preferred language for emails."
 
 msgid ""
 "New users will be required to validate their email address prior to logging "
@@ -18248,9 +19470,13 @@ msgid ""
 "setting disabled, users will be logged in immediately upon registering, and "
 "may select their own passwords during registration."
 msgstr ""
+"New users will be required to validate their email address prior to logging "
+"into the site, and will be assigned a system-generated password. With this "
+"setting disabled, users will be logged in immediately upon registering, and "
+"may select their own passwords during registration."
 
 msgid "Notification email address"
-msgstr ""
+msgstr "Notification email address"
 
 msgid ""
 "The email address to be used as the 'from' address for all account "
@@ -18259,806 +19485,867 @@ msgid ""
 "this address for any new registrations. Leave empty to use the default "
 "system email address <em>(%site-email).</em>"
 msgstr ""
+"The email address to be used as the 'from' address for all account "
+"notifications listed below. If <em>'Visitors, but administrator approval is "
+"required'</em> is selected above, a notification email will also be sent to "
+"this address for any new registrations. Leave empty to use the default "
+"system email address <em>(%site-email).</em>"
 
 msgid "Further instructions have been sent to your email address."
-msgstr ""
+msgstr "Further instructions have been sent to your email address."
 
 msgid "When the user has the following roles"
-msgstr ""
+msgstr "When the user has the following roles"
 
 msgid "The user is not a member of @roles"
-msgstr ""
+msgstr "The user is not a member of @roles"
 
 msgid "The user is a member of @roles"
-msgstr ""
+msgstr "The user is a member of @roles"
 
 msgid "Use Replica Server"
-msgstr ""
+msgstr "Use Replica Server"
 
 msgid "Query parameter"
-msgstr ""
+msgstr "Query parameter"
 
 msgid "The query parameter to use."
-msgstr ""
+msgstr "The query parameter to use."
 
 msgid "Fallback value"
-msgstr ""
+msgstr "Fallback value"
 
 msgid ""
 "The fallback value to use when the above query parameter is not present."
 msgstr ""
+"The fallback value to use when the above query parameter is not present."
 
 msgid ""
 "Conjunction to use when handling multiple values. E.g. "
 "\"?value[0]=a&value[1]=b\"."
 msgstr ""
+"Conjunction to use when handling multiple values. E.g. "
+"\"?value[0]=a&value[1]=b\"."
 
 msgid "Use Secondary Server"
-msgstr ""
+msgstr "Use Secondary Server"
 
 msgid "Type attribute"
-msgstr ""
+msgstr "Type attribute"
 
 msgid "The type of this row."
-msgstr ""
+msgstr "The type of this row."
 
 msgid "Text attribute"
-msgstr ""
+msgstr "Text attribute"
 
 msgid ""
 "The field that is going to be used as the OPML text attribute for each row."
 msgstr ""
+"The field that is going to be used as the OPML text attribute for each row."
 
 msgid "Created attribute"
-msgstr ""
+msgstr "Created attribute"
 
 msgid ""
 "The field that is going to be used as the OPML created attribute for each "
 "row."
 msgstr ""
+"The field that is going to be used as the OPML created attribute for each "
+"row."
 
 msgid "Description attribute"
-msgstr ""
+msgstr "Description attribute"
 
 msgid ""
 "The field that is going to be used as the OPML description attribute for "
 "each row."
 msgstr ""
+"The field that is going to be used as the OPML description attribute for "
+"each row."
 
 msgid "HTML URL attribute"
-msgstr ""
+msgstr "HTML URL attribute"
 
 msgid ""
 "The field that is going to be used as the OPML htmlUrl attribute for each "
 "row."
 msgstr ""
+"The field that is going to be used as the OPML htmlUrl attribute for each "
+"row."
 
 msgid "Language attribute"
-msgstr ""
+msgstr "Language attribute"
 
 msgid ""
 "The field that is going to be used as the OPML language attribute for each "
 "row."
 msgstr ""
+"The field that is going to be used as the OPML language attribute for each "
+"row."
 
 msgid "XML URL attribute"
-msgstr ""
+msgstr "XML URL attribute"
 
 msgid "URL attribute"
-msgstr ""
+msgstr "URL attribute"
 
 msgid ""
 "Row style plugin requires specifying which views field to use for OPML text "
 "attribute."
 msgstr ""
+"Row style plugin requires specifying which views field to use for OPML text "
+"attribute."
 
 msgid ""
 "Row style plugin requires specifying which views field to use for XML URL "
 "attribute."
 msgstr ""
+"Row style plugin requires specifying which views field to use for XML URL "
+"attribute."
 
 msgid ""
 "Row style plugin requires specifying which views field to use for URL "
 "attribute."
 msgstr ""
+"Row style plugin requires specifying which views field to use for URL "
+"attribute."
 
 msgid "OPML fields"
-msgstr ""
+msgstr "OPML fields"
 
 msgid "Display fields as OPML items."
-msgstr ""
+msgstr "Display fields as OPML items."
 
 msgid "OPML Feed"
-msgstr ""
+msgstr "OPML Feed"
 
 msgid "Generates an OPML feed from a view."
-msgstr ""
+msgstr "Generates an OPML feed from a view."
 
 msgid "Duplicate of @label"
-msgstr ""
+msgstr "Duplicate of @label"
 
 msgid "Site header"
-msgstr ""
+msgstr "Site header"
 
 msgid ""
 "The default administration theme for Drupal 8 was designed with clean lines,"
 " simple blocks, and sans-serif font to emphasize the tools and tasks at "
 "hand."
 msgstr ""
+"The default administration theme for Drupal 8 was designed with clean lines,"
+" simple blocks, and sans-serif font to emphasize the tools and tasks at "
+"hand."
 
 msgid "\"On\" label"
-msgstr ""
+msgstr "\"On\" label"
 
 msgid "\"Off\" label"
-msgstr ""
+msgstr "\"Off\" label"
 
 msgid "Edit menu link %title"
-msgstr ""
+msgstr "Edit menu link %title"
 
 msgid ""
 "This link is provided by the @name module. The title and path cannot be "
 "edited."
 msgstr ""
+"This link is provided by the @name module. The title and path cannot be "
+"edited."
 
 msgid "Add comment type"
-msgstr ""
+msgstr "Add comment type"
 
 msgid "Format type machine name"
-msgstr ""
+msgstr "Format type machine name"
 
 msgid "Boolean settings"
-msgstr ""
+msgstr "Boolean settings"
 
 msgid "On label"
-msgstr ""
+msgstr "On label"
 
 msgid "Off label"
-msgstr ""
+msgstr "Off label"
 
 msgid "The comment type"
-msgstr ""
+msgstr "The comment type"
 
 msgid "Comments without subject field"
-msgstr ""
+msgstr "Comments without subject field"
 
 msgid "Allows commenting on content, comments without subject field"
-msgstr ""
+msgstr "Allows commenting on content, comments without subject field"
 
 msgid "The comment type label"
-msgstr ""
+msgstr "The comment type label"
 
 msgid "The comment type description"
-msgstr ""
+msgstr "The comment type description"
 
 msgid "The language of the content or translation."
-msgstr ""
+msgstr "The language of the content or translation."
 
 msgid "The language the original content is in."
-msgstr ""
+msgstr "The language the original content is in."
 
 msgid "Allowed value with label"
-msgstr ""
+msgstr "Allowed value with label"
 
 msgid "Data type callback"
-msgstr ""
+msgstr "Data type callback"
 
 msgid "Callable"
-msgstr ""
+msgstr "Callable"
 
 msgid "Interaction type"
-msgstr ""
+msgstr "Interaction type"
 
 msgid "Enabling REST support for an entity type"
-msgstr ""
+msgstr "Enabling REST support for an entity type"
 
 msgid "Configuring search pages"
-msgstr ""
+msgstr "Configuring search pages"
 
 msgid "Managing the search index"
-msgstr ""
+msgstr "Managing the search index"
 
 msgid "Displaying the Search block"
-msgstr ""
+msgstr "Displaying the Search block"
 
 msgid "Searching your site"
-msgstr ""
+msgstr "Searching your site"
 
 msgid "Extending the Search module"
-msgstr ""
+msgstr "Extending the Search module"
 
 msgid "Search index progress"
-msgstr ""
+msgstr "Search index progress"
 
 msgid "@percent% (@remaining remaining)"
-msgstr ""
+msgstr "@percent% (@remaining remaining)"
 
 msgid "Indexing progress"
-msgstr ""
+msgstr "Indexing progress"
 
 msgid "Updating default configuration (@percent%)."
-msgstr ""
+msgstr "Updating default configuration (@percent%)."
 
 msgid "Allows commenting on content"
-msgstr ""
+msgstr "Allows commenting on content"
 
 msgid "Manage form and displays settings of comments."
-msgstr ""
+msgstr "Manage form and displays settings of comments."
 
 msgid "%num_indexed of %num_total indexed"
-msgstr ""
+msgstr "%num_indexed of %num_total indexed"
 
 msgid "Does not use index"
-msgstr ""
+msgstr "Does not use index"
 
 msgid "Overall results:"
-msgstr ""
+msgstr "Overall results:"
 
 msgid "Converts an image to grayscale."
-msgstr ""
+msgstr "Converts an image to grayscale."
 
 msgid "Activity Tracker"
-msgstr ""
+msgstr "Activity Tracker"
 
 msgid "Add \"…\" at the end of trimmed text"
-msgstr ""
+msgstr "Add \"…\" at the end of trimmed text"
 
 msgid "First page"
-msgstr ""
+msgstr "First page"
 
 msgid "Base field bundle override"
-msgstr ""
+msgstr "Base field bundle override"
 
 msgid "Datetime timestamp display format settings"
-msgstr ""
+msgstr "Datetime timestamp display format settings"
 
 msgid "Boolean checkbox display format settings"
-msgstr ""
+msgstr "Boolean checkbox display format settings"
 
 msgid "Installed themes"
-msgstr ""
+msgstr "Installed themes"
 
 msgid "The %file does not exist."
-msgstr ""
+msgstr "The %file does not exist."
 
 msgid "The %file exists."
-msgstr ""
+msgstr "The %file exists."
 
 msgid "The %file is not readable."
-msgstr ""
+msgstr "The %file is not readable."
 
 msgid "The %file is not writable."
-msgstr ""
+msgstr "The %file is not writable."
 
 msgid "The @file is writable."
-msgstr ""
+msgstr "The @file is writable."
 
 msgid "The @file is owned by the web server."
-msgstr ""
+msgstr "The @file is owned by the web server."
 
 msgid "Negate the condition"
-msgstr ""
+msgstr "Negate the condition"
 
 msgid "Datetime Timestamp"
-msgstr ""
+msgstr "Datetime Timestamp"
 
 msgid "%theme theme installed."
-msgstr ""
+msgstr "%theme theme installed."
 
 msgid "Display prefix and suffix"
-msgstr ""
+msgstr "Display prefix and suffix"
 
 msgid "Text (plain)"
-msgstr ""
+msgstr "Text (plain)"
 
 msgid "A field containing a plain string value."
-msgstr ""
+msgstr "A field containing a plain string value."
 
 msgid "Text (plain, long)"
-msgstr ""
+msgstr "Text (plain, long)"
 
 msgid "A field containing a long string value."
-msgstr ""
+msgstr "A field containing a long string value."
 
 msgid "You cannot use an external URL, please enter a relative path."
-msgstr ""
+msgstr "You cannot use an external URL, please enter a relative path."
 
 msgid ""
 "This path does not exist or you do not have permission to link to %path."
 msgstr ""
+"This path does not exist or you do not have permission to link to %path."
 
 msgid "Install newly added themes"
-msgstr ""
+msgstr "Install newly added themes"
 
 msgid ""
 "Blocks are placed and configured specifically for each theme. The Block "
 "layout page opens with the default theme, but you can toggle to other "
 "installed themes."
 msgstr ""
+"Blocks are placed and configured specifically for each theme. The Block "
+"layout page opens with the default theme, but you can toggle to other "
+"installed themes."
 
 msgid "Enable the personal contact form by default for new users"
-msgstr ""
+msgstr "Enable the personal contact form by default for new users"
 
 msgid "Add contact form"
-msgstr ""
+msgstr "Add contact form"
 
 msgid "Default form identifier"
-msgstr ""
+msgstr "Default form identifier"
 
 msgid ""
 "When listing forms, those with lighter (smaller) weights get listed before "
 "forms with heavier (larger) weights. Forms with equal weights are sorted "
 "alphabetically."
 msgstr ""
+"When listing forms, those with lighter (smaller) weights get listed before "
+"forms with heavier (larger) weights. Forms with equal weights are sorted "
+"alphabetically."
 
 msgid "Make this the default form"
-msgstr ""
+msgstr "Make this the default form"
 
 msgid "Send yourself a copy"
-msgstr ""
+msgstr "Send yourself a copy"
 
 msgid "Content translation field settings"
-msgstr ""
+msgstr "Content translation field settings"
 
 msgid "Allowed types: @extensions."
-msgstr ""
+msgstr "Allowed types: @extensions."
 
 msgid "Back to content editing"
-msgstr ""
+msgstr "Back to content editing"
 
 msgid "Align images"
-msgstr ""
+msgstr "Align images"
 
 msgid ""
 "Uses a <code>data-align</code> attribute on <code>&lt;img&gt;</code> tags to"
 " align images."
 msgstr ""
+"Uses a <code>data-align</code> attribute on <code>&lt;img&gt;</code> tags to"
+" align images."
 
 msgid "Caption images"
-msgstr ""
+msgstr "Caption images"
 
 msgid ""
 "Uses a <code>data-caption</code> attribute on <code>&lt;img&gt;</code> tags "
 "to caption images."
 msgstr ""
+"Uses a <code>data-caption</code> attribute on <code>&lt;img&gt;</code> tags "
+"to caption images."
 
 msgid "Display author and date information"
-msgstr ""
+msgstr "Display author and date information"
 
 msgid "Breakpoint ID"
-msgstr ""
+msgstr "Breakpoint ID"
 
 msgid "Unable to delete the shortcut for %title."
-msgstr ""
+msgstr "Unable to delete the shortcut for %title."
 
 msgid "Maximum number of levels"
-msgstr ""
+msgstr "Maximum number of levels"
 
 msgid "All errors have been logged."
-msgstr ""
+msgstr "All errors have been logged."
 
 msgid ""
 "You may need to check the <code>watchdog</code> database table manually."
 msgstr ""
+"You may need to check the <code>watchdog</code> database table manually."
 
 msgid "Failed:"
-msgstr ""
+msgstr "Failed:"
 
 msgid "Update #@count"
-msgstr ""
+msgstr "Update #@count"
 
 msgid "The following updates returned messages:"
-msgstr ""
+msgstr "The following updates returned messages:"
 
 msgid "Review updates"
-msgstr ""
+msgstr "Review updates"
 
 msgid "Starting updates"
-msgstr ""
+msgstr "Starting updates"
 
 msgid "Installed theme"
 msgid_plural "Installed themes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Installed theme"
+msgstr[1] "Installed themes"
 
 msgid "Uninstalled theme"
 msgid_plural "Uninstalled themes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Uninstalled theme"
+msgstr[1] "Uninstalled themes"
 
 msgid "%theme is the default theme and cannot be uninstalled."
-msgstr ""
+msgstr "%theme is the default theme and cannot be uninstalled."
 
 msgid "The %theme theme has been uninstalled."
-msgstr ""
+msgstr "The %theme theme has been uninstalled."
 
 msgid "The %theme theme has been installed."
-msgstr ""
+msgstr "The %theme theme has been installed."
 
 msgid "Empty time zone"
-msgstr ""
+msgstr "Empty time zone"
 
 msgid "Users may set their own time zone at registration"
-msgstr ""
+msgstr "Users may set their own time zone at registration"
 
 msgid "Menu levels"
-msgstr ""
+msgstr "Menu levels"
 
 msgid "Whether or not the content related to a term is sticky."
-msgstr ""
+msgstr "Whether or not the content related to a term is sticky."
 
 msgid "The date the content related to a term was posted."
-msgstr ""
+msgstr "The date the content related to a term was posted."
 
 msgid "Text (formatted) settings"
-msgstr ""
+msgstr "Text (formatted) settings"
 
 msgid "Text (formatted, long) settings"
-msgstr ""
+msgstr "Text (formatted, long) settings"
 
 msgid "Text (formatted, long, with summary) settings"
-msgstr ""
+msgstr "Text (formatted, long, with summary) settings"
 
 msgid "Text (formatted)"
-msgstr ""
+msgstr "Text (formatted)"
 
 msgid "This field stores a text with a text format."
-msgstr ""
+msgstr "This field stores a text with a text format."
 
 msgid "This field stores a long text with a text format."
-msgstr ""
+msgstr "This field stores a long text with a text format."
 
 msgid "This field stores long text with a format and an optional summary."
-msgstr ""
+msgstr "This field stores long text with a format and an optional summary."
 
 msgid "Require email verification when a visitor creates an account"
-msgstr ""
+msgstr "Require email verification when a visitor creates an account"
 
 msgid "@entity_type revision"
-msgstr ""
+msgstr "@entity_type revision"
 
 msgid "@entity_type revisions"
-msgstr ""
+msgstr "@entity_type revisions"
 
 msgid "Include reset button (resets all applied exposed filters)"
-msgstr ""
+msgstr "Include reset button (resets all applied exposed filters)"
 
 msgid "REST export settings"
-msgstr ""
+msgstr "REST export settings"
 
 msgid "Provide a REST export"
-msgstr ""
+msgstr "Provide a REST export"
 
 msgid "REST export path"
-msgstr ""
+msgstr "REST export path"
 
 msgid "Default value callback"
-msgstr ""
+msgstr "Default value callback"
 
 msgid "URI as link display format settings"
-msgstr ""
+msgstr "URI as link display format settings"
 
 msgid "Timestamp ago display format settings"
-msgstr ""
+msgstr "Timestamp ago display format settings"
 
 msgid "Link to URI"
-msgstr ""
+msgstr "Link to URI"
 
 msgid "The description of this feed"
-msgstr ""
+msgstr "The description of this feed"
 
 msgid ""
 "The length of time between feed updates. Requires a correctly configured "
 "cron maintenance task."
 msgstr ""
+"The length of time between feed updates. Requires a correctly configured "
+"cron maintenance task."
 
 msgid "Edit storage settings."
-msgstr ""
+msgstr "Edit storage settings."
 
 msgid ""
 "The minimum allowed image size expressed as WIDTH×HEIGHT (e.g. 640×480). "
 "Leave blank for no restriction. If a smaller image is uploaded, it will be "
 "rejected."
 msgstr ""
+"The minimum allowed image size expressed as WIDTH×HEIGHT (e.g. 640×480). "
+"Leave blank for no restriction. If a smaller image is uploaded, it will be "
+"rejected."
 
 msgid "Improving table accessibility"
-msgstr ""
+msgstr "Improving table accessibility"
 
 msgid "OPML field options"
-msgstr ""
+msgstr "OPML field options"
 
 msgid "Testing multilingual"
-msgstr ""
+msgstr "Testing multilingual"
 
 msgid "Minimal profile for running tests with a multilingual installer."
-msgstr ""
+msgstr "Minimal profile for running tests with a multilingual installer."
 
 msgid ""
 "This block is broken or missing. You may be missing content or you might "
 "need to enable the original module."
 msgstr ""
+"This block is broken or missing. You may be missing content or you might "
+"need to enable the original module."
 
 msgid "Broken/Missing"
-msgstr ""
+msgstr "Broken/Missing"
 
 msgctxt "Validation"
 msgid "Email"
-msgstr ""
+msgstr "Email"
 
 msgid "Comments are responses to content."
-msgstr ""
+msgstr "Comments are responses to content."
 
 msgid "Filename: %name"
-msgstr ""
+msgstr "Filename: %name"
 
 msgid "Recipient username"
-msgstr ""
+msgstr "Recipient username"
 
 msgid "Content language of view row"
-msgstr ""
+msgstr "Content language of view row"
 
 msgid "Install and set as default"
-msgstr ""
+msgstr "Install and set as default"
 
 msgid "Create and manage contact forms."
-msgstr ""
+msgstr "Create and manage contact forms."
 
 msgid "Site administration toolbar"
-msgstr ""
+msgstr "Site administration toolbar"
 
 msgid "Base field override"
-msgstr ""
+msgstr "Base field override"
 
 msgid "Text (formatted, long, with summary)"
-msgstr ""
+msgstr "Text (formatted, long, with summary)"
 
 msgid "Text (formatted, long)"
-msgstr ""
+msgstr "Text (formatted, long)"
 
 msgid ""
 "You can align images (<code>data-align=\"center\"</code>), but also videos, "
 "blockquotes, and so on."
 msgstr ""
+"You can align images (<code>data-align=\"center\"</code>), but also videos, "
+"blockquotes, and so on."
 
 msgid "Making this field required is recommended."
-msgstr ""
+msgstr "Making this field required is recommended."
 
 msgid "Leave preview?"
-msgstr ""
+msgstr "Leave preview?"
 
 msgid "Leave preview"
-msgstr ""
+msgstr "Leave preview"
 
 msgid ""
 "Leaving the preview will cause unsaved changes to be lost. Are you sure you "
 "want to leave the preview?"
 msgstr ""
+"Leaving the preview will cause unsaved changes to be lost. Are you sure you "
+"want to leave the preview?"
 
 msgid ""
 "The human-readable name of this content type. This text will be displayed as"
 " part of the list on the <em>Add content</em> page. This name must be "
 "unique."
 msgstr ""
+"The human-readable name of this content type. This text will be displayed as"
+" part of the list on the <em>Add content</em> page. This name must be "
+"unique."
 
 msgid "Search for @keywords"
-msgstr ""
+msgstr "Search for @keywords"
 
 msgid "Set a new image"
-msgstr ""
+msgstr "Set a new image"
 
 msgid "The text with the text format applied."
-msgstr ""
+msgstr "The text with the text format applied."
 
 msgid "Processed summary"
-msgstr ""
+msgstr "Processed summary"
 
 msgid "The summary text with the text format applied."
-msgstr ""
+msgstr "The summary text with the text format applied."
 
 msgid "Trays"
-msgstr ""
+msgstr "Trays"
 
 msgid "Original language of the user information"
-msgstr ""
+msgstr "Original language of the user information"
 
 msgid "Preferred language of the user"
-msgstr ""
+msgstr "Preferred language of the user"
 
 msgid "Preferred admin language"
-msgstr ""
+msgstr "Preferred admin language"
 
 msgid "Preferred administrative language of the user"
-msgstr ""
+msgstr "Preferred administrative language of the user"
 
 msgid "Cache metadata"
-msgstr ""
+msgstr "Cache metadata"
 
 msgid "Cache contexts"
-msgstr ""
+msgstr "Cache contexts"
 
 msgid "Path is empty."
-msgstr ""
+msgstr "Path is empty."
 
 msgid "No query allowed."
-msgstr ""
+msgstr "No query allowed."
 
 msgid ""
 "Invalid path. Valid characters are alphanumerics as well as \"-\", \".\", "
 "\"_\" and \"~\"."
 msgstr ""
+"Invalid path. Valid characters are alphanumerics as well as \"-\", \".\", "
+"\"_\" and \"~\"."
 
 msgid "Classy"
-msgstr ""
+msgstr "Classy"
 
 msgid "Select a @context value:"
-msgstr ""
+msgstr "Select a @context value:"
 
 msgid "Configuration entity dependencies"
-msgstr ""
+msgstr "Configuration entity dependencies"
 
 msgid "Content entity dependencies"
-msgstr ""
+msgstr "Content entity dependencies"
 
 msgid "Enforced configuration dependencies"
-msgstr ""
+msgstr "Enforced configuration dependencies"
 
 msgid "String (long) settings"
-msgstr ""
+msgstr "String (long) settings"
 
 msgid "URI settings"
-msgstr ""
+msgstr "URI settings"
 
 msgid "Created timestamp settings"
-msgstr ""
+msgstr "Created timestamp settings"
 
 msgid "Changed timestamp settings"
-msgstr ""
+msgstr "Changed timestamp settings"
 
 msgid "Page @items.current"
-msgstr ""
+msgstr "Page @items.current"
 
 msgid "The selected style or row format does not use fields."
-msgstr ""
+msgstr "The selected style or row format does not use fields."
 
 msgid "The selected display type does not use @type plugins"
-msgstr ""
+msgstr "The selected display type does not use @type plugins"
 
 msgid "The entity type"
-msgstr ""
+msgstr "The entity type"
 
 msgid "Database storage size"
-msgstr ""
+msgstr "Database storage size"
 
 msgid "Text with text format"
-msgstr ""
+msgstr "Text with text format"
 
 msgid "Field widgets"
-msgstr ""
+msgstr "Field widgets"
 
 msgid "Field widget"
-msgstr ""
+msgstr "Field widget"
 
 msgid "Widget type machine name"
-msgstr ""
+msgstr "Widget type machine name"
 
 msgid "Textarea display format settings"
-msgstr ""
+msgstr "Textarea display format settings"
 
 msgid "Email field display format settings"
-msgstr ""
+msgstr "Email field display format settings"
 
 msgid "Link to the entity"
-msgstr ""
+msgstr "Link to the entity"
 
 msgid "Synchronizing extensions: @op @name."
-msgstr ""
+msgstr "Synchronizing extensions: @op @name."
 
 msgid "Link to the @entity_label"
-msgstr ""
+msgstr "Link to the @entity_label"
 
 msgid "Linked to the @entity_label"
-msgstr ""
+msgstr "Linked to the @entity_label"
 
 msgid "Simple page"
-msgstr ""
+msgstr "Simple page"
 
 msgid "Jump to the first comment."
-msgstr ""
+msgstr "Jump to the first comment."
 
 msgid "Jump to the first new comment."
-msgstr ""
+msgstr "Jump to the first new comment."
 
 msgid "Share your thoughts and opinions."
-msgstr ""
+msgstr "Share your thoughts and opinions."
 
 msgid "Content translation content settings"
-msgstr ""
+msgstr "Content translation content settings"
 
 msgid "Content translation enabled"
-msgstr ""
+msgstr "Content translation enabled"
 
 msgid "Group by column"
-msgstr ""
+msgstr "Group by column"
 
 msgid "Group by columns"
-msgstr ""
+msgstr "Group by columns"
 
 msgid "Re-use an existing field"
-msgstr ""
+msgstr "Re-use an existing field"
 
 msgid "You need to select a field type or an existing field."
-msgstr ""
+msgstr "You need to select a field type or an existing field."
 
 msgid "Log in to post new content in the forum."
-msgstr ""
+msgstr "Log in to post new content in the forum."
 
 msgid "Influence of '@title'"
-msgstr ""
+msgstr "Influence of '@title'"
 
 msgid "Installing supporting modules"
-msgstr ""
+msgstr "Installing supporting modules"
 
 msgid "The default search index will be rebuilt."
-msgstr ""
+msgstr "The default search index will be rebuilt."
 
 msgid "All search indexes will be rebuilt."
-msgstr ""
+msgstr "All search indexes will be rebuilt."
 
 msgid "Add shortcut link"
-msgstr ""
+msgstr "Add shortcut link"
 
 msgid "Popular content block settings"
-msgstr ""
+msgstr "Popular content block settings"
 
 msgid "Publish status"
-msgstr ""
+msgstr "Publish status"
 
 msgid "The corresponding entity field"
-msgstr ""
+msgstr "The corresponding entity field"
 
 msgid "The plugin ID"
-msgstr ""
+msgstr "The plugin ID"
 
 msgid "Row options"
-msgstr ""
+msgstr "Row options"
 
 msgid "Display extender settings"
-msgstr ""
+msgstr "Display extender settings"
 
 msgid "View block"
-msgstr ""
+msgstr "View block"
 
 msgid "Number integer display format settings"
-msgstr ""
+msgstr "Number integer display format settings"
 
 msgid "Static menu link overrides"
-msgstr ""
+msgstr "Static menu link overrides"
 
 msgctxt "Plural"
 msgid "Disabled"
-msgstr ""
+msgstr "Disabled"
 
 msgid ""
 "Alternative text is required.<br />(Only in rare cases should this be left "
 "empty. To create empty alternative text, enter <code>\"\"</code> — two "
 "double quotes without any content)."
 msgstr ""
+"Alternative text is required.<br />(Only in rare cases should this be left "
+"empty. To create empty alternative text, enter <code>\"\"</code> — two "
+"double quotes without any content)."
 
 msgid ""
 "Images must be larger than <strong>@min</strong> pixels. Images larger than "
 "<strong>@max</strong> pixels will be resized."
 msgstr ""
+"Images must be larger than <strong>@min</strong> pixels. Images larger than "
+"<strong>@max</strong> pixels will be resized."
 
 msgid "Images must be larger than <strong>@min</strong> pixels."
-msgstr ""
+msgstr "Images must be larger than <strong>@min</strong> pixels."
 
 msgid "Node authored by (uid)"
-msgstr ""
+msgstr "Node authored by (uid)"
 
 msgid "Revision authored by (uid)"
-msgstr ""
+msgstr "Revision authored by (uid)"
 
 msgid "The location this shortcut points to."
-msgstr ""
+msgstr "The location this shortcut points to."
 
 msgid ""
 "Unable to install @extension, %config_names already exists in active "
@@ -19067,303 +20354,321 @@ msgid_plural ""
 "Unable to install @extension, %config_names already exist in active "
 "configuration."
 msgstr[0] ""
+"Unable to install @extension, %config_names already exists in active "
+"configuration."
 msgstr[1] ""
+"Unable to install @extension, %config_names already exist in active "
+"configuration."
 
 msgid "narrow"
-msgstr ""
+msgstr "narrow"
 
 msgctxt "Plural"
 msgid "Enabled"
-msgstr ""
+msgstr "Enabled"
 
 msgid "Active menu trail"
-msgstr ""
+msgstr "Active menu trail"
 
 msgid "Configuration updates"
-msgstr ""
+msgstr "Configuration updates"
 
 msgid "The listed configuration will be updated."
-msgstr ""
+msgstr "The listed configuration will be updated."
 
 msgid "An entity field containing a password value."
-msgstr ""
+msgstr "An entity field containing a password value."
 
 msgid "Selected default language no longer exists."
-msgstr ""
+msgstr "Selected default language no longer exists."
 
 msgid "The username of the content author."
-msgstr ""
+msgstr "The username of the content author."
 
 msgid "Defining responsive image styles"
-msgstr ""
+msgstr "Defining responsive image styles"
 
 msgid "Using responsive image styles in Image fields"
-msgstr ""
+msgstr "Using responsive image styles in Image fields"
 
 msgid "Responsive image styles"
-msgstr ""
+msgstr "Responsive image styles"
 
 msgid "Edit responsive image style"
-msgstr ""
+msgstr "Edit responsive image style"
 
 msgid "Duplicate responsive image style"
-msgstr ""
+msgstr "Duplicate responsive image style"
 
 msgid "Add responsive image style"
-msgstr ""
+msgstr "Add responsive image style"
 
 msgid "Responsive image style"
-msgstr ""
+msgstr "Responsive image style"
 
 msgid "Image style mappings"
-msgstr ""
+msgstr "Image style mappings"
 
 msgid "Image style mapping"
-msgstr ""
+msgstr "Image style mapping"
 
 msgid "Responsive image mapping type"
-msgstr ""
+msgstr "Responsive image mapping type"
 
 msgid "Sizes attribute"
-msgstr ""
+msgstr "Sizes attribute"
 
 msgid "<em>Duplicate responsive image style</em> @label"
-msgstr ""
+msgstr "<em>Duplicate responsive image style</em> @label"
 
 msgid "<em>Edit responsive image style</em> @label"
-msgstr ""
+msgstr "<em>Edit responsive image style</em> @label"
 
 msgid "Responsive image style @label saved."
-msgstr ""
+msgstr "Responsive image style @label saved."
 
 msgid "Responsive image style: @responsive_image_style"
-msgstr ""
+msgstr "Responsive image style: @responsive_image_style"
 
 msgid "Select a responsive image style."
-msgstr ""
+msgstr "Select a responsive image style."
 
 msgid "The target entity"
-msgstr ""
+msgstr "The target entity"
 
 msgid ""
 "Change site name, email address, slogan, default front page, and error "
 "pages."
 msgstr ""
+"Change site name, email address, slogan, default front page, and error "
+"pages."
 
 msgid "Content Language Settings"
-msgstr ""
+msgstr "Content Language Settings"
 
 msgid "Original language of content in view row"
-msgstr ""
+msgstr "Original language of content in view row"
 
 msgid "@entity_type_label ID"
-msgstr ""
+msgstr "@entity_type_label ID"
 
 msgid "Rendering Language"
-msgstr ""
+msgstr "Rendering Language"
 
 msgid ""
 "All content that supports translations will be displayed in the selected "
 "language."
 msgstr ""
+"All content that supports translations will be displayed in the selected "
+"language."
 
 msgid "The contextual filter values are provided by the URL."
-msgstr ""
+msgstr "The contextual filter values are provided by the URL."
 
 msgid "Entity reference field storage settings"
-msgstr ""
+msgstr "Entity reference field storage settings"
 
 msgid "Entity reference field settings"
-msgstr ""
+msgstr "Entity reference field settings"
 
 msgid "Entity reference selection plugin settings"
-msgstr ""
+msgstr "Entity reference selection plugin settings"
 
 msgid "Display in native language"
-msgstr ""
+msgstr "Display in native language"
 
 msgid "HTTP cookies"
-msgstr ""
+msgstr "HTTP cookies"
 
 msgid "HTTP headers"
-msgstr ""
+msgstr "HTTP headers"
 
 msgid "Is super user"
-msgstr ""
+msgstr "Is super user"
 
 msgid "Displayed in native language"
-msgstr ""
+msgstr "Displayed in native language"
 
 msgid "Submitted by @username on @datetime"
-msgstr ""
+msgstr "Submitted by @username on @datetime"
 
 msgid "Submitted by @author_name on @date"
-msgstr ""
+msgstr "Submitted by @author_name on @date"
 
 msgid "User is admin"
-msgstr ""
+msgstr "User is admin"
 
 msgid "Account's permissions"
-msgstr ""
+msgstr "Account's permissions"
 
 msgid "Existing password"
-msgstr ""
+msgstr "Existing password"
 
 msgid "Display the author name."
-msgstr ""
+msgstr "Display the author name."
 
 msgid "Using the personal contact form"
-msgstr ""
+msgstr "Using the personal contact form"
 
 msgid "Adding content to contact forms"
-msgstr ""
+msgstr "Adding content to contact forms"
 
 msgid "Display an icon"
-msgstr ""
+msgstr "Display an icon"
 
 msgid "Speeding up your site"
-msgstr ""
+msgstr "Speeding up your site"
 
 msgid "Site default language code"
-msgstr ""
+msgstr "Site default language code"
 
 msgid "Page caching"
-msgstr ""
+msgstr "Page caching"
 
 msgid "Contains US ASCII characters only"
-msgstr ""
+msgstr "Contains US ASCII characters only"
 
 msgid "Delete @language translation"
-msgstr ""
+msgstr "Delete @language translation"
 
 msgid "The core.extension configuration does not exist."
-msgstr ""
+msgstr "The core.extension configuration does not exist."
 
 msgid "Unable to install the %module module since it does not exist."
-msgstr ""
+msgstr "Unable to install the %module module since it does not exist."
 
 msgid "Unable to install the %theme theme since it does not exist."
-msgstr ""
+msgstr "Unable to install the %theme theme since it does not exist."
 
 msgid "Interface text"
-msgstr ""
+msgstr "Interface text"
 
 msgid ""
 "Order of language detection methods for interface text. If a translation of "
 "interface text is available in the detected language, it will be displayed."
 msgstr ""
+"Order of language detection methods for interface text. If a translation of "
+"interface text is available in the detected language, it will be displayed."
 
 msgid "Interface text language selected for page"
-msgstr ""
+msgstr "Interface text language selected for page"
 
 msgid ""
 "Customize %language_name language detection to differ from Interface text "
 "language detection settings"
 msgstr ""
+"Customize %language_name language detection to differ from Interface text "
+"language detection settings"
 
 msgid "Entity link"
-msgstr ""
+msgstr "Entity link"
 
 msgid "Select pager"
-msgstr ""
+msgstr "Select pager"
 
 msgid "Timestamp display format settings"
-msgstr ""
+msgstr "Timestamp display format settings"
 
 msgid "Future format"
-msgstr ""
+msgstr "Future format"
 
 msgid "Past format"
-msgstr ""
+msgstr "Past format"
 
 msgid "@requirements_message (Currently using @item version @version)"
-msgstr ""
+msgstr "@requirements_message (Currently using @item version @version)"
 
 msgid "The MyISAM storage engine is not supported."
-msgstr ""
+msgstr "The MyISAM storage engine is not supported."
 
 msgid ""
 "Unable to uninstall the %profile profile since it is the install profile."
 msgstr ""
+"Unable to uninstall the %profile profile since it is the install profile."
 
 msgid "The @module module is required"
-msgstr ""
+msgstr "The @module module is required"
 
 msgid "- Default site/user time zone -"
-msgstr ""
+msgstr "- Default site/user time zone -"
 
 msgid "Date format: @date_format"
-msgstr ""
+msgstr "Date format: @date_format"
 
 msgid "Custom date format: @custom_date_format"
-msgstr ""
+msgstr "Custom date format: @custom_date_format"
 
 msgid "Time zone: @timezone"
-msgstr ""
+msgstr "Time zone: @timezone"
 
 msgid "Translate interface text"
-msgstr ""
+msgstr "Translate interface text"
 
 msgid "Last run: %time ago."
-msgstr ""
+msgstr "Last run: %time ago."
 
 msgid "Plural variants"
-msgstr ""
+msgstr "Plural variants"
 
 msgid "Place block <span class=\"visually-hidden\">in the %region region</span>"
-msgstr ""
+msgstr "Place block <span class=\"visually-hidden\">in the %region region</span>"
 
 msgid "@date by @username"
-msgstr ""
+msgstr "@date by @username"
 
 msgid "Apache version"
-msgstr ""
+msgstr "Apache version"
 
 msgid "%type: @message in %function (line %line of %file)."
-msgstr ""
+msgstr "%type: @message in %function (line %line of %file)."
 
 msgid "Container cannot be saved to cache."
-msgstr ""
+msgstr "Container cannot be saved to cache."
 
 msgid ""
 "The database server version %version is less than the minimum required "
 "version %minimum_version."
 msgstr ""
+"The database server version %version is less than the minimum required "
+"version %minimum_version."
 
 msgid "1 error has been found: "
 msgid_plural "@count errors have been found: "
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 error has been found: "
+msgstr[1] "@count errors have been found: "
 
 msgid "imminently"
-msgstr ""
+msgstr "imminently"
 
 msgid "The blocked IP address."
-msgstr ""
+msgstr "The blocked IP address."
 
 msgid "The time that the comment was created, as a Unix timestamp."
-msgstr ""
+msgstr "The time that the comment was created, as a Unix timestamp."
 
 msgid "Location of the comment form."
-msgstr ""
+msgstr "Location of the comment form."
 
 msgid "Do not use this breakpoint."
-msgstr ""
+msgstr "Do not use this breakpoint."
 
 msgid "Run database updates"
-msgstr ""
+msgstr "Run database updates"
 
 msgid "The weight of the role."
-msgstr ""
+msgstr "The weight of the role."
 
 msgid ""
 "Security warning: Couldn't write .htaccess file. Please create a .htaccess "
 "file in your %directory directory which contains the following lines: "
 "<pre><code>@htaccess</code></pre>"
 msgstr ""
+"Security warning: Couldn't write .htaccess file. Please create a .htaccess "
+"file in your %directory directory which contains the following lines: "
+"<pre><code>@htaccess</code></pre>"
 
 msgid "Please continue to <a href=\":error_url\">the error page</a>"
-msgstr ""
+msgstr "Please continue to <a href=\":error_url\">the error page</a>"
 
 msgid ""
 "The installer requires that you create a translations directory as part of "
@@ -19371,18 +20676,28 @@ msgid ""
 "More details about installing Drupal are available in <a "
 "href=\":install_txt\">INSTALL.txt</a>."
 msgstr ""
+"The installer requires that you create a translations directory as part of "
+"the installation process. Create the directory %translations_directory . "
+"More details about installing Drupal are available in <a "
+"href=\":install_txt\">INSTALL.txt</a>."
 
 msgid ""
 "The installer requires read permissions to %translations_directory at all "
 "times. The <a href=\":handbook_url\">webhosting issues</a> documentation "
 "section offers help on this and other topics."
 msgstr ""
+"The installer requires read permissions to %translations_directory at all "
+"times. The <a href=\":handbook_url\">webhosting issues</a> documentation "
+"section offers help on this and other topics."
 
 msgid ""
 "The installer requires write permissions to %translations_directory during "
 "the installation process. The <a href=\":handbook_url\">webhosting "
 "issues</a> documentation section offers help on this and other topics."
 msgstr ""
+"The installer requires write permissions to %translations_directory during "
+"the installation process. The <a href=\":handbook_url\">webhosting "
+"issues</a> documentation section offers help on this and other topics."
 
 msgid ""
 "The installer requires to contact the translation server to download a "
@@ -19390,85 +20705,97 @@ msgid ""
 "website can reach the translation server at <a "
 "href=\":server_url\">@server_url</a>."
 msgstr ""
+"The installer requires to contact the translation server to download a "
+"translation file. Check your internet connection and verify that your "
+"website can reach the translation server at <a "
+"href=\":server_url\">@server_url</a>."
 
 msgid ""
 "The %language translation file is not available at the translation server. "
 "<a href=\":url\">Choose a different language</a> or select English and "
 "translate your website later."
 msgstr ""
+"The %language translation file is not available at the translation server. "
+"<a href=\":url\">Choose a different language</a> or select English and "
+"translate your website later."
 
 msgid "contact form"
-msgstr ""
+msgstr "contact form"
 
 msgid "0 seconds"
-msgstr ""
+msgstr "0 seconds"
 
 msgid "Primary admin actions"
-msgstr ""
+msgstr "Primary admin actions"
 
 msgid "Basic block"
-msgstr ""
+msgstr "Basic block"
 
 msgid "Website feedback"
-msgstr ""
+msgstr "Website feedback"
 
 msgid ""
 "Enter a comma-separated list. For example: Amsterdam, Mexico City, "
 "\"Cleveland, Ohio\""
 msgstr ""
+"Enter a comma-separated list. For example: Amsterdam, Mexico City, "
+"\"Cleveland, Ohio\""
 
 msgid "Basic HTML"
-msgstr ""
+msgstr "Basic HTML"
 
 msgid "Restricted HTML"
-msgstr ""
+msgstr "Restricted HTML"
 
 msgid "Default long date"
-msgstr ""
+msgstr "Default long date"
 
 msgid "Default medium date"
-msgstr ""
+msgstr "Default medium date"
 
 msgctxt "PHP date format"
 msgid "D, m/d/Y - H:i"
-msgstr ""
+msgstr "D, m/d/Y - H:i"
 
 msgid "Default short date"
-msgstr ""
+msgstr "Default short date"
 
 msgctxt "PHP date format"
 msgid "m/d/Y - H:i"
-msgstr ""
+msgstr "m/d/Y - H:i"
 
 msgid "Block the selected user(s)"
-msgstr ""
+msgstr "Block the selected user(s)"
 
 msgid "Cancel the selected user account(s)"
-msgstr ""
+msgstr "Cancel the selected user account(s)"
 
 msgid "Unblock the selected user(s)"
-msgstr ""
+msgstr "Unblock the selected user(s)"
 
 msgid "Configuration synchronization"
-msgstr ""
+msgstr "Configuration synchronization"
 
 msgid "Import and export your configuration."
-msgstr ""
+msgstr "Import and export your configuration."
 
 msgid "Entity/field definitions"
-msgstr ""
+msgstr "Entity/field definitions"
 
 msgid "@local-task-title@active"
-msgstr ""
+msgstr "@local-task-title@active"
 
 msgid "Core (Experimental)"
-msgstr ""
+msgstr "Core (Experimental)"
 
 msgid ""
 "The %language translation file could not be downloaded. <a "
 "href=\":url\">Choose a different language</a> or select English and "
 "translate your website later."
 msgstr ""
+"The %language translation file could not be downloaded. <a "
+"href=\":url\">Choose a different language</a> or select English and "
+"translate your website later."
 
 msgid ""
 "The @drupal installer requires that you create a %file as part of the "
@@ -19476,18 +20803,28 @@ msgid ""
 "about installing Drupal are available in <a "
 "href=\":install_txt\">INSTALL.txt</a>."
 msgstr ""
+"The @drupal installer requires that you create a %file as part of the "
+"installation process. Copy the %default_file file to %file. More details "
+"about installing Drupal are available in <a "
+"href=\":install_txt\">INSTALL.txt</a>."
 
 msgid ""
 "@drupal requires read permissions to %file at all times. The <a "
 "href=\":handbook_url\">webhosting issues</a> documentation section offers "
 "help on this and other topics."
 msgstr ""
+"@drupal requires read permissions to %file at all times. The <a "
+"href=\":handbook_url\">webhosting issues</a> documentation section offers "
+"help on this and other topics."
 
 msgid ""
 "The @drupal installer requires write permissions to %file during the "
 "installation process. The <a href=\":handbook_url\">webhosting issues</a> "
 "documentation section offers help on this and other topics."
 msgstr ""
+"The @drupal installer requires write permissions to %file during the "
+"installation process. The <a href=\":handbook_url\">webhosting issues</a> "
+"documentation section offers help on this and other topics."
 
 msgid ""
 "The @drupal installer failed to create a %file file with proper file "
@@ -19498,54 +20835,70 @@ msgid ""
 "href=\":handbook_url\">webhosting issues</a> documentation section offers "
 "help on this and other topics."
 msgstr ""
+"The @drupal installer failed to create a %file file with proper file "
+"ownership. Log on to your web server, remove the existing %file file, and "
+"create a new one by copying the %default_file file to %file. More details "
+"about installing Drupal are available in <a "
+"href=\":install_txt\">INSTALL.txt</a>. The <a "
+"href=\":handbook_url\">webhosting issues</a> documentation section offers "
+"help on this and other topics."
 
 msgid ""
 "Check the messages and <a href=\":retry\">retry</a>, or you may choose to <a"
 " href=\":cont\">continue anyway</a>."
 msgstr ""
+"Check the messages and <a href=\":retry\">retry</a>, or you may choose to <a"
+" href=\":cont\">continue anyway</a>."
 
 msgid "Check the messages and <a href=\":url\">try again</a>."
-msgstr ""
+msgstr "Check the messages and <a href=\":url\">try again</a>."
 
 msgid ""
 "The following modules are required but were not found. Move them into the "
 "appropriate modules subdirectory, such as <em>/modules</em>. Missing "
 "modules: @modules"
 msgstr ""
+"The following modules are required but were not found. Move them into the "
+"appropriate modules subdirectory, such as <em>/modules</em>. Missing "
+"modules: @modules"
 
 msgid "Updating @module"
-msgstr ""
+msgstr "Updating @module"
 
 msgid "Post updating @module"
-msgstr ""
+msgstr "Post updating @module"
 
 msgid "Date (e.g. @format)"
-msgstr ""
+msgstr "Date (e.g. @format)"
 
 msgid "Time (e.g. @format)"
-msgstr ""
+msgstr "Time (e.g. @format)"
 
 msgid "@uri"
-msgstr ""
+msgstr "@uri"
 
 msgid "Operating in maintenance mode. <a href=\":url\">Go online.</a>"
-msgstr ""
+msgstr "Operating in maintenance mode. <a href=\":url\">Go online.</a>"
 
 msgid "Textfield size: @size"
-msgstr ""
+msgstr "Textfield size: @size"
 
 msgid "Number of rows: @rows"
-msgstr ""
+msgstr "Number of rows: @rows"
 
 msgid ""
 "WARNING: You are not using an encrypted connection, so your password will be"
 " sent in plain text. <a href=\":https-link\">Learn more</a>."
 msgstr ""
+"WARNING: You are not using an encrypted connection, so your password will be"
+" sent in plain text. <a href=\":https-link\">Learn more</a>."
 
 msgid ""
 "@name cannot be longer than %max characters but is currently %length "
 "characters long."
 msgstr ""
+"@name cannot be longer than %max characters but is currently %length "
+"characters long."
 
 msgid ""
 "All necessary changes to %dir and %file have been made, so you should remove"
@@ -19553,59 +20906,77 @@ msgid ""
 "unsure how to do so, consult the <a href=\":handbook_url\">online "
 "handbook</a>."
 msgstr ""
+"All necessary changes to %dir and %file have been made, so you should remove"
+" write permissions to them now in order to avoid security risks. If you are "
+"unsure how to do so, consult the <a href=\":handbook_url\">online "
+"handbook</a>."
 
 msgid ""
 "A working <a href=\":cron\">cron maintenance task</a> is required to update "
 "feeds automatically."
 msgstr ""
+"A working <a href=\":cron\">cron maintenance task</a> is required to update "
+"feeds automatically."
 
 msgid ""
 "The length of time between feed updates. Requires a correctly configured <a "
 "href=\":cron\">cron maintenance task</a>."
 msgstr ""
+"The length of time between feed updates. Requires a correctly configured <a "
+"href=\":cron\">cron maintenance task</a>."
 
 msgid ""
 "Requires a correctly configured <a href=\":cron\">cron maintenance task</a>."
 msgstr ""
+"Requires a correctly configured <a href=\":cron\">cron maintenance task</a>."
 
 msgid ""
 "<a href=\":login\">Log in</a> or <a href=\":register\">register</a> to post "
 "comments"
 msgstr ""
+"<a href=\":login\">Log in</a> or <a href=\":register\">register</a> to post "
+"comments"
 
 msgid "<a href=\":login\">Log in</a> to post comments"
-msgstr ""
+msgstr "<a href=\":login\">Log in</a> to post comments"
 
 msgid "[@form] @subject"
-msgstr ""
+msgstr "[@form] @subject"
 
 msgid "Hello @recipient-name,"
-msgstr ""
+msgstr "Hello @recipient-name,"
 
 msgid "@name (not verified)"
-msgstr ""
+msgstr "@name (not verified)"
 
 msgid ""
 "Before you can translate content, there must be at least two languages added"
 " on the <a href=\":url\">languages administration</a> page."
 msgstr ""
+"Before you can translate content, there must be at least two languages added"
+" on the <a href=\":url\">languages administration</a> page."
 
 msgid "Date part order: @order"
-msgstr ""
+msgstr "Date part order: @order"
 
 msgid "Time type: @time_type"
-msgstr ""
+msgstr "Time type: @time_type"
 
 msgid ""
 "The Database Logging module logs system events in the Drupal database. For "
 "more information, see the <a href=\":dblog\">online documentation for the "
 "Database Logging module</a>."
 msgstr ""
+"The Database Logging module logs system events in the Drupal database. For "
+"more information, see the <a href=\":dblog\">online documentation for the "
+"Database Logging module</a>."
 
 msgid ""
 "The maximum number of messages to keep in the database log. Requires a <a "
 "href=\":cron\">cron maintenance task</a>."
 msgstr ""
+"The maximum number of messages to keep in the database log. Requires a <a "
+"href=\":cron\">cron maintenance task</a>."
 
 msgid ""
 "Pages which are suitable for caching are cached the first time they are "
@@ -19613,25 +20984,33 @@ msgid ""
 " content is handled automatically so that both cache correctness and hit "
 "ratio is maintained."
 msgstr ""
+"Pages which are suitable for caching are cached the first time they are "
+"requested, then the cached version is served for all later requests. Dynamic"
+" content is handled automatically so that both cache correctness and hit "
+"ratio is maintained."
 
 msgid "@size limit."
-msgstr ""
+msgstr "@size limit."
 
 msgid "Limit allowed HTML tags and correct faulty HTML"
-msgstr ""
+msgstr "Limit allowed HTML tags and correct faulty HTML"
 
 msgid ""
 "Explanation of the language options is found on the <a "
 "href=\":languages_list_page\">languages list page</a>."
 msgstr ""
+"Explanation of the language options is found on the <a "
+"href=\":languages_list_page\">languages list page</a>."
 
 msgid "Site's default language (@language)"
-msgstr ""
+msgstr "Site's default language (@language)"
 
 msgid ""
 "Each menu has a corresponding block that is managed on the <a "
 "href=\":blocks\">Block layout page</a>."
 msgstr ""
+"Each menu has a corresponding block that is managed on the <a "
+"href=\":blocks\">Block layout page</a>."
 
 msgid ""
 "When new content is created, the Node module records basic information about"
@@ -19642,19 +21021,30 @@ msgid ""
 "Default settings can be configured for each <a href=\":content-type\">type "
 "of content</a> on your site."
 msgstr ""
+"When new content is created, the Node module records basic information about"
+" the content, including the author, date of creation, and the <a href"
+"=\":content-type\">Content type</a>. It also manages the <em>publishing "
+"options</em>, which define whether or not the content is published, promoted"
+" to the front page of the site, and/or sticky at the top of content lists. "
+"Default settings can be configured for each <a href=\":content-type\">type "
+"of content</a> on your site."
 
 msgid "This text will be displayed on the <em>Add new content</em> page."
-msgstr ""
+msgstr "This text will be displayed on the <em>Add new content</em> page."
 
 msgid ""
 "Set and configure the default theme for your website.  Alternative <a "
 "href=\":themes\">themes</a> are available."
 msgstr ""
+"Set and configure the default theme for your website.  Alternative <a "
+"href=\":themes\">themes</a> are available."
 
 msgid ""
 "You can place blocks for each theme on the <a href=\":blocks\">block "
 "layout</a> page."
 msgstr ""
+"You can place blocks for each theme on the <a href=\":blocks\">block "
+"layout</a> page."
 
 msgid ""
 "Regularly review available updates to maintain a secure and current site. "
@@ -19662,88 +21052,108 @@ msgid ""
 "is updated. Enable the <a href=\":update-manager\">Update Manager module</a>"
 " to update and install modules and themes."
 msgstr ""
+"Regularly review available updates to maintain a secure and current site. "
+"Always run the <a href=\":update-php\">update script</a> each time a module "
+"is updated. Enable the <a href=\":update-manager\">Update Manager module</a>"
+" to update and install modules and themes."
 
 msgid "Configure your <a href=\":user-edit\">account time zone setting</a>."
-msgstr ""
+msgstr "Configure your <a href=\":user-edit\">account time zone setting</a>."
 
 msgid ""
 "One or more problems were detected with your Drupal installation. Check the "
 "<a href=\":status\">status report</a> for more information."
 msgstr ""
+"One or more problems were detected with your Drupal installation. Check the "
+"<a href=\":status\">status report</a> for more information."
 
 msgid "Uninstall @theme theme"
-msgstr ""
+msgstr "Uninstall @theme theme"
 
 msgid "Set @theme as default theme"
-msgstr ""
+msgstr "Set @theme as default theme"
 
 msgid "Install @theme theme"
-msgstr ""
+msgstr "Install @theme theme"
 
 msgid "Install @theme as default theme"
-msgstr ""
+msgstr "Install @theme as default theme"
 
 msgid ""
 "Defined on the <a href=\":appearance\">Appearance Settings</a> or <a "
 "href=\":theme\">Theme Settings</a> page."
 msgstr ""
+"Defined on the <a href=\":appearance\">Appearance Settings</a> or <a "
+"href=\":theme\">Theme Settings</a> page."
 
 msgid "Defined on the <a href=\":information\">Site Information</a> page."
-msgstr ""
+msgstr "Defined on the <a href=\":information\">Site Information</a> page."
 
 msgid "Installation tasks"
-msgstr ""
+msgstr "Installation tasks"
 
 msgid "Uninstalled modules"
-msgstr ""
+msgstr "Uninstalled modules"
 
 msgid "Uninstalled themes"
-msgstr ""
+msgstr "Uninstalled themes"
 
 msgid "Check for updates of uninstalled modules and themes"
-msgstr ""
+msgstr "Check for updates of uninstalled modules and themes"
 
 msgid "@label:@column"
-msgstr ""
+msgstr "@label:@column"
 
 msgid "@label (@name:delta)"
-msgstr ""
+msgstr "@label (@name:delta)"
 
 msgid "Add section"
-msgstr ""
+msgstr "Add section"
 
 msgid ""
 "There was a problem checking <a href=\":update-report\">available "
 "updates</a> for your modules or themes."
 msgstr ""
+"There was a problem checking <a href=\":update-report\">available "
+"updates</a> for your modules or themes."
 
 msgid ""
 "Download additional <a href=\":modules\">contributed modules</a> to extend "
 "your site's functionality."
 msgstr ""
+"Download additional <a href=\":modules\">contributed modules</a> to extend "
+"your site's functionality."
 
 msgid ""
 "For more information, see the <a href=\":views\">online documentation for "
 "the Views module</a>."
 msgstr ""
+"For more information, see the <a href=\":views\">online documentation for "
+"the Views module</a>."
 
 msgid "You must select a language to continue the installation."
-msgstr ""
+msgstr "You must select a language to continue the installation."
 
 msgid ""
 "Several special characters are allowed, including space, period (.), hyphen "
 "(-), apostrophe ('), underscore (_), and the @ sign."
 msgstr ""
+"Several special characters are allowed, including space, period (.), hyphen "
+"(-), apostrophe ('), underscore (_), and the @ sign."
 
 msgid ""
 "Block placement is specific to each theme on your site. Changes will not be "
 "saved until you click <em>Save blocks</em> at the bottom of the page."
 msgstr ""
+"Block placement is specific to each theme on your site. Changes will not be "
+"saved until you click <em>Save blocks</em> at the bottom of the page."
 
 msgid ""
 "The Database Logging module logs system events in the Drupal database. "
 "Monitor your site or debug site problems on this page."
 msgstr ""
+"The Database Logging module logs system events in the Drupal database. "
+"Monitor your site or debug site problems on this page."
 
 msgid ""
 "There has been more than one failed login attempt for this account. It is "
@@ -19754,55 +21164,64 @@ msgid_plural ""
 "is temporarily blocked. Try again later or <a href=\":url\">request a new "
 "password</a>."
 msgstr[0] ""
+"There has been more than one failed login attempt for this account. It is "
+"temporarily blocked. Try again later or <a href=\":url\">request a new "
+"password</a>."
 msgstr[1] ""
+"There have been more than @count failed login attempts for this account. It "
+"is temporarily blocked. Try again later or <a href=\":url\">request a new "
+"password</a>."
 
 msgid "Delete %label"
-msgstr ""
+msgstr "Delete %label"
 
 msgid "Max 1300x1300"
-msgstr ""
+msgstr "Max 1300x1300"
 
 msgid "Max 2600x2600"
-msgstr ""
+msgstr "Max 2600x2600"
 
 msgid "Max 325x325"
-msgstr ""
+msgstr "Max 325x325"
 
 msgid "Max 650x650"
-msgstr ""
+msgstr "Max 650x650"
 
 msgid "Narrow"
-msgstr ""
+msgstr "Narrow"
 
 msgid "Config override test"
-msgstr ""
+msgstr "Config override test"
 
 msgid "This entity (%type: %label) cannot be referenced."
-msgstr ""
+msgstr "This entity (%type: %label) cannot be referenced."
 
 msgid "Importing configuration"
-msgstr ""
+msgstr "Importing configuration"
 
 msgid "Starting configuration import."
-msgstr ""
+msgstr "Starting configuration import."
 
 msgid "Configuration import has encountered an error."
-msgstr ""
+msgstr "Configuration import has encountered an error."
 
 msgid "Authored on @date"
-msgstr ""
+msgstr "Authored on @date"
 
 msgid "Add @entity-type"
-msgstr ""
+msgstr "Add @entity-type"
 
 msgid "Size of email field"
-msgstr ""
+msgstr "Size of email field"
 
 msgid ""
 "Operations on Unicode strings are emulated on a best-effort basis. Install "
 "the <a href=\"http://php.net/mbstring\">PHP mbstring extension</a> for "
 "improved Unicode support."
 msgstr ""
+"Operations on Unicode strings are emulated on a best-effort basis. Install "
+"the <a href=\"http://php.net/mbstring\">PHP mbstring extension</a> for "
+"improved Unicode support."
 
 msgid ""
 "Multibyte string function overloading in PHP is active and must be disabled."
@@ -19810,6 +21229,10 @@ msgid ""
 "the <a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for "
 "more information."
 msgstr ""
+"Multibyte string function overloading in PHP is active and must be disabled."
+" Check the php.ini <em>mbstring.func_overload</em> setting. Please refer to "
+"the <a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for "
+"more information."
 
 msgid ""
 "Multibyte string input conversion in PHP is active and must be disabled. "
@@ -19817,6 +21240,10 @@ msgid ""
 "refer to the <a href=\"http://php.net/mbstring\">PHP mbstring "
 "documentation</a> for more information."
 msgstr ""
+"Multibyte string input conversion in PHP is active and must be disabled. "
+"Check the php.ini <em>mbstring.encoding_translation</em> setting. Please "
+"refer to the <a href=\"http://php.net/mbstring\">PHP mbstring "
+"documentation</a> for more information."
 
 msgid ""
 "Multibyte string input conversion in PHP is active and must be disabled. "
@@ -19824,6 +21251,10 @@ msgid ""
 "<a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for more "
 "information."
 msgstr ""
+"Multibyte string input conversion in PHP is active and must be disabled. "
+"Check the php.ini <em>mbstring.http_input</em> setting. Please refer to the "
+"<a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for more "
+"information."
 
 msgid ""
 "Multibyte string output conversion in PHP is active and must be disabled. "
@@ -19831,176 +21262,200 @@ msgid ""
 " <a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for more"
 " information."
 msgstr ""
+"Multibyte string output conversion in PHP is active and must be disabled. "
+"Check the php.ini <em>mbstring.http_output</em> setting. Please refer to the"
+" <a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for more"
+" information."
 
 msgid "United Nations' official languages"
-msgstr ""
+msgstr "United Nations' official languages"
 
 msgid "All @count languages"
-msgstr ""
+msgstr "All @count languages"
 
 msgid "Completed step @current of @total."
-msgstr ""
+msgstr "Completed step @current of @total."
 
 msgid ""
 "Control which roles can \"View the administration theme\" on the <a "
 "href=\":permissions\">Permissions page</a>."
 msgstr ""
+"Control which roles can \"View the administration theme\" on the <a "
+"href=\":permissions\">Permissions page</a>."
 
 msgid "Bundle assigned to the auto-created entities."
-msgstr ""
+msgstr "Bundle assigned to the auto-created entities."
 
 msgid "Revision create time"
-msgstr ""
+msgstr "Revision create time"
 
 msgid "Administrative task links"
-msgstr ""
+msgstr "Administrative task links"
 
 msgid "Site information links"
-msgstr ""
+msgstr "Site information links"
 
 msgid "Site section links"
-msgstr ""
+msgstr "Site section links"
 
 msgid "All content, by month."
-msgstr ""
+msgstr "All content, by month."
 
 msgid "All content promoted to the front page."
-msgstr ""
+msgstr "All content promoted to the front page."
 
 msgid "Name or email contains"
-msgstr ""
+msgstr "Name or email contains"
 
 msgid "A list of new users"
-msgstr ""
+msgstr "A list of new users"
 
 msgid "Who's online block"
-msgstr ""
+msgstr "Who's online block"
 
 msgid ""
 "Shows the user names of the most recently active users, and the total number"
 " of active users."
 msgstr ""
+"Shows the user names of the most recently active users, and the total number"
+" of active users."
 
 msgid "There are currently @total users online."
-msgstr ""
+msgstr "There are currently @total users online."
 
 msgid "There are currently 0 users online."
-msgstr ""
+msgstr "There are currently 0 users online."
 
 msgid "A list of users that are currently logged in."
-msgstr ""
+msgstr "A list of users that are currently logged in."
 
 msgid "View edit page"
-msgstr ""
+msgstr "View edit page"
 
 msgid "Manage view settings"
-msgstr ""
+msgstr "Manage view settings"
 
 msgid "View or edit the configuration."
-msgstr ""
+msgstr "View or edit the configuration."
 
 msgid "Displays in this view"
-msgstr ""
+msgstr "Displays in this view"
 
 msgid ""
 "A display is a way of outputting the results, e.g., as a page or a block. A "
 "view can contain multiple displays, which are listed here. The active "
 "display is highlighted."
 msgstr ""
+"A display is a way of outputting the results, e.g., as a page or a block. A "
+"view can contain multiple displays, which are listed here. The active "
+"display is highlighted."
 
 msgid "View administration"
-msgstr ""
+msgstr "View administration"
 
 msgid "Filter your view"
-msgstr ""
+msgstr "Filter your view"
 
 msgid "Filter actions"
-msgstr ""
+msgstr "Filter actions"
 
 msgid "Add, rearrange or remove filters."
-msgstr ""
+msgstr "Add, rearrange or remove filters."
 
 msgid ""
 "Control the order in which the results are output. Click on an active sort "
 "rule to configure it."
 msgstr ""
+"Control the order in which the results are output. Click on an active sort "
+"rule to configure it."
 
 msgid "Sort actions"
-msgstr ""
+msgstr "Sort actions"
 
 msgid "Add, rearrange or remove sorting rules."
-msgstr ""
+msgstr "Add, rearrange or remove sorting rules."
 
 msgid "Default revision"
-msgstr ""
+msgstr "Default revision"
 
 msgid "Basic site settings"
-msgstr ""
+msgstr "Basic site settings"
 
 msgid ""
 "Create and manage fields, forms, and display settings for your content."
 msgstr ""
+"Create and manage fields, forms, and display settings for your content."
 
 msgid "Manage menus and menu links."
-msgstr ""
+msgstr "Manage menus and menu links."
 
 msgid ""
 "Configure default user account settings, including fields, registration "
 "requirements, and email messages."
 msgstr ""
+"Configure default user account settings, including fields, registration "
+"requirements, and email messages."
 
 msgid ""
 "Select and configure text editors, and how content is filtered when "
 "displayed."
 msgstr ""
+"Select and configure text editors, and how content is filtered when "
+"displayed."
 
 msgid "Configure caching and bandwidth optimization."
-msgstr ""
+msgstr "Configure caching and bandwidth optimization."
 
 msgid "Configure the display of error messages and database logging."
-msgstr ""
+msgstr "Configure the display of error messages and database logging."
 
 msgid "Take the site offline for updates and other maintenance tasks."
-msgstr ""
+msgstr "Take the site offline for updates and other maintenance tasks."
 
 msgid "Configure and use development tools."
-msgstr ""
+msgstr "Configure and use development tools."
 
 msgid "Configure the location of uploaded files and how they are accessed."
-msgstr ""
+msgstr "Configure the location of uploaded files and how they are accessed."
 
 msgid "Add custom URLs to existing paths."
-msgstr ""
+msgstr "Add custom URLs to existing paths."
 
 msgid "Configure site search, metadata, and search engine optimization."
-msgstr ""
+msgstr "Configure site search, metadata, and search engine optimization."
 
 msgid "Configure the locale and timezone settings."
-msgstr ""
+msgstr "Configure the locale and timezone settings."
 
 msgid "Configure how dates and times are displayed."
-msgstr ""
+msgstr "Configure how dates and times are displayed."
 
 msgid "Configure languages for content, interface, and configuration."
-msgstr ""
+msgstr "Configure languages for content, interface, and configuration."
 
 msgid ""
 "Configure the import of translation files, and add or customize interface "
 "translations."
 msgstr ""
+"Configure the import of translation files, and add or customize interface "
+"translations."
 
 msgid "Configure regional settings, localization, and translation."
-msgstr ""
+msgstr "Configure regional settings, localization, and translation."
 
 msgid ""
 "Configure the site description, the number of items per feed, and whether "
 "feeds should be titles/teasers/full-text."
 msgstr ""
+"Configure the site description, the number of items per feed, and whether "
+"feeds should be titles/teasers/full-text."
 
 msgid ""
 "The specified file %file could not be moved/copied because no file by that "
 "name exists. Please check that you supplied the correct filename."
 msgstr ""
+"The specified file %file could not be moved/copied because no file by that "
+"name exists. Please check that you supplied the correct filename."
 
 msgid ""
 "The specified file %file could not be moved/copied because the destination "
@@ -20008,40 +21463,54 @@ msgid ""
 "file or directory permissions. More information is available in the system "
 "log."
 msgstr ""
+"The specified file %file could not be moved/copied because the destination "
+"directory is not properly configured. This may be caused by a problem with "
+"file or directory permissions. More information is available in the system "
+"log."
 
 msgid ""
 "The file %file could not be moved/copied because a file by that name already"
 " exists in the destination directory."
 msgstr ""
+"The file %file could not be moved/copied because a file by that name already"
+" exists in the destination directory."
 
 msgid ""
 "The specified file %file was not moved/copied because it would overwrite "
 "itself."
 msgstr ""
+"The specified file %file was not moved/copied because it would overwrite "
+"itself."
 
 msgid ""
 "File %file (%realpath) could not be moved/copied because it does not exist."
 msgstr ""
+"File %file (%realpath) could not be moved/copied because it does not exist."
 
 msgid "File %file could not be moved/copied because it does not exist."
-msgstr ""
+msgstr "File %file could not be moved/copied because it does not exist."
 
 msgid ""
 "File %file could not be moved/copied because the destination directory "
 "%destination is not configured correctly."
 msgstr ""
+"File %file could not be moved/copied because the destination directory "
+"%destination is not configured correctly."
 
 msgid ""
 "File %file could not be moved/copied because a file by that name already "
 "exists in the destination directory (%destination)"
 msgstr ""
+"File %file could not be moved/copied because a file by that name already "
+"exists in the destination directory (%destination)"
 
 msgid ""
 "File %file could not be moved/copied because it would overwrite itself."
 msgstr ""
+"File %file could not be moved/copied because it would overwrite itself."
 
 msgid "%type: @message in %function (line %line of %file) @backtrace_string."
-msgstr ""
+msgstr "%type: @message in %function (line %line of %file) @backtrace_string."
 
 msgid ""
 "The directory %directory could not be created. To proceed with the "
@@ -20049,339 +21518,370 @@ msgid ""
 "the permissions to create it automatically. For more information, see the <a"
 " href=\":handbook_url\">online handbook</a>."
 msgstr ""
+"The directory %directory could not be created. To proceed with the "
+"installation, either create the directory or ensure that the installer has "
+"the permissions to create it automatically. For more information, see the <a"
+" href=\":handbook_url\">online handbook</a>."
 
 msgid "Starting execution of @module_cron()."
-msgstr ""
+msgstr "Starting execution of @module_cron()."
 
 msgid ""
 "Starting execution of @module_cron(), execution of @module_previous_cron() "
 "took @time."
 msgstr ""
+"Starting execution of @module_cron(), execution of @module_previous_cron() "
+"took @time."
 
 msgid "Execution of @module_previous_cron() took @time."
-msgstr ""
+msgstr "Execution of @module_previous_cron() took @time."
 
 msgid ""
 "The message to display to the user after submission of this form. Leave "
 "blank for no message."
 msgstr ""
+"The message to display to the user after submission of this form. Leave "
+"blank for no message."
 
 msgid ""
 "Path to redirect the user to after submission of this form. For example, "
 "type \"/about\" to redirect to that page. Use a relative path with a slash "
 "in front."
 msgstr ""
+"Path to redirect the user to after submission of this form. For example, "
+"type \"/about\" to redirect to that page. Use a relative path with a slash "
+"in front."
 
 msgid ""
 "Specify an alternative path by which this data can be accessed. For example,"
 " type \"/about\" when writing an about page."
 msgstr ""
+"Specify an alternative path by which this data can be accessed. For example,"
+" type \"/about\" when writing an about page."
 
 msgid ""
 "Control default display settings for your site, across all themes. Use "
 "theme-specific settings to override these defaults."
 msgstr ""
+"Control default display settings for your site, across all themes. Use "
+"theme-specific settings to override these defaults."
 
 msgid "Page element display"
-msgstr ""
+msgstr "Page element display"
 
 msgid "Use the logo supplied by the theme"
-msgstr ""
+msgstr "Use the logo supplied by the theme"
 
 msgid ""
 "Your shortcut icon, or favicon, is displayed in the address bar and "
 "bookmarks of most browsers."
 msgstr ""
+"Your shortcut icon, or favicon, is displayed in the address bar and "
+"bookmarks of most browsers."
 
 msgid "Use the favicon supplied by the theme"
-msgstr ""
+msgstr "Use the favicon supplied by the theme"
 
 msgid "Upload favicon image"
-msgstr ""
+msgstr "Upload favicon image"
 
 msgid "Apply to selected items"
-msgstr ""
+msgstr "Apply to selected items"
 
 msgid "Recommendations to make your password stronger:"
-msgstr ""
+msgstr "Recommendations to make your password stronger:"
 
 msgid "Combine multiple fields together and search by them."
-msgstr ""
+msgstr "Combine multiple fields together and search by them."
 
 msgid "Field %field set in %filter is not set in display %display."
-msgstr ""
+msgstr "Field %field set in %filter is not set in display %display."
 
 msgid "A label is required for the specified operator."
-msgstr ""
+msgstr "A label is required for the specified operator."
 
 msgid "A label is required if the value for this item is defined."
-msgstr ""
+msgstr "A label is required if the value for this item is defined."
 
 msgid "A value is required if the label for this item is defined."
-msgstr ""
+msgstr "A value is required if the label for this item is defined."
 
 msgid "Leave empty to show all pages."
-msgstr ""
+msgstr "Leave empty to show all pages."
 
 msgid "@label moderation state"
-msgstr ""
+msgstr "@label moderation state"
 
 msgid "Date range settings"
-msgstr ""
+msgstr "Date range settings"
 
 msgid "Default start date type"
-msgstr ""
+msgstr "Default start date type"
 
 msgid "Default start date value"
-msgstr ""
+msgstr "Default start date value"
 
 msgid "Default end date type"
-msgstr ""
+msgstr "Default end date type"
 
 msgid "Default end date value"
-msgstr ""
+msgstr "Default end date value"
 
 msgid "Date separator"
-msgstr ""
+msgstr "Date separator"
 
 msgid "The string to separate the start and end dates"
-msgstr ""
+msgstr "The string to separate the start and end dates"
 
 msgid ""
 "Specify pages by using their paths. Enter one path per line. The '*' "
 "character is a wildcard. An example path is %user-wildcard for every user "
 "page. %front is the front page."
 msgstr ""
+"Specify pages by using their paths. Enter one path per line. The '*' "
+"character is a wildcard. An example path is %user-wildcard for every user "
+"page. %front is the front page."
 
 msgid "Is front page"
-msgstr ""
+msgstr "Is front page"
 
 msgid "Recipient email address"
-msgstr ""
+msgstr "Recipient email address"
 
 msgid "Are you sure you want to remove the @entity-type %label?"
-msgstr ""
+msgstr "Are you sure you want to remove the @entity-type %label?"
 
 msgid "The @entity-type %label has been removed."
-msgstr ""
+msgstr "The @entity-type %label has been removed."
 
 msgid "General System Information"
-msgstr ""
+msgstr "General System Information"
 
 msgid "Disclaimer block"
-msgstr ""
+msgstr "Disclaimer block"
 
 msgid "A locally hosted audio file."
-msgstr ""
+msgstr "A locally hosted audio file."
 
 msgid "A locally hosted video file."
-msgstr ""
+msgstr "A locally hosted video file."
 
 msgid "Tell us what you think"
-msgstr ""
+msgstr "Tell us what you think"
 
 msgid "Banner block"
-msgstr ""
+msgstr "Banner block"
 
 msgid "A disclaimer block contains disclaimer and copyright text."
-msgstr ""
+msgstr "A disclaimer block contains disclaimer and copyright text."
 
 msgid "Footer promo block"
-msgstr ""
+msgstr "Footer promo block"
 
 msgid ""
 "A footer promo block contains a title, promo text, and a \"find out more\" "
 "link."
 msgstr ""
+"A footer promo block contains a title, promo text, and a \"find out more\" "
+"link."
 
 msgid "Recipe Name"
-msgstr ""
+msgstr "Recipe Name"
 
 msgid "Content Link"
-msgstr ""
+msgstr "Content Link"
 
 msgid "Find out more link"
-msgstr ""
+msgstr "Find out more link"
 
 msgid "Promo text"
-msgstr ""
+msgstr "Promo text"
 
 msgid "Promo title"
-msgstr ""
+msgstr "Promo title"
 
 msgid ""
 "This image will be used on both the recipe page and wherever the recipe is "
 "promoted."
 msgstr ""
+"This image will be used on both the recipe page and wherever the recipe is "
+"promoted."
 
 msgid "List the ingredients required for this recipe, one per item."
-msgstr ""
+msgstr "List the ingredients required for this recipe, one per item."
 
 msgid "Recipe category"
-msgstr ""
+msgstr "Recipe category"
 
 msgid "Recipe instruction"
-msgstr ""
+msgstr "Recipe instruction"
 
 msgid "Provide a short overview of this recipe."
-msgstr ""
+msgstr "Provide a short overview of this recipe."
 
 msgid "Large 21:9 (1440x620)"
-msgstr ""
+msgstr "Large 21:9 (1440x620)"
 
 msgid "Large 21:9 2x (2880x1240)"
-msgstr ""
+msgstr "Large 21:9 2x (2880x1240)"
 
 msgid "Large 3:2 2x (1536x1024)"
-msgstr ""
+msgstr "Large 3:2 2x (1536x1024)"
 
 msgid "Large 3:2 (768x512)"
-msgstr ""
+msgstr "Large 3:2 (768x512)"
 
 msgid "Medium 21:9 (1024x440)"
-msgstr ""
+msgstr "Medium 21:9 (1024x440)"
 
 msgid "Medium 3:2 2x (1200x800)"
-msgstr ""
+msgstr "Medium 3:2 2x (1200x800)"
 
 msgid "Medium 3:2 (600x400)"
-msgstr ""
+msgstr "Medium 3:2 (600x400)"
 
 msgid "Medium 8:7 (266x236)"
-msgstr ""
+msgstr "Medium 8:7 (266x236)"
 
 msgid "Scale crop 7:3 large"
-msgstr ""
+msgstr "Scale crop 7:3 large"
 
 msgid "Small 21:9 (768x330)"
-msgstr ""
+msgstr "Small 21:9 (768x330)"
 
 msgid "Square Large"
-msgstr ""
+msgstr "Square Large"
 
 msgid "Square Medium"
-msgstr ""
+msgstr "Square Medium"
 
 msgid "Square Small"
-msgstr ""
+msgstr "Square Small"
 
 msgid "3:2 Image"
-msgstr ""
+msgstr "3:2 Image"
 
 msgid "Configuration validation"
-msgstr ""
+msgstr "Configuration validation"
 
 msgid "Preset Name"
-msgstr ""
+msgstr "Preset Name"
 
 msgid "Audio"
-msgstr ""
+msgstr "Audio"
 
 msgid "Node type"
-msgstr ""
+msgstr "Node type"
 
 msgid "content types"
-msgstr ""
+msgstr "content types"
 
 msgid "Heading"
-msgstr ""
+msgstr "Heading"
 
 msgid "Andorra"
-msgstr ""
+msgstr "Andorra"
 
 msgid "Configure content formatting and authoring."
-msgstr ""
+msgstr "Configure content formatting and authoring."
 
 msgid "Configure the administrative user interface."
-msgstr ""
+msgstr "Configure the administrative user interface."
 
 msgid "Manage the content workflow."
-msgstr ""
+msgstr "Manage the content workflow."
 
 msgid "Get a status report about your site's operation."
-msgstr ""
+msgstr "Get a status report about your site's operation."
 
 msgid ""
 "Unrecognized username or password. <a href=\":password\">Forgot your "
 "password?</a>"
 msgstr ""
+"Unrecognized username or password. <a href=\":password\">Forgot your "
+"password?</a>"
 
 msgid "Video"
-msgstr ""
+msgstr "Video"
 
 msgid "Unauthorized"
-msgstr ""
+msgstr "Unauthorized"
 
 msgid "users"
-msgstr ""
+msgstr "users"
 
 msgid "RDF"
-msgstr ""
+msgstr "RDF"
 
 msgid "About"
-msgstr ""
+msgstr "About"
 
 msgid "Edit action"
-msgstr ""
+msgstr "Edit action"
 
 msgid "Any text to display before this link. You may include HTML."
-msgstr ""
+msgstr "Any text to display before this link. You may include HTML."
 
 msgid "Display score"
-msgstr ""
+msgstr "Display score"
 
 msgid "Save book pages"
-msgstr ""
+msgstr "Save book pages"
 
 msgid "Last checked: @time ago"
-msgstr ""
+msgstr "Last checked: @time ago"
 
 msgid "Provider name"
-msgstr ""
+msgstr "Provider name"
 
 msgid "Moderation state"
-msgstr ""
+msgstr "Moderation state"
 
 msgid "This identifier is used by another handler."
-msgstr ""
+msgstr "This identifier is used by another handler."
 
 msgid ""
 "An error occurred while processing %error_operation with arguments: "
 "@arguments"
 msgstr ""
+"An error occurred while processing %error_operation with arguments: "
+"@arguments"
 
 msgid "Formatter settings"
-msgstr ""
+msgstr "Formatter settings"
 
 msgid "Users cannot post comments."
-msgstr ""
+msgstr "Users cannot post comments."
 
 msgid "Displaying menus"
-msgstr ""
+msgstr "Displaying menus"
 
 msgid ""
 "%capital_name contains terms with multiple parents. Drag and drop of terms "
 "with multiple parents is not supported, but you can re-enable drag-and-drop "
 "support by editing each term to include only a single parent."
 msgstr ""
+"%capital_name contains terms with multiple parents. Drag and drop of terms "
+"with multiple parents is not supported, but you can re-enable drag-and-drop "
+"support by editing each term to include only a single parent."
 
 msgid "Inline Form Errors"
-msgstr ""
+msgstr "Inline Form Errors"
 
 msgid "Last access timestamp"
-msgstr ""
+msgstr "Last access timestamp"
 
 msgid "Severity level"
-msgstr ""
+msgstr "Severity level"
 
 msgid "Transitions"
-msgstr ""
+msgstr "Transitions"
 
 msgid "Vocabulary machine name"
-msgstr ""
+msgstr "Vocabulary machine name"
 
 msgid "Preset ID"
-msgstr ""
+msgstr "Preset ID"
 
 msgid ""
 "A unique machine-readable name for this content type. It must only contain "
@@ -20389,21 +21889,25 @@ msgid ""
 "constructing the URL of the %node-add page, in which underscores will be "
 "converted into hyphens."
 msgstr ""
+"A unique machine-readable name for this content type. It must only contain "
+"lowercase letters, numbers, and underscores. This name will be used for "
+"constructing the URL of the %node-add page, in which underscores will be "
+"converted into hyphens."
 
 msgid "The author's host name."
-msgstr ""
+msgstr "The author's host name."
 
 msgid "Default moderation state"
-msgstr ""
+msgstr "Default moderation state"
 
 msgid "Full data (serialized)"
-msgstr ""
+msgstr "Full data (serialized)"
 
 msgid "HTTP method"
-msgstr ""
+msgstr "HTTP method"
 
 msgid "User limit"
-msgstr ""
+msgstr "User limit"
 
 msgid ""
 "If checked, multiple values for this field will be shown in the same row. If"
@@ -20411,65 +21915,74 @@ msgid ""
 " by, please make sure to group by \"Entity ID\" for this setting to have any"
 " effect."
 msgstr ""
+"If checked, multiple values for this field will be shown in the same row. If"
+" not checked, each value in this field will create a new row. If using group"
+" by, please make sure to group by \"Entity ID\" for this setting to have any"
+" effect."
 
 msgid "Filter HTML"
-msgstr ""
+msgstr "Filter HTML"
 
 msgid "Configuration Manager"
-msgstr ""
+msgstr "Configuration Manager"
 
 msgid "Maximum attempts"
-msgstr ""
+msgstr "Maximum attempts"
 
 msgid "No blocked IP addresses available."
-msgstr ""
+msgstr "No blocked IP addresses available."
 
 msgid ""
 "The first mlid in the materialized path. If N = depth, then pN must equal "
 "the mlid. If depth > 1 then p(N-1) must equal the plid. All pX where X > "
 "depth must equal zero. The columns p1 .. p9 are also called the parents."
 msgstr ""
+"The first mlid in the materialized path. If N = depth, then pN must equal "
+"the mlid. If depth > 1 then p(N-1) must equal the plid. All pX where X > "
+"depth must equal zero. The columns p1 .. p9 are also called the parents."
 
 msgid "The third mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The third mlid in the materialized path. See p1."
 
 msgid "The fourth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The fourth mlid in the materialized path. See p1."
 
 msgid "The fifth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The fifth mlid in the materialized path. See p1."
 
 msgid "The sixth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The sixth mlid in the materialized path. See p1."
 
 msgid "The seventh mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The seventh mlid in the materialized path. See p1."
 
 msgid "The eighth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The eighth mlid in the materialized path. See p1."
 
 msgid "The ninth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The ninth mlid in the materialized path. See p1."
 
 msgid ""
 "Flag that indicates that this link was generated during the update from "
 "Drupal 5."
 msgstr ""
+"Flag that indicates that this link was generated during the update from "
+"Drupal 5."
 
 msgid "Displaying @start - @end of @total"
-msgstr ""
+msgstr "Displaying @start - @end of @total"
 
 msgid "The revision ID."
-msgstr ""
+msgstr "The revision ID."
 
 msgid "All field aliases must be unique"
-msgstr ""
+msgstr "All field aliases must be unique"
 
 msgid "Editorial"
-msgstr ""
+msgstr "Editorial"
 
 msgid "Enter a part of the block name to filter by."
-msgstr ""
+msgstr "Enter a part of the block name to filter by."
 
 msgid ""
 "The width of each column will be calculated automatically based on the "
@@ -20477,106 +21990,129 @@ msgid ""
 "injects classes based on a grid system, disabling this option may prove "
 "beneficial."
 msgstr ""
+"The width of each column will be calculated automatically based on the "
+"number of columns provided. If additional classes are entered or a theme "
+"injects classes based on a grid system, disabling this option may prove "
+"beneficial."
 
 msgid ""
 "Add the default views column classes like views-col, col-1 and clearfix to "
 "the output. You can use this to quickly reduce the amount of markup the view"
 " provides by default, at the cost of making it more difficult to apply CSS."
 msgstr ""
+"Add the default views column classes like views-col, col-1 and clearfix to "
+"the output. You can use this to quickly reduce the amount of markup the view"
+" provides by default, at the cost of making it more difficult to apply CSS."
 
 msgid "The most recent of last comment posted or entity updated time."
-msgstr ""
+msgstr "The most recent of last comment posted or entity updated time."
 
 msgid "The User ID of the author of the last comment of an entity."
-msgstr ""
+msgstr "The User ID of the author of the last comment of an entity."
 
 msgid ""
 "The handler for this item is broken or missing. The following details are "
 "available:"
 msgstr ""
+"The handler for this item is broken or missing. The following details are "
+"available:"
 
 msgid "View basic information"
-msgstr ""
+msgstr "View basic information"
 
 msgid ""
 "@groupName button group in position @position of @positionCount in row @row "
 "of @rowCount."
 msgstr ""
+"@groupName button group in position @position of @positionCount in row @row "
+"of @rowCount."
 
 msgid ""
 "@name @type in position @position of @positionCount in @groupName button "
 "group in row @row of @rowCount."
 msgstr ""
+"@name @type in position @position of @positionCount in @groupName button "
+"group in row @row of @rowCount."
 
 msgid "Press the down arrow key to create a new button group in a new row."
-msgstr ""
+msgstr "Press the down arrow key to create a new button group in a new row."
 
 msgid "Editing the name of the new button group in a dialog."
-msgstr ""
+msgstr "Editing the name of the new button group in a dialog."
 
 msgid "Editing the name of the \"@groupName\" button group in a dialog."
-msgstr ""
+msgstr "Editing the name of the \"@groupName\" button group in a dialog."
 
 msgid ""
 "An entity with this machine name already exists but the import did not "
 "specify a UUID."
 msgstr ""
+"An entity with this machine name already exists but the import did not "
+"specify a UUID."
 
 msgid ""
 "An entity with this machine name already exists but the UUID does not match."
 msgstr ""
+"An entity with this machine name already exists but the UUID does not match."
 
 msgid ""
 "An entity with this UUID already exists but the machine name does not match."
 msgstr ""
+"An entity with this UUID already exists but the machine name does not match."
 
 msgid "Enter a part of the field or @bundle to filter by."
-msgstr ""
+msgstr "Enter a part of the field or @bundle to filter by."
 
 msgid "Add @language translation for %label"
-msgstr ""
+msgstr "Add @language translation for %label"
 
 msgid "@language translation of %label was deleted"
-msgstr ""
+msgstr "@language translation of %label was deleted"
 
 msgid "Edit @language translation for %label"
-msgstr ""
+msgstr "Edit @language translation for %label"
 
 msgid ""
 "Are you sure you want to apply the updated %name image effect to all images?"
 msgstr ""
+"Are you sure you want to apply the updated %name image effect to all images?"
 
 msgid ""
 "The rebuild_access setting is enabled in settings.php. It is recommended to "
 "have this setting disabled unless you are performing a rebuild."
 msgstr ""
+"The rebuild_access setting is enabled in settings.php. It is recommended to "
+"have this setting disabled unless you are performing a rebuild."
 
 msgid "Preferred admin language code"
-msgstr ""
+msgstr "Preferred admin language code"
 
 msgid ""
 "The user's preferred language code for receiving emails and viewing the "
 "site."
 msgstr ""
+"The user's preferred language code for receiving emails and viewing the "
+"site."
 
 msgid "Preferred language code"
-msgstr ""
+msgstr "Preferred language code"
 
 msgid "The user's preferred language code for viewing administration pages."
-msgstr ""
+msgstr "The user's preferred language code for viewing administration pages."
 
 msgid "The password of this user (hashed)."
-msgstr ""
+msgstr "The password of this user (hashed)."
 
 msgid "Initial email"
-msgstr ""
+msgstr "Initial email"
 
 msgid "User ID from route context"
-msgstr ""
+msgstr "User ID from route context"
 
 msgid ""
 "Changing the title here means it cannot be dynamically altered anymore."
 msgstr ""
+"Changing the title here means it cannot be dynamically altered anymore."
 
 msgid ""
 "This view will be displayed by visiting this path on your site. You may use "
@@ -20584,78 +22120,91 @@ msgid ""
 "filters: For example, \"node/%/feed\". If needed you can even specify named "
 "route parameters like taxonomy/term/%taxonomy_term"
 msgstr ""
+"This view will be displayed by visiting this path on your site. You may use "
+"\"%\" in your URL to represent values that will be used for contextual "
+"filters: For example, \"node/%/feed\". If needed you can even specify named "
+"route parameters like taxonomy/term/%taxonomy_term"
 
 msgid ""
 "Some of the pending updates cannot be applied because their dependencies "
 "were not met."
 msgstr ""
+"Some of the pending updates cannot be applied because their dependencies "
+"were not met."
 
 msgid "taxonomy term"
-msgstr ""
+msgstr "taxonomy term"
 
 msgid "Revision user"
-msgstr ""
+msgstr "Revision user"
 
 msgid "In-place content editing."
-msgstr ""
+msgstr "In-place content editing."
 
 msgid ""
 "An entity field containing a UNIX timestamp of when the entity has been last"
 " updated."
 msgstr ""
+"An entity field containing a UNIX timestamp of when the entity has been last"
+" updated."
 
 msgid ""
 "An entity field containing a UNIX timestamp of when the entity has been "
 "created."
 msgstr ""
+"An entity field containing a UNIX timestamp of when the entity has been "
+"created."
 
 msgid "An entity field for storing a serialized array of values."
-msgstr ""
+msgstr "An entity field for storing a serialized array of values."
 
 msgid "The config name @config_name is invalid."
-msgstr ""
+msgstr "The config name @config_name is invalid."
 
 msgid "The configuration was imported with errors."
-msgstr ""
+msgstr "The configuration was imported with errors."
 
 msgid "Deleted and replaced configuration entity \"@name\""
-msgstr ""
+msgstr "Deleted and replaced configuration entity \"@name\""
 
 msgid "HTML help"
-msgstr ""
+msgstr "HTML help"
 
 msgid "Title field required"
-msgstr ""
+msgstr "Title field required"
 
 msgid "Updates for: @module_list"
-msgstr ""
+msgstr "Updates for: @module_list"
 
 msgid ""
 "You have not created any content types yet. Go to the <a "
 "href=\"@create_content\">content type creation page</a> to add a new content"
 " type."
 msgstr ""
+"You have not created any content types yet. Go to the <a "
+"href=\"@create_content\">content type creation page</a> to add a new content"
+" type."
 
 msgid "Embed display options"
-msgstr ""
+msgstr "Embed display options"
 
 msgid "Boolean sort expose settings"
-msgstr ""
+msgstr "Boolean sort expose settings"
 
 msgid "Standard sort expose settings"
-msgstr ""
+msgstr "Standard sort expose settings"
 
 msgid "Random sort expose settings"
-msgstr ""
+msgstr "Random sort expose settings"
 
 msgid "Default views column classes"
-msgstr ""
+msgstr "Default views column classes"
 
 msgid "Book traversal links for"
-msgstr ""
+msgstr "Book traversal links for"
 
 msgid "Administer comment types and settings"
-msgstr ""
+msgstr "Administer comment types and settings"
 
 msgid ""
 "Allow other users to contact you via a personal contact form which keeps "
@@ -20663,35 +22212,44 @@ msgid ""
 "administrators are still able to contact you even if you choose to disable "
 "this feature."
 msgstr ""
+"Allow other users to contact you via a personal contact form which keeps "
+"your email address hidden. Note that some privileged users such as site "
+"administrators are still able to contact you even if you choose to disable "
+"this feature."
 
 msgid "%sender-name (@sender-from) sent %recipient-name an email."
-msgstr ""
+msgstr "%sender-name (@sender-from) sent %recipient-name an email."
 
 msgid "Email notification threshold"
-msgstr ""
+msgstr "Email notification threshold"
 
 msgid ""
 "Whenever your site checks for available updates and finds new releases, it "
 "can notify a list of users via email. Put each address on a separate line. "
 "If blank, no emails will be sent."
 msgstr ""
+"Whenever your site checks for available updates and finds new releases, it "
+"can notify a list of users via email. Put each address on a separate line. "
+"If blank, no emails will be sent."
 
 msgid "This account's preferred language for emails and site presentation."
-msgstr ""
+msgstr "This account's preferred language for emails and site presentation."
 
 msgid ""
 "Password reset instructions will be mailed to %email. You must log out to "
 "use the password reset link in the email."
 msgstr ""
+"Password reset instructions will be mailed to %email. You must log out to "
+"use the password reset link in the email."
 
 msgid "Duplicate view"
-msgstr ""
+msgstr "Duplicate view"
 
 msgid "@field_name: @label"
-msgstr ""
+msgstr "@field_name: @label"
 
 msgid "This link is provided by the Views module from view %label."
-msgstr ""
+msgstr "This link is provided by the Views module from view %label."
 
 msgid ""
 "\n"
@@ -20722,98 +22280,124 @@ msgid ""
 "            <li><code>&lt;code data-caption=\"Hello world in JavaScript.\"&gt;alert(\"Hello world!\");&lt;/code&gt;</code></li>\n"
 "        </ul>"
 msgstr ""
+"\n"
+"        <p>You can caption images, videos, blockquotes, and so on. Examples:</p>\n"
+"        <ul>\n"
+"            <li><code>&lt;img src=\"\" data-caption=\"This is a caption\" /&gt;</code></li>\n"
+"            <li><code>&lt;video src=\"\" data-caption=\"The Drupal Dance\" /&gt;</code></li>\n"
+"            <li><code>&lt;blockquote data-caption=\"Dries Buytaert\"&gt;Drupal is awesome!&lt;/blockquote&gt;</code></li>\n"
+"            <li><code>&lt;code data-caption=\"Hello world in JavaScript.\"&gt;alert(\"Hello world!\");&lt;/code&gt;</code></li>\n"
+"        </ul>"
 
 msgid "Drupal database update"
-msgstr ""
+msgstr "Drupal database update"
 
 msgid ""
 "Use this utility to update your database whenever a new release of Drupal or"
 " a module is installed."
 msgstr ""
+"Use this utility to update your database whenever a new release of Drupal or"
+" a module is installed."
 
 msgid ""
 "<strong>Back up your code</strong>. Hint: when backing up module code, do "
 "not leave that backup in the 'modules' or 'sites/*/modules' directories as "
 "this may confuse Drupal's auto-discovery mechanism."
 msgstr ""
+"<strong>Back up your code</strong>. Hint: when backing up module code, do "
+"not leave that backup in the 'modules' or 'sites/*/modules' directories as "
+"this may confuse Drupal's auto-discovery mechanism."
 
 msgid ""
 "<strong>Back up your database</strong>. This process will change your "
 "database values and in case of emergency you may need to revert to a backup."
 msgstr ""
+"<strong>Back up your database</strong>. This process will change your "
+"database values and in case of emergency you may need to revert to a backup."
 
 msgid ""
 "Install your new files in the appropriate location, as described in the "
 "handbook."
 msgstr ""
+"Install your new files in the appropriate location, as described in the "
+"handbook."
 
 msgid "When you have performed the steps above, you may proceed."
-msgstr ""
+msgstr "When you have performed the steps above, you may proceed."
 
 msgid "Formatted text default display format settings"
-msgstr ""
+msgstr "Formatted text default display format settings"
 
 msgid "Summary or trimmed formatted text display format settings"
-msgstr ""
+msgstr "Summary or trimmed formatted text display format settings"
 
 msgid "%field settings for %bundle"
-msgstr ""
+msgstr "%field settings for %bundle"
 
 msgctxt "Validation"
 msgid "Entity Reference reference access"
-msgstr ""
+msgstr "Entity Reference reference access"
 
 msgid "You do not have access to the referenced entity (%type: %id)."
-msgstr ""
+msgstr "You do not have access to the referenced entity (%type: %id)."
 
 msgid ""
 "You can caption images (<code>data-caption=\"Text\"</code>), but also "
 "videos, blockquotes, and so on."
 msgstr ""
+"You can caption images (<code>data-caption=\"Text\"</code>), but also "
+"videos, blockquotes, and so on."
 
 msgid ""
 "CTRL+Left click will prevent this dialog from showing and proceed to the "
 "clicked link."
 msgstr ""
+"CTRL+Left click will prevent this dialog from showing and proceed to the "
+"clicked link."
 
 msgid ""
 "If more than one application will be sharing this database, a unique table "
 "name prefix – such as %prefix – will prevent collisions."
 msgstr ""
+"If more than one application will be sharing this database, a unique table "
+"name prefix – such as %prefix – will prevent collisions."
 
 msgctxt "Validation"
 msgid "Regex"
-msgstr ""
+msgstr "Regex"
 
 msgid "The formatted text of the area"
-msgstr ""
+msgstr "The formatted text of the area"
 
 msgid ""
 "Entities exist of type %entity_type and %bundle_label %bundle. These "
 "entities need to be deleted before importing."
 msgstr ""
+"Entities exist of type %entity_type and %bundle_label %bundle. These "
+"entities need to be deleted before importing."
 
 msgid "The message language code."
-msgstr ""
+msgstr "The message language code."
 
 msgid ""
 "A boolean indicating whether the translation is visible to non-translators."
 msgstr ""
+"A boolean indicating whether the translation is visible to non-translators."
 
 msgid "Fields and field types"
-msgstr ""
+msgstr "Fields and field types"
 
 msgid "Enabling field types, widgets, and formatters"
-msgstr ""
+msgstr "Enabling field types, widgets, and formatters"
 
 msgid "Images larger than <strong>@max</strong> pixels will be resized."
-msgstr ""
+msgstr "Images larger than <strong>@max</strong> pixels will be resized."
 
 msgid "The reference view %view_name cannot be found."
-msgstr ""
+msgstr "The reference view %view_name cannot be found."
 
 msgid "An autocomplete text field with tagging support."
-msgstr ""
+msgstr "An autocomplete text field with tagging support."
 
 msgid ""
 "You can also configure a default image that will be used if no image is "
@@ -20821,145 +22405,177 @@ msgid ""
 " the field in the field storage settings when you create a field, and the "
 "setting can be overridden for each entity sub-type that uses the field."
 msgstr ""
+"You can also configure a default image that will be used if no image is "
+"uploaded in an image field. This default can be defined for all instances of"
+" the field in the field storage settings when you create a field, and the "
+"setting can be overridden for each entity sub-type that uses the field."
 
 msgid "@title [%language translation]"
-msgstr ""
+msgstr "@title [%language translation]"
 
 msgid "Provides links to perform entity operations."
-msgstr ""
+msgstr "Provides links to perform entity operations."
 
 msgid "@label (@id)"
-msgstr ""
+msgstr "@label (@id)"
 
 msgid "Query arguments"
-msgstr ""
+msgstr "Query arguments"
 
 msgid "Request format"
-msgstr ""
+msgstr "Request format"
 
 msgid "A flag indicating whether this is the default translation."
-msgstr ""
+msgstr "A flag indicating whether this is the default translation."
 
 msgid "Field settings (@on_label / @off_label)"
-msgstr ""
+msgstr "Field settings (@on_label / @off_label)"
 
 msgid "@on_label / @off_label"
-msgstr ""
+msgstr "@on_label / @off_label"
 
 msgid "By @author @time ago"
-msgstr ""
+msgstr "By @author @time ago"
 
 msgid ""
 "Search looks for exact, case-insensitive keywords; keywords shorter than a "
 "minimum length are ignored."
 msgstr ""
+"Search looks for exact, case-insensitive keywords; keywords shorter than a "
+"minimum length are ignored."
 
 msgid ""
 "Use upper-case OR to get more results. Example: cat OR dog (content contains"
 " either \"cat\" or \"dog\")."
 msgstr ""
+"Use upper-case OR to get more results. Example: cat OR dog (content contains"
+" either \"cat\" or \"dog\")."
 
 msgid "Fallback date format"
-msgstr ""
+msgstr "Fallback date format"
 
 msgid "Primary tabs display toggle"
-msgstr ""
+msgstr "Primary tabs display toggle"
 
 msgid "Hide lower priority columns"
-msgstr ""
+msgstr "Hide lower priority columns"
 
 msgid "Allows users to configure languages and apply them to content."
-msgstr ""
+msgstr "Allows users to configure languages and apply them to content."
 
 msgid ""
 "You can use upper-case AND to require all words, but this is the same as the"
 " default behavior. Example: cat AND dog (same as cat dog, content must "
 "contain both \"cat\" and \"dog\")."
 msgstr ""
+"You can use upper-case AND to require all words, but this is the same as the"
+" default behavior. Example: cat AND dog (same as cat dog, content must "
+"contain both \"cat\" and \"dog\")."
 
 msgid "Use quotes to search for a phrase. Example: \"the cat eats mice\"."
-msgstr ""
+msgstr "Use quotes to search for a phrase. Example: \"the cat eats mice\"."
 
 msgid ""
 "You can precede keywords by - to exclude them; you must still have at least "
 "one \"positive\" keyword. Example: cat -dog (content must contain cat and "
 "cannot contain dog)."
 msgstr ""
+"You can precede keywords by - to exclude them; you must still have at least "
+"one \"positive\" keyword. Example: cat -dog (content must contain cat and "
+"cannot contain dog)."
 
 msgid "No eligible views were found."
-msgstr ""
+msgstr "No eligible views were found."
 
 msgid "Testing config overrides"
-msgstr ""
+msgstr "Testing config overrides"
 
 msgid "Minimal profile for running tests with config overrides in a profile."
-msgstr ""
+msgstr "Minimal profile for running tests with config overrides in a profile."
 
 msgid "The hashed password"
-msgstr ""
+msgstr "The hashed password"
 
 msgid "@entity using @field_name"
-msgstr ""
+msgstr "@entity using @field_name"
 
 msgid ""
 "The <em>Autocomplete (Tags style)</em> widget displays a multi-text field in"
 " which users can type in a comma-separated list of entity labels."
 msgstr ""
+"The <em>Autocomplete (Tags style)</em> widget displays a multi-text field in"
+" which users can type in a comma-separated list of entity labels."
 
 msgid ""
 "Revisions allow you to track differences between multiple versions of your "
 "content, and revert to older versions."
 msgstr ""
+"Revisions allow you to track differences between multiple versions of your "
+"content, and revert to older versions."
 
 msgid "Testing multilingual with English"
-msgstr ""
+msgstr "Testing multilingual with English"
 
 msgid "Checkout complete! Thank you for your purchase."
-msgstr ""
+msgstr "Checkout complete! Thank you for your purchase."
 
 msgid "Resolving missing content"
-msgstr ""
+msgstr "Resolving missing content"
 
 msgid "The following @entity-type translations will be deleted:"
-msgstr ""
+msgstr "The following @entity-type translations will be deleted:"
 
 msgid "The @entity-type %label @language translation has been deleted."
-msgstr ""
+msgstr "The @entity-type %label @language translation has been deleted."
 
 msgid ""
 "Are you sure you want to delete the @language translation of the @entity-"
 "type %label?"
 msgstr ""
+"Are you sure you want to delete the @language translation of the @entity-"
+"type %label?"
 
 msgid ""
 "Unable to uninstall the %module module since the %dependent_module module is"
 " installed."
 msgstr ""
+"Unable to uninstall the %module module since the %dependent_module module is"
+" installed."
 
 msgid ""
 "Unable to install the %theme theme since it requires the %required_theme "
 "theme."
 msgstr ""
+"Unable to install the %theme theme since it requires the %required_theme "
+"theme."
 
 msgid ""
 "Unable to uninstall the %theme theme since the %dependent_theme theme is "
 "installed."
 msgstr ""
+"Unable to uninstall the %theme theme since the %dependent_theme theme is "
+"installed."
 
 msgid ""
 "Configuration %name depends on the %owner module that will not be installed "
 "after import."
 msgstr ""
+"Configuration %name depends on the %owner module that will not be installed "
+"after import."
 
 msgid ""
 "Configuration %name depends on the %owner theme that will not be installed "
 "after import."
 msgstr ""
+"Configuration %name depends on the %owner theme that will not be installed "
+"after import."
 
 msgid ""
 "Configuration %name depends on the %owner extension that will not be "
 "installed after import."
 msgstr ""
+"Configuration %name depends on the %owner extension that will not be "
+"installed after import."
 
 msgid ""
 "Unable to install the %module module since it requires the %required_module "
@@ -20968,7 +22584,11 @@ msgid_plural ""
 "Unable to install the %module module since it requires the %required_module "
 "modules."
 msgstr[0] ""
+"Unable to install the %module module since it requires the %required_module "
+"module."
 msgstr[1] ""
+"Unable to install the %module module since it requires the %required_module "
+"modules."
 
 msgid ""
 "Configuration %name depends on the %module module that will not be installed"
@@ -20977,7 +22597,11 @@ msgid_plural ""
 "Configuration %name depends on modules (%module) that will not be installed "
 "after import."
 msgstr[0] ""
+"Configuration %name depends on the %module module that will not be installed"
+" after import."
 msgstr[1] ""
+"Configuration %name depends on modules (%module) that will not be installed "
+"after import."
 
 msgid ""
 "Configuration %name depends on the %theme theme that will not be installed "
@@ -20986,7 +22610,11 @@ msgid_plural ""
 "Configuration %name depends on themes (%theme) that will not be installed "
 "after import."
 msgstr[0] ""
+"Configuration %name depends on the %theme theme that will not be installed "
+"after import."
 msgstr[1] ""
+"Configuration %name depends on themes (%theme) that will not be installed "
+"after import."
 
 msgid ""
 "Configuration %name depends on the %config configuration that will not exist"
@@ -20995,15 +22623,19 @@ msgid_plural ""
 "Configuration %name depends on configuration (%config) that will not exist "
 "after import."
 msgstr[0] ""
+"Configuration %name depends on the %config configuration that will not exist"
+" after import."
 msgstr[1] ""
+"Configuration %name depends on configuration (%config) that will not exist "
+"after import."
 
 msgctxt "Validation"
 msgid "NotNull"
-msgstr ""
+msgstr "NotNull"
 
 msgctxt "Validation"
 msgid "Null"
-msgstr ""
+msgstr "Null"
 
 msgid ""
 "For more detailed information, see the <a "
@@ -21011,61 +22643,67 @@ msgid ""
 "unsure what these terms mean you should probably contact your hosting "
 "provider."
 msgstr ""
+"For more detailed information, see the <a "
+"href=\"https://www.drupal.org/upgrade\">upgrading handbook</a>. If you are "
+"unsure what these terms mean you should probably contact your hosting "
+"provider."
 
 msgid "Entity delete link"
-msgstr ""
+msgstr "Entity delete link"
 
 msgid "Entity edit link"
-msgstr ""
+msgstr "Entity edit link"
 
 msgid "Link to @entity_type_label"
-msgstr ""
+msgstr "Link to @entity_type_label"
 
 msgid "Provide a view link to the @entity_type_label."
-msgstr ""
+msgstr "Provide a view link to the @entity_type_label."
 
 msgid "Link to edit @entity_type_label"
-msgstr ""
+msgstr "Link to edit @entity_type_label"
 
 msgid "Provide an edit link to the @entity_type_label."
-msgstr ""
+msgstr "Provide an edit link to the @entity_type_label."
 
 msgid "Link to delete @entity_type_label"
-msgstr ""
+msgstr "Link to delete @entity_type_label"
 
 msgid "Provide a delete link to the @entity_type_label."
-msgstr ""
+msgstr "Provide a delete link to the @entity_type_label."
 
 msgid "Cache tags"
-msgstr ""
+msgstr "Cache tags"
 
 msgid ""
 "Use <em>@interval</em> where you want the formatted interval text to appear."
 msgstr ""
+"Use <em>@interval</em> where you want the formatted interval text to appear."
 
 msgid "How many time interval units should be shown in the formatted output."
-msgstr ""
+msgstr "How many time interval units should be shown in the formatted output."
 
 msgid "Future date: %display"
-msgstr ""
+msgstr "Future date: %display"
 
 msgid "Past date: %display"
-msgstr ""
+msgstr "Past date: %display"
 
 msgid ""
 "Indicates if the last edit of a translation belongs to current revision."
 msgstr ""
+"Indicates if the last edit of a translation belongs to current revision."
 
 msgid "Testing config import"
-msgstr ""
+msgstr "Testing config import"
 
 msgid "Tests install profiles in the config importer."
-msgstr ""
+msgstr "Tests install profiles in the config importer."
 
 msgid "Module %name has been enabled."
 msgid_plural "@count modules have been enabled: %names."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Module %name has been enabled."
+msgstr[1] "@count modules have been enabled: %names."
 
 msgid ""
 "The MySQLnd driver version %version is less than the minimum required "
@@ -21073,6 +22711,10 @@ msgid ""
 "alternatively switch mysql drivers to libmysqlclient version "
 "%libmysqlclient_minimum_version or up."
 msgstr ""
+"The MySQLnd driver version %version is less than the minimum required "
+"version. Upgrade to MySQLnd version %mysqlnd_minimum_version or up, or "
+"alternatively switch mysql drivers to libmysqlclient version "
+"%libmysqlclient_minimum_version or up."
 
 msgid ""
 "The libmysqlclient driver version %version is less than the minimum required"
@@ -21080,96 +22722,108 @@ msgid ""
 "or up, or alternatively switch mysql drivers to MySQLnd version "
 "%mysqlnd_minimum_version or up."
 msgstr ""
+"The libmysqlclient driver version %version is less than the minimum required"
+" version. Upgrade to libmysqlclient version %libmysqlclient_minimum_version "
+"or up, or alternatively switch mysql drivers to MySQLnd version "
+"%mysqlnd_minimum_version or up."
 
 msgid ""
 "Drupal could not be correctly setup with the existing database due to the "
 "following error: @error."
 msgstr ""
+"Drupal could not be correctly setup with the existing database due to the "
+"following error: @error."
 
 msgid "A value must be selected for %part."
-msgstr ""
+msgstr "A value must be selected for %part."
 
 msgid "@title (value @number)"
-msgstr ""
+msgstr "@title (value @number)"
 
 msgid "Shown tabs"
-msgstr ""
+msgstr "Shown tabs"
 
 msgid "Select tabs being shown in the block"
-msgstr ""
+msgstr "Select tabs being shown in the block"
 
 msgid "Show primary tabs"
-msgstr ""
+msgstr "Show primary tabs"
 
 msgid "Show secondary tabs"
-msgstr ""
+msgstr "Show secondary tabs"
 
 msgid "@label (@type)"
-msgstr ""
+msgstr "@label (@type)"
 
 msgid "Comment_forum"
-msgstr ""
+msgstr "Comment_forum"
 
 msgid "Default comment field"
-msgstr ""
+msgstr "Default comment field"
 
 msgid "Overridden block the selected user(s)"
-msgstr ""
+msgstr "Overridden block the selected user(s)"
 
 msgid ""
 "Entity type mismatch on rename. @old_type not equal to @new_type for "
 "existing configuration @old_name and staged configuration @new_name."
 msgstr ""
+"Entity type mismatch on rename. @old_type not equal to @new_type for "
+"existing configuration @old_name and staged configuration @new_name."
 
 msgid ""
 "Rename operation for simple configuration. Existing configuration @old_name "
 "and staged configuration @new_name."
 msgstr ""
+"Rename operation for simple configuration. Existing configuration @old_name "
+"and staged configuration @new_name."
 
 msgid ""
 "Back up your database and site before you continue. <a "
 "href=\":backup_url\">Learn how</a>."
 msgstr ""
+"Back up your database and site before you continue. <a "
+"href=\":backup_url\">Learn how</a>."
 
 msgid "Revision translation affected"
-msgstr ""
+msgstr "Revision translation affected"
 
 msgid "Medium (220×220)"
-msgstr ""
+msgstr "Medium (220×220)"
 
 msgid "Thumbnail (100×100)"
-msgstr ""
+msgstr "Thumbnail (100×100)"
 
 msgid "HTML Date"
-msgstr ""
+msgstr "HTML Date"
 
 msgid "HTML Datetime"
-msgstr ""
+msgstr "HTML Datetime"
 
 msgid "HTML Month"
-msgstr ""
+msgstr "HTML Month"
 
 msgid "HTML Time"
-msgstr ""
+msgstr "HTML Time"
 
 msgid "HTML Year"
-msgstr ""
+msgstr "HTML Year"
 
 msgid "HTML Yearless date"
-msgstr ""
+msgstr "HTML Yearless date"
 
 msgctxt "PHP date format"
 msgid "l, F j, Y - H:i"
-msgstr ""
+msgstr "l, F j, Y - H:i"
 
 msgid "Inaccessible"
-msgstr ""
+msgstr "Inaccessible"
 
 msgid "Filter by name or description"
-msgstr ""
+msgstr "Filter by name or description"
 
 msgid "The response failed verification so will not be processed."
-msgstr ""
+msgstr "The response failed verification so will not be processed."
 
 msgid ""
 "Your MySQL server and PHP MySQL driver must support utf8mb4 character "
@@ -21178,27 +22832,41 @@ msgid ""
 "compiled in. See the <a href=\":documentation\" target=\"_blank\">MySQL "
 "documentation</a> for more information."
 msgstr ""
+"Your MySQL server and PHP MySQL driver must support utf8mb4 character "
+"encoding. Make sure to use a database system that supports this (such as "
+"MySQL/MariaDB/Percona 5.5.3 and up), and that the utf8mb4 character set is "
+"compiled in. See the <a href=\":documentation\" target=\"_blank\">MySQL "
+"documentation</a> for more information."
 
 msgid ""
 "The %driver database must use %encoding encoding to work with Drupal. "
 "Recreate the database with %encoding encoding. See <a "
 "href=\"INSTALL.pgsql.txt\">INSTALL.pgsql.txt</a> for more details."
 msgstr ""
+"The %driver database must use %encoding encoding to work with Drupal. "
+"Recreate the database with %encoding encoding. See <a "
+"href=\"INSTALL.pgsql.txt\">INSTALL.pgsql.txt</a> for more details."
 
 msgid ""
 "The %setting setting is currently set to '%current_value', but needs to be "
 "'%needed_value'. Change this by running the following query: "
 "<code>@query</code>"
 msgstr ""
+"The %setting setting is currently set to '%current_value', but needs to be "
+"'%needed_value'. Change this by running the following query: "
+"<code>@query</code>"
 
 msgid "URI field size: @size"
-msgstr ""
+msgstr "URI field size: @size"
 
 msgid ""
 "Failed to connect to the server. The server reports the following message: "
 "<p class=\"error\">@message</p> For more help installing or updating code on"
 " your server, see the <a href=\":handbook_url\">handbook</a>."
 msgstr ""
+"Failed to connect to the server. The server reports the following message: "
+"<p class=\"error\">@message</p> For more help installing or updating code on"
+" your server, see the <a href=\":handbook_url\">handbook</a>."
 
 msgid ""
 "<ul>\n"
@@ -21207,53 +22875,68 @@ msgid ""
 "<li>View your <a href=\":base-url\">existing site</a>.</li>\n"
 "</ul>"
 msgstr ""
+"<ul>\n"
+"<li>To start over, you must empty your existing database and copy <em>default.settings.php</em> over <em>settings.php</em>.</li>\n"
+"<li>To upgrade an existing installation, proceed to the <a href=\":update-url\">update script</a>.</li>\n"
+"<li>View your <a href=\":base-url\">existing site</a>.</li>\n"
+"</ul>"
 
 msgid "File Transfer failed, reason: @reason"
-msgstr ""
+msgstr "File Transfer failed, reason: @reason"
 
 msgctxt "Validation"
 msgid "Unique field constraint"
-msgstr ""
+msgstr "Unique field constraint"
 
 msgid "A @entity_type with @field_name %value already exists."
-msgstr ""
+msgstr "A @entity_type with @field_name %value already exists."
 
 msgid "In reply to @parent_title by @parent_username"
-msgstr ""
+msgstr "In reply to @parent_title by @parent_username"
 
 msgid "Name for @anonymous"
-msgstr ""
+msgstr "Name for @anonymous"
 
 msgid "@source_name to @target_name"
-msgstr ""
+msgstr "@source_name to @target_name"
 
 msgid "@label <span class=\"visually-hidden\">(@source_language)</span>"
-msgstr ""
+msgstr "@label <span class=\"visually-hidden\">(@source_language)</span>"
 
 msgid ""
 "@sender-name (@sender-url) sent a message using the contact form at @form-"
 "url."
 msgstr ""
+"@sender-name (@sender-url) sent a message using the contact form at @form-"
+"url."
 
 msgid "[@site-name] @subject"
-msgstr ""
+msgstr "[@site-name] @subject"
 
 msgid ""
 "@sender-name (@sender-url) has sent you a message via your contact form at "
 "@site-name."
 msgstr ""
+"@sender-name (@sender-url) has sent you a message via your contact form at "
+"@site-name."
 
 msgid ""
 "No eligible views were found. <a href=\":create\">Create a view</a> with an "
 "<em>Entity Reference</em> display, or add such a display to an <a "
 "href=\":existing\">existing view</a>."
 msgstr ""
+"No eligible views were found. <a href=\":create\">Create a view</a> with an "
+"<em>Entity Reference</em> display, or add such a display to an <a "
+"href=\":existing\">existing view</a>."
 
 msgid ""
 "For more information see W3C's <a href=\":html-specifications\">HTML "
 "Specifications</a> or use your favorite search engine to find other sites "
 "that explain HTML."
 msgstr ""
+"For more information see W3C's <a href=\":html-specifications\">HTML "
+"Specifications</a> or use your favorite search engine to find other sites "
+"that explain HTML."
 
 msgid ""
 "If you do encounter problems, try using HTML character entities. A common "
@@ -21261,9 +22944,13 @@ msgid ""
 "list of entities see HTML's <a href=\":html-entities\">entities</a> page. "
 "Some of the available characters include:"
 msgstr ""
+"If you do encounter problems, try using HTML character entities. A common "
+"example looks like &amp;amp; for an ampersand &amp; character. For a full "
+"list of entities see HTML's <a href=\":html-entities\">entities</a> page. "
+"Some of the available characters include:"
 
 msgid "image from @field_name"
-msgstr ""
+msgstr "image from @field_name"
 
 msgid ""
 "Define how to decide which language is used to display page elements "
@@ -21277,9 +22964,19 @@ msgid ""
 "page. The default language can be changed in the <a href=\":admin-change-"
 "language\">list of languages</a>."
 msgstr ""
+"Define how to decide which language is used to display page elements "
+"(primarily text provided by modules, such as field labels and help text). "
+"This decision is made by evaluating a series of detection methods for "
+"languages; the first detection method that gets a result will determine "
+"which language is used for that type of text. Be aware that some language "
+"detection methods are unreliable under certain conditions, such as browser "
+"detection when page-caching is enabled and a user is not currently logged "
+"in. Define the order of evaluation of language detection methods on this "
+"page. The default language can be changed in the <a href=\":admin-change-"
+"language\">list of languages</a>."
 
 msgid "@message (@percent%)."
-msgstr ""
+msgstr "@message (@percent%)."
 
 msgid ""
 "One translation string was skipped because of disallowed or malformed HTML. "
@@ -21288,7 +22985,11 @@ msgid_plural ""
 "@count translation strings were skipped because of disallowed or malformed "
 "HTML. <a href=\":url\">See the log</a> for details."
 msgstr[0] ""
+"One translation string was skipped because of disallowed or malformed HTML. "
+"<a href=\":url\">See the log</a> for details."
 msgstr[1] ""
+"@count translation strings were skipped because of disallowed or malformed "
+"HTML. <a href=\":url\">See the log</a> for details."
 
 msgid ""
 "The Node module gives users with the <em>Administer content types</em> "
@@ -21298,6 +22999,12 @@ msgid ""
 "href=\":field\">fields</a> and configure default settings that suit the "
 "differing needs of various site content."
 msgstr ""
+"The Node module gives users with the <em>Administer content types</em> "
+"permission the ability to <a href=\":content-new\">create new content "
+"types</a> in addition to the default ones already configured. Creating "
+"custom content types gives you the flexibility to add <a "
+"href=\":field\">fields</a> and configure default settings that suit the "
+"differing needs of various site content."
 
 msgid ""
 "If the site is experiencing problems with permissions to content, you may "
@@ -21308,25 +23015,36 @@ msgid ""
 "automatically use the new permissions. <a href=\":rebuild\">Rebuild "
 "permissions</a>"
 msgstr ""
+"If the site is experiencing problems with permissions to content, you may "
+"have to rebuild the permissions cache. Rebuilding will remove all privileges"
+" to content and replace them with permissions based on the current modules "
+"and settings. Rebuilding may take some time if there is a lot of content or "
+"complex permission settings. After rebuilding has completed, content will "
+"automatically use the new permissions. <a href=\":rebuild\">Rebuild "
+"permissions</a>"
 
 msgid "No content types available. <a href=\":link\">Add content type</a>."
-msgstr ""
+msgstr "No content types available. <a href=\":link\">Add content type</a>."
 
 msgid "… @excerpt … @excerpt …"
-msgstr ""
+msgstr "… @excerpt … @excerpt …"
 
 msgid ""
 "For more information, see the online handbook entry for <a href=\":memory-"
 "limit\">increasing the PHP memory limit</a>."
 msgstr ""
+"For more information, see the online handbook entry for <a href=\":memory-"
+"limit\">increasing the PHP memory limit</a>."
 
 msgid "Last run @time ago"
-msgstr ""
+msgstr "Last run @time ago"
 
 msgid ""
 "For more information, see the online handbook entry for <a href=\":cron-"
 "handbook\">configuring cron jobs</a>."
 msgstr ""
+"For more information, see the online handbook entry for <a href=\":cron-"
+"handbook\">configuring cron jobs</a>."
 
 msgid ""
 "Update notifications are not enabled. It is <strong>highly "
@@ -21335,6 +23053,11 @@ msgid ""
 "on new releases. For more information, <a href=\":update\">Update status "
 "handbook page</a>."
 msgstr ""
+"Update notifications are not enabled. It is <strong>highly "
+"recommended</strong> that you enable the Update Manager module from the <a "
+"href=\":module\">module administration page</a> in order to stay up-to-date "
+"on new releases. For more information, <a href=\":update\">Update status "
+"handbook page</a>."
 
 msgid ""
 "The trusted_host_patterns setting is not configured in settings.php. This "
@@ -21343,37 +23066,46 @@ msgid ""
 "href=\":url\">Protecting against HTTP HOST Header attacks</a> for more "
 "information."
 msgstr ""
+"The trusted_host_patterns setting is not configured in settings.php. This "
+"can lead to security vulnerabilities. It is <strong>highly "
+"recommended</strong> that you configure this. See <a "
+"href=\":url\">Protecting against HTTP HOST Header attacks</a> for more "
+"information."
 
 msgid "Put your site into <a href=\":url\">maintenance mode</a>."
-msgstr ""
+msgstr "Put your site into <a href=\":url\">maintenance mode</a>."
 
 msgid "All errors have been <a href=\":url\">logged</a>."
-msgstr ""
+msgstr "All errors have been <a href=\":url\">logged</a>."
 
 msgid "Screenshot for @theme theme"
-msgstr ""
+msgstr "Screenshot for @theme theme"
 
 msgid "Settings for @theme theme"
-msgstr ""
+msgstr "Settings for @theme theme"
 
 msgid "Powered by <a href=\":poweredby\">Drupal</a>"
-msgstr ""
+msgstr "Powered by <a href=\":poweredby\">Drupal</a>"
 
 msgid "Number of summary rows: @rows"
-msgstr ""
+msgstr "Number of summary rows: @rows"
 
 msgid "Boolean indicating whether the node is published."
-msgstr ""
+msgstr "Boolean indicating whether the node is published."
 
 msgid ""
 "Your site is currently configured to send these emails when any updates are "
 "available. To get notified only for security updates, @url."
 msgstr ""
+"Your site is currently configured to send these emails when any updates are "
+"available. To get notified only for security updates, @url."
 
 msgid ""
 "Your site is currently configured to send these emails only when security "
 "updates are available. To get notified for any available updates, @url."
 msgstr ""
+"Your site is currently configured to send these emails only when security "
+"updates are available. To get notified for any available updates, @url."
 
 msgid ""
 "You can choose to send email only if a security update is available, or to "
@@ -21383,162 +23115,193 @@ msgid ""
 "page, and will also display an error message on administration pages if "
 "there is a security update."
 msgstr ""
+"You can choose to send email only if a security update is available, or to "
+"be notified about all newer versions. If there are updates available of "
+"Drupal core or any of your installed modules and themes, your site will "
+"always print a message on the <a href=\":status_report\">status report</a> "
+"page, and will also display an error message on administration pages if "
+"there is a security update."
 
 msgid "PHP OPcode caching"
-msgstr ""
+msgstr "PHP OPcode caching"
 
 msgid "@tour_item of @total"
-msgstr ""
+msgstr "@tour_item of @total"
 
 msgid "Version: @module-version"
-msgstr ""
+msgstr "Version: @module-version"
 
 msgid "Requires: @module-list"
-msgstr ""
+msgstr "Requires: @module-list"
 
 msgid "Required by: @module-list"
-msgstr ""
+msgstr "Required by: @module-list"
 
 msgid ""
 "Required if you want to change the %mail or %pass below. <a "
 "href=\":request_new_url\" title=\"Send password reset instructions via "
 "email.\">Reset your password</a>."
 msgstr ""
+"Required if you want to change the %mail or %pass below. <a "
+"href=\":request_new_url\" title=\"Send password reset instructions via "
+"email.\">Reset your password</a>."
 
 msgid ""
 "Password reset instructions will be sent to your registered email address."
 msgstr ""
+"Password reset instructions will be sent to your registered email address."
 
 msgid ""
 "This link is provided by the Views module. The path can be changed by "
 "editing the view <a href=\":url\">@label</a>"
 msgstr ""
+"This link is provided by the Views module. The path can be changed by "
+"editing the view <a href=\":url\">@label</a>"
 
 msgid "@type language selected for page"
-msgstr ""
+msgstr "@type language selected for page"
 
 msgid "Will not be accessible."
-msgstr ""
+msgstr "Will not be accessible."
 
 msgid "@code (@title)"
-msgstr ""
+msgstr "@code (@title)"
 
 msgid ""
 "The following tokens are available. You may use Twig syntax in this field."
 msgstr ""
+"The following tokens are available. You may use Twig syntax in this field."
 
 msgid ""
 "Override the view and other argument titles. You may use Twig syntax in this"
 " field as well as the \"arguments\" and \"raw_arguments\" arrays."
 msgstr ""
+"Override the view and other argument titles. You may use Twig syntax in this"
+" field as well as the \"arguments\" and \"raw_arguments\" arrays."
 
 msgid ""
 "Override the view and other argument titles. You may use Twig syntax in this"
 " field."
 msgstr ""
+"Override the view and other argument titles. You may use Twig syntax in this"
+" field."
 
 msgid "The following replacement tokens are available for this argument."
-msgstr ""
+msgstr "The following replacement tokens are available for this argument."
 
 msgid ""
 "The category this block will appear under on the <a href=\":href\">blocks "
 "placement page</a>."
 msgstr ""
+"The category this block will appear under on the <a href=\":href\">blocks "
+"placement page</a>."
 
 msgid ""
 "You may also adjust the @settings for the currently selected access "
 "restriction."
 msgstr ""
+"You may also adjust the @settings for the currently selected access "
+"restriction."
 
 msgid ""
 "You may also adjust the @settings for the currently selected cache "
 "mechanism."
 msgstr ""
+"You may also adjust the @settings for the currently selected cache "
+"mechanism."
 
 msgid "You may also adjust the @settings for the currently selected style."
-msgstr ""
+msgstr "You may also adjust the @settings for the currently selected style."
 
 msgid ""
 "You may also adjust the @settings for the currently selected row style."
 msgstr ""
+"You may also adjust the @settings for the currently selected row style."
 
 msgid "You may also adjust the @settings for the currently selected pager."
-msgstr ""
+msgstr "You may also adjust the @settings for the currently selected pager."
 
 msgid ""
 "Views can be exported and imported as configuration files by using the <a "
 "href=\":config\">Configuration Manager module</a>."
 msgstr ""
+"Views can be exported and imported as configuration files by using the <a "
+"href=\":config\">Configuration Manager module</a>."
 
 msgid "Advanced Views settings"
-msgstr ""
+msgstr "Advanced Views settings"
 
 msgid "View @display_title"
-msgstr ""
+msgstr "View @display_title"
 
 msgid "Duplicate as @type"
-msgstr ""
+msgstr "Duplicate as @type"
 
 msgid "Add @display"
-msgstr ""
+msgstr "Add @display"
 
 msgid "By breaking this lock, any unsaved changes made by @user will be lost."
 msgstr ""
+"By breaking this lock, any unsaved changes made by @user will be lost."
 
 msgid ""
 "@display '@id': Component '@name' was disabled because its settings depend "
 "on removed dependencies."
 msgstr ""
+"@display '@id': Component '@name' was disabled because its settings depend "
+"on removed dependencies."
 
 msgid "No widget available for: %type."
-msgstr ""
+msgstr "No widget available for: %type."
 
 msgid "Create tasks that the system can execute."
-msgstr ""
+msgstr "Create tasks that the system can execute."
 
 msgid "Selection handler for entity reference fields have been adjusted."
-msgstr ""
+msgstr "Selection handler for entity reference fields have been adjusted."
 
 msgid ""
 "Configure how content is filtered when displayed, including which HTML tags "
 "are rendered, and enable module-provided filters."
 msgstr ""
+"Configure how content is filtered when displayed, including which HTML tags "
+"are rendered, and enable module-provided filters."
 
 msgid "- None (original image) -"
-msgstr ""
+msgstr "- None (original image) -"
 
 msgid "Checking site status"
-msgstr ""
+msgstr "Checking site status"
 
 msgid "Cache maximum age"
-msgstr ""
+msgstr "Cache maximum age"
 
 msgid "Creating and managing views"
-msgstr ""
+msgstr "Creating and managing views"
 
 msgid "Enabling and disabling views"
-msgstr ""
+msgstr "Enabling and disabling views"
 
 msgid "Exporting and importing views"
-msgstr ""
+msgstr "Exporting and importing views"
 
 msgid "Stable"
-msgstr ""
+msgstr "Stable"
 
 msgid "Aggregator RSS feed"
-msgstr ""
+msgstr "Aggregator RSS feed"
 
 msgid "Aggregator sources"
-msgstr ""
+msgstr "Aggregator sources"
 
 msgid "@label (@name:@column)"
-msgstr ""
+msgstr "@label (@name:@column)"
 
 msgid "Account cancellation request for [user:display-name] at [site:name]"
-msgstr ""
+msgstr "Account cancellation request for [user:display-name] at [site:name]"
 
 msgid "Replacement login information for [user:display-name] at [site:name]"
-msgstr ""
+msgstr "Replacement login information for [user:display-name] at [site:name]"
 
 msgid ""
 "[user:display-name],\n"
@@ -21556,6 +23319,20 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"A site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:\n"
+"\n"
+"[user:one-time-login-url]\n"
+"\n"
+"This link can only be used once to log in and will lead you to a page where you can set your password.\n"
+"\n"
+"After setting your password, you will be able to log in at [site:login-url] in the future using:\n"
+"\n"
+"username: [user:name]\n"
+"password: Your password\n"
+"\n"
+"--  [site:name] team"
 
 msgid ""
 "[user:display-name],\n"
@@ -21573,20 +23350,39 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"Thank you for registering at [site:name]. You may now log in by clicking this link or copying and pasting it into your browser:\n"
+"\n"
+"[user:one-time-login-url]\n"
+"\n"
+"This link can only be used once to log in and will lead you to a page where you can set your password.\n"
+"\n"
+"After setting your password, you will be able to log in at [site:login-url] in the future using:\n"
+"\n"
+"username: [user:name]\n"
+"password: Your password\n"
+"\n"
+"--  [site:name] team"
 
 msgid "Account details for [user:display-name] at [site:name]"
-msgstr ""
+msgstr "Account details for [user:display-name] at [site:name]"
 
 msgid ""
 "Account details for [user:display-name] at [site:name] (pending admin "
 "approval)"
 msgstr ""
+"Account details for [user:display-name] at [site:name] (pending admin "
+"approval)"
 
 msgid ""
 "[user:display-name] has applied for an account.\n"
 "\n"
 "[user:edit-url]"
 msgstr ""
+"[user:display-name] has applied for an account.\n"
+"\n"
+"[user:edit-url]"
 
 msgid ""
 "[user:display-name],\n"
@@ -21606,12 +23402,28 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"Your account at [site:name] has been activated.\n"
+"\n"
+"You may now log in by clicking this link or copying and pasting it into your browser:\n"
+"\n"
+"[user:one-time-login-url]\n"
+"\n"
+"This link can only be used once to log in and will lead you to a page where you can set your password.\n"
+"\n"
+"After setting your password, you will be able to log in at [site:login-url] in the future using:\n"
+"\n"
+"username: [user:account-name]\n"
+"password: Your password\n"
+"\n"
+"--  [site:name] team"
 
 msgid "Account details for [user:display-name] at [site:name] (approved)"
-msgstr ""
+msgstr "Account details for [user:display-name] at [site:name] (approved)"
 
 msgid "Account details for [user:display-name] at [site:name] (blocked)"
-msgstr ""
+msgstr "Account details for [user:display-name] at [site:name] (blocked)"
 
 msgid ""
 "[user:display-name],\n"
@@ -21620,172 +23432,194 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"Your account on [site:name] has been canceled.\n"
+"\n"
+"--  [site:name] team"
 
 msgid "Account details for [user:display-name] at [site:name] (canceled)"
-msgstr ""
+msgstr "Account details for [user:display-name] at [site:name] (canceled)"
 
 msgid "Find and manage custom blocks."
-msgstr ""
+msgstr "Find and manage custom blocks."
 
 msgid "Recent comments."
-msgstr ""
+msgstr "Recent comments."
 
 msgid "Find and manage files."
-msgstr ""
+msgstr "Find and manage files."
 
 msgid "Files overview"
-msgstr ""
+msgstr "Files overview"
 
 msgid "File usage information for {{ arguments.fid }}"
-msgstr ""
+msgstr "File usage information for {{ arguments.fid }}"
 
 msgid ""
 "<p>This page provides the ability to add common languages to your "
 "site.</p><p>If the desired language is not available, you can add a custom "
 "language.</p>"
 msgstr ""
+"<p>This page provides the ability to add common languages to your "
+"site.</p><p>If the desired language is not available, you can add a custom "
+"language.</p>"
 
 msgid "Editing languages"
-msgstr ""
+msgstr "Editing languages"
 
 msgid "Recent content."
-msgstr ""
+msgstr "Recent content."
 
 msgid "All content, by letter."
-msgstr ""
+msgstr "All content, by letter."
 
 msgid "Content belonging to a certain taxonomy term."
-msgstr ""
+msgstr "Content belonging to a certain taxonomy term."
 
 msgid "Shows a list of the newest user accounts on the site."
-msgstr ""
+msgstr "Shows a list of the newest user accounts on the site."
 
 msgid ""
 "The following reason prevents @module.module_name from being uninstalled:"
 msgid_plural ""
 "The following reasons prevent @module.module_name from being uninstalled:"
 msgstr[0] ""
+"The following reason prevents @module.module_name from being uninstalled:"
 msgstr[1] ""
+"The following reasons prevent @module.module_name from being uninstalled:"
 
 msgid "Fallback sort expose settings"
-msgstr ""
+msgstr "Fallback sort expose settings"
 
 msgid "width @data.width"
-msgstr ""
+msgstr "width @data.width"
 
 msgid "height @data.height"
-msgstr ""
+msgstr "height @data.height"
 
 msgid "This entity (%type: %id) cannot be referenced."
-msgstr ""
+msgstr "This entity (%type: %id) cannot be referenced."
 
 msgid "A default base theme using Drupal 8.0.0's core markup and CSS."
-msgstr ""
+msgstr "A default base theme using Drupal 8.0.0's core markup and CSS."
 
 msgid "Install configuration"
-msgstr ""
+msgstr "Install configuration"
 
 msgid "Show &mdash; @configuration.label"
-msgstr ""
+msgstr "Show &mdash; @configuration.label"
 
 msgid "Hide &mdash; @configuration.label"
-msgstr ""
+msgstr "Hide &mdash; @configuration.label"
 
 msgid "Session exists"
-msgstr ""
+msgstr "Session exists"
 
 msgid "Default configuration hash"
-msgstr ""
+msgstr "Default configuration hash"
 
 msgid ""
 "Field %field set in %filter is not usable for this filter type. Combined "
 "field filter only works for simple fields."
 msgstr ""
+"Field %field set in %filter is not usable for this filter type. Combined "
+"field filter only works for simple fields."
 
 msgid "Renders an entity in a view mode."
-msgstr ""
+msgstr "Renders an entity in a view mode."
 
 msgctxt "decimal places"
 msgid "Scale"
-msgstr ""
+msgstr "Scale"
 
 msgid "The new size setting for email widgets has been added."
-msgstr ""
+msgstr "The new size setting for email widgets has been added."
 
 msgid "Did not save to map table due to NULL value for key field @field"
-msgstr ""
+msgstr "Did not save to map table due to NULL value for key field @field"
 
 msgid "A boolean indicating whether the node is visible on the front page."
-msgstr ""
+msgstr "A boolean indicating whether the node is visible on the front page."
 
 msgid ""
 "A boolean indicating whether the node should sort to the top of content "
 "lists."
 msgstr ""
+"A boolean indicating whether the node should sort to the top of content "
+"lists."
 
 msgid "The %entity_type entity type needs to be installed."
-msgstr ""
+msgstr "The %entity_type entity type needs to be installed."
 
 msgid "The %entity_type entity type needs to be updated."
-msgstr ""
+msgstr "The %entity_type entity type needs to be updated."
 
 msgid "The %field_name field needs to be installed."
-msgstr ""
+msgstr "The %field_name field needs to be installed."
 
 msgid "The %field_name field needs to be updated."
-msgstr ""
+msgstr "The %field_name field needs to be updated."
 
 msgid "The %field_name field needs to be uninstalled."
-msgstr ""
+msgstr "The %field_name field needs to be uninstalled."
 
 msgid "Custom text: @true_label / @false_label"
-msgstr ""
+msgstr "Custom text: @true_label / @false_label"
 
 msgid "Display: @true_label / @false_label"
-msgstr ""
+msgstr "Display: @true_label / @false_label"
 
 msgid ""
 "See <a href=\"http://php.net/manual/function.date.php\" "
 "target=\"_blank\">the documentation for PHP date formats</a>."
 msgstr ""
+"See <a href=\"http://php.net/manual/function.date.php\" "
+"target=\"_blank\">the documentation for PHP date formats</a>."
 
 msgid "An icon that links to the feed URL"
-msgstr ""
+msgstr "An icon that links to the feed URL"
 
 msgid "Parent website of the feed."
-msgstr ""
+msgstr "Parent website of the feed."
 
 msgid "Parent website's description of the feed."
-msgstr ""
+msgstr "Parent website's description of the feed."
 
 msgid "Check my spelling as I type"
-msgstr ""
+msgstr "Check my spelling as I type"
 
 msgid "Language list ID"
-msgstr ""
+msgstr "Language list ID"
 
 msgid "Remove content from front page"
-msgstr ""
+msgstr "Remove content from front page"
 
 msgid "Continuing on"
-msgstr ""
+msgstr "Continuing on"
 
 msgid ""
 "The %field_type_label field type is used in the following field: @fields"
 msgid_plural ""
 "The %field_type_label field type is used in the following fields: @fields"
 msgstr[0] ""
+"The %field_type_label field type is used in the following field: @fields"
 msgstr[1] ""
+"The %field_type_label field type is used in the following fields: @fields"
 
 msgid ""
 "<p>This page provides the ability to edit a language on your site, including"
 " custom languages.</p>"
 msgstr ""
+"<p>This page provides the ability to edit a language on your site, including"
+" custom languages.</p>"
 
 msgid ""
 "<p>You cannot change the code of a language on the site, since it is used by"
 " the system to keep track of the language.</p>"
 msgstr ""
+"<p>You cannot change the code of a language on the site, since it is used by"
+" the system to keep track of the language.</p>"
 
 msgid ""
 "<p>The language name is used throughout the site for all users and is "
@@ -21793,32 +23627,44 @@ msgid ""
 "Interface Translation module, and names of both built-in and custom "
 "languages can be translated using the Configuration Translation module.</p>"
 msgstr ""
+"<p>The language name is used throughout the site for all users and is "
+"written in English. Names of built-in languages can be translated using the "
+"Interface Translation module, and names of both built-in and custom "
+"languages can be translated using the Configuration Translation module.</p>"
 
 msgid ""
 "<p>Choose if the language is a \"Left to right\" or \"Right to left\" "
 "language.</p><p>Note that not all themes support \"Right to left\" layouts, "
 "so test your theme if you are using \"Right to left\".</p>"
 msgstr ""
+"<p>Choose if the language is a \"Left to right\" or \"Right to left\" "
+"language.</p><p>Note that not all themes support \"Right to left\" layouts, "
+"so test your theme if you are using \"Right to left\".</p>"
 
 msgid ""
 "<p>The \"Languages\" page allows you to add, edit, delete, and reorder "
 "languages for the site.</p>"
 msgstr ""
+"<p>The \"Languages\" page allows you to add, edit, delete, and reorder "
+"languages for the site.</p>"
 
 msgid ""
 "<p>To add more languages to your site, click the \"Add language\" "
 "button.</p><p>Added languages will be displayed in the language list and can"
 " then be edited or deleted.</p>"
 msgstr ""
+"<p>To add more languages to your site, click the \"Add language\" "
+"button.</p><p>Added languages will be displayed in the language list and can"
+" then be edited or deleted.</p>"
 
 msgid "Reordering languages"
-msgstr ""
+msgstr "Reordering languages"
 
 msgid "Set a language as default"
-msgstr ""
+msgstr "Set a language as default"
 
 msgid "Modifying languages"
-msgstr ""
+msgstr "Modifying languages"
 
 msgid ""
 "<p>Operations are provided for editing and deleting your "
@@ -21828,61 +23674,80 @@ msgid ""
 "it, and content in this language will be set to be language neutral. Note "
 "that you cannot delete the default language of the site.</p>"
 msgstr ""
+"<p>Operations are provided for editing and deleting your "
+"languages.</p><p>You can edit the name and the direction of the "
+"language.</p><p>Deleted languages can be added back at a later time. "
+"Deleting a language will remove all interface translations associated with "
+"it, and content in this language will be set to be language neutral. Note "
+"that you cannot delete the default language of the site.</p>"
 
 msgid "Choose the language you want to translate."
-msgstr ""
+msgstr "Choose the language you want to translate."
 
 msgid ""
 "Enter the specific word or sentence you want to translate, you can also "
 "write just a part of a word."
 msgstr ""
+"Enter the specific word or sentence you want to translate, you can also "
+"write just a part of a word."
 
 msgid "Filter the search"
-msgstr ""
+msgstr "Filter the search"
 
 msgid ""
 "You can search for untranslated strings if you want to translate something "
 "that isn't translated yet. If you want to modify an existing translation, "
 "you might want to search only for translated strings."
 msgstr ""
+"You can search for untranslated strings if you want to translate something "
+"that isn't translated yet. If you want to modify an existing translation, "
+"you might want to search only for translated strings."
 
 msgid "Apply your search criteria"
-msgstr ""
+msgstr "Apply your search criteria"
 
 msgid "To apply your search criteria, click on the <em>Filter</em> button."
-msgstr ""
+msgstr "To apply your search criteria, click on the <em>Filter</em> button."
 
 msgid ""
 "You can write your own translation in the text fields of the right column. "
 "Try to figure out in which context the text will be used in order to "
 "translate it in the appropriate way."
 msgstr ""
+"You can write your own translation in the text fields of the right column. "
+"Try to figure out in which context the text will be used in order to "
+"translate it in the appropriate way."
 
 msgid "Validate the translation"
-msgstr ""
+msgstr "Validate the translation"
 
 msgid ""
 "When you have finished your translations, click on the <em>Save "
 "translations</em> button. You must save your translations, each time before "
 "changing the page or making a new search."
 msgstr ""
+"When you have finished your translations, click on the <em>Save "
+"translations</em> button. You must save your translations, each time before "
+"changing the page or making a new search."
 
 msgid "{{ arguments.created_year_month }}"
-msgstr ""
+msgstr "{{ arguments.created_year_month }}"
 
 msgid "Find and manage content"
-msgstr ""
+msgstr "Find and manage content"
 
 msgid "Welcome to [site:name]"
-msgstr ""
+msgstr "Welcome to [site:name]"
 
 msgid "{{ arguments.tid }}"
-msgstr ""
+msgstr "{{ arguments.tid }}"
 
 msgid ""
 "Perform administrative tasks, including adding a description and creating a "
 "clone. Click the drop-down button to view the available options."
 msgstr ""
+"Perform administrative tasks, including adding a description and creating a "
+"clone. Click the drop-down button to view the available options."
 
 msgid ""
 "Choose how to output results. E.g., choose <em>Content</em> to output each "
@@ -21891,20 +23756,30 @@ msgid ""
 "result. Additional formats can be added by installing modules to "
 "<em>extend</em> Drupal's base functionality."
 msgstr ""
+"Choose how to output results. E.g., choose <em>Content</em> to output each "
+"item completely, using your configured display settings. Or choose "
+"<em>Fields</em>, which allows you to output only specific fields for each "
+"result. Additional formats can be added by installing modules to "
+"<em>extend</em> Drupal's base functionality."
 
 msgid ""
 "If this view uses fields, they are listed here. You can click on a field to "
 "configure it."
 msgstr ""
+"If this view uses fields, they are listed here. You can click on a field to "
+"configure it."
 
 msgid ""
 "Add filters to limit the results in the output. E.g., to only show content "
 "that is <em>published</em>, you would add a filter for <em>Published</em> "
 "and select <em>Yes</em>."
 msgstr ""
+"Add filters to limit the results in the output. E.g., to only show content "
+"that is <em>published</em>, you would add a filter for <em>Published</em> "
+"and select <em>Yes</em>."
 
 msgid "Show a preview of the view output."
-msgstr ""
+msgstr "Show a preview of the view output."
 
 msgid ""
 "PHP OPcode caching can improve your site's performance considerably. It is "
@@ -21912,249 +23787,265 @@ msgid ""
 "href=\"http://php.net/manual/opcache.installation.php\" "
 "target=\"_blank\">OPcache</a> installed on your server."
 msgstr ""
+"PHP OPcode caching can improve your site's performance considerably. It is "
+"<strong>highly recommended</strong> to have <a "
+"href=\"http://php.net/manual/opcache.installation.php\" "
+"target=\"_blank\">OPcache</a> installed on your server."
 
 msgid "This identifier has illegal characters."
-msgstr ""
+msgstr "This identifier has illegal characters."
 
 msgid "Add a new @entity_type."
-msgstr ""
+msgstr "Add a new @entity_type."
 
 msgid "There is no @entity_type yet. @add_link"
-msgstr ""
+msgstr "There is no @entity_type yet. @add_link"
 
 msgid "Store new items in"
-msgstr ""
+msgstr "Store new items in"
 
 msgid "Delete @entity_type"
-msgstr ""
+msgstr "Delete @entity_type"
 
 msgctxt "Entity type label"
 msgid "@count @label"
 msgid_plural "@count @label entities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count @label"
+msgstr[1] "@count @label entities"
 
 msgid "Parent path"
-msgstr ""
+msgstr "Parent path"
 
 msgid "Selected combination of day and month is not valid."
-msgstr ""
+msgstr "Selected combination of day and month is not valid."
 
 msgid "Determines if a password needs hashing"
-msgstr ""
+msgstr "Determines if a password needs hashing"
 
 msgid ""
 "View display '@id': Comment field formatter '@name' was disabled because it "
 "is using the comment view display '@display' (@mode) that was just disabled."
 msgstr ""
+"View display '@id': Comment field formatter '@name' was disabled because it "
+"is using the comment view display '@display' (@mode) that was just disabled."
 
 msgid "No entity view display updated."
-msgstr ""
+msgstr "No entity view display updated."
 
 msgid "administration theme"
-msgstr ""
+msgstr "administration theme"
 
 msgid "All @entity_type_plural have been deleted."
-msgstr ""
+msgstr "All @entity_type_plural have been deleted."
 
 msgid "Content moderation state"
-msgstr ""
+msgstr "Content moderation state"
 
 msgid "content moderation state"
-msgstr ""
+msgstr "content moderation state"
 
 msgid "content moderation states"
-msgstr ""
+msgstr "content moderation states"
 
 msgid "Configure Content Moderation permissions"
-msgstr ""
+msgstr "Configure Content Moderation permissions"
 
 msgid "Testing missing dependencies"
-msgstr ""
+msgstr "Testing missing dependencies"
 
 msgid ""
 "Minimal profile for running a test when dependencies are listed but missing."
 msgstr ""
+"Minimal profile for running a test when dependencies are listed but missing."
 
 msgid "The field ID."
-msgstr ""
+msgstr "The field ID."
 
 msgid "Last upgrade: @date"
-msgstr ""
+msgstr "Last upgrade: @date"
 
 msgid "A boolean indicating the published state."
-msgstr ""
+msgstr "A boolean indicating the published state."
 
 msgid "Warnings found"
-msgstr ""
+msgstr "Warnings found"
 
 msgid "Errors found"
-msgstr ""
+msgstr "Errors found"
 
 msgid ""
 "An intentionally plain theme with no styling to demonstrate default Drupal’s"
 " HTML and CSS. Learn how to build a custom theme from Stark in the <a "
 "href=\"https://www.drupal.org/docs/8/theming\">Theming Guide</a>."
 msgstr ""
+"An intentionally plain theme with no styling to demonstrate default Drupal’s"
+" HTML and CSS. Learn how to build a custom theme from Stark in the <a "
+"href=\"https://www.drupal.org/docs/8/theming\">Theming Guide</a>."
 
 msgid "There are no @label yet."
-msgstr ""
+msgstr "There are no @label yet."
 
 msgid "The %field date is incomplete."
-msgstr ""
+msgstr "The %field date is incomplete."
 
 msgid "Remove the @label role from the selected user(s)"
-msgstr ""
+msgstr "Remove the @label role from the selected user(s)"
 
 msgid "!!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz"
-msgstr ""
+msgstr "!!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz"
 
 msgid "!!binary MQNAY291bnQ="
-msgstr ""
+msgstr "!!binary MQNAY291bnQ="
 
 msgid "Entity reference selection handler settings"
-msgstr ""
+msgstr "Entity reference selection handler settings"
 
 msgid "Default selection handler settings"
-msgstr ""
+msgstr "Default selection handler settings"
 
 msgid "File selection handler settings"
-msgstr ""
+msgstr "File selection handler settings"
 
 msgid "User selection handler settings"
-msgstr ""
+msgstr "User selection handler settings"
 
 msgid "Views selection handler settings"
-msgstr ""
+msgstr "Views selection handler settings"
 
 msgid "The \"%plugin_id\" was not found"
-msgstr ""
+msgstr "The \"%plugin_id\" was not found"
 
 msgid ""
 "You must have the pdo_sqlite PHP extension installed. See "
 "core/INSTALL.sqlite.txt for instructions."
 msgstr ""
+"You must have the pdo_sqlite PHP extension installed. See "
+"core/INSTALL.sqlite.txt for instructions."
 
 msgid "No installation found. Use the 'install' command."
-msgstr ""
+msgstr "No installation found. Use the 'install' command."
 
 msgid "Select and configure themes."
-msgstr ""
+msgstr "Select and configure themes."
 
 msgid "Breadcrumbs"
-msgstr ""
+msgstr "Breadcrumbs"
 
 msgid "Powered by Drupal"
-msgstr ""
+msgstr "Powered by Drupal"
 
 msgid "Help"
-msgstr ""
+msgstr "Help"
 
 msgid "Primary tabs"
-msgstr ""
+msgstr "Primary tabs"
 
 msgid "Status messages"
-msgstr ""
+msgstr "Status messages"
 
 msgid "Block"
-msgstr ""
+msgstr "Block"
 
 msgid ""
 "Use <em>articles</em> for time-sensitive content like news, press releases "
 "or blog posts."
 msgstr ""
+"Use <em>articles</em> for time-sensitive content like news, press releases "
+"or blog posts."
 
 msgid "Tools"
-msgstr ""
+msgstr "Tools"
 
 msgid "Comments published"
-msgstr ""
+msgstr "Comments published"
 
 msgid "Main page content"
-msgstr ""
+msgstr "Main page content"
 
 msgid "Footer menu"
-msgstr ""
+msgstr "Footer menu"
 
 msgid "Tabs"
-msgstr ""
+msgstr "Tabs"
 
 msgid "Page title"
-msgstr ""
+msgstr "Page title"
 
 msgid "A basic block contains a title and a body."
-msgstr ""
+msgstr "A basic block contains a title and a body."
 
 msgid "Default comments"
-msgstr ""
+msgstr "Default comments"
 
 msgid "Promoted to front page"
-msgstr ""
+msgstr "Promoted to front page"
 
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 msgid "Basic page"
-msgstr ""
+msgstr "Basic page"
 
 msgid ""
 "Use <em>basic pages</em> for your static content, such as an 'About us' "
 "page."
 msgstr ""
+"Use <em>basic pages</em> for your static content, such as an 'About us' "
+"page."
 
 msgid "Administrator"
-msgstr ""
+msgstr "Administrator"
 
 msgid "Authenticated user"
-msgstr ""
+msgstr "Authenticated user"
 
 msgid "Full comment"
-msgstr ""
+msgstr "Full comment"
 
 msgid "Save comment"
-msgstr ""
+msgstr "Save comment"
 
 msgid "Unpublish comment"
-msgstr ""
+msgstr "Unpublish comment"
 
 msgid "Personal contact form"
-msgstr ""
+msgstr "Personal contact form"
 
 msgid "Your message has been sent."
-msgstr ""
+msgstr "Your message has been sent."
 
 msgid "Large (480×480)"
-msgstr ""
+msgstr "Large (480×480)"
 
 msgid "English"
-msgstr ""
+msgstr "English"
 
 msgid "Not specified"
-msgstr ""
+msgstr "Not specified"
 
 msgid "Full content"
-msgstr ""
+msgstr "Full content"
 
 msgid "Search result highlighting input"
-msgstr ""
+msgstr "Search result highlighting input"
 
 msgid "Make content sticky"
-msgstr ""
+msgstr "Make content sticky"
 
 msgid "Site branding"
-msgstr ""
+msgstr "Site branding"
 
 msgid "Comments unapproved"
-msgstr ""
+msgstr "Comments unapproved"
 
 msgid "The unapproved comments listing."
-msgstr ""
+msgstr "The unapproved comments listing."
 
 msgid "User account menu"
-msgstr ""
+msgstr "User account menu"
 
 msgid "{{ message }}"
-msgstr ""
+msgstr "{{ message }}"
 
 msgid ""
 "<p>Now that you have an overview of the \"Edit language\" feature, you can "
@@ -22162,6 +24053,10 @@ msgid ""
 "href=\"[site:url]admin/config/regional/language\">Viewing configured "
 "languages</a></li></ul></p>"
 msgstr ""
+"<p>Now that you have an overview of the \"Edit language\" feature, you can "
+"continue by:<ul><li>Editing a language</li><li><a "
+"href=\"[site:url]admin/config/regional/language\">Viewing configured "
+"languages</a></li></ul></p>"
 
 msgid ""
 "<p>Now that you have an overview of the \"Languages\" page, you can continue"
@@ -22169,6 +24064,10 @@ msgid ""
 "a language</a></li><li>Reordering languages</li><li>Editing a "
 "language</li><li>Deleting a language</li></ul></p>"
 msgstr ""
+"<p>Now that you have an overview of the \"Languages\" page, you can continue"
+" by:<ul><li><a href=\"[site:url]admin/config/regional/language/add\">Adding "
+"a language</a></li><li>Reordering languages</li><li>Editing a "
+"language</li><li>Deleting a language</li></ul></p>"
 
 msgid ""
 "This page allows you to translate the user interface or modify existing "
@@ -22177,6 +24076,11 @@ msgid ""
 "href=\"[site:url]admin/config/regional/language\">Languages page</a>, in "
 "order to use this page."
 msgstr ""
+"This page allows you to translate the user interface or modify existing "
+"translations. If you have installed your site initially in English, you must"
+" first add another language on the <a "
+"href=\"[site:url]admin/config/regional/language\">Languages page</a>, in "
+"order to use this page."
 
 msgid ""
 "The translations you have made here will be used on your site's user "
@@ -22187,6 +24091,13 @@ msgid ""
 "href=\"[site:url]admin/config/regional/translate/import\">import them</a> "
 "later."
 msgstr ""
+"The translations you have made here will be used on your site's user "
+"interface. If you want to use them on another site or modify them on an "
+"external translation editor, you can <a "
+"href=\"[site:url]admin/config/regional/translate/export\">export them</a> to"
+" a .po file and <a "
+"href=\"[site:url]admin/config/regional/translate/import\">import them</a> "
+"later."
 
 msgid ""
 "No front page content has been created yet.<br/>Follow the <a "
@@ -22194,31 +24105,39 @@ msgid ""
 "href=\"https://www.drupal.org/docs/user_guide/en/index.html\">User Guide</a>"
 " to start building your site."
 msgstr ""
+"No front page content has been created yet.<br/>Follow the <a "
+"target=\"_blank\" "
+"href=\"https://www.drupal.org/docs/user_guide/en/index.html\">User Guide</a>"
+" to start building your site."
 
 msgid ""
 "There is content for the entity type: @entity_type. <a href=\":url\">Remove "
 "@entity_type_plural</a>."
 msgstr ""
+"There is content for the entity type: @entity_type. <a href=\":url\">Remove "
+"@entity_type_plural</a>."
 
 msgid "HTML Week"
-msgstr ""
+msgstr "HTML Week"
 
 msgid ""
 "@site is currently under maintenance. We should be back shortly. Thank you "
 "for your patience."
 msgstr ""
+"@site is currently under maintenance. We should be back shortly. Thank you "
+"for your patience."
 
 msgid "Links related to the active user account"
-msgstr ""
+msgstr "Links related to the active user account"
 
 msgid "User tool links, often added by modules"
-msgstr ""
+msgstr "User tool links, often added by modules"
 
 msgid "Taxonomy term page"
-msgstr ""
+msgstr "Taxonomy term page"
 
 msgid "Compact"
-msgstr ""
+msgstr "Compact"
 
 msgid ""
 "[user:display-name],\n"
@@ -22235,6 +24154,19 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"A request to cancel your account has been made at [site:name].\n"
+"\n"
+"You may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\n"
+"\n"
+"[user:cancel-url]\n"
+"\n"
+"NOTE: The cancellation of your account is not reversible.\n"
+"\n"
+"This link expires in one day and nothing will happen if it is not used.\n"
+"\n"
+"--  [site:name] team"
 
 msgid ""
 "[user:display-name],\n"
@@ -22249,6 +24181,17 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"A request to reset the password for your account has been made at [site:name].\n"
+"\n"
+"You may now log in by clicking this link or copying and pasting it into your browser:\n"
+"\n"
+"[user:one-time-login-url]\n"
+"\n"
+"This link can only be used once to log in and will lead you to a page where you can set your password. It expires after one day and nothing will happen if it's not used.\n"
+"\n"
+"--  [site:name] team"
 
 msgid ""
 "[user:display-name],\n"
@@ -22257,6 +24200,11 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"Thank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.\n"
+"\n"
+"--  [site:name] team"
 
 msgid ""
 "[user:display-name],\n"
@@ -22265,9 +24213,14 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"Your account on [site:name] has been blocked.\n"
+"\n"
+"--  [site:name] team"
 
 msgid "Custom block library"
-msgstr ""
+msgstr "Custom block library"
 
 msgid ""
 "<p>Now that you have an overview of the \"Add languages\" feature, you can "
@@ -22276,30 +24229,35 @@ msgid ""
 "href=\"[site:url]admin/config/regional/language\">Viewing configured "
 "languages</a></li></ul></p>"
 msgstr ""
+"<p>Now that you have an overview of the \"Add languages\" feature, you can "
+"continue by:<ul><li>Adding a language</li><li>Adding a custom "
+"language</li><li><a "
+"href=\"[site:url]admin/config/regional/language\">Viewing configured "
+"languages</a></li></ul></p>"
 
 msgid "There are no custom blocks available."
-msgstr ""
+msgstr "There are no custom blocks available."
 
 msgid "Find and manage comments."
-msgstr ""
+msgstr "Find and manage comments."
 
 msgid "Language direction"
-msgstr ""
+msgstr "Language direction"
 
 msgid "Adding languages"
-msgstr ""
+msgstr "Adding languages"
 
 msgid "The approved comments listing."
-msgstr ""
+msgstr "The approved comments listing."
 
 msgid "Lists (Views)"
-msgstr ""
+msgstr "Lists (Views)"
 
 msgid "Watchdog"
-msgstr ""
+msgstr "Watchdog"
 
 msgid "Recent log messages"
-msgstr ""
+msgstr "Recent log messages"
 
 msgid ""
 "<p>To reorder the languages on your site, use the drag icons next to each "
@@ -22309,12 +24267,18 @@ msgid ""
 "done with reordering the languages, click the \"Save configuration\" button "
 "for the changes to take effect.</p>"
 msgstr ""
+"<p>To reorder the languages on your site, use the drag icons next to each "
+"language.</p><p>The order shown here is the display order for language lists"
+" on the site such as in the language switcher blocks provided by the "
+"Interface Translation and Content Translation modules.</p><p>When you are "
+"done with reordering the languages, click the \"Save configuration\" button "
+"for the changes to take effect.</p>"
 
 msgid "No log messages available."
-msgstr ""
+msgstr "No log messages available."
 
 msgid "Manage user accounts, roles, and permissions."
-msgstr ""
+msgstr "Manage user accounts, roles, and permissions."
 
 msgid ""
 "One translation file imported. %number translations were added, %update "
@@ -22323,41 +24287,45 @@ msgid_plural ""
 "@count translation files imported. %number translations were added, %update "
 "translations were updated and %delete translations were removed."
 msgstr[0] ""
+"One translation file imported. %number translations were added, %update "
+"translations were updated and %delete translations were removed."
 msgstr[1] ""
+"@count translation files imported. %number translations were added, %update "
+"translations were updated and %delete translations were removed."
 
 msgid "Fid"
-msgstr ""
+msgstr "Fid"
 
 msgid "MIME type"
-msgstr ""
+msgstr "MIME type"
 
 msgid "Size"
-msgstr ""
+msgstr "Size"
 
 msgid "Items per page"
-msgstr ""
+msgstr "Items per page"
 
 msgid "Temporary"
-msgstr ""
+msgstr "Temporary"
 
 msgid "1 place"
 msgid_plural "@count places"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 place"
+msgstr[1] "@count places"
 
 msgid "Registering module"
-msgstr ""
+msgstr "Registering module"
 
 msgid "1"
 msgid_plural "@count"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1"
+msgstr[1] "@count"
 
 msgid "User"
-msgstr ""
+msgstr "User"
 
 msgid "Select language"
-msgstr ""
+msgstr "Select language"
 
 msgid ""
 "<p>Choose a language from the list, or choose \"Custom language...\" at the "
@@ -22366,6 +24334,11 @@ msgid ""
 " additional form where you can provide the name, code, and direction of the "
 "language.</p>"
 msgstr ""
+"<p>Choose a language from the list, or choose \"Custom language...\" at the "
+"end of the list.</p><p>Click the \"Add language\" button when you are done "
+"choosing your language.</p><p>When adding a custom language, you will get an"
+" additional form where you can provide the name, code, and direction of the "
+"language.</p>"
 
 msgid ""
 "<p>You can change the default language of the site by choosing one of your "
@@ -22373,604 +24346,641 @@ msgid ""
 "situations where no choice is made but a language should be set, for example"
 " as the language of the displayed interface.</p>"
 msgstr ""
+"<p>You can change the default language of the site by choosing one of your "
+"configured languages as default. The site will use the default language in "
+"situations where no choice is made but a language should be set, for example"
+" as the language of the displayed interface.</p>"
 
 msgid "User interface translation"
-msgstr ""
+msgstr "User interface translation"
 
 msgid "Translation language"
-msgstr ""
+msgstr "Translation language"
 
 msgid "Monthly archive"
-msgstr ""
+msgstr "Monthly archive"
 
 msgid ""
 "A user is considered online for this long after they have last viewed a "
 "page."
 msgstr ""
+"A user is considered online for this long after they have last viewed a "
+"page."
 
 msgid "Main navigation"
-msgstr ""
+msgstr "Main navigation"
 
 msgid "Initializing."
-msgstr ""
+msgstr "Initializing."
 
 msgid "Starting configuration update"
-msgstr ""
+msgstr "Starting configuration update"
 
 msgid "Custom block type"
-msgstr ""
+msgstr "Custom block type"
 
 msgctxt "View entity type"
 msgid "View"
-msgstr ""
+msgstr "View"
 
 msgid "No content available."
-msgstr ""
+msgstr "No content available."
 
 msgid "@type_label bundle"
-msgstr ""
+msgstr "@type_label bundle"
 
 msgid "Custom menu link"
-msgstr ""
+msgstr "Custom menu link"
 
 msgid "Small"
-msgstr ""
+msgstr "Small"
 
 msgid "Large"
-msgstr ""
+msgstr "Large"
 
 msgid "Author"
-msgstr ""
+msgstr "Author"
 
 msgid "Icons"
-msgstr ""
+msgstr "Icons"
 
 msgid "Down"
-msgstr ""
+msgstr "Down"
 
 msgid "E-mail from name"
-msgstr ""
+msgstr "E-mail from name"
 
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 msgid "Solid"
-msgstr ""
+msgstr "Solid"
 
 msgid "Light"
-msgstr ""
+msgstr "Light"
 
 msgid "Animation"
-msgstr ""
+msgstr "Animation"
 
 msgid "Local"
-msgstr ""
+msgstr "Local"
 
 msgid "Variants"
-msgstr ""
+msgstr "Variants"
 
 msgid "Libraries"
-msgstr ""
+msgstr "Libraries"
 
 msgid ""
 "The %dependency library, which the %library library depends on, is not "
 "installed."
 msgstr ""
+"The %dependency library, which the %library library depends on, is not "
+"installed."
 
 msgid ""
 "The version %dependency_version of the %dependency library is not compatible"
 " with the %library library."
 msgstr ""
+"The version %dependency_version of the %dependency library is not compatible"
+" with the %library library."
 
 msgid "The %library library could not be found."
-msgstr ""
+msgstr "The %library library could not be found."
 
 msgid "The version of the %library library could not be detected."
-msgstr ""
+msgstr "The version of the %library library could not be detected."
 
 msgid ""
 "The installed version %version of the %library library is not supported."
 msgstr ""
+"The installed version %version of the %library library is not supported."
 
 msgid "The %variant variant of the %library library could not be found."
-msgstr ""
+msgstr "The %variant variant of the %library library could not be found."
 
 msgid "Accept"
-msgstr ""
+msgstr "Accept"
 
 msgid "E-mail from address"
-msgstr ""
+msgstr "E-mail from address"
 
 msgid "SMTP Authentication"
-msgstr ""
+msgstr "SMTP Authentication"
 
 msgid "Enable debugging"
-msgstr ""
+msgstr "Enable debugging"
 
 msgid "Use SSL"
-msgstr ""
+msgstr "Use SSL"
 
 msgid "Install options"
-msgstr ""
+msgstr "Install options"
 
 msgid "To uninstall this module you must turn it off here first."
-msgstr ""
+msgstr "To uninstall this module you must turn it off here first."
 
 msgid "SMTP server settings"
-msgstr ""
+msgstr "SMTP server settings"
 
 msgid "The address of your outgoing SMTP server."
-msgstr ""
+msgstr "The address of your outgoing SMTP server."
 
 msgid ""
 "The address of your outgoing SMTP backup server. If the primary server can't"
 " be found this one will be tried. This is optional."
 msgstr ""
+"The address of your outgoing SMTP backup server. If the primary server can't"
+" be found this one will be tried. This is optional."
 
 msgid "SMTP port"
-msgstr ""
+msgstr "SMTP port"
 
 msgid "Use TLS"
-msgstr ""
+msgstr "Use TLS"
 
 msgid ""
 "This allows connection to an SMTP server that requires SSL encryption such "
 "as Gmail."
 msgstr ""
+"This allows connection to an SMTP server that requires SSL encryption such "
+"as Gmail."
 
 msgid "Use encrypted protocol"
-msgstr ""
+msgstr "Use encrypted protocol"
 
 msgid "Leave blank if your SMTP server does not require authentication."
-msgstr ""
+msgstr "Leave blank if your SMTP server does not require authentication."
 
 msgid "SMTP Username."
-msgstr ""
+msgstr "SMTP Username."
 
 msgid "E-mail options"
-msgstr ""
+msgstr "E-mail options"
 
 msgid "Turn this module on or off"
-msgstr ""
+msgstr "Turn this module on or off"
 
 msgid "SMTP server"
-msgstr ""
+msgstr "SMTP server"
 
 msgid "SMTP backup server"
-msgstr ""
+msgstr "SMTP backup server"
 
 msgid "The e-mail address that all e-mails will be from."
-msgstr ""
+msgstr "The e-mail address that all e-mails will be from."
 
 msgid "Send test e-mail"
-msgstr ""
+msgstr "Send test e-mail"
 
 msgid "E-mail address to send a test e-mail to"
-msgstr ""
+msgstr "E-mail address to send a test e-mail to"
 
 msgid "Type in an address to have a test e-mail sent there."
-msgstr ""
+msgstr "Type in an address to have a test e-mail sent there."
 
 msgid ""
 "Checking this box will print SMTP messages from the server for every e-mail "
 "that is sent."
 msgstr ""
+"Checking this box will print SMTP messages from the server for every e-mail "
+"that is sent."
 
 msgid "You must enter an SMTP server address."
-msgstr ""
+msgstr "You must enter an SMTP server address."
 
 msgid "You must enter an SMTP port number."
-msgstr ""
+msgstr "You must enter an SMTP port number."
 
 msgid "The provided from e-mail address is not valid."
-msgstr ""
+msgstr "The provided from e-mail address is not valid."
 
 msgid "Sending mail to: @to"
-msgstr ""
+msgstr "Sending mail to: @to"
 
 msgid "Attahment could not be found or accessed."
-msgstr ""
+msgstr "Attahment could not be found or accessed."
 
 msgid "Attachment could not be found or accessed."
-msgstr ""
+msgstr "Attachment could not be found or accessed."
 
 msgid "Token"
-msgstr ""
+msgstr "Token"
 
 msgid "custom block"
-msgstr ""
+msgstr "custom block"
 
 msgid "content item"
-msgstr ""
+msgstr "content item"
 
 msgid "custom menu link"
-msgstr ""
+msgstr "custom menu link"
 
 msgid "Pathauto pattern"
-msgstr ""
+msgstr "Pathauto pattern"
 
 msgid "The first element of the array."
-msgstr ""
+msgstr "The first element of the array."
 
 msgid "Update URL alias"
-msgstr ""
+msgstr "Update URL alias"
 
 msgid "Previous"
-msgstr ""
+msgstr "Previous"
 
 msgid "Information"
-msgstr ""
+msgstr "Information"
 
 msgid "Add required context"
-msgstr ""
+msgstr "Add required context"
 
 msgid "Finish"
-msgstr ""
+msgstr "Finish"
 
 msgid "@description"
-msgstr ""
+msgstr "@description"
 
 msgid "Pager offset"
-msgstr ""
+msgstr "Pager offset"
 
 msgid "The name of the menu."
-msgstr ""
+msgstr "The name of the menu."
 
 msgid "Tokens"
-msgstr ""
+msgstr "Tokens"
 
 msgid "Available tokens"
-msgstr ""
+msgstr "Available tokens"
 
 msgid "No tokens available."
-msgstr ""
+msgstr "No tokens available."
 
 msgid "Click a token to insert it into the field you've last clicked."
-msgstr ""
+msgstr "Click a token to insert it into the field you've last clicked."
 
 msgid "Insert this token into your form"
-msgstr ""
+msgstr "Insert this token into your form"
 
 msgid "First click a text field to insert your tokens into."
-msgstr ""
+msgstr "First click a text field to insert your tokens into."
 
 msgid "The explanation of the most recent changes made to the node."
-msgstr ""
+msgstr "The explanation of the most recent changes made to the node."
 
 msgid "The title of the current page."
-msgstr ""
+msgstr "The title of the current page."
 
 msgid "The URL of the current page."
-msgstr ""
+msgstr "The URL of the current page."
 
 msgid "The page number of the current page when viewing paged lists."
-msgstr ""
+msgstr "The page number of the current page when viewing paged lists."
 
 msgid "The source node for this current node's translation set."
-msgstr ""
+msgstr "The source node for this current node's translation set."
 
 msgid "The URL of the confirm delete page for the user account."
-msgstr ""
+msgstr "The URL of the confirm delete page for the user account."
 
 msgid "The URL of the one-time login page for the user account."
-msgstr ""
+msgstr "The URL of the one-time login page for the user account."
 
 msgid "Tokens related to menu links."
-msgstr ""
+msgstr "Tokens related to menu links."
 
 msgid "The unique ID of the menu link."
-msgstr ""
+msgstr "The unique ID of the menu link."
 
 msgid "The title of the menu link."
-msgstr ""
+msgstr "The title of the menu link."
 
 msgid "The URL of the menu link."
-msgstr ""
+msgstr "The URL of the menu link."
 
 msgid "The menu link's parent."
-msgstr ""
+msgstr "The menu link's parent."
 
 msgid "Tokens related to the current page request."
-msgstr ""
+msgstr "Tokens related to the current page request."
 
 msgid "The book page associated with the node."
-msgstr ""
+msgstr "The book page associated with the node."
 
 msgid "The menu link for this node."
-msgstr ""
+msgstr "The menu link for this node."
 
 msgid "The menu link's root."
-msgstr ""
+msgstr "The menu link's root."
 
 msgid "Tokens related to the current date and time."
-msgstr ""
+msgstr "Tokens related to the current date and time."
 
 msgid "The URL of the @entity."
-msgstr ""
+msgstr "The URL of the @entity."
 
 msgid "The content type of the node."
-msgstr ""
+msgstr "The content type of the node."
 
 msgid "Tokens related to content types."
-msgstr ""
+msgstr "Tokens related to content types."
 
 msgid "The name of the content type."
-msgstr ""
+msgstr "The name of the content type."
 
 msgid "The unique machine-readable name of the content type."
-msgstr ""
+msgstr "The unique machine-readable name of the content type."
 
 msgid "The optional description of the content type."
-msgstr ""
+msgstr "The optional description of the content type."
 
 msgid "The number of nodes belonging to the content type."
-msgstr ""
+msgstr "The number of nodes belonging to the content type."
 
 msgid "The URL of the content type's edit page."
-msgstr ""
+msgstr "The URL of the content type's edit page."
 
 msgid "The URL of the taxonomy term's edit page."
-msgstr ""
+msgstr "The URL of the taxonomy term's edit page."
 
 msgid "The unique machine-readable name of the vocabulary."
-msgstr ""
+msgstr "The unique machine-readable name of the vocabulary."
 
 msgid "The URL of the vocabulary's edit page."
-msgstr ""
+msgstr "The URL of the vocabulary's edit page."
 
 msgid ""
 "The specific argument of the current page (e.g. 'arg:1' on the page 'node/1'"
 " returns '1')."
 msgstr ""
+"The specific argument of the current page (e.g. 'arg:1' on the page 'node/1'"
+" returns '1')."
 
 msgid "Tokens related to URLs."
-msgstr ""
+msgstr "Tokens related to URLs."
 
 msgid "The relative URL."
-msgstr ""
+msgstr "The relative URL."
 
 msgid "The absolute URL."
-msgstr ""
+msgstr "The absolute URL."
 
 msgid "Tokens related to menus."
-msgstr ""
+msgstr "Tokens related to menus."
 
 msgid "The unique machine-readable name of the menu."
-msgstr ""
+msgstr "The unique machine-readable name of the menu."
 
 msgid "The optional description of the menu."
-msgstr ""
+msgstr "The optional description of the menu."
 
 msgid "The number of menu links belonging to the menu."
-msgstr ""
+msgstr "The number of menu links belonging to the menu."
 
 msgid "The URL of the menu's edit page."
-msgstr ""
+msgstr "The URL of the menu's edit page."
 
 msgid "The menu of the menu link."
-msgstr ""
+msgstr "The menu of the menu link."
 
 msgid "The URL of the menu link's edit page."
-msgstr ""
+msgstr "The URL of the menu link's edit page."
 
 msgid "The user roles associated with the user account."
-msgstr ""
+msgstr "The user roles associated with the user account."
 
 msgid "The URL without the protocol and trailing backslash."
-msgstr ""
+msgstr "The URL without the protocol and trailing backslash."
 
 msgid "Tokens related to arrays of strings."
-msgstr ""
+msgstr "Tokens related to arrays of strings."
 
 msgid "The last element of the array."
-msgstr ""
+msgstr "The last element of the array."
 
 msgid "The number of elements in the array."
-msgstr ""
+msgstr "The number of elements in the array."
 
 msgid "The array reversed."
-msgstr ""
+msgstr "The array reversed."
 
 msgid "The array of keys of the array."
-msgstr ""
+msgstr "The array of keys of the array."
 
 msgid ""
 "The values of the array joined together with a custom string in-between each"
 " value."
 msgstr ""
+"The values of the array joined together with a custom string in-between each"
+" value."
 
 msgid "A date in '@type' format. (%date)"
-msgstr ""
+msgstr "A date in '@type' format. (%date)"
 
 msgid "The root term of the taxonomy term."
-msgstr ""
+msgstr "The root term of the taxonomy term."
 
 msgid "The size of the file, in bytes."
-msgstr ""
+msgstr "The size of the file, in bytes."
 
 msgid "SMTP Authentication Support"
-msgstr ""
+msgstr "SMTP Authentication Support"
 
 msgid "Chaos tool suite"
-msgstr ""
+msgstr "Chaos tool suite"
 
 msgid ""
 "Provides a user interface for the Token API and some missing core tokens."
 msgstr ""
+"Provides a user interface for the Token API and some missing core tokens."
 
 msgid "The value of a specific query string field of the current page."
-msgstr ""
+msgstr "The value of a specific query string field of the current page."
 
 msgid "A random number from 0 to @max."
-msgstr ""
+msgstr "A random number from 0 to @max."
 
 msgid "A random hash. The possible hashing algorithms are: @hash-algos."
-msgstr ""
+msgstr "A random hash. The possible hashing algorithms are: @hash-algos."
 
 msgid ""
 "Attempting to perform token replacement for token type %type without "
 "required data"
 msgstr ""
+"Attempting to perform token replacement for token type %type without "
+"required data"
 
 msgid "@type field."
-msgstr ""
+msgstr "@type field."
 
 msgid "No tokens available"
-msgstr ""
+msgstr "No tokens available"
 
 msgid "Token registry caches cleared."
-msgstr ""
+msgstr "Token registry caches cleared."
 
 msgid "The path component of the URL."
-msgstr ""
+msgstr "The path component of the URL."
 
 msgid "The unaliased URL."
-msgstr ""
+msgstr "The unaliased URL."
 
 msgid "The specific value of the array."
-msgstr ""
+msgstr "The specific value of the array."
 
 msgid ""
 "The list of available tokens that can be used in e-mails is provided below."
 msgstr ""
+"The list of available tokens that can be used in e-mails is provided below."
 
 msgid "An array of all the term's parents, starting with the root."
-msgstr ""
+msgstr "An array of all the term's parents, starting with the root."
 
 msgid "An array of all the menu link's parents, starting with the root."
-msgstr ""
+msgstr "An array of all the menu link's parents, starting with the root."
 
 msgid "The original @entity data if the @entity is being updated or saved."
-msgstr ""
+msgstr "The original @entity data if the @entity is being updated or saved."
 
 msgid "The base name of the file."
-msgstr ""
+msgstr "The base name of the file."
 
 msgid "Tokens for lists of @type values."
-msgstr ""
+msgstr "Tokens for lists of @type values."
 
 msgid "Browse available tokens."
-msgstr ""
+msgstr "Browse available tokens."
 
 msgid "Conditions"
-msgstr ""
+msgstr "Conditions"
 
 msgid "Verbose"
-msgstr ""
+msgstr "Verbose"
 
 msgid "Display alias changes (except during bulk updates)."
-msgstr ""
+msgstr "Display alias changes (except during bulk updates)."
 
 msgid "Replace by separator"
-msgstr ""
+msgstr "Replace by separator"
 
 msgid "Maximum alias length"
-msgstr ""
+msgstr "Maximum alias length"
 
 msgid "Maximum component length"
-msgstr ""
+msgstr "Maximum component length"
 
 msgid "Update action"
-msgstr ""
+msgstr "Update action"
 
 msgid "Strings to Remove"
-msgstr ""
+msgstr "Strings to Remove"
 
 msgid "Pathauto"
-msgstr ""
+msgstr "Pathauto"
 
 msgid "Period"
-msgstr ""
+msgstr "Period"
 
 msgid "Asterisk"
-msgstr ""
+msgstr "Asterisk"
 
 msgid ""
 "The automatically generated alias %original_alias conflicted with an "
 "existing alias. Alias changed to %alias."
 msgstr ""
+"The automatically generated alias %original_alias conflicted with an "
+"existing alias. Alias changed to %alias."
 
 msgid "Delete aliases"
-msgstr ""
+msgstr "Delete aliases"
 
 msgid "Automatic alias"
-msgstr ""
+msgstr "Automatic alias"
 
 msgid ""
 "Character used to separate words in titles. This will replace any spaces and"
 " punctuation characters. Using a space or + character can cause unexpected "
 "results."
 msgstr ""
+"Character used to separate words in titles. This will replace any spaces and"
+" punctuation characters. Using a space or + character can cause unexpected "
+"results."
 
 msgid "Character case"
-msgstr ""
+msgstr "Character case"
 
 msgid "Do nothing. Leave the old alias intact."
-msgstr ""
+msgstr "Do nothing. Leave the old alias intact."
 
 msgid "Create a new alias. Leave the existing alias functioning."
-msgstr ""
+msgstr "Create a new alias. Leave the existing alias functioning."
 
 msgid "Create a new alias. Delete the old alias."
-msgstr ""
+msgstr "Create a new alias. Delete the old alias."
 
 msgid "Transliterate prior to creating alias"
-msgstr ""
+msgstr "Transliterate prior to creating alias"
 
 msgid ""
 "Filters the new alias to only letters and numbers found in the ASCII-96 set."
 msgstr ""
+"Filters the new alias to only letters and numbers found in the ASCII-96 set."
 
 msgid "No action (do not replace)"
-msgstr ""
+msgstr "No action (do not replace)"
 
 msgid "Delete all aliases. Number of aliases which will be deleted: %count."
-msgstr ""
+msgstr "Delete all aliases. Number of aliases which will be deleted: %count."
 
 msgid ""
 "Delete aliases for all @label. Number of aliases which will be deleted: "
 "%count."
 msgstr ""
+"Delete aliases for all @label. Number of aliases which will be deleted: "
+"%count."
 
 msgid "Delete aliases now!"
-msgstr ""
+msgstr "Delete aliases now!"
 
 msgid "All of your path aliases have been deleted."
-msgstr ""
+msgstr "All of your path aliases have been deleted."
 
 msgid "Patterns"
-msgstr ""
+msgstr "Patterns"
 
 msgid "Colon"
-msgstr ""
+msgstr "Colon"
 
 msgid "Semicolon"
-msgstr ""
+msgstr "Semicolon"
 
 msgid "Slash"
-msgstr ""
+msgstr "Slash"
 
 msgid "Punctuation"
-msgstr ""
+msgstr "Punctuation"
 
 msgid ""
 "What should Pathauto do when updating an existing content item which already"
 " has an alias?"
 msgstr ""
+"What should Pathauto do when updating an existing content item which already"
+" has an alias?"
 
 msgid "Reduce strings to letters and numbers"
-msgstr ""
+msgstr "Reduce strings to letters and numbers"
 
 msgid ""
 "Words to strip out of the URL alias, separated by commas. Do not use this to"
 " remove punctuation."
 msgstr ""
+"Words to strip out of the URL alias, separated by commas. Do not use this to"
+" remove punctuation."
 
 msgid "Choose aliases to delete"
-msgstr ""
+msgstr "Choose aliases to delete"
 
 msgid "All aliases"
-msgstr ""
+msgstr "All aliases"
 
 msgid ""
 "<strong>Note:</strong> there is no confirmation. Be sure of your action "
@@ -22978,232 +24988,247 @@ msgid ""
 "make a backup of the database and/or the url_alias table prior to using this"
 " feature."
 msgstr ""
+"<strong>Note:</strong> there is no confirmation. Be sure of your action "
+"before clicking the \"Delete aliases now!\" button.<br />You may want to "
+"make a backup of the database and/or the url_alias table prior to using this"
+" feature."
 
 msgid "Ignoring alias %alias because it is the same as the internal path."
-msgstr ""
+msgstr "Ignoring alias %alias because it is the same as the internal path."
 
 msgid "Created new alias %alias for %source, replacing %old_alias."
-msgstr ""
+msgstr "Created new alias %alias for %source, replacing %old_alias."
 
 msgid "Created new alias %alias for %source."
-msgstr ""
+msgstr "Created new alias %alias for %source."
 
 msgid "Administer pathauto"
-msgstr ""
+msgstr "Administer pathauto"
 
 msgid ""
 "Allows a user to configure patterns for automated aliases and bulk delete "
 "URL-aliases."
 msgstr ""
+"Allows a user to configure patterns for automated aliases and bulk delete "
+"URL-aliases."
 
 msgid "Notify of Path Changes"
-msgstr ""
+msgstr "Notify of Path Changes"
 
 msgid "Determines whether or not users are notified."
-msgstr ""
+msgstr "Determines whether or not users are notified."
 
 msgid "Bulk updating URL aliases"
-msgstr ""
+msgstr "Bulk updating URL aliases"
 
 msgid "An error occurred while processing @operation with arguments : @args"
-msgstr ""
+msgstr "An error occurred while processing @operation with arguments : @args"
 
 msgid "Generated 1 URL alias."
 msgid_plural "Generated @count URL aliases."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Generated 1 URL alias."
+msgstr[1] "Generated @count URL aliases."
 
 msgid "Underscore"
-msgstr ""
+msgstr "Underscore"
 
 msgid "No new URL aliases to generate."
-msgstr ""
+msgstr "No new URL aliases to generate."
 
 msgid "Double quotation marks"
-msgstr ""
+msgstr "Double quotation marks"
 
 msgid "Single quotation marks (apostrophe)"
-msgstr ""
+msgstr "Single quotation marks (apostrophe)"
 
 msgid "Back tick"
-msgstr ""
+msgstr "Back tick"
 
 msgid "Hyphen"
-msgstr ""
+msgstr "Hyphen"
 
 msgid "Vertical bar (pipe)"
-msgstr ""
+msgstr "Vertical bar (pipe)"
 
 msgid "Left curly bracket"
-msgstr ""
+msgstr "Left curly bracket"
 
 msgid "Left square bracket"
-msgstr ""
+msgstr "Left square bracket"
 
 msgid "Right curly bracket"
-msgstr ""
+msgstr "Right curly bracket"
 
 msgid "Right square bracket"
-msgstr ""
+msgstr "Right square bracket"
 
 msgid "Plus sign"
-msgstr ""
+msgstr "Plus sign"
 
 msgid "Equal sign"
-msgstr ""
+msgstr "Equal sign"
 
 msgid "Percent sign"
-msgstr ""
+msgstr "Percent sign"
 
 msgid "Caret"
-msgstr ""
+msgstr "Caret"
 
 msgid "Dollar sign"
-msgstr ""
+msgstr "Dollar sign"
 
 msgid "Number sign (pound sign, hash)"
-msgstr ""
+msgstr "Number sign (pound sign, hash)"
 
 msgid "At sign"
-msgstr ""
+msgstr "At sign"
 
 msgid "Exclamation mark"
-msgstr ""
+msgstr "Exclamation mark"
 
 msgid "Tilde"
-msgstr ""
+msgstr "Tilde"
 
 msgid "Left parenthesis"
-msgstr ""
+msgstr "Left parenthesis"
 
 msgid "Right parenthesis"
-msgstr ""
+msgstr "Right parenthesis"
 
 msgid "Question mark"
-msgstr ""
+msgstr "Question mark"
 
 msgid "Less-than sign"
-msgstr ""
+msgstr "Less-than sign"
 
 msgid "Greater-than sign"
-msgstr ""
+msgstr "Greater-than sign"
 
 msgid "Backslash"
-msgstr ""
+msgstr "Backslash"
 
 msgid "Generate automatic URL alias"
-msgstr ""
+msgstr "Generate automatic URL alias"
 
 msgid "Uncheck this to create a custom alias below."
-msgstr ""
+msgstr "Uncheck this to create a custom alias below."
 
 msgid ""
 "The array values each cleaned by Pathauto and then joined with the slash "
 "into a string that resembles an URL."
 msgstr ""
+"The array values each cleaned by Pathauto and then joined with the slash "
+"into a string that resembles an URL."
 
 msgid "General settings"
-msgstr ""
+msgstr "General settings"
 
 msgid "Red"
-msgstr ""
+msgstr "Red"
 
 msgid "Green"
-msgstr ""
+msgstr "Green"
 
 msgid "Blue"
-msgstr ""
+msgstr "Blue"
 
 msgid "Secret Key"
-msgstr ""
+msgstr "Secret Key"
 
 msgid "Installation"
-msgstr ""
+msgstr "Installation"
 
 msgid "Public Key"
-msgstr ""
+msgstr "Public Key"
 
 msgid "Orange"
-msgstr ""
+msgstr "Orange"
 
 msgid "Behavior"
-msgstr ""
+msgstr "Behavior"
 
 msgid "Captcha Point"
-msgstr ""
+msgstr "Captcha Point"
 
 msgid "Joined path"
-msgstr ""
+msgstr "Joined path"
 
 msgid ""
 "Provides a mechanism for modules to automatically generate aliases for the "
 "content they manage."
 msgstr ""
+"Provides a mechanism for modules to automatically generate aliases for the "
+"content they manage."
 
 msgid ""
 "This question is for testing whether or not you are a human visitor and to "
 "prevent automated spam submissions."
 msgstr ""
+"This question is for testing whether or not you are a human visitor and to "
+"prevent automated spam submissions."
 
 msgid "Example"
-msgstr ""
+msgstr "Example"
 
 msgid "normal"
-msgstr ""
+msgstr "normal"
 
 msgid "Code length"
-msgstr ""
+msgstr "Code length"
 
 msgid "Font size"
-msgstr ""
+msgstr "Font size"
 
 msgid "Characters to use in the code"
-msgstr ""
+msgstr "Characters to use in the code"
 
 msgid "The list of characters to use should not contain spaces."
-msgstr ""
+msgstr "The list of characters to use should not contain spaces."
 
 msgid "Math question"
-msgstr ""
+msgstr "Math question"
 
 msgid ""
 "Encountered an illegal byte while splitting an utf8 string in characters."
 msgstr ""
+"Encountered an illegal byte while splitting an utf8 string in characters."
 
 msgid "low"
-msgstr ""
+msgstr "low"
 
 msgid "medium"
-msgstr ""
+msgstr "medium"
 
 msgid "high"
-msgstr ""
+msgstr "high"
 
 msgid "Add CAPTCHA administration links to forms"
-msgstr ""
+msgstr "Add CAPTCHA administration links to forms"
 
 msgid "Challenge description"
-msgstr ""
+msgstr "Challenge description"
 
 msgid "Persistence"
-msgstr ""
+msgstr "Persistence"
 
 msgid "Always add a challenge."
-msgstr ""
+msgstr "Always add a challenge."
 
 msgid "Log wrong responses"
-msgstr ""
+msgstr "Log wrong responses"
 
 msgid "Challenge type"
-msgstr ""
+msgstr "Challenge type"
 
 msgid ""
 "This page gives an overview of all available challenge types, generated with"
 " their current settings."
 msgstr ""
+"This page gives an overview of all available challenge types, generated with"
+" their current settings."
 
 msgid "10 more examples of this challenge."
-msgstr ""
+msgstr "10 more examples of this challenge."
 
 msgid ""
 "\"CAPTCHA\" is an acronym for \"Completely Automated Public Turing test to "
@@ -23215,69 +25240,86 @@ msgid ""
 "for a human to solve correctly, but hard enough to keep automated scripts "
 "and spam bots out."
 msgstr ""
+"\"CAPTCHA\" is an acronym for \"Completely Automated Public Turing test to "
+"tell Computers and Humans Apart\". It is typically a challenge-response test"
+" to determine whether the user is human. The CAPTCHA module is a tool to "
+"fight automated submission by malicious users (spamming) of for example "
+"comments forms, user registration forms, guestbook forms, etc. You can "
+"extend the desired forms with an additional challenge, which should be easy "
+"for a human to solve correctly, but hard enough to keep automated scripts "
+"and spam bots out."
 
 msgid "CAPTCHA is a trademark of Carnegie Mellon University."
-msgstr ""
+msgstr "CAPTCHA is a trademark of Carnegie Mellon University."
 
 msgid "Enabled challenge"
-msgstr ""
+msgstr "Enabled challenge"
 
 msgid "Place a CAPTCHA here for untrusted users."
-msgstr ""
+msgstr "Place a CAPTCHA here for untrusted users."
 
 msgid "The answer you entered for the CAPTCHA was not correct."
-msgstr ""
+msgstr "The answer you entered for the CAPTCHA was not correct."
 
 msgid ""
 "Solve this simple math problem and enter the result. E.g. for 1+3, enter 4."
 msgstr ""
+"Solve this simple math problem and enter the result. E.g. for 1+3, enter 4."
 
 msgid "Code settings"
-msgstr ""
+msgstr "Code settings"
 
 msgid ""
 "The code length influences the size of the image. Note that larger values "
 "make the image generation more CPU intensive."
 msgstr ""
+"The code length influences the size of the image. Note that larger values "
+"make the image generation more CPU intensive."
 
 msgid "Font settings"
-msgstr ""
+msgstr "Font settings"
 
 msgid "tiny"
-msgstr ""
+msgstr "tiny"
 
 msgid "small"
-msgstr ""
+msgstr "small"
 
 msgid "large"
-msgstr ""
+msgstr "large"
 
 msgid ""
 "The font size influences the size of the image. Note that larger values make"
 " the image generation more CPU intensive."
 msgstr ""
+"The font size influences the size of the image. Note that larger values make"
+" the image generation more CPU intensive."
 
 msgid "Character spacing"
-msgstr ""
+msgstr "Character spacing"
 
 msgid ""
 "Define the average spacing between characters. Note that larger values make "
 "the image generation more CPU intensive."
 msgstr ""
+"Define the average spacing between characters. Note that larger values make "
+"the image generation more CPU intensive."
 
 msgid "Enter the hexadecimal code for the text color (e.g. #000 or #004283)."
-msgstr ""
+msgstr "Enter the hexadecimal code for the text color (e.g. #000 or #004283)."
 
 msgid "Additional variation of text color"
-msgstr ""
+msgstr "Additional variation of text color"
 
 msgid ""
 "The different characters will have randomized colors in the specified range "
 "around the text color."
 msgstr ""
+"The different characters will have randomized colors in the specified range "
+"around the text color."
 
 msgid "Distortion and noise"
-msgstr ""
+msgstr "Distortion and noise"
 
 msgid ""
 "With these settings you can control the degree of obfuscation by distortion "
@@ -23285,64 +25327,72 @@ msgid ""
 "in the image is reasonably readable. For example, do not combine high levels"
 " of distortion and noise."
 msgstr ""
+"With these settings you can control the degree of obfuscation by distortion "
+"and added noise. Do not exaggerate the obfuscation and assure that the code "
+"in the image is reasonably readable. For example, do not combine high levels"
+" of distortion and noise."
 
 msgid "Distortion level"
-msgstr ""
+msgstr "Distortion level"
 
 msgid "severe"
-msgstr ""
+msgstr "severe"
 
 msgid "Set the degree of wave distortion in the image."
-msgstr ""
+msgstr "Set the degree of wave distortion in the image."
 
 msgid "Smooth distortion"
-msgstr ""
+msgstr "Smooth distortion"
 
 msgid "This option adds randomly colored point noise."
-msgstr ""
+msgstr "This option adds randomly colored point noise."
 
 msgid "Add line noise"
-msgstr ""
+msgstr "Add line noise"
 
 msgid "This option enables lines randomly drawn on top of the text code."
-msgstr ""
+msgstr "This option enables lines randomly drawn on top of the text code."
 
 msgid "Noise level"
-msgstr ""
+msgstr "Noise level"
 
 msgid "Background color is not a valid hexadecimal color value."
-msgstr ""
+msgstr "Background color is not a valid hexadecimal color value."
 
 msgid "Text color is not a valid hexadecimal color value."
-msgstr ""
+msgstr "Text color is not a valid hexadecimal color value."
 
 msgid ""
 "Generation of image CAPTCHA failed. Check your image CAPTCHA configuration "
 "and especially the used font."
 msgstr ""
+"Generation of image CAPTCHA failed. Check your image CAPTCHA configuration "
+"and especially the used font."
 
 msgid "Image CAPTCHA"
-msgstr ""
+msgstr "Image CAPTCHA"
 
 msgid "What code is in the image?"
-msgstr ""
+msgstr "What code is in the image?"
 
 msgid "Enable statistics"
-msgstr ""
+msgstr "Enable statistics"
 
 msgid "File format"
-msgstr ""
+msgstr "File format"
 
 msgid "Fonts"
-msgstr ""
+msgstr "Fonts"
 
 msgid ""
 "This option enables bilinear interpolation of the distortion which makes the"
 " image look smoother, but it is more CPU intensive."
 msgstr ""
+"This option enables bilinear interpolation of the distortion which makes the"
+" image look smoother, but it is more CPU intensive."
 
 msgid "Add salt and pepper noise"
-msgstr ""
+msgstr "Add salt and pepper noise"
 
 msgid ""
 "The image CAPTCHA is a popular challenge where a random textual code is "
@@ -23350,194 +25400,228 @@ msgid ""
 "which is rather CPU intensive for the server. Be careful with the size and "
 "computation related settings."
 msgstr ""
+"The image CAPTCHA is a popular challenge where a random textual code is "
+"obfuscated in an image. The image is generated on the fly for each request, "
+"which is rather CPU intensive for the server. Be careful with the size and "
+"computation related settings."
 
 msgid "@type (from module @module)"
-msgstr ""
+msgstr "@type (from module @module)"
 
 msgid "Form protection"
-msgstr ""
+msgstr "Form protection"
 
 msgid "Default challenge type"
-msgstr ""
+msgstr "Default challenge type"
 
 msgid ""
 "Allow CAPTCHAs and CAPTCHA administration links on administrative pages"
 msgstr ""
+"Allow CAPTCHAs and CAPTCHA administration links on administrative pages"
 
 msgid "Add a description to the CAPTCHA"
-msgstr ""
+msgstr "Add a description to the CAPTCHA"
 
 msgid ""
 "Add a configurable description to explain the purpose of the CAPTCHA to the "
 "visitor."
 msgstr ""
+"Add a configurable description to explain the purpose of the CAPTCHA to the "
+"visitor."
 
 msgid "Default CAPTCHA validation"
-msgstr ""
+msgstr "Default CAPTCHA validation"
 
 msgid ""
 "Define how the response should be processed by default. Note that the "
 "modules that provide the actual challenges can override or ignore this."
 msgstr ""
+"Define how the response should be processed by default. Note that the "
+"modules that provide the actual challenges can override or ignore this."
 
 msgid ""
 "Case sensitive validation: the response has to exactly match the solution."
 msgstr ""
+"Case sensitive validation: the response has to exactly match the solution."
 
 msgid "Case insensitive validation: lowercase/uppercase errors are ignored."
-msgstr ""
+msgstr "Case insensitive validation: lowercase/uppercase errors are ignored."
 
 msgid "CAPTCHA: challenge \"@type\" enabled"
-msgstr ""
+msgstr "CAPTCHA: challenge \"@type\" enabled"
 
 msgid "CAPTCHA: no challenge enabled"
-msgstr ""
+msgstr "CAPTCHA: no challenge enabled"
 
 msgid "Test one two three"
-msgstr ""
+msgstr "Test one two three"
 
 msgid "Already 1 blocked form submission"
 msgid_plural "Already @count blocked form submissions"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Already 1 blocked form submission"
+msgstr[1] "Already @count blocked form submissions"
 
 msgid "Presolved image CAPTCHA example, generated with the current settings."
-msgstr ""
+msgstr "Presolved image CAPTCHA example, generated with the current settings."
 
 msgid "extra large"
-msgstr ""
+msgstr "extra large"
 
 msgid "tight"
-msgstr ""
+msgstr "tight"
 
 msgid "extra wide"
-msgstr ""
+msgstr "extra wide"
 
 msgid ""
 "The built-in font only supports Latin2 characters. Only use \"a\" to \"z\" "
 "and numbers."
 msgstr ""
+"The built-in font only supports Latin2 characters. Only use \"a\" to \"z\" "
+"and numbers."
 
 msgid ""
 "CAPTCHA validation error: unknown CAPTCHA session ID. Contact the site "
 "administrator if this problem persists."
 msgstr ""
+"CAPTCHA validation error: unknown CAPTCHA session ID. Contact the site "
+"administrator if this problem persists."
 
 msgid "CAPTCHA validation error: unknown CAPTCHA session ID (%csid)."
-msgstr ""
+msgstr "CAPTCHA validation error: unknown CAPTCHA session ID (%csid)."
 
 msgid "Color and image settings"
-msgstr ""
+msgstr "Color and image settings"
 
 msgid ""
 "Configuration of the background, text colors and file format of the image "
 "CAPTCHA."
 msgstr ""
+"Configuration of the background, text colors and file format of the image "
+"CAPTCHA."
 
 msgid "Add URL redirect from this page to another location"
-msgstr ""
+msgstr "Add URL redirect from this page to another location"
 
 msgid "Invalid number of redirects."
-msgstr ""
+msgstr "Invalid number of redirects."
 
 msgid "Spam control"
-msgstr ""
+msgstr "Spam control"
 
 msgid ""
 "Enter the hexadecimal code for the background color (e.g. #FFF or #FFCE90). "
 "When using the PNG file format with transparent background, it is "
 "recommended to set this close to the underlying background color."
 msgstr ""
+"Enter the hexadecimal code for the background color (e.g. #FFF or #FFCE90). "
+"When using the PNG file format with transparent background, it is "
+"recommended to set this close to the underlying background color."
 
 msgid ""
 "Select the file format for the image. JPEG usually results in smaller files,"
 " PNG allows tranparency."
 msgstr ""
+"Select the file format for the image. JPEG usually results in smaller files,"
+" PNG allows tranparency."
 
 msgid "JPEG"
-msgstr ""
+msgstr "JPEG"
 
 msgid "PNG"
-msgstr ""
+msgstr "PNG"
 
 msgid "PNG with transparent background"
-msgstr ""
+msgstr "PNG with transparent background"
 
 msgid "@level - no distortion"
-msgstr ""
+msgstr "@level - no distortion"
 
 msgid "@level - low"
-msgstr ""
+msgstr "@level - low"
 
 msgid "@level - medium"
-msgstr ""
+msgstr "@level - medium"
 
 msgid "@level - high"
-msgstr ""
+msgstr "@level - high"
 
 msgid "No TrueType support"
-msgstr ""
+msgstr "No TrueType support"
 
 msgid ""
 "The Image CAPTCHA module can not use TrueType fonts because your PHP setup "
 "does not support it. You can only use a PHP built-in bitmap font of fixed "
 "size."
 msgstr ""
+"The Image CAPTCHA module can not use TrueType fonts because your PHP setup "
+"does not support it. You can only use a PHP built-in bitmap font of fixed "
+"size."
 
 msgid "Font preview of @font (@file)"
-msgstr ""
+msgstr "Font preview of @font (@file)"
 
 msgid "Preview of built-in font"
-msgstr ""
+msgstr "Preview of built-in font"
 
 msgid "You need to select at least one font."
-msgstr ""
+msgstr "You need to select at least one font."
 
 msgid "The following fonts are not readable: %fonts."
-msgstr ""
+msgstr "The following fonts are not readable: %fonts."
 
 msgid "Enter the characters shown in the image."
-msgstr ""
+msgstr "Enter the characters shown in the image."
 
 msgid ""
 "CAPTCHA problem: unexpected result from hook_captcha() of module %module "
 "when trying to retrieve challenge type %type for form %form_id."
 msgstr ""
+"CAPTCHA problem: unexpected result from hook_captcha() of module %module "
+"when trying to retrieve challenge type %type for form %form_id."
 
 msgid ""
 "Omit challenges in a multi-step/preview workflow once the user successfully "
 "responds to a challenge."
 msgstr ""
+"Omit challenges in a multi-step/preview workflow once the user successfully "
+"responds to a challenge."
 
 msgid ""
 "Omit challenges on a form type once the user successfully responds to a "
 "challenge on a form of that type."
 msgstr ""
+"Omit challenges on a form type once the user successfully responds to a "
+"challenge on a form of that type."
 
 msgid ""
 "Omit challenges on all forms once the user successfully responds to any "
 "challenge on the site."
 msgstr ""
+"Omit challenges on all forms once the user successfully responds to any "
+"challenge on the site."
 
 msgid ""
 "Define if challenges should be omitted during the rest of a session once the"
 " user successfully responds to a challenge."
 msgstr ""
+"Define if challenges should be omitted during the rest of a session once the"
+" user successfully responds to a challenge."
 
 msgid "CAPTCHA session reuse attack detected."
-msgstr ""
+msgstr "CAPTCHA session reuse attack detected."
 
 msgid "CAPTCHA placement caching"
-msgstr ""
+msgstr "CAPTCHA placement caching"
 
 msgid "Administer CAPTCHA settings"
-msgstr ""
+msgstr "Administer CAPTCHA settings"
 
 msgid "Skip CAPTCHA"
-msgstr ""
+msgstr "Skip CAPTCHA"
 
 msgid "Users with this permission will not be offered a CAPTCHA."
-msgstr ""
+msgstr "Users with this permission will not be offered a CAPTCHA."
 
 msgid ""
 "Select the fonts to use for the text in the image CAPTCHA. Apart from the "
@@ -23545,179 +25629,200 @@ msgid ""
 "extension .ttf) by putting them in %fonts_library_general or "
 "%fonts_library_specific."
 msgstr ""
+"Select the fonts to use for the text in the image CAPTCHA. Apart from the "
+"provided defaults, you can also use your own TrueType fonts (filename "
+"extension .ttf) by putting them in %fonts_library_general or "
+"%fonts_library_specific."
 
 msgid "RTL support"
-msgstr ""
+msgstr "RTL support"
 
 msgid "The CAPTCHA settings have been saved."
-msgstr ""
+msgstr "The CAPTCHA settings have been saved."
 
 msgid "Cleared the CAPTCHA placement cache."
-msgstr ""
+msgstr "Cleared the CAPTCHA placement cache."
 
 msgid "The CAPTCHA type to use for this form."
-msgstr ""
+msgstr "The CAPTCHA type to use for this form."
 
 msgid "Challenge %challenge by module %module"
-msgstr ""
+msgstr "Challenge %challenge by module %module"
 
 msgid "No variation"
-msgstr ""
+msgstr "No variation"
 
 msgid "Little variation"
-msgstr ""
+msgstr "Little variation"
 
 msgid "Medium variation"
-msgstr ""
+msgstr "Medium variation"
 
 msgid "High variation"
-msgstr ""
+msgstr "High variation"
 
 msgid "Very high variation"
-msgstr ""
+msgstr "Very high variation"
 
 msgid ""
 "Enable this option to render the code from right to left for right to left "
 "languages."
 msgstr ""
+"Enable this option to render the code from right to left for right to left "
+"languages."
 
 msgid "Widget settings"
-msgstr ""
+msgstr "Widget settings"
 
 msgid "Dark"
-msgstr ""
+msgstr "Dark"
 
 msgid "@error"
-msgstr ""
+msgstr "@error"
 
 msgid "Image (default)"
-msgstr ""
+msgstr "Image (default)"
 
 msgid "Delete redirect"
-msgstr ""
+msgstr "Delete redirect"
 
 msgid "Redirect"
-msgstr ""
+msgstr "Redirect"
 
 msgid "List of redirects"
-msgstr ""
+msgstr "List of redirects"
 
 msgid "Filter"
-msgstr ""
+msgstr "Filter"
 
 msgid "With selection"
-msgstr ""
+msgstr "With selection"
 
 msgid "Status code"
-msgstr ""
+msgstr "Status code"
 
 msgid "300 Multiple Choices"
-msgstr ""
+msgstr "300 Multiple Choices"
 
 msgid "301 Moved Permanently"
-msgstr ""
+msgstr "301 Moved Permanently"
 
 msgid "302 Found"
-msgstr ""
+msgstr "302 Found"
 
 msgid "303 See Other"
-msgstr ""
+msgstr "303 See Other"
 
 msgid "304 Not Modified"
-msgstr ""
+msgstr "304 Not Modified"
 
 msgid "305 Use Proxy"
-msgstr ""
+msgstr "305 Use Proxy"
 
 msgid "307 Temporary Redirect"
-msgstr ""
+msgstr "307 Temporary Redirect"
 
 msgid "Original language"
-msgstr ""
+msgstr "Original language"
 
 msgid "There is no redirect yet."
-msgstr ""
+msgstr "There is no redirect yet."
 
 msgid "Destination"
-msgstr ""
+msgstr "Destination"
 
 msgid "Add redirect"
-msgstr ""
+msgstr "Add redirect"
 
 msgid "Status Code"
-msgstr ""
+msgstr "Status Code"
 
 msgid ""
 "You are attempting to redirect the page to itself. This will result in an "
 "infinite loop."
 msgstr ""
+"You are attempting to redirect the page to itself. This will result in an "
+"infinite loop."
 
 msgid "Generate"
-msgstr ""
+msgstr "Generate"
 
 msgid "All languages"
-msgstr ""
+msgstr "All languages"
 
 msgid ""
 "A redirect set for a specific language will always be used when requesting "
 "this page in that language, and takes precedence over redirects set for "
 "<em>All languages</em>."
 msgstr ""
+"A redirect set for a specific language will always be used when requesting "
+"this page in that language, and takes precedence over redirects set for "
+"<em>All languages</em>."
 
 msgid "Redirect status"
-msgstr ""
+msgstr "Redirect status"
 
 msgid "Display a warning message to users when they are redirected."
-msgstr ""
+msgstr "Display a warning message to users when they are redirected."
 
 msgid "Automatically create redirects when URL aliases are changed."
-msgstr ""
+msgstr "Automatically create redirects when URL aliases are changed."
 
 msgid "Default redirect status"
-msgstr ""
+msgstr "Default redirect status"
 
 msgid "Configure behavior for URL redirects."
-msgstr ""
+msgstr "Configure behavior for URL redirects."
 
 msgid ""
 "You can find more information about HTTP redirect status codes at <a href"
 "=\"@status-codes\">@status-codes</a>."
 msgstr ""
+"You can find more information about HTTP redirect status codes at <a href"
+"=\"@status-codes\">@status-codes</a>."
 
 msgid "The redirect has been saved."
-msgstr ""
+msgstr "The redirect has been saved."
 
 msgid "No URL redirects available."
-msgstr ""
+msgstr "No URL redirects available."
 
 msgid ""
 "The source path %source is already being redirected. Do you want to <a href"
 "=\"@edit-page\">edit the existing redirect</a>?"
 msgstr ""
+"The source path %source is already being redirected. Do you want to <a href"
+"=\"@edit-page\">edit the existing redirect</a>?"
 
 msgid "How many URL redirects would you like to generate?"
-msgstr ""
+msgstr "How many URL redirects would you like to generate?"
 
 msgid "Delete all URL redirects before generating new URL redirects."
-msgstr ""
+msgstr "Delete all URL redirects before generating new URL redirects."
 
 msgid ""
 "The source path %path is likely a valid path. It is preferred to <a href"
 "=\"@url-alias\">create URL aliases</a> for existing paths rather than "
 "redirects."
 msgstr ""
+"The source path %path is likely a valid path. It is preferred to <a href"
+"=\"@url-alias\">create URL aliases</a> for existing paths rather than "
+"redirects."
 
 msgid ""
 "The base source path %source is already being redirected. Do you want to <a "
 "href=\"@edit-page\">edit the existing redirect</a>?"
 msgstr ""
+"The base source path %source is already being redirected. Do you want to <a "
+"href=\"@edit-page\">edit the existing redirect</a>?"
 
 msgid ""
 "Are you sure you want to delete the URL redirect from %source to %redirect?"
 msgstr ""
+"Are you sure you want to delete the URL redirect from %source to %redirect?"
 
 msgid "Retain query string through redirect."
-msgstr ""
+msgstr "Retain query string through redirect."
 
 msgid ""
 "For example, given a redirect from %source to %redirect, if a user visits "
@@ -23725,65 +25830,69 @@ msgid ""
 "in the redirection will always take precedence over the current query "
 "string."
 msgstr ""
+"For example, given a redirect from %source to %redirect, if a user visits "
+"%sourcequery they would be redirected to %redirectquery. The query strings "
+"in the redirection will always take precedence over the current query "
+"string."
 
 msgid "(formerly Global Redirect features)"
-msgstr ""
+msgstr "(formerly Global Redirect features)"
 
 msgid "Allow redirections on admin paths."
-msgstr ""
+msgstr "Allow redirections on admin paths."
 
 msgid "Last accessed"
-msgstr ""
+msgstr "Last accessed"
 
 msgid "Filter 404s"
-msgstr ""
+msgstr "Filter 404s"
 
 msgid "Fix 404 pages"
-msgstr ""
+msgstr "Fix 404 pages"
 
 msgid "Add redirects for 404 pages."
-msgstr ""
+msgstr "Add redirects for 404 pages."
 
 msgid "Fix 404 pages with URL redirects"
-msgstr ""
+msgstr "Fix 404 pages with URL redirects"
 
 msgid "‹ previous"
-msgstr ""
+msgstr "‹ previous"
 
 msgid "Redirect type"
-msgstr ""
+msgstr "Redirect type"
 
 msgid "URL redirects"
-msgstr ""
+msgstr "URL redirects"
 
 msgid "Redirect users from one URL to another."
-msgstr ""
+msgstr "Redirect users from one URL to another."
 
 msgid "Deleted URL redirect @rid."
-msgstr ""
+msgstr "Deleted URL redirect @rid."
 
 msgid "One URL redirect created."
 msgid_plural "@count URL redirects created."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "One URL redirect created."
+msgstr[1] "@count URL redirects created."
 
 msgid "Redirect module form elements"
-msgstr ""
+msgstr "Redirect module form elements"
 
 msgid "URL Redirects"
-msgstr ""
+msgstr "URL Redirects"
 
 msgid "The user ID of the node author."
-msgstr ""
+msgstr "The user ID of the node author."
 
 msgid "Add another"
-msgstr ""
+msgstr "Add another"
 
 msgid "Search server"
-msgstr ""
+msgstr "Search server"
 
 msgid "Fields indexed in this index"
-msgstr ""
+msgstr "Fields indexed in this index"
 
 msgid ""
 "This page lists which fields are indexed in this index, grouped by "
@@ -23792,33 +25901,47 @@ msgid ""
 "search displays based on the index. Fields with type \"Fulltext\" can also "
 "be used for fulltext searching."
 msgstr ""
+"This page lists which fields are indexed in this index, grouped by "
+"datasource. (Datasource-independent fields are listed under \"General\".) "
+"Indexed fields can be used to add filters or sorting to views or other "
+"search displays based on the index. Fields with type \"Fulltext\" can also "
+"be used for fulltext searching."
 
 msgid "Add fields"
-msgstr ""
+msgstr "Add fields"
 
 msgid ""
 "With the \"Add fields\" button you can add additional fields to this index."
 msgstr ""
+"With the \"Add fields\" button you can add additional fields to this index."
 
 msgid ""
 "A label for the field that will be used to refer to the field in most places"
 " in the user interface."
 msgstr ""
+"A label for the field that will be used to refer to the field in most places"
+" in the user interface."
 
 msgid ""
 "The internal ID to use for this field. Can safely be ignored by "
 "inexperienced users in most cases. Changing a field's machine name requires "
 "reindexing of the index."
 msgstr ""
+"The internal ID to use for this field. Can safely be ignored by "
+"inexperienced users in most cases. Changing a field's machine name requires "
+"reindexing of the index."
 
 msgid "Property path"
-msgstr ""
+msgstr "Property path"
 
 msgid ""
 "The internal relationship linking the indexed item to the field, with links "
 "being separated by colons (:). This can be useful information for advanced "
 "users, but can otherwise be ignored."
 msgstr ""
+"The internal relationship linking the indexed item to the field, with links "
+"being separated by colons (:). This can be useful information for advanced "
+"users, but can otherwise be ignored."
 
 msgid ""
 "The data type to use when indexing the field. Determines how a field can be "
@@ -23826,74 +25949,98 @@ msgid ""
 "=\"#search-api-data-types-table\">\"Data types\" box</a> at the bottom of "
 "the page."
 msgstr ""
+"The data type to use when indexing the field. Determines how a field can be "
+"used in searches. For information on the available types, see the <a href"
+"=\"#search-api-data-types-table\">\"Data types\" box</a> at the bottom of "
+"the page."
 
 msgid "Boost"
-msgstr ""
+msgstr "Boost"
 
 msgid ""
 "Only applicable for fulltext fields. Determines how \"important\" the field "
 "is compared to other fulltext fields, to influence scoring of fulltext "
 "searches."
 msgstr ""
+"Only applicable for fulltext fields. Determines how \"important\" the field "
+"is compared to other fulltext fields, to influence scoring of fulltext "
+"searches."
 
 msgid "Edit field"
-msgstr ""
+msgstr "Edit field"
 
 msgid ""
 "Some fields have additional configuration available, in which case an "
 "\"Edit\" link is displayed in the \"Operations\" column."
 msgstr ""
+"Some fields have additional configuration available, in which case an "
+"\"Edit\" link is displayed in the \"Operations\" column."
 
 msgid "Remove field"
-msgstr ""
+msgstr "Remove field"
 
 msgid ""
 "Removes a field from the index again. (Note: Sometimes, a field is required "
 "(for example, by a processor) and cannot be removed.)"
 msgstr ""
+"Removes a field from the index again. (Note: Sometimes, a field is required "
+"(for example, by a processor) and cannot be removed.)"
 
 msgid "Save changes"
-msgstr ""
+msgstr "Save changes"
 
 msgid ""
 "This saves all changes made to the fields for this index. Until this button "
 "is pressed, all added, changed or removed fields will only be stored "
 "temporarily and not effect the actual index used in the rest of the site."
 msgstr ""
+"This saves all changes made to the fields for this index. Until this button "
+"is pressed, all added, changed or removed fields will only be stored "
+"temporarily and not effect the actual index used in the rest of the site."
 
 msgid "Cancel changes"
-msgstr ""
+msgstr "Cancel changes"
 
 msgid ""
 "If you have made changes to the index's fields but not yet saved them, the "
 "\"Cancel\" link lets you discard those changes."
 msgstr ""
+"If you have made changes to the index's fields but not yet saved them, the "
+"\"Cancel\" link lets you discard those changes."
 
 msgid "Add or edit a Search API index"
-msgstr ""
+msgstr "Add or edit a Search API index"
 
 msgid "Adding or editing an index"
-msgstr ""
+msgstr "Adding or editing an index"
 
 msgid ""
 "This form can be used to edit an existing index or add a new index to your "
 "site. Indexes define a set of data that will be indexed and can then be "
 "searched."
 msgstr ""
+"This form can be used to edit an existing index or add a new index to your "
+"site. Indexes define a set of data that will be indexed and can then be "
+"searched."
 
 msgid "Index name"
-msgstr ""
+msgstr "Index name"
 
 msgid ""
 "Enter a name to identify this index. For example, \"Content index\". This "
 "will only be displayed in the admin user interface."
 msgstr ""
+"Enter a name to identify this index. For example, \"Content index\". This "
+"will only be displayed in the admin user interface."
 
 msgid ""
 "Datasources define the types of items that will be indexed in this index. By"
 " default, all content entities (like content, comments and taxonomy terms) "
 "will be available here, but modules can also add their own."
 msgstr ""
+"Datasources define the types of items that will be indexed in this index. By"
+" default, all content entities (like content, comments and taxonomy terms) "
+"will be available here, but modules can also add their own."
 
 msgid ""
 "An index's tracker is the system that keeps track of which items there are "
@@ -23901,48 +26048,64 @@ msgid ""
 "Changing the tracker of an existing index will lead to reindexing of all "
 "items."
 msgstr ""
+"An index's tracker is the system that keeps track of which items there are "
+"available for the index, and which of them still need to be indexed. "
+"Changing the tracker of an existing index will lead to reindexing of all "
+"items."
 
 msgid "If the index is attached to a server, this server is listed here."
-msgstr ""
+msgstr "If the index is attached to a server, this server is listed here."
 
 msgid ""
 "The search server that the index should use for indexing and searching. If "
 "no server is selected here, the index cannot be enabled. An index can only "
 "have one server, but a server can have any number of indexes."
 msgstr ""
+"The search server that the index should use for indexing and searching. If "
+"no server is selected here, the index cannot be enabled. An index can only "
+"have one server, but a server can have any number of indexes."
 
 msgid "Index description"
-msgstr ""
+msgstr "Index description"
 
 msgid ""
 "Optionally, enter a description to explain the function of the index in more"
 " detail. This will only be displayed in the admin user interface."
 msgstr ""
+"Optionally, enter a description to explain the function of the index in more"
+" detail. This will only be displayed in the admin user interface."
 
 msgid ""
 "These options allow more detailed configuration of index behavior, but can "
 "usually safely be ignored by inexperienced users."
 msgstr ""
+"These options allow more detailed configuration of index behavior, but can "
+"usually safely be ignored by inexperienced users."
 
 msgid "Processors used for this index"
-msgstr ""
+msgstr "Processors used for this index"
 
 msgid ""
 "Processors customize different aspects of an index's functionality. They can"
 " keep items from being indexed, change how certain fields are indexed and "
 "influence searches."
 msgstr ""
+"Processors customize different aspects of an index's functionality. They can"
+" keep items from being indexed, change how certain fields are indexed and "
+"influence searches."
 
 msgid "Enable processors"
-msgstr ""
+msgstr "Enable processors"
 
 msgid ""
 "This lists all processors available for this index and lets you choose the "
 "ones that should be active. (Note: Some processors cannot be disabled.)"
 msgstr ""
+"This lists all processors available for this index and lets you choose the "
+"ones that should be active. (Note: Some processors cannot be disabled.)"
 
 msgid "Processor order"
-msgstr ""
+msgstr "Processor order"
 
 msgid ""
 "This shows you which enabled processors will be active in the different "
@@ -23950,49 +26113,60 @@ msgid ""
 " should usually not be necessary, and only be used by advanced users as some"
 " processors will lead to unexpected results when used in the wrong order."
 msgstr ""
+"This shows you which enabled processors will be active in the different "
+"parts of the indexing/searching workflow, and lets you re-arrange them. This"
+" should usually not be necessary, and only be used by advanced users as some"
+" processors will lead to unexpected results when used in the wrong order."
 
 msgid "Processor settings"
-msgstr ""
+msgstr "Processor settings"
 
 msgid ""
 "Some processors have additional configuration available, which you are able "
 "to change here."
 msgstr ""
+"Some processors have additional configuration available, which you are able "
+"to change here."
 
 msgid "Information about an index"
-msgstr ""
+msgstr "Information about an index"
 
 msgid "This page shows a summary of a search index and its status."
-msgstr ""
+msgstr "This page shows a summary of a search index and its status."
 
 msgid "Index status"
-msgstr ""
+msgstr "Index status"
 
 msgid ""
 "This gives a summary about how many items are known for this index, and how "
 "many have been indexed in their latest version. Items that are not indexed "
 "yet cannot be found by searches."
 msgstr ""
+"This gives a summary about how many items are known for this index, and how "
+"many have been indexed in their latest version. Items that are not indexed "
+"yet cannot be found by searches."
 
 msgid "Shows whether the index is currently enabled or disabled."
-msgstr ""
+msgstr "Shows whether the index is currently enabled or disabled."
 
 msgid "Datasources"
-msgstr ""
+msgstr "Datasources"
 
 msgid "Lists all datasources that are enabled for this index."
-msgstr ""
+msgstr "Lists all datasources that are enabled for this index."
 
 msgid ""
 "The tracker used by the index. Only one (\"Default\") is available by "
 "default."
 msgstr ""
+"The tracker used by the index. Only one (\"Default\") is available by "
+"default."
 
 msgid "Server"
-msgstr ""
+msgstr "Server"
 
 msgid "Server index status"
-msgstr ""
+msgstr "Server index status"
 
 msgid ""
 "For enabled indexes, the number of items that can actually be retrieved from"
@@ -24002,24 +26176,30 @@ msgid ""
 "/frequently-asked-questions#server-index-status\">see the module's "
 "documentation</a>."
 msgstr ""
+"For enabled indexes, the number of items that can actually be retrieved from"
+" the server is listed here. For reasons why this number might differ from "
+"the number under \"Index status\", <a "
+"href=\"https://www.drupal.org/docs/8/modules/search-api/getting-started"
+"/frequently-asked-questions#server-index-status\">see the module's "
+"documentation</a>."
 
 msgid "Cron batch size"
-msgstr ""
+msgstr "Cron batch size"
 
 msgid "The number of items that will be indexed at once during cron runs."
-msgstr ""
+msgstr "The number of items that will be indexed at once during cron runs."
 
 msgid "Start indexing now"
-msgstr ""
+msgstr "Start indexing now"
 
 msgid "Meta tags"
-msgstr ""
+msgstr "Meta tags"
 
 msgid "Country name"
-msgstr ""
+msgstr "Country name"
 
 msgid "Relation"
-msgstr ""
+msgstr "Relation"
 
 msgid ""
 "The \"Start indexing now\" form allows indexing items manually right away, "
@@ -24027,9 +26207,13 @@ msgid ""
 "The form might be disabled if indexing is currently not possible for some "
 "reason, or not necessary."
 msgstr ""
+"The \"Start indexing now\" form allows indexing items manually right away, "
+"with a batch process. Otherwise, items are only indexed during cron runs. "
+"The form might be disabled if indexing is currently not possible for some "
+"reason, or not necessary."
 
 msgid "Track items for index"
-msgstr ""
+msgstr "Track items for index"
 
 msgid ""
 "In certain situations, the index's tracker doesn't have the latest state of "
@@ -24037,54 +26221,70 @@ msgid ""
 "during cron runs, but can also be manually triggered here, with the \"Track "
 "now\" button."
 msgstr ""
+"In certain situations, the index's tracker doesn't have the latest state of "
+"the items available for indexing. This will be automatically rectified "
+"during cron runs, but can also be manually triggered here, with the \"Track "
+"now\" button."
 
 msgid "Queue all items for reindexing"
-msgstr ""
+msgstr "Queue all items for reindexing"
 
 msgid ""
 "This will queue all items on this index for reindexing. Previously indexed "
 "data will remain on the search server, so searches on this index will "
 "continue to yield results."
 msgstr ""
+"This will queue all items on this index for reindexing. Previously indexed "
+"data will remain on the search server, so searches on this index will "
+"continue to yield results."
 
 msgid "Clear all indexed data"
-msgstr ""
+msgstr "Clear all indexed data"
 
 msgid ""
 "This will remove all indexed content for this index from the search server "
 "and queue it for reindexing. Searches on this index will not return any "
 "results until items are reindexed."
 msgstr ""
+"This will remove all indexed content for this index from the search server "
+"and queue it for reindexing. Searches on this index will not return any "
+"results until items are reindexed."
 
 msgid "Add or edit a Search API server"
-msgstr ""
+msgstr "Add or edit a Search API server"
 
 msgid "Adding or editing a Server"
-msgstr ""
+msgstr "Adding or editing a Server"
 
 msgid ""
 "This form can be used to edit an existing server or add a new server to your"
 " site. Servers will hold your indexed data."
 msgstr ""
+"This form can be used to edit an existing server or add a new server to your"
+" site. Servers will hold your indexed data."
 
 msgid "Server name"
-msgstr ""
+msgstr "Server name"
 
 msgid ""
 "Enter a name to identify this server. For example, \"Solr server\". This "
 "will only be displayed in the admin user interface."
 msgstr ""
+"Enter a name to identify this server. For example, \"Solr server\". This "
+"will only be displayed in the admin user interface."
 
 msgid "Server description"
-msgstr ""
+msgstr "Server description"
 
 msgid ""
 "Optionally, enter a description to explain the function of the server in "
 "more detail. This will only be displayed in the admin user interface."
 msgstr ""
+"Optionally, enter a description to explain the function of the server in "
+"more detail. This will only be displayed in the admin user interface."
 
 msgid "Server backend"
-msgstr ""
+msgstr "Server backend"
 
 msgid ""
 "Servers can be based on different technologies. These are called "
@@ -24094,33 +26294,42 @@ msgid ""
 "href=\"https://www.drupal.org/project/search_api_solr\">\"Solr\"</a>, which "
 "requires to be set up separately."
 msgstr ""
+"Servers can be based on different technologies. These are called "
+"\"backends\". A server uses exactly one backend and cannot change it later. "
+"You can make the \"Database\" backend available by enabling the \"Database "
+"Search\" module. Another very common backend is <a "
+"href=\"https://www.drupal.org/project/search_api_solr\">\"Solr\"</a>, which "
+"requires to be set up separately."
 
 msgid "Information about a server"
-msgstr ""
+msgstr "Information about a server"
 
 msgid "This page shows a summary of a search server."
-msgstr ""
+msgstr "This page shows a summary of a search server."
 
 msgid "Shows whether the server is currently enabled or disabled."
-msgstr ""
+msgstr "Shows whether the server is currently enabled or disabled."
 
 msgid "Backend class"
-msgstr ""
+msgstr "Backend class"
 
 msgid ""
 "The backend plugin used for this server. The backend plugin determines how "
 "items are indexed and searched – for example, using the database or an "
 "Apache Solr server."
 msgstr ""
+"The backend plugin used for this server. The backend plugin determines how "
+"items are indexed and searched – for example, using the database or an "
+"Apache Solr server."
 
 msgid "Search indexes"
-msgstr ""
+msgstr "Search indexes"
 
 msgid "Lists all search indexes that are attached to this server."
-msgstr ""
+msgstr "Lists all search indexes that are attached to this server."
 
 msgid "Delete all indexed data"
-msgstr ""
+msgstr "Delete all indexed data"
 
 msgid ""
 "This will permanently remove all data currently indexed on this server for "
@@ -24128,223 +26337,249 @@ msgid ""
 "reindexing occurs, searches for the affected indexes will not return any "
 "results."
 msgstr ""
+"This will permanently remove all data currently indexed on this server for "
+"indexes that aren't read-only. Items are queued for reindexing. Until "
+"reindexing occurs, searches for the affected indexes will not return any "
+"results."
 
 msgid "enabled"
-msgstr ""
+msgstr "enabled"
 
 msgid "all"
-msgstr ""
+msgstr "all"
 
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 msgid "Always"
-msgstr ""
+msgstr "Always"
 
 msgid "Field ID"
-msgstr ""
+msgstr "Field ID"
 
 msgid "Transliteration"
-msgstr ""
+msgstr "Transliteration"
 
 msgid "Read only"
-msgstr ""
+msgstr "Read only"
 
 msgid "Exception"
-msgstr ""
+msgstr "Exception"
 
 msgid ""
 "You must include at least one positive keyword with @count characters or "
 "more."
 msgstr ""
+"You must include at least one positive keyword with @count characters or "
+"more."
 
 msgid "Add server"
-msgstr ""
+msgstr "Add server"
 
 msgid "Unavailable"
-msgstr ""
+msgstr "Unavailable"
 
 msgid "Data types"
-msgstr ""
+msgstr "Data types"
 
 msgid "Relevance"
-msgstr ""
+msgstr "Relevance"
 
 msgid "HTML filter"
-msgstr ""
+msgstr "HTML filter"
 
 msgid ""
 "The number of characters a word has to be to be indexed. A lower setting "
 "means better search result ranking, but also a larger database. Each search "
 "query must contain at least one keyword that is this size (or longer)."
 msgstr ""
+"The number of characters a word has to be to be indexed. A lower setting "
+"means better search result ranking, but also a larger database. Each search "
+"query must contain at least one keyword that is this size (or longer)."
 
 msgid "Indexed"
-msgstr ""
+msgstr "Indexed"
 
 msgid "The changes were successfully saved."
-msgstr ""
+msgstr "The changes were successfully saved."
 
 msgid "Add index"
-msgstr ""
+msgstr "Add index"
 
 msgid "Save and add fields"
-msgstr ""
+msgstr "Save and add fields"
 
 msgid "Machine name: @name"
-msgstr ""
+msgstr "Machine name: @name"
 
 msgid "Autocomplete settings"
-msgstr ""
+msgstr "Autocomplete settings"
 
 msgid "Ignore case"
-msgstr ""
+msgstr "Ignore case"
 
 msgid "Default content index"
-msgstr ""
+msgstr "Default content index"
 
 msgid "Default content index created by the Database Search Defaults module"
-msgstr ""
+msgstr "Default content index created by the Database Search Defaults module"
 
 msgid "Database Server"
-msgstr ""
+msgstr "Database Server"
 
 msgid "Default database server created by the Database Search Defaults module"
 msgstr ""
+"Default database server created by the Database Search Defaults module"
 
 msgid "Add tracking for specific roles"
-msgstr ""
+msgstr "Add tracking for specific roles"
 
 msgid "Search content"
-msgstr ""
+msgstr "Search content"
 
 msgid "A search page preconfigured to search through the content of your site"
 msgstr ""
+"A search page preconfigured to search through the content of your site"
 
 msgid "Please enter some keywords to search."
-msgstr ""
+msgstr "Please enter some keywords to search."
 
 msgid "Search Content"
-msgstr ""
+msgstr "Search Content"
 
 msgid "Displaying results @start - @end of @total"
-msgstr ""
+msgstr "Displaying results @start - @end of @total"
 
 msgid "Module %module granted %permission permission to authenticated users."
-msgstr ""
+msgstr "Module %module granted %permission permission to authenticated users."
 
 msgid "Opt-in or out of tracking"
-msgstr ""
+msgstr "Opt-in or out of tracking"
 
 msgid "Message type"
-msgstr ""
+msgstr "Message type"
 
 msgid "Downloads"
-msgstr ""
+msgstr "Downloads"
 
 msgid "Privacy"
-msgstr ""
+msgstr "Privacy"
 
 msgid "Not configured"
-msgstr ""
+msgstr "Not configured"
 
 msgid "Create field"
-msgstr ""
+msgstr "Create field"
 
 msgid "Domains"
-msgstr ""
+msgstr "Domains"
 
 msgid "@module (<span class=\"admin-enabled\">enabled</span>)"
-msgstr ""
+msgstr "@module (<span class=\"admin-enabled\">enabled</span>)"
 
 msgid "Add tracking to specific pages"
-msgstr ""
+msgstr "Add tracking to specific pages"
 
 msgid "Track translation sets as one unit"
-msgstr ""
+msgstr "Track translation sets as one unit"
 
 msgid ""
 "When a node is part of a translation set, record statistics for the "
 "originating node instead. This allows for a translation set to be treated as"
 " a single unit."
 msgstr ""
+"When a node is part of a translation set, record statistics for the "
+"originating node instead. This allows for a translation set to be treated as"
+" a single unit."
 
 msgid "Track internal search"
-msgstr ""
+msgstr "Track internal search"
 
 msgid "Track AdSense ads"
-msgstr ""
+msgstr "Track AdSense ads"
 
 msgid ""
 "If checked, your AdSense ads will be tracked in your Google Analytics "
 "account."
 msgstr ""
+"If checked, your AdSense ads will be tracked in your Google Analytics "
+"account."
 
 msgid "Custom JavaScript code"
-msgstr ""
+msgstr "Custom JavaScript code"
 
 msgid "Code snippet (before)"
-msgstr ""
+msgstr "Code snippet (before)"
 
 msgid "Code snippet (after)"
-msgstr ""
+msgstr "Code snippet (after)"
 
 msgid ""
 "Do not add the tracker code provided by Google into the javascript code "
 "snippets! This module already builds the tracker code based on your Google "
 "Analytics account number and settings."
 msgstr ""
+"Do not add the tracker code provided by Google into the javascript code "
+"snippets! This module already builds the tracker code based on your Google "
+"Analytics account number and settings."
 
 msgid ""
 "Do not include the &lt;script&gt; tags in the javascript code snippets."
 msgstr ""
+"Do not include the &lt;script&gt; tags in the javascript code snippets."
 
 msgid "Users are tracked by default, but you are able to opt out."
-msgstr ""
+msgstr "Users are tracked by default, but you are able to opt out."
 
 msgid "Enable user tracking"
-msgstr ""
+msgstr "Enable user tracking"
 
 msgid "Users are <em>not</em> tracked by default, but you are able to opt in."
 msgstr ""
+"Users are <em>not</em> tracked by default, but you are able to opt in."
 
 msgid "Google Analytics"
-msgstr ""
+msgstr "Google Analytics"
 
 msgid "Google Analytics module"
-msgstr ""
+msgstr "Google Analytics module"
 
 msgid ""
 "Specify pages by using their paths. Enter one path per line. The '*' "
 "character is a wildcard. Example paths are %blog for the blog page and "
 "%blog-wildcard for every personal blog. %front is the front page."
 msgstr ""
+"Specify pages by using their paths. Enter one path per line. The '*' "
+"character is a wildcard. Example paths are %blog for the blog page and "
+"%blog-wildcard for every personal blog. %front is the front page."
 
 msgid "Pages on which this PHP code returns <code>TRUE</code> (experts only)"
-msgstr ""
+msgstr "Pages on which this PHP code returns <code>TRUE</code> (experts only)"
 
 msgid "Pages or PHP code"
-msgstr ""
+msgstr "Pages or PHP code"
 
 msgid ""
 "If the PHP option is chosen, enter PHP code between %php. Note that "
 "executing incorrect PHP code can break your Drupal site."
 msgstr ""
+"If the PHP option is chosen, enter PHP code between %php. Note that "
+"executing incorrect PHP code can break your Drupal site."
 
 msgid "Not customizable"
-msgstr ""
+msgstr "Not customizable"
 
 msgid "Colorbox"
-msgstr ""
+msgstr "Colorbox"
 
 msgid "Site search"
-msgstr ""
+msgstr "Site search"
 
 msgid "Web Property ID"
-msgstr ""
+msgstr "Web Property ID"
 
 msgid "Anonymize visitors IP address"
-msgstr ""
+msgstr "Anonymize visitors IP address"
 
 msgid ""
 "Tell Google Analytics to anonymize the information sent by the tracker "
@@ -24354,9 +26589,15 @@ msgid ""
 "information for privacy reasons and this setting may help you to comply with"
 " the local laws."
 msgstr ""
+"Tell Google Analytics to anonymize the information sent by the tracker "
+"objects by removing the last octet of the IP address prior to its storage. "
+"Note that this will slightly reduce the accuracy of geographic reporting. In"
+" some countries it is not allowed to collect personally identifying "
+"information for privacy reasons and this setting may help you to comply with"
+" the local laws."
 
 msgid "Locally cache tracking code file"
-msgstr ""
+msgstr "Locally cache tracking code file"
 
 msgid ""
 "If checked, the tracking code file is retrieved from Google Analytics and "
@@ -24364,347 +26605,377 @@ msgid ""
 "to tracking code are reflected in the local copy. Do not activate this until"
 " after Google Analytics has confirmed that site tracking is working!"
 msgstr ""
+"If checked, the tracking code file is retrieved from Google Analytics and "
+"cached locally. It is updated daily from Google's servers to ensure updates "
+"to tracking code are reflected in the local copy. Do not activate this until"
+" after Google Analytics has confirmed that site tracking is working!"
 
 msgid "Custom variables"
-msgstr ""
+msgstr "Custom variables"
 
 msgid ""
 "The %element-title is using the following forbidden tokens with personal "
 "identifying information: @invalid-tokens."
 msgstr ""
+"The %element-title is using the following forbidden tokens with personal "
+"identifying information: @invalid-tokens."
 
 msgid ""
 "The role names the user account is a member of as comma separated list."
 msgstr ""
+"The role names the user account is a member of as comma separated list."
 
 msgid "The role ids the user account is a member of as comma separated list."
-msgstr ""
+msgstr "The role ids the user account is a member of as comma separated list."
 
 msgid "Locally cached tracking code file has been updated."
-msgstr ""
+msgstr "Locally cached tracking code file has been updated."
 
 msgid "Locally cached tracking code file has been saved."
-msgstr ""
+msgstr "Locally cached tracking code file has been saved."
 
 msgid "Local cache has been purged."
-msgstr ""
+msgstr "Local cache has been purged."
 
 msgid "Tracking scope"
-msgstr ""
+msgstr "Tracking scope"
 
 msgid "Allow users to customize tracking on their account page"
-msgstr ""
+msgstr "Allow users to customize tracking on their account page"
 
 msgid "No customization allowed"
-msgstr ""
+msgstr "No customization allowed"
 
 msgid "Tracking on by default, users with %permission permission can opt out"
-msgstr ""
+msgstr "Tracking on by default, users with %permission permission can opt out"
 
 msgid "Tracking off by default, users with %permission permission can opt in"
-msgstr ""
+msgstr "Tracking off by default, users with %permission permission can opt in"
 
 msgid "Every page except the listed pages"
-msgstr ""
+msgstr "Every page except the listed pages"
 
 msgid "The listed pages only"
-msgstr ""
+msgstr "The listed pages only"
 
 msgid "Links and downloads"
-msgstr ""
+msgstr "Links and downloads"
 
 msgid "Track clicks on mailto links"
-msgstr ""
+msgstr "Track clicks on mailto links"
 
 msgid "Track downloads (clicks on file links) for the following extensions"
-msgstr ""
+msgstr "Track downloads (clicks on file links) for the following extensions"
 
 msgid "List of download file extensions"
-msgstr ""
+msgstr "List of download file extensions"
 
 msgid ""
 "A valid Google Analytics Web Property ID is case sensitive and formatted "
 "like UA-xxxxxxx-yy."
 msgstr ""
+"A valid Google Analytics Web Property ID is case sensitive and formatted "
+"like UA-xxxxxxx-yy."
 
 msgid "Administer Google Analytics"
-msgstr ""
+msgstr "Administer Google Analytics"
 
 msgid "Perform maintenance tasks for Google Analytics."
-msgstr ""
+msgstr "Perform maintenance tasks for Google Analytics."
 
 msgid "Allow users to decide if tracking code will be added to pages or not."
-msgstr ""
+msgstr "Allow users to decide if tracking code will be added to pages or not."
 
 msgid "Use PHP for tracking visibility"
-msgstr ""
+msgstr "Use PHP for tracking visibility"
 
 msgid "On by default with opt out"
-msgstr ""
+msgstr "On by default with opt out"
 
 msgid "Off by default with opt in"
-msgstr ""
+msgstr "Off by default with opt in"
 
 msgid "Not tracked"
-msgstr ""
+msgstr "Not tracked"
 
 msgid "What are you tracking?"
-msgstr ""
+msgstr "What are you tracking?"
 
 msgid "A single domain (default)"
-msgstr ""
+msgstr "A single domain (default)"
 
 msgid "Domain: @domain"
-msgstr ""
+msgstr "Domain: @domain"
 
 msgid "One domain with multiple subdomains"
-msgstr ""
+msgstr "One domain with multiple subdomains"
 
 msgid "Examples: @domains"
-msgstr ""
+msgstr "Examples: @domains"
 
 msgid "Multiple top-level domains"
-msgstr ""
+msgstr "Multiple top-level domains"
 
 msgid "List of top-level domains"
-msgstr ""
+msgstr "List of top-level domains"
 
 msgid "Add to the selected roles only"
-msgstr ""
+msgstr "Add to the selected roles only"
 
 msgid "Add to every role except the selected ones"
-msgstr ""
+msgstr "Add to every role except the selected ones"
 
 msgid ""
 "If none of the roles are selected, all users will be tracked. If a user has "
 "any of the roles checked, that user will be tracked (or excluded, depending "
 "on the setting above)."
 msgstr ""
+"If none of the roles are selected, all users will be tracked. If a user has "
+"any of the roles checked, that user will be tracked (or excluded, depending "
+"on the setting above)."
 
 msgid "Track clicks on outbound links"
-msgstr ""
+msgstr "Track clicks on outbound links"
 
 msgid ""
 "A list of top-level domains is required if <em>Multiple top-level "
 "domains</em> has been selected."
 msgstr ""
+"A list of top-level domains is required if <em>Multiple top-level "
+"domains</em> has been selected."
 
 msgid "All pages with exceptions"
-msgstr ""
+msgstr "All pages with exceptions"
 
 msgid "Excepted: @roles"
-msgstr ""
+msgstr "Excepted: @roles"
 
 msgid "A single domain"
-msgstr ""
+msgstr "A single domain"
 
 msgid "No privacy"
-msgstr ""
+msgstr "No privacy"
 
 msgid "@items enabled"
-msgstr ""
+msgstr "@items enabled"
 
 msgid "Outbound links"
-msgstr ""
+msgstr "Outbound links"
 
 msgid "Enter PHP code in the field for tracking visibility settings."
-msgstr ""
+msgstr "Enter PHP code in the field for tracking visibility settings."
 
 msgid "Google Analytics module form element."
-msgstr ""
+msgstr "Google Analytics module form element."
 
 msgid "Mailto links"
-msgstr ""
+msgstr "Mailto links"
 
 msgid "AdSense ads"
-msgstr ""
+msgstr "AdSense ads"
 
 msgid "Anonymize IP"
-msgstr ""
+msgstr "Anonymize IP"
 
 msgid "Track messages of type"
-msgstr ""
+msgstr "Track messages of type"
 
 msgid "Search and Advertising"
-msgstr ""
+msgstr "Search and Advertising"
 
 msgid "Metric"
-msgstr ""
+msgstr "Metric"
 
 msgid ""
 "To adjust global defaults, go to admin/config/search/metatag. If you need to"
 " set meta tags for a specific entity, edit its bundle and add the Metatag "
 "field."
 msgstr ""
+"To adjust global defaults, go to admin/config/search/metatag. If you need to"
+" set meta tags for a specific entity, edit its bundle and add the Metatag "
+"field."
 
 msgid "Metatag defaults"
-msgstr ""
+msgstr "Metatag defaults"
 
 msgid "403 access denied"
-msgstr ""
+msgstr "403 access denied"
 
 msgid "[node:title] | [site:name]"
-msgstr ""
+msgstr "[node:title] | [site:name]"
 
 msgid "404 page not found"
-msgstr ""
+msgstr "404 page not found"
 
 msgid "[site:url]"
-msgstr ""
+msgstr "[site:url]"
 
 msgid "[current-page:url]"
-msgstr ""
+msgstr "[current-page:url]"
 
 msgid "[current-page:title] | [site:name]"
-msgstr ""
+msgstr "[current-page:title] | [site:name]"
 
 msgid "[node:summary]"
-msgstr ""
+msgstr "[node:summary]"
 
 msgid "[node:url]"
-msgstr ""
+msgstr "[node:url]"
 
 msgid "[term:url]"
-msgstr ""
+msgstr "[term:url]"
 
 msgid "[term:description]"
-msgstr ""
+msgstr "[term:description]"
 
 msgid "[term:name] | [site:name]"
-msgstr ""
+msgstr "[term:name] | [site:name]"
 
 msgid "[user:url]"
-msgstr ""
+msgstr "[user:url]"
 
 msgid "[site:name]"
-msgstr ""
+msgstr "[site:name]"
 
 msgid "[user:display-name] | [site:name]"
-msgstr ""
+msgstr "[user:display-name] | [site:name]"
 
 msgid "Audience"
-msgstr ""
+msgstr "Audience"
 
 msgid "License"
-msgstr ""
+msgstr "License"
 
 msgid "Date Created"
-msgstr ""
+msgstr "Date Created"
 
 msgid "Id"
-msgstr ""
+msgstr "Id"
 
 msgid "Latitude"
-msgstr ""
+msgstr "Latitude"
 
 msgid "Longitude"
-msgstr ""
+msgstr "Longitude"
 
 msgid "Phone number"
-msgstr ""
+msgstr "Phone number"
 
 msgid "Google"
-msgstr ""
+msgstr "Google"
 
 msgid "Street address"
-msgstr ""
+msgstr "Street address"
 
 msgid "Publisher"
-msgstr ""
+msgstr "Publisher"
 
 msgid "Publisher URL"
-msgstr ""
+msgstr "Publisher URL"
 
 msgid "Rating"
-msgstr ""
+msgstr "Rating"
 
 msgid "Creator"
-msgstr ""
+msgstr "Creator"
 
 msgid ""
 "Allows your site to be tracked by Google Analytics by adding a Javascript "
 "tracking code to every page."
 msgstr ""
+"Allows your site to be tracked by Google Analytics by adding a Javascript "
+"tracking code to every page."
 
 msgid "Image type"
-msgstr ""
+msgstr "Image type"
 
 msgid "References"
-msgstr ""
+msgstr "References"
 
 msgid "Canonical URL"
-msgstr ""
+msgstr "Canonical URL"
 
 msgid "Robots"
-msgstr ""
+msgstr "Robots"
 
 msgid "Bing"
-msgstr ""
+msgstr "Bing"
 
 msgid "Shortlink URL"
-msgstr ""
+msgstr "Shortlink URL"
 
 msgid ""
 "Provides search engines with specific directions for what to do when this "
 "page is indexed."
 msgstr ""
+"Provides search engines with specific directions for what to do when this "
+"page is indexed."
 
 msgid "Using defaults"
-msgstr ""
+msgstr "Using defaults"
 
 msgid "Image URL"
-msgstr ""
+msgstr "Image URL"
 
 msgid "Fax number"
-msgstr ""
+msgstr "Fax number"
 
 msgid "See also"
-msgstr ""
+msgstr "See also"
 
 msgid "Video width"
-msgstr ""
+msgstr "Video width"
 
 msgid "Video height"
-msgstr ""
+msgstr "Video height"
 
 msgid "Abstract"
-msgstr ""
+msgstr "Abstract"
 
 msgid "Origin"
-msgstr ""
+msgstr "Origin"
 
 msgid "Lifetime"
-msgstr ""
+msgstr "Lifetime"
 
 msgid "Honeypot"
-msgstr ""
+msgstr "Honeypot"
 
 msgid ""
 "Congratulations on installing Honeypot on your site! With just a few clicks, you can have your site well-protected against automated spam bots.\r\n"
 "\r\n"
 "Click Next to be guided through this configuration page."
 msgstr ""
+"Congratulations on installing Honeypot on your site! With just a few clicks, you can have your site well-protected against automated spam bots.\r\n"
+"\r\n"
+"Click Next to be guided through this configuration page."
 
 msgid "Protect all forms"
-msgstr ""
+msgstr "Protect all forms"
 
 msgid ""
 "Protecting all the forms is the easiest way to quickly cut down on spam on your site, but doing this disables Drupal's caching for every page where a form is displayed.\r\n"
 "\r\n"
 "Note: If you have the honeypot time limit enabled, this option may cause issues with Drupal Commerce product forms or similarly-sparse forms that are able to be completed in a very short time."
 msgstr ""
+"Protecting all the forms is the easiest way to quickly cut down on spam on your site, but doing this disables Drupal's caching for every page where a form is displayed.\r\n"
+"\r\n"
+"Note: If you have the honeypot time limit enabled, this option may cause issues with Drupal Commerce product forms or similarly-sparse forms that are able to be completed in a very short time."
 
 msgid "Log blocked form submissions"
-msgstr ""
+msgstr "Log blocked form submissions"
 
 msgid ""
 "Check this box to log every form submission using watchdog. If you have "
 "Database Logging enabled, you can view these log entries in the Recent log "
 "messages page under Reports."
 msgstr ""
+"Check this box to log every form submission using watchdog. If you have "
+"Database Logging enabled, you can view these log entries in the Recent log "
+"messages page under Reports."
 
 msgid "Honeypot Element Name"
-msgstr ""
+msgstr "Honeypot Element Name"
 
 msgid ""
 "Spam bots typically fill out any field they believe will help get links back"
@@ -24712,9 +26983,13 @@ msgid ""
 "'homepage', or 'link' makes it hard for them to resist filling in the "
 "field—and easy to catch them in the trap and reject their submissions!"
 msgstr ""
+"Spam bots typically fill out any field they believe will help get links back"
+" to their site, so tempting them with a field named something like 'url', "
+"'homepage', or 'link' makes it hard for them to resist filling in the "
+"field—and easy to catch them in the trap and reject their submissions!"
 
 msgid "Honeypot Time Limit"
-msgstr ""
+msgstr "Honeypot Time Limit"
 
 msgid ""
 "If you enter a positive value, Honeypot will require that all protected "
@@ -24722,414 +26997,421 @@ msgid ""
 "least 5-10 seconds to complete (if you're a human), so setting this to a "
 "value < 5 will help protect against spam bots. Set to 0 to disable."
 msgstr ""
+"If you enter a positive value, Honeypot will require that all protected "
+"forms take at least that many seconds long to fill out. Most forms take at "
+"least 5-10 seconds to complete (if you're a human), so setting this to a "
+"value < 5 will help protect against spam bots. Set to 0 to disable."
 
 msgid "Honeypot form-specific settings"
-msgstr ""
+msgstr "Honeypot form-specific settings"
 
 msgid ""
 "If you would like to choose particular forms to be protected by Honeypot, "
 "check the forms you wish to protect in this section. Most common types of "
 "forms are available for protection."
 msgstr ""
+"If you would like to choose particular forms to be protected by Honeypot, "
+"check the forms you wish to protect in this section. Most common types of "
+"forms are available for protection."
 
 msgid "Expiration"
-msgstr ""
+msgstr "Expiration"
 
 msgid "seconds"
-msgstr ""
+msgstr "seconds"
 
 msgid "Footer_en"
-msgstr ""
+msgstr "Footer_en"
 
 msgid "Footer links (en)"
-msgstr ""
+msgstr "Footer links (en)"
 
 msgid "Thursday"
-msgstr ""
+msgstr "Thursday"
 
 msgctxt "Long month name"
 msgid "September"
-msgstr ""
+msgstr "September"
 
 msgid "1 minute"
 msgid_plural "@count minutes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 minute"
+msgstr[1] "@count minutes"
 
 msgid "Contact message"
-msgstr ""
+msgstr "Contact message"
 
 msgid "Search task"
-msgstr ""
+msgstr "Search task"
 
 msgid "Shortcut link"
-msgstr ""
+msgstr "Shortcut link"
 
 msgid "Reusable"
-msgstr ""
+msgstr "Reusable"
 
 msgid "Form ID"
-msgstr ""
+msgstr "Form ID"
 
 msgid "The sender's name"
-msgstr ""
+msgstr "The sender's name"
 
 msgid "The sender's email"
-msgstr ""
+msgstr "The sender's email"
 
 msgid "Recipient ID"
-msgstr ""
+msgstr "Recipient ID"
 
 msgid "Redirect ID"
-msgstr ""
+msgstr "Redirect ID"
 
 msgid "User ID"
-msgstr ""
+msgstr "User ID"
 
 msgid "Task type"
-msgstr ""
+msgstr "Task type"
 
 msgid "Server ID"
-msgstr ""
+msgstr "Server ID"
 
 msgid "Index ID"
-msgstr ""
+msgstr "Index ID"
 
 msgid "Task data"
-msgstr ""
+msgstr "Task data"
 
 msgid "Path"
-msgstr ""
+msgstr "Path"
 
 msgid "Enabled"
-msgstr ""
+msgstr "Enabled"
 
 msgid "Menu link title"
-msgstr ""
+msgstr "Menu link title"
 
 msgid "Indicates whether the menu link should be rediscovered"
-msgstr ""
+msgstr "Indicates whether the menu link should be rediscovered"
 
 msgid "Show as expanded"
-msgstr ""
+msgstr "Show as expanded"
 
 msgid "Parent plugin ID"
-msgstr ""
+msgstr "Parent plugin ID"
 
 msgid "Content types"
-msgstr ""
+msgstr "Content types"
 
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 msgid "Array"
-msgstr ""
+msgstr "Array"
 
 msgid "Random"
-msgstr ""
+msgstr "Random"
 
 msgid "Image with image style"
-msgstr ""
+msgstr "Image with image style"
 
 msgid "Menus"
-msgstr ""
+msgstr "Menus"
 
 msgid "Nodes"
-msgstr ""
+msgstr "Nodes"
 
 msgid "Site information"
-msgstr ""
+msgstr "Site information"
 
 msgid "Taxonomy terms"
-msgstr ""
+msgstr "Taxonomy terms"
 
 msgid "Vocabularies"
-msgstr ""
+msgstr "Vocabularies"
 
 msgid "Menu links"
-msgstr ""
+msgstr "Menu links"
 
 msgid "List of @type values"
-msgstr ""
+msgstr "List of @type values"
 
 msgid "Translation source node"
-msgstr ""
+msgstr "Translation source node"
 
 msgid "Comment count"
-msgstr ""
+msgstr "Comment count"
 
 msgid "Menu link"
-msgstr ""
+msgstr "Menu link"
 
 msgid "Summary"
-msgstr ""
+msgstr "Summary"
 
 msgid "Original @entity"
-msgstr ""
+msgstr "Original @entity"
 
 msgid "Edit URL"
-msgstr ""
+msgstr "Edit URL"
 
 msgid "Date created"
-msgstr ""
+msgstr "Date created"
 
 msgid "Date changed"
-msgstr ""
+msgstr "Date changed"
 
 msgid "Machine-readable name"
-msgstr ""
+msgstr "Machine-readable name"
 
 msgid "Parents"
-msgstr ""
+msgstr "Parents"
 
 msgid "Root term"
-msgstr ""
+msgstr "Root term"
 
 msgid "Term ID"
-msgstr ""
+msgstr "Term ID"
 
 msgid "Parent term"
-msgstr ""
+msgstr "Parent term"
 
 msgid "Vocabulary ID"
-msgstr ""
+msgstr "Vocabulary ID"
 
 msgid "Term count"
-msgstr ""
+msgstr "Term count"
 
 msgid "Base name"
-msgstr ""
+msgstr "Base name"
 
 msgid "File byte size"
-msgstr ""
+msgstr "File byte size"
 
 msgid "File ID"
-msgstr ""
+msgstr "File ID"
 
 msgid "File name"
-msgstr ""
+msgstr "File name"
 
 msgid "File size"
-msgstr ""
+msgstr "File size"
 
 msgid "Owner"
-msgstr ""
+msgstr "Owner"
 
 msgid "Account cancellation URL"
-msgstr ""
+msgstr "Account cancellation URL"
 
 msgid "One-time login URL"
-msgstr ""
+msgstr "One-time login URL"
 
 msgid "User role names"
-msgstr ""
+msgstr "User role names"
 
 msgid "User role ids"
-msgstr ""
+msgstr "User role ids"
 
 msgid "Deprecated: User Name"
-msgstr ""
+msgstr "Deprecated: User Name"
 
 msgid "Account Name"
-msgstr ""
+msgstr "Account Name"
 
 msgid "Display Name"
-msgstr ""
+msgstr "Display Name"
 
 msgid "Email"
-msgstr ""
+msgstr "Email"
 
 msgid "Last login"
-msgstr ""
+msgstr "Last login"
 
 msgid "Link ID"
-msgstr ""
+msgstr "Link ID"
 
 msgid "Parent"
-msgstr ""
+msgstr "Parent"
 
 msgid "Root"
-msgstr ""
+msgstr "Root"
 
 msgid "Page number"
-msgstr ""
+msgstr "Page number"
 
 msgid "Query string value"
-msgstr ""
+msgstr "Query string value"
 
 msgid "Relative URL"
-msgstr ""
+msgstr "Relative URL"
 
 msgid "Absolute URL"
-msgstr ""
+msgstr "Absolute URL"
 
 msgid "Brief URL"
-msgstr ""
+msgstr "Brief URL"
 
 msgid "Unaliased URL"
-msgstr ""
+msgstr "Unaliased URL"
 
 msgid "Arguments"
-msgstr ""
+msgstr "Arguments"
 
 msgid "First"
-msgstr ""
+msgstr "First"
 
 msgid "Last"
-msgstr ""
+msgstr "Last"
 
 msgid "Count"
-msgstr ""
+msgstr "Count"
 
 msgid "Reversed"
-msgstr ""
+msgstr "Reversed"
 
 msgid "Keys"
-msgstr ""
+msgstr "Keys"
 
 msgid "Imploded"
-msgstr ""
+msgstr "Imploded"
 
 msgid "Value"
-msgstr ""
+msgstr "Value"
 
 msgid "Number"
-msgstr ""
+msgstr "Number"
 
 msgid "Height"
-msgstr ""
+msgstr "Height"
 
 msgid "Width"
-msgstr ""
+msgstr "Width"
 
 msgid "SEO"
-msgstr ""
+msgstr "SEO"
 
 msgid "URI"
-msgstr ""
+msgstr "URI"
 
 msgid "Comment ID"
-msgstr ""
+msgstr "Comment ID"
 
 msgid "IP Address"
-msgstr ""
+msgstr "IP Address"
 
 msgid "Email address"
-msgstr ""
+msgstr "Email address"
 
 msgid "Home page"
-msgstr ""
+msgstr "Home page"
 
 msgid "Menu link count"
-msgstr ""
+msgstr "Menu link count"
 
 msgid "Slogan"
-msgstr ""
+msgstr "Slogan"
 
 msgid "URL (brief)"
-msgstr ""
+msgstr "URL (brief)"
 
 msgid "Login page"
-msgstr ""
+msgstr "Login page"
 
 msgid "Short format"
-msgstr ""
+msgstr "Short format"
 
 msgid "Medium format"
-msgstr ""
+msgstr "Medium format"
 
 msgid "Long format"
-msgstr ""
+msgstr "Long format"
 
 msgid "Time-since"
-msgstr ""
+msgstr "Time-since"
 
 msgid "Raw timestamp"
-msgstr ""
+msgstr "Raw timestamp"
 
 msgid "Total rows"
-msgstr ""
+msgstr "Total rows"
 
 msgid "@label ID"
-msgstr ""
+msgstr "@label ID"
 
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 msgid "Comment status"
-msgstr ""
+msgstr "Comment status"
 
 msgid "Last comment timestamp"
-msgstr ""
+msgstr "Last comment timestamp"
 
 msgid "Last comment name"
-msgstr ""
+msgstr "Last comment name"
 
 msgid "Last comment user ID"
-msgstr ""
+msgstr "Last comment user ID"
 
 msgid "Number of comments"
-msgstr ""
+msgstr "Number of comments"
 
 msgid "Disqus status value"
-msgstr ""
+msgstr "Disqus status value"
 
 msgid "Disqus thread identifier"
-msgstr ""
+msgstr "Disqus thread identifier"
 
 msgid "Alternative text"
-msgstr ""
+msgstr "Alternative text"
 
 msgid "@type type with delta @delta"
-msgstr ""
+msgstr "@type type with delta @delta"
 
 msgid "Link text"
-msgstr ""
+msgstr "Link text"
 
 msgid "Guide menu (en)"
-msgstr ""
+msgstr "Guide menu (en)"
 
 msgid "Menu for guide page (en)"
-msgstr ""
+msgstr "Menu for guide page (en)"
 
 msgid "Appears in: @bundles."
-msgstr ""
+msgstr "Appears in: @bundles."
 
 msgid "Also known as:"
-msgstr ""
+msgstr "Also known as:"
 
 msgid "@label (@name)"
-msgstr ""
+msgstr "@label (@name)"
 
 msgid "Main navigation (en)"
-msgstr ""
+msgstr "Main navigation (en)"
 
 msgid "User guide"
-msgstr ""
+msgstr "User guide"
 
 msgid "contact_message_event_form"
-msgstr ""
+msgstr "contact_message_event_form"
 
 msgid "Event"
-msgstr ""
+msgstr "Event"
 
 msgid "Event submission received."
-msgstr ""
+msgstr "Event submission received."
 
 msgid "Address"
-msgstr ""
+msgstr "Address"
 
 msgid "Where the event is located"
-msgstr ""
+msgstr "Where the event is located"
 
 msgid "End time"
-msgstr ""
+msgstr "End time"
 
 msgid "End time for the event."
-msgstr ""
+msgstr "End time for the event."
 
 msgid "Event link"
-msgstr ""
+msgstr "Event link"
 
 msgid ""
 "Link to event's official page, or a page with more information regarding the"
@@ -25139,76 +27421,76 @@ msgstr ""
 " the event."
 
 msgid "Event picture"
-msgstr ""
+msgstr "Event picture"
 
 msgid "Picture or logo that can be used for the event page."
-msgstr ""
+msgstr "Picture or logo that can be used for the event page."
 
 msgid "Start time"
-msgstr ""
+msgstr "Start time"
 
 msgid "Start time of the event."
-msgstr ""
+msgstr "Start time of the event."
 
 msgid "Guide search"
-msgstr ""
+msgstr "Guide search"
 
 msgid "Guide search view"
-msgstr ""
+msgstr "Guide search view"
 
 msgid "Master"
-msgstr ""
+msgstr "Master"
 
 msgid "No matching results"
-msgstr ""
+msgstr "No matching results"
 
 msgid "Synchronizing configuration: @op @name."
-msgstr ""
+msgstr "Synchronizing configuration: @op @name."
 
 msgid "Finalizing configuration synchronization."
-msgstr ""
+msgstr "Finalizing configuration synchronization."
 
 msgid "Unexpected error during import with operation @op for @name: @message"
-msgstr ""
+msgstr "Unexpected error during import with operation @op for @name: @message"
 
 msgid "This will also remove 1 placed block instance."
 msgid_plural "This will also remove @count placed block instances."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "This will also remove 1 placed block instance."
+msgstr[1] "This will also remove @count placed block instances."
 
 msgid "Upload requirements"
-msgstr ""
+msgstr "Upload requirements"
 
 msgid "Deleted 1 comment."
 msgid_plural "Deleted @count comments."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Deleted 1 comment."
+msgstr[1] "Deleted @count comments."
 
 msgid "Deleted 1 post."
 msgid_plural "Deleted @count posts."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Deleted 1 post."
+msgstr[1] "Deleted @count posts."
 
 msgid "Recently modified"
-msgstr ""
+msgstr "Recently modified"
 
 msgid "for text search"
-msgstr ""
+msgstr "for text search"
 
 msgid "The username %value is already taken."
-msgstr ""
+msgstr "The username %value is already taken."
 
 msgid "The email address %value is already taken."
-msgstr ""
+msgstr "The email address %value is already taken."
 
 msgid "Development version open data portal."
-msgstr ""
+msgstr "Development version open data portal."
 
 msgid "%name is not recognized as a username or an email address."
-msgstr ""
+msgstr "%name is not recognized as a username or an email address."
 
 msgid "Read more"
-msgstr ""
+msgstr "Read more"
 
 msgid ""
 "In case there is an open data event missing from the list below, you may "
@@ -25218,45 +27500,45 @@ msgstr ""
 "event information to us and we'll add it."
 
 msgid "Submit an event"
-msgstr ""
+msgstr "Submit an event"
 
 msgid "Free text search"
-msgstr ""
+msgstr "Free text search"
 
 msgid "Showing events"
-msgstr ""
+msgstr "Showing events"
 
 msgid "Show past events"
-msgstr ""
+msgstr "Show past events"
 
 msgid "Read more >>"
-msgstr ""
+msgstr "Read more >>"
 
 msgid "No recently modified data sets found"
-msgstr ""
+msgstr "No recently modified data sets found"
 
 msgid "No new data sets found"
-msgstr ""
+msgstr "No new data sets found"
 
 msgid "No popular data sets found"
-msgstr ""
+msgstr "No popular data sets found"
 
 msgid "News and articles"
 msgstr "News"
 
 msgid "Categories"
-msgstr ""
+msgstr "Categories"
 
 msgid "Finnish open data portal"
-msgstr ""
+msgstr "Finnish open data portal"
 
 msgid "No articles found."
-msgstr ""
+msgstr "No articles found."
 
 msgid "1 block is available in the modified list."
 msgid_plural "@count blocks are available in the modified list."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 block is available in the modified list."
+msgstr[1] "@count blocks are available in the modified list."
 
 msgid ""
 "Events calendar displays various open data related events hosted in Finland "
@@ -25266,26 +27548,29 @@ msgstr ""
 " abroad."
 
 msgid "All Finnish open data from one place"
-msgstr ""
+msgstr "All Finnish open data from one place"
 
 msgid ""
 "Open data is information that is stored on a computer, for example "
 "structural text, tables, maps and images. Open data can be used freely when "
 "also providing it's origin."
 msgstr ""
+"Open data is information that is stored on a computer, for example "
+"structural text, tables, maps and images. Open data can be used freely when "
+"also providing it's origin."
 
 msgid "Search datasets..."
-msgstr ""
+msgstr "Search datasets..."
 
 msgid "Recent"
-msgstr ""
+msgstr "Recent"
 
 msgid "Popular"
-msgstr ""
+msgstr "Popular"
 
 msgctxt "x datasets"
 msgid "Datasets"
-msgstr ""
+msgstr "Datasets"
 
 msgctxt "x organizations"
 msgid "Organizations"
@@ -25296,7 +27581,7 @@ msgid "Applications"
 msgstr "Showcases"
 
 msgid "Datasets"
-msgstr ""
+msgstr "Datasets"
 
 msgid "Applications"
 msgstr "Showcases"
@@ -25305,7 +27590,7 @@ msgid "Organizations"
 msgstr "Publishers"
 
 msgid "Open data categories"
-msgstr ""
+msgstr "Open data categories"
 
 msgid "Utilize data sets"
 msgstr "Utilise datasets"
@@ -25314,7 +27599,7 @@ msgid "Browse data sets"
 msgstr "Browse datasets"
 
 msgid "Offer data for use"
-msgstr ""
+msgstr "Offer data for use"
 
 msgid ""
 "Does your organization generate data, which could be useful or interesting "
@@ -25324,7 +27609,7 @@ msgstr ""
 "for other users? We offer guidance and a way to distribute your datasets."
 
 msgid "Begin data distribution"
-msgstr ""
+msgstr "Begin data distribution"
 
 msgid "Find and examine applications"
 msgstr "Find and examine showcases"
@@ -25343,27 +27628,27 @@ msgstr "Showcase gallery"
 
 msgctxt "recently modified datasets"
 msgid "Recently modified"
-msgstr ""
+msgstr "Recently modified"
 
 msgctxt "new datasets"
 msgid "New"
-msgstr ""
+msgstr "New"
 
 msgctxt "popular datasets"
 msgid "Popular"
-msgstr ""
+msgstr "Popular"
 
 msgid "More recently modified datasets"
-msgstr ""
+msgstr "More recently modified datasets"
 
 msgid "Release date"
-msgstr ""
+msgstr "Release date"
 
 msgid "More new data sets"
-msgstr ""
+msgstr "More new data sets"
 
 msgid "More popular datasets"
-msgstr ""
+msgstr "More popular datasets"
 
 msgid ""
 "Central Open Data distribution platform for datasets released by finnish "
@@ -25373,106 +27658,106 @@ msgstr ""
 "Opendata.fi is a service for publishing and utilising open data for everyone."
 
 msgid "Service provided by Population Register Centre"
-msgstr ""
+msgstr "Service provided by Population Register Centre"
 
 msgid "Follow us"
-msgstr ""
+msgstr "Follow us"
 
 msgid "Updating translations for JavaScript and default configuration."
-msgstr ""
+msgstr "Updating translations for JavaScript and default configuration."
 
 msgid "Updated default configuration."
-msgstr ""
+msgstr "Updated default configuration."
 
 msgid "Finnish"
-msgstr ""
+msgstr "Finnish"
 
 msgid "Swedish"
-msgstr ""
+msgstr "Swedish"
 
 msgid "JavaScript"
-msgstr ""
+msgstr "JavaScript"
 
 msgid "Popovers"
-msgstr ""
+msgstr "Popovers"
 
 msgid "Tooltips"
-msgstr ""
+msgstr "Tooltips"
 
 msgid "Modals"
-msgstr ""
+msgstr "Modals"
 
 msgid "CDN (Content Delivery Network)"
-msgstr ""
+msgstr "CDN (Content Delivery Network)"
 
 msgid "Advanced Cache"
-msgstr ""
+msgstr "Advanced Cache"
 
 msgid "Custom URLs"
-msgstr ""
+msgstr "Custom URLs"
 
 msgid "Navbar"
-msgstr ""
+msgstr "Navbar"
 
 msgid "Region Wells"
-msgstr ""
+msgstr "Region Wells"
 
 msgid "Images"
-msgstr ""
+msgstr "Images"
 
 msgid "Container"
-msgstr ""
+msgstr "Container"
 
 msgid "Tables"
-msgstr ""
+msgstr "Tables"
 
 msgid "Etusivu"
-msgstr ""
+msgstr "Etusivu"
 
 msgid "Tietoaineistot"
-msgstr ""
+msgstr "Tietoaineistot"
 
 msgid "Organisaatiot"
-msgstr ""
+msgstr "Organisaatiot"
 
 msgid "Käyttösovellukset"
-msgstr ""
+msgstr "Käyttösovellukset"
 
 msgid "Ajankohtaista"
-msgstr ""
+msgstr "Ajankohtaista"
 
 msgid "Opas"
-msgstr ""
+msgstr "Opas"
 
 msgid "Lisää"
-msgstr ""
+msgstr "Lisää"
 
 msgid "Kirjaudu sisään"
-msgstr ""
+msgstr "Kirjaudu sisään"
 
 msgid "Rekisteröidy palveluun"
-msgstr ""
+msgstr "Rekisteröidy palveluun"
 
 msgid "Profiili"
-msgstr ""
+msgstr "Profiili"
 
 msgid "Kirjaudu ulos"
-msgstr ""
+msgstr "Kirjaudu ulos"
 
 msgid "Tapahtumakalenteri"
-msgstr ""
+msgstr "Tapahtumakalenteri"
 
 msgid "Avoindata.fi"
-msgstr ""
+msgstr "Avoindata.fi"
 
 msgid "All Finnish open data from one place."
-msgstr ""
+msgstr "All Finnish open data from one place."
 
 msgid "Show all"
-msgstr ""
+msgstr "Show all"
 
 msgid "Type what are you searching for"
-msgstr ""
+msgstr "Type what are you searching for"
 
 msgid ""
 "Avoindata.fi service offers over 1000 interesting data sets available for "
@@ -25482,7 +27767,7 @@ msgstr ""
 "everyone to download, inspect and use freely."
 
 msgid "Date modified"
-msgstr ""
+msgstr "Date modified"
 
 msgid "Most recent applications"
 msgstr "Most recent showcases"
@@ -25491,234 +27776,251 @@ msgid "Show all applications"
 msgstr "Show all showcases"
 
 msgid "Newsfeed"
-msgstr ""
+msgstr "Newsfeed"
 
 msgid "All News"
-msgstr ""
+msgstr "All News"
 
 msgid "Events"
-msgstr ""
+msgstr "Events"
 
 msgid "All Events"
-msgstr ""
+msgstr "All Events"
 
 msgid "Enter the password that accompanies your username."
-msgstr ""
+msgstr "Enter the password that accompanies your username."
 
 msgid "Register new account"
-msgstr ""
+msgstr "Register new account"
 
 msgid "Download feature"
-msgstr ""
+msgstr "Download feature"
 
 msgid "Add and configure"
-msgstr ""
+msgstr "Add and configure"
 
 msgid "Save and add"
-msgstr ""
+msgstr "Save and add"
 
 msgid "Update style"
-msgstr ""
+msgstr "Update style"
 
 msgid "Write"
-msgstr ""
+msgstr "Write"
 
 msgid "Restore"
-msgstr ""
+msgstr "Restore"
 
 msgid "Rebuild"
-msgstr ""
+msgstr "Rebuild"
 
 msgid "format"
-msgstr ""
+msgstr "format"
 
 msgid "Comment types"
-msgstr ""
+msgstr "Comment types"
 
 msgid "Form modes"
-msgstr ""
+msgstr "Form modes"
 
 msgid "Disqus"
-msgstr ""
+msgstr "Disqus"
 
 msgid "Date and time formats"
-msgstr ""
+msgstr "Date and time formats"
 
 msgid "Search API"
-msgstr ""
+msgstr "Search API"
 
 msgid "Metatag"
-msgstr ""
+msgstr "Metatag"
 
 msgid "Easy Breadcrumb"
-msgstr ""
+msgstr "Easy Breadcrumb"
 
 msgid "Text formats and editors"
-msgstr ""
+msgstr "Text formats and editors"
 
 msgid "Font Awesome Settings"
-msgstr ""
+msgstr "Font Awesome Settings"
 
 msgid "Honeypot configuration"
-msgstr ""
+msgstr "Honeypot configuration"
 
 msgid "CAPTCHA module settings"
-msgstr ""
+msgstr "CAPTCHA module settings"
 
 msgid "Field list"
-msgstr ""
+msgstr "Field list"
 
 msgid "Available translation updates"
-msgstr ""
+msgstr "Available translation updates"
 
 msgid "List and edit site comments and the comment approval queue."
-msgstr ""
+msgstr "List and edit site comments and the comment approval queue."
 
 msgid "Manage custom form modes."
-msgstr ""
+msgstr "Manage custom form modes."
 
 msgid "Manage tagging, categorization, and classification of your content."
-msgstr ""
+msgstr "Manage tagging, categorization, and classification of your content."
 
 msgid "Administer blocks, content types, menus, etc."
-msgstr ""
+msgstr "Administer blocks, content types, menus, etc."
 
 msgid "Administer how and where CAPTCHA is used."
-msgstr ""
+msgstr "Administer how and where CAPTCHA is used."
 
 msgid ""
 "Allow for site emails to be sent through an SMTP server of your choice."
 msgstr ""
+"Allow for site emails to be sent through an SMTP server of your choice."
 
 msgid ""
 "Configure tracking behavior to get insights into your website traffic and "
 "marketing effectiveness."
 msgstr ""
+"Configure tracking behavior to get insights into your website traffic and "
+"marketing effectiveness."
 
 msgid "Manage automatic site maintenance tasks."
-msgstr ""
+msgstr "Manage automatic site maintenance tasks."
 
 msgid "Configure basic site settings, actions, and cron."
-msgstr ""
+msgstr "Configure basic site settings, actions, and cron."
 
 msgid "Global settings for the display of Font Awesome icons."
-msgstr ""
+msgstr "Global settings for the display of Font Awesome icons."
 
 msgid ""
 "Configure Honeypot spam prevention and the forms on which Honeypot will be "
 "used."
 msgstr ""
+"Configure Honeypot spam prevention and the forms on which Honeypot will be "
+"used."
 
 msgid "Controls settings for the module Easy Breadcrumb"
-msgstr ""
+msgstr "Controls settings for the module Easy Breadcrumb"
 
 msgid ""
 "Choose which image toolkit to use if you have installed optional toolkits."
 msgstr ""
+"Choose which image toolkit to use if you have installed optional toolkits."
 
 msgid "Configure Metatag defaults."
-msgstr ""
+msgstr "Configure Metatag defaults."
 
 msgid "Create and configure search indexes and servers."
-msgstr ""
+msgstr "Create and configure search indexes and servers."
 
 msgid "Provides configuration options for the Disqus comment system."
-msgstr ""
+msgstr "Provides configuration options for the Disqus comment system."
 
 msgid ""
 "Get a status report about available interface translations for your "
 "installed modules and themes."
 msgstr ""
+"Get a status report about available interface translations for your "
+"installed modules and themes."
 
 msgid "Overview of plugins used in all views."
-msgstr ""
+msgstr "Overview of plugins used in all views."
 
 msgid "Profile"
-msgstr ""
+msgstr "Profile"
 
 msgid "Logout"
-msgstr ""
+msgstr "Logout"
 
 msgid "CustomMessage: !customMessage"
-msgstr ""
+msgstr "CustomMessage: !customMessage"
 
 msgid "Allows users to translate content entities."
-msgstr ""
+msgstr "Allows users to translate content entities."
 
 msgid "Tray @action."
-msgstr ""
+msgstr "Tray @action."
 
 msgid "!tour_item of !total"
-msgstr ""
+msgstr "!tour_item of !total"
 
 msgid "Random number generation"
-msgstr ""
+msgstr "Random number generation"
 
 msgid "Font Awesome 5"
-msgstr ""
+msgstr "Font Awesome 5"
 
 msgid "Trusted Host Settings"
-msgstr ""
+msgstr "Trusted Host Settings"
 
 msgid ""
 "External resources can be optimized automatically, which can reduce both the"
 " size and number of requests made to your website."
 msgstr ""
+"External resources can be optimized automatically, which can reduce both the"
+" size and number of requests made to your website."
 
 msgid "Configure page caching strategy with APE."
-msgstr ""
+msgstr "Configure page caching strategy with APE."
 
 msgid ""
 "The CAPTCHA module will disable the caching of pages that contain a CAPTCHA "
 "element."
 msgstr ""
+"The CAPTCHA module will disable the caching of pages that contain a CAPTCHA "
+"element."
 
 msgid ""
 "Drupal provides an <a href=\":module_enable\">Internal Page Cache module</a>"
 " that is recommended for small to medium-sized websites."
 msgstr ""
+"Drupal provides an <a href=\":module_enable\">Internal Page Cache module</a>"
+" that is recommended for small to medium-sized websites."
 
 msgid "CAPTCHA"
-msgstr ""
+msgstr "CAPTCHA"
 
 msgid "Aggregate CSS files"
-msgstr ""
+msgstr "Aggregate CSS files"
 
 msgid "The website encountered an unexpected error. Please try again later."
-msgstr ""
+msgstr "The website encountered an unexpected error. Please try again later."
 
 msgid ""
 "The toolbar cannot be set to a horizontal orientation when it is locked."
 msgstr ""
+"The toolbar cannot be set to a horizontal orientation when it is locked."
 
 msgid "@label"
-msgstr ""
+msgstr "@label"
 
 msgid "System maintenance"
-msgstr ""
+msgstr "System maintenance"
 
 msgid "System information"
-msgstr ""
+msgstr "System information"
 
 msgid ""
 "This page lists all configuration items on your site that have translatable "
 "text, like your site name, role names, etc."
 msgstr ""
+"This page lists all configuration items on your site that have translatable "
+"text, like your site name, role names, etc."
 
 msgid "Horizontal orientation"
-msgstr ""
+msgstr "Horizontal orientation"
 
 msgid "Tray \"@tray\" @action."
-msgstr ""
+msgstr "Tray \"@tray\" @action."
 
 msgid "Leave blank to show all strings. The search is case sensitive."
-msgstr ""
+msgstr "Leave blank to show all strings. The search is case sensitive."
 
 msgid "Go to page @key"
-msgstr ""
+msgstr "Go to page @key"
 
 msgid "Provides Drush commands for language manipulation"
-msgstr ""
+msgstr "Provides Drush commands for language manipulation"
 
 msgid ""
 "This page allows a translator to search for specific translated and "
@@ -25729,12 +28031,19 @@ msgid ""
 " translation editor.) Searches may be limited to strings in a specific "
 "language."
 msgstr ""
+"This page allows a translator to search for specific translated and "
+"untranslated strings, and is used when creating or editing translations. "
+"(Note: Because translation tasks involve many strings, it may be more "
+"convenient to <a title=\"User interface translation export\" "
+"href=\":export\">export</a> strings for offline editing in a desktop Gettext"
+" translation editor.) Searches may be limited to strings in a specific "
+"language."
 
 msgid "Source text only, no translations"
-msgstr ""
+msgstr "Source text only, no translations"
 
 msgid "Interface translation export"
-msgstr ""
+msgstr "Interface translation export"
 
 msgid ""
 "This page exports the translated strings used by your site. An export file "
@@ -25744,224 +28053,271 @@ msgid ""
 "includes the original strings only (used to create new translations with a "
 "Gettext translation editor)."
 msgstr ""
+"This page exports the translated strings used by your site. An export file "
+"may be in Gettext Portable Object (<em>.po</em>) form, which includes both "
+"the original string and the translation (used to share translations with "
+"others), or in Gettext Portable Object Template (<em>.pot</em>) form, which "
+"includes the original strings only (used to create new translations with a "
+"Gettext translation editor)."
 
 msgid ""
 "There was a problem checking <a href=\":update-report\">available "
 "updates</a> for Drupal."
 msgstr ""
+"There was a problem checking <a href=\":update-report\">available "
+"updates</a> for Drupal."
 
 msgid "Tuottajat"
-msgstr ""
+msgstr "Tuottajat"
 
 msgid "Field storage"
-msgstr ""
+msgstr "Field storage"
 
 msgid "Performance and scalability"
-msgstr ""
+msgstr "Performance and scalability"
 
 msgid "Examples"
-msgstr ""
+msgstr "Examples"
 
 msgid "Chaos tool suite (Experimental)"
-msgstr ""
+msgstr "Chaos tool suite (Experimental)"
 
 msgid "Enter a part of the module name or description"
-msgstr ""
+msgstr "Enter a part of the module name or description"
 
 msgid ""
 "Machine name: <span dir=\"ltr\" class=\"table-filter-text-source\">@machine-"
 "name</span>"
 msgstr ""
+"Machine name: <span dir=\"ltr\" class=\"table-filter-text-source\">@machine-"
+"name</span>"
 
 msgid ""
 "Aggregates syndicated content (RSS, RDF, and Atom feeds) from external "
 "sources."
 msgstr ""
+"Aggregates syndicated content (RSS, RDF, and Atom feeds) from external "
+"sources."
 
 msgid ""
 "Provides an automated way to run cron jobs, by executing them at the end of "
 "a server response."
 msgstr ""
+"Provides an automated way to run cron jobs, by executing them at the end of "
+"a server response."
 
 msgid "Configure <span class=\"visually-hidden\">the @module module</span>"
-msgstr ""
+msgstr "Configure <span class=\"visually-hidden\">the @module module</span>"
 
 msgid ""
 "Sends pages using the BigPipe technique that allows browsers to show them "
 "much faster."
 msgstr ""
+"Sends pages using the BigPipe technique that allows browsers to show them "
+"much faster."
 
 msgid ""
 "Controls the visual building blocks a page is constructed with. Blocks are "
 "boxes of content rendered into an area, or region, of a web page."
 msgstr ""
+"Controls the visual building blocks a page is constructed with. Blocks are "
+"boxes of content rendered into an area, or region, of a web page."
 
 msgid "Manage breakpoints and breakpoint groups for responsive designs."
-msgstr ""
+msgstr "Manage breakpoints and breakpoint groups for responsive designs."
 
 msgid "Allows administrators to manage configuration changes."
-msgstr ""
+msgstr "Allows administrators to manage configuration changes."
 
 msgid "Provides moderation states for content."
-msgstr ""
+msgstr "Provides moderation states for content."
 
 msgid "Allows administrators to create custom menu links."
-msgstr ""
+msgstr "Allows administrators to create custom menu links."
 
 msgid "Records which user has read which content."
-msgstr ""
+msgstr "Records which user has read which content."
 
 msgid ""
 "Places error messages adjacent to form inputs, for improved usability and "
 "accessibility."
 msgstr ""
+"Places error messages adjacent to form inputs, for improved usability and "
+"accessibility."
 
 msgid "Caches pages for any user, handling dynamic content correctly."
-msgstr ""
+msgstr "Caches pages for any user, handling dynamic content correctly."
 
 msgid ""
 "Caches pages for anonymous users. Use when an external page cache is not "
 "available."
 msgstr ""
+"Caches pages for anonymous users. Use when an external page cache is not "
+"available."
 
 msgid ""
 "Allows users to add and arrange blocks and content fields directly on the "
 "content."
 msgstr ""
+"Allows users to add and arrange blocks and content fields directly on the "
+"content."
 
 msgid "Provides a way for modules or themes to register layouts."
-msgstr ""
+msgstr "Provides a way for modules or themes to register layouts."
 
 msgid "Manages the creation, configuration, and display of media items."
-msgstr ""
+msgstr "Manages the creation, configuration, and display of media items."
 
 msgid ""
 "Enriches your content with metadata to let other applications (e.g. search "
 "engines, aggregators) better understand its relationships and attributes."
 msgstr ""
+"Enriches your content with metadata to let other applications (e.g. search "
+"engines, aggregators) better understand its relationships and attributes."
 
 msgid ""
 "Allows users to directly edit the configuration of blocks on the current "
 "page."
 msgstr ""
+"Allows users to directly edit the configuration of blocks on the current "
+"page."
 
 msgid "Logs content statistics for your site."
-msgstr ""
+msgstr "Logs content statistics for your site."
 
 msgid ""
 "Provides a means to associate text formats with text editor libraries such "
 "as WYSIWYGs or toolbars."
 msgstr ""
+"Provides a means to associate text formats with text editor libraries such "
+"as WYSIWYGs or toolbars."
 
 msgid ""
 "Provides a toolbar that shows the top-level administration menu items and "
 "links from other modules."
 msgstr ""
+"Provides a toolbar that shows the top-level administration menu items and "
+"links from other modules."
 
 msgid "Create customized lists and queries from your database."
-msgstr ""
+msgstr "Create customized lists and queries from your database."
 
 msgid ""
 "Provides UI and API for managing workflows. This module can be used with the"
 " Content moderation module to add highly customizable workflows to content."
 msgstr ""
+"Provides UI and API for managing workflows. This module can be used with the"
+" Content moderation module to add highly customizable workflows to content."
 
 msgid ""
 "Provides a number of utility and helper APIs for Drupal developers and site "
 "builders."
 msgstr ""
+"Provides a number of utility and helper APIs for Drupal developers and site "
+"builders."
 
 msgid ""
 "Provides improvements to blocks that will one day be added to Drupal core."
 msgstr ""
+"Provides improvements to blocks that will one day be added to Drupal core."
 
 msgid ""
 "A set of improvements to the core Views code that allows for greater control"
 " over Blocks."
 msgstr ""
+"A set of improvements to the core Views code that allows for greater control"
+" over Blocks."
 
 msgid ""
 "Allows users to configure the display and form display by arranging fields "
 "in several columns."
 msgstr ""
+"Allows users to configure the display and form display by arranging fields "
+"in several columns."
 
 msgid ""
 "Enhances the media list with additional features to more easily find and use"
 " existing media items."
 msgstr ""
+"Enhances the media list with additional features to more easily find and use"
+" existing media items."
 
 msgid "Provides a requirement for multilingual migrations."
-msgstr ""
+msgstr "Provides a requirement for multilingual migrations."
 
 msgid ""
 "Allows users to stage content or preview a full site by using multiple "
 "workspaces on a single site."
 msgstr ""
+"Allows users to stage content or preview a full site by using multiple "
+"workspaces on a single site."
 
 msgid "Creates app feed component"
-msgstr ""
+msgstr "Creates app feed component"
 
 msgid "Shows Articles page"
-msgstr ""
+msgstr "Shows Articles page"
 
 msgid "Creates categories component"
-msgstr ""
+msgstr "Creates categories component"
 
 msgid "Creates dataset list component"
-msgstr ""
+msgstr "Creates dataset list component"
 
 msgid "Shows Events page"
-msgstr ""
+msgstr "Shows Events page"
 
 msgid "Creates footer component"
-msgstr ""
+msgstr "Creates footer component"
 
 msgid "Manages the guide and its menu"
-msgstr ""
+msgstr "Manages the guide and its menu"
 
 msgid "Creates a header"
-msgstr ""
+msgstr "Creates a header"
 
 msgid "Creates a hero component"
-msgstr ""
+msgstr "Creates a hero component"
 
 msgid "Creates infobox component"
-msgstr ""
+msgstr "Creates infobox component"
 
 msgid "Creates news feed component"
-msgstr ""
+msgstr "Creates news feed component"
 
 msgid "Creates servicemessage component"
-msgstr ""
+msgstr "Creates servicemessage component"
 
 msgid "Modifies user validation"
-msgstr ""
+msgstr "Modifies user validation"
 
 msgid "Examples of how Drupal 8 migration compares to previous versions."
-msgstr ""
+msgstr "Examples of how Drupal 8 migration compares to previous versions."
 
 msgid "Specialized examples of Drupal 8 migration."
-msgstr ""
+msgstr "Specialized examples of Drupal 8 migration."
 
 msgid "Simple JSON Migration example"
-msgstr ""
+msgstr "Simple JSON Migration example"
 
 msgid "Defines datetime form elements and a datetime field type."
-msgstr ""
+msgstr "Defines datetime form elements and a datetime field type."
 
 msgid "Provides the ability to store end dates."
-msgstr ""
+msgstr "Provides the ability to store end dates."
 
 msgid "Defines an image field type and provides image manipulation tools."
-msgstr ""
+msgstr "Defines an image field type and provides image manipulation tools."
 
 msgid "Provides a simple link field type."
-msgstr ""
+msgstr "Provides a simple link field type."
 
 msgid ""
 "Offers an implementation of the Search API that uses database tables for "
 "indexing content."
 msgstr ""
+"Offers an implementation of the Search API that uses database tables for "
+"indexing content."
 
 msgid ""
 "Enable this module for a best-practice default setup of Search API with the "
@@ -25969,82 +28325,91 @@ msgid ""
 "module again for performance reasons. The provided configuration will not be"
 " removed."
 msgstr ""
+"Enable this module for a best-practice default setup of Search API with the "
+"Database backend. After installation it is recommended to uninstall this "
+"module again for performance reasons. The provided configuration will not be"
+" removed."
 
 msgid "Provides a generic framework for modules offering search capabilities."
 msgstr ""
+"Provides a generic framework for modules offering search capabilities."
 
 msgid "Drush support for direct upgrades from older Drupal versions."
-msgstr ""
+msgstr "Drush support for direct upgrades from older Drupal versions."
 
 msgid "Handles migrations"
-msgstr ""
+msgstr "Handles migrations"
 
 msgid "Contains migrations from older Drupal versions."
-msgstr ""
+msgstr "Contains migrations from older Drupal versions."
 
 msgid "Provides a user interface for migrating from older Drupal versions."
-msgstr ""
+msgstr "Provides a user interface for migrating from older Drupal versions."
 
 msgid "Enhancements to core migration support"
-msgstr ""
+msgstr "Enhancements to core migration support"
 
 msgid "Tools to assist in developing and running migrations."
-msgstr ""
+msgstr "Tools to assist in developing and running migrations."
 
 msgid "Provides a translation interface for configuration."
-msgstr ""
+msgstr "Provides a translation interface for configuration."
 
 msgid "Uses the Disqus web service to enhance comments."
-msgstr ""
+msgstr "Uses the Disqus web service to enhance comments."
 
 msgid "Provides configurable path based breadcrumbs."
-msgstr ""
+msgstr "Provides configurable path based breadcrumbs."
 
 msgid ""
 "Allows an entity type to borrow the fields and display configuration of "
 "another entity type."
 msgstr ""
+"Allows an entity type to borrow the fields and display configuration of "
+"another entity type."
 
 msgid "The most popular icon set and toolkit on the web."
-msgstr ""
+msgstr "The most popular icon set and toolkit on the web."
 
 msgid "Adds a Font Awesome Media Entity Type."
-msgstr ""
+msgstr "Adds a Font Awesome Media Entity Type."
 
 msgid "Allows version-dependent and shared usage of external libraries."
-msgstr ""
+msgstr "Allows version-dependent and shared usage of external libraries."
 
 msgid "Allows users to redirect from old URLs to new URLs."
-msgstr ""
+msgstr "Allows users to redirect from old URLs to new URLs."
 
 msgid ""
 "Logs 404 errors and allows users to create redirects for often requested but"
 " missing pages."
 msgstr ""
+"Logs 404 errors and allows users to create redirects for often requested but"
+" missing pages."
 
 msgid "Allows users to redirect between domains."
-msgstr ""
+msgstr "Allows users to redirect between domains."
 
 msgid "Twig filters for value(s) and label."
-msgstr ""
+msgstr "Twig filters for value(s) and label."
 
 msgid "Provides some extra Twig functions and filters."
-msgstr ""
+msgstr "Provides some extra Twig functions and filters."
 
 msgid "Allows finer control of the Cache Control header."
-msgstr ""
+msgstr "Allows finer control of the Cache Control header."
 
 msgid "Adds endpoints and functionality for testing ape."
-msgstr ""
+msgstr "Adds endpoints and functionality for testing ape."
 
 msgid "Manage meta tags for all entities."
-msgstr ""
+msgstr "Manage meta tags for all entities."
 
 msgid "Provides metatag support for Page Manager variants."
-msgstr ""
+msgstr "Provides metatag support for Page Manager variants."
 
 msgid "Provides support for applinks.org meta tags."
-msgstr ""
+msgstr "Provides support for applinks.org meta tags."
 
 msgid ""
 "Provides the fifteen <a "
@@ -26052,130 +28417,156 @@ msgid ""
 "Set 1.1</a> meta tags from the <a href=\"http://dublincore.org/\">Dublin "
 "Core Metadata Institute</a>."
 msgstr ""
+"Provides the fifteen <a "
+"href=\"http://dublincore.org/documents/dces/\">Dublin Core Metadata Element "
+"Set 1.1</a> meta tags from the <a href=\"http://dublincore.org/\">Dublin "
+"Core Metadata Institute</a>."
 
 msgid ""
 "Provides forty additional meta tags from the <a "
 "href=\"http://dublincore.org/\">Dublin Core Metadata Institute</a>."
 msgstr ""
+"Provides forty additional meta tags from the <a "
+"href=\"http://dublincore.org/\">Dublin Core Metadata Institute</a>."
 
 msgid ""
 "A set of meta tags specially for controlling advanced functionality with "
 "Facebook."
 msgstr ""
+"A set of meta tags specially for controlling advanced functionality with "
+"Facebook."
 
 msgid "Provides support for many different favicons."
-msgstr ""
+msgstr "Provides support for many different favicons."
 
 msgid "Provides support for meta tags used for Google Custom Search Engine."
-msgstr ""
+msgstr "Provides support for meta tags used for Google Custom Search Engine."
 
 msgid "Provides support for Google's Plus meta tags."
-msgstr ""
+msgstr "Provides support for Google's Plus meta tags."
 
 msgid ""
 "Provides support for the hreflang meta tag with some extra logic to simplify"
 " it."
 msgstr ""
+"Provides support for the hreflang meta tag with some extra logic to simplify"
+" it."
 
 msgid ""
 "Provides support for meta tags used to control the mobile browser "
 "experience."
 msgstr ""
+"Provides support for meta tags used to control the mobile browser "
+"experience."
 
 msgid "Provides support for Open Graph Protocol meta tags."
-msgstr ""
+msgstr "Provides support for Open Graph Protocol meta tags."
 
 msgid ""
 "Provides additional Open Graph Protocol meta tags for describing products."
 msgstr ""
+"Provides additional Open Graph Protocol meta tags for describing products."
 
 msgid "Provides support for Pinterest's custom meta tags."
-msgstr ""
+msgstr "Provides support for Pinterest's custom meta tags."
 
 msgid "Provides support for Twitter's Card meta tags."
-msgstr ""
+msgstr "Provides support for Twitter's Card meta tags."
 
 msgid "Verifies ownership of a site for search engines and other services."
-msgstr ""
+msgstr "Verifies ownership of a site for search engines and other services."
 
 msgid "Provides views integration for metatags."
-msgstr ""
+msgstr "Provides views integration for metatags."
 
 msgid "Provides the CAPTCHA API for adding challenges to arbitrary forms."
-msgstr ""
+msgstr "Provides the CAPTCHA API for adding challenges to arbitrary forms."
 
 msgid "Mitigates spam form submissions using the honeypot method."
-msgstr ""
+msgstr "Mitigates spam form submissions using the honeypot method."
 
 msgid "Provides an image based CAPTCHA."
-msgstr ""
+msgstr "Provides an image based CAPTCHA."
 
 msgid ""
 "Protect your website from spam and abuse while letting real people pass "
 "through with ease."
 msgstr ""
+"Protect your website from spam and abuse while letting real people pass "
+"through with ease."
 
 msgid "FontAwesome Menu Icons"
-msgstr ""
+msgstr "FontAwesome Menu Icons"
 
 msgid "Serializes entities using Hypertext Application Language."
-msgstr ""
+msgstr "Serializes entities using Hypertext Application Language."
 
 msgid "Provides the HTTP Basic authentication provider"
-msgstr ""
+msgstr "Provides the HTTP Basic authentication provider"
 
 msgid "Exposes entities as a JSON:API-specification-compliant web API."
-msgstr ""
+msgstr "Exposes entities as a JSON:API-specification-compliant web API."
 
 msgid "Exposes entities and other resources as RESTful web API"
-msgstr ""
+msgstr "Exposes entities and other resources as RESTful web API"
 
 msgid ""
 "Provides a service for (de)serializing data to/from formats such as JSON and"
 " XML"
 msgstr ""
+"Provides a service for (de)serializing data to/from formats such as JSON and"
+" XML"
 
 msgid ""
 "Regularly review and install <a href=\":updates\">available updates</a> to "
 "maintain a secure and current site. Always run the <a href=\":update-"
 "php\">update script</a> each time a module is updated."
 msgstr ""
+"Regularly review and install <a href=\":updates\">available updates</a> to "
+"maintain a secure and current site. Always run the <a href=\":update-"
+"php\">update script</a> each time a module is updated."
 
 msgid "Disqus comment"
-msgstr ""
+msgstr "Disqus comment"
 
 msgid ""
 "Provides a filter plugin that is in use in the following filter formats: "
 "%formats"
 msgstr ""
+"Provides a filter plugin that is in use in the following filter formats: "
+"%formats"
 
 msgid "content items"
-msgstr ""
+msgstr "content items"
 
 msgid "shortcut links"
-msgstr ""
+msgstr "shortcut links"
 
 msgid ""
 "The following modules will be completely uninstalled from your site, and "
 "<em>all data from these modules will be lost</em>!"
 msgstr ""
+"The following modules will be completely uninstalled from your site, and "
+"<em>all data from these modules will be lost</em>!"
 
 msgid "!modules modules are available in the modified list."
-msgstr ""
+msgstr "!modules modules are available in the modified list."
 
 msgid "Applicationsasd"
-msgstr ""
+msgstr "Applicationsasd"
 
 msgid "News"
-msgstr ""
+msgstr "News"
 
 msgid "The callback URL is not local and not trusted: !url"
-msgstr ""
+msgstr "The callback URL is not local and not trusted: !url"
 
 msgid "Show all columns"
-msgstr ""
+msgstr "Show all columns"
 
 msgid ""
 "Show table cells that were hidden to make the table fit within a small "
 "screen."
 msgstr ""
+"Show table cells that were hidden to make the table fit within a small "
+"screen."

--- a/ansible/roles/drupal/files/i18n/fi/drupal8.po
+++ b/ansible/roles/drupal/files/i18n/fi/drupal8.po
@@ -25,271 +25,273 @@ msgid "Next"
 msgstr "Seuraava"
 
 msgid "Pages"
-msgstr ""
+msgstr "Sivut"
 
 msgid "delete"
-msgstr ""
+msgstr "poista"
 
 msgid "Create a new user account."
-msgstr ""
+msgstr "Luo uusi käyttäjätili."
 
 msgid "Markup"
-msgstr ""
+msgstr "Markup"
 
 msgid "Prefix"
-msgstr ""
+msgstr "Etuliite"
 
 msgid "Suffix"
-msgstr ""
+msgstr "Jälkiliite"
 
 msgid "Approve"
-msgstr ""
+msgstr "Hyväksy"
 
 msgid "Moderated content"
-msgstr ""
+msgstr "Moderoitu sisältö"
 
 msgid "Attribute"
-msgstr ""
+msgstr "Attribuutti"
 
 msgid "Groups"
-msgstr ""
+msgstr "Ryhmät"
 
 msgid "Group"
-msgstr ""
+msgstr "Ryhmä"
 
 msgid "Replies"
-msgstr ""
+msgstr "Vastaukset"
 
 msgid "Closed"
-msgstr ""
+msgstr "Suljettu"
 
 msgid "yes"
 msgstr "kyllä"
 
 msgid "Send email"
-msgstr ""
+msgstr "Lähetä sähköposti"
 
 msgid "Actions"
-msgstr ""
+msgstr "Toimenpiteet"
 
 msgid "disabled"
-msgstr ""
+msgstr "ei käytössä"
 
 msgid "Last comment"
-msgstr ""
+msgstr "Viimeisin kommentti"
 
 msgid "Enable"
-msgstr ""
+msgstr "Ota käyttöön"
 
 msgid "Disable"
-msgstr ""
+msgstr "Poista käytöstä"
 
 msgid "Explanation or submission guidelines"
-msgstr ""
+msgstr "Selitys tai ohjeet"
 
 msgid "Email settings"
-msgstr ""
+msgstr "Sähköpostiasetukset"
 
 msgid "Disabled"
-msgstr ""
+msgstr "Ei käytössä"
 
 msgid "Articles"
-msgstr ""
+msgstr "Artikkelit"
 
 msgid "footer"
-msgstr ""
+msgstr "alatunniste"
 
 msgid "not verified"
-msgstr ""
+msgstr "ei varmistettu"
 
 msgid "Last updated"
 msgstr "Viimeksi päivitetty"
 
 msgid "For"
-msgstr ""
+msgstr "&nbsp;"
 
 msgid "new"
-msgstr ""
+msgstr "uudet"
 
 msgid "Block title"
-msgstr ""
+msgstr "Lohkon otsikko"
 
 msgid "The title of the block as shown to the user."
-msgstr ""
+msgstr "Lohkon otsikko sellaisena kuin se näytetään käyttäjille."
 
 msgid "Logging"
-msgstr ""
+msgstr "Lokit"
 
 msgid "Yes"
-msgstr ""
+msgstr "Kyllä"
 
 msgid "No"
-msgstr ""
+msgstr "Ei"
 
 msgid "Homepage"
-msgstr ""
+msgstr "Kotisivu"
 
 msgid "Version"
-msgstr ""
+msgstr "Versio"
 
 msgid "view"
-msgstr ""
+msgstr "näkymä"
 
 msgid "unpublished"
-msgstr ""
+msgstr "julkaisematon"
 
 msgid "updated"
-msgstr ""
+msgstr "päivitetty"
 
 msgid "Overview"
-msgstr ""
+msgstr "Yleiskatsaus"
 
 msgid "File information"
-msgstr ""
+msgstr "Tiedoston tiedot"
 
 msgid "Tag"
-msgstr ""
+msgstr "Tagi"
 
 msgid "File path"
-msgstr ""
+msgstr "Tiedostopolku"
 
 msgid "Release notes"
-msgstr ""
+msgstr "Julkaisutiedote"
 
 msgid "Links"
 msgstr "Linkit"
 
 msgid "Daily"
-msgstr ""
+msgstr "Päivittäin"
 
 msgid "Weekly"
-msgstr ""
+msgstr "Viikoittain"
 
 msgid "Monthly"
-msgstr ""
+msgstr "Kuukausittain"
 
 msgid "None"
 msgstr "Ei mitään"
 
 msgid "Display settings"
-msgstr ""
+msgstr "Näyttöasetukset"
 
 msgid "This action cannot be undone."
-msgstr ""
+msgstr "Tätä toimintoa ei voi perua."
 
 msgid "Test"
-msgstr ""
+msgstr "Testi"
 
 msgid "Block settings"
-msgstr ""
+msgstr "Lohkon asetukset"
 
 msgid "- None -"
-msgstr ""
+msgstr "- Ei mikään -"
 
 msgid "Country"
-msgstr ""
+msgstr "Maa"
 
 msgid "Center"
-msgstr ""
+msgstr "Keskellä"
 
 msgid "Help text"
-msgstr ""
+msgstr "Ohjeteksti"
 
 msgid "Types"
-msgstr ""
+msgstr "Tyypit"
 
 msgid "Multiple"
-msgstr ""
+msgstr "Monivalinta"
 
 msgid "Required"
-msgstr ""
+msgstr "Pakollinen"
 
 msgid "root"
-msgstr ""
+msgstr "juuri"
 
 msgid "Pages at a given level are ordered first by weight and then by title."
 msgstr ""
+"Kunkin tason sivut järjestetään ensimmäiseksi painon ja  sen jälkeen otsikon"
+" perusteella."
 
 msgid "Depth"
-msgstr ""
+msgstr "Syvyys"
 
 msgid "none"
 msgstr "ei mitään"
 
 msgid "Category"
-msgstr ""
+msgstr "Kategoria"
 
 msgid "Add container"
-msgstr ""
+msgstr "Lisää sisältäjä"
 
 msgid "edit container"
-msgstr ""
+msgstr "muokkaa säiliötä"
 
 msgid "edit"
-msgstr ""
+msgstr "muokkaa"
 
 msgid "Go to previous page"
 msgstr "Edellinen sivu"
 
 msgid "Go to parent page"
-msgstr ""
+msgstr "Mene yläsivulle"
 
 msgid "Book"
-msgstr ""
+msgstr "Kirja"
 
 msgid "Description field"
-msgstr ""
+msgstr "Kuvauskenttä"
 
 msgid "settings"
-msgstr ""
+msgstr "asetukset"
 
 msgid "Back"
-msgstr ""
+msgstr "Takaisin"
 
 msgid "Node ID"
-msgstr ""
+msgstr "Node ID"
 
 msgid "Outline"
-msgstr ""
+msgstr "Hierarkia"
 
 msgid "header"
-msgstr ""
+msgstr "ylätunniste"
 
 msgid "Session opened for %name."
-msgstr ""
+msgstr "Istunto avattu tunnukselle %name."
 
 msgid "Image settings"
-msgstr ""
+msgstr "Kuva-asetukset"
 
 msgid "True"
-msgstr ""
+msgstr "Tosi"
 
 msgid "False"
-msgstr ""
+msgstr "Epätosi"
 
 msgid "Move"
-msgstr ""
+msgstr "Siirrä"
 
 msgid "Open"
-msgstr ""
+msgstr "Avoin"
 
 msgid "Blank"
-msgstr ""
+msgstr "Tyhjä"
 
 msgid "Tags"
 msgstr "Tunnisteet"
 
 msgid "Forms"
-msgstr ""
+msgstr "Lomakkeet"
 
 msgid "On"
-msgstr ""
+msgstr "On"
 
 msgid "Body"
-msgstr ""
+msgstr "Body"
 
 msgid "Language"
-msgstr ""
+msgstr "Language"
 
 msgid "Comments"
 msgstr "Kommentit"
@@ -298,22 +300,22 @@ msgid "Article"
 msgstr "Artikkeli"
 
 msgid "Default"
-msgstr ""
+msgstr "Default"
 
 msgid "Administration"
-msgstr ""
+msgstr "Administration"
 
 msgid "Register"
 msgstr "Rekisteröidy"
 
 msgid "Taxonomy term"
-msgstr ""
+msgstr "Taxonomy term"
 
 msgid "Feed"
-msgstr ""
+msgstr "Feed"
 
 msgid "Action"
-msgstr ""
+msgstr "Action"
 
 msgid "Subject"
 msgstr "Aihe"
@@ -337,28 +339,28 @@ msgid "Name"
 msgstr "Nimi"
 
 msgid "Use count"
-msgstr ""
+msgstr "Use count"
 
 msgid "Title"
-msgstr ""
+msgstr "Title"
 
 msgid "Operations"
-msgstr ""
+msgstr "Operations"
 
 msgid "more"
-msgstr ""
+msgstr "more"
 
 msgid "Type"
-msgstr ""
+msgstr "Type"
 
 msgid "File"
-msgstr ""
+msgstr "Tiedosto"
 
 msgid "Username"
 msgstr "Käyttäjätunnus"
 
 msgid "List"
-msgstr ""
+msgstr "List"
 
 msgid "Preview"
 msgstr "Esikatselu"
@@ -370,22 +372,22 @@ msgid "user"
 msgstr "käyttäjä"
 
 msgid "Content"
-msgstr ""
+msgstr "Content"
 
 msgid "Go to next page"
 msgstr "Seuraava sivu"
 
 msgid "Label"
-msgstr ""
+msgstr "Label"
 
 msgid "Advanced options"
-msgstr ""
+msgstr "Advanced options"
 
 msgid "Weight"
-msgstr ""
+msgstr "Paino"
 
 msgid "Link"
-msgstr ""
+msgstr "Linkki"
 
 msgid "Search"
 msgstr "Haku"
@@ -397,55 +399,55 @@ msgid "Password"
 msgstr "Salasana"
 
 msgid "Save configuration"
-msgstr ""
+msgstr "Tallenna asetukset"
 
 msgid "Confirm"
-msgstr ""
+msgstr "Vahvista"
 
 msgid "Settings"
-msgstr ""
+msgstr "Asetukset"
 
 msgid "Delete"
-msgstr ""
+msgstr "Poista"
 
 msgid "Remove"
-msgstr ""
+msgstr "Poista"
 
 msgid "Export"
-msgstr ""
+msgstr "Vie"
 
 msgid "Import"
-msgstr ""
+msgstr "Tuo"
 
 msgid "Update"
-msgstr ""
+msgstr "Päivitys"
 
 msgid "Download"
-msgstr ""
+msgstr "Lataa"
 
 msgid "Edit"
 msgstr "Muokkaa"
 
 msgid "Cancel"
-msgstr ""
+msgstr "Peruuta"
 
 msgid "Taxonomy"
-msgstr ""
+msgstr "Luokittelu"
 
 msgid "Development"
-msgstr ""
+msgstr "Kehitys"
 
 msgid "User interface"
-msgstr ""
+msgstr "Käyttöliittymä"
 
 msgid "The configuration options have been saved."
-msgstr ""
+msgstr "Asetusten muutokset tallennettu."
 
 msgid "closed"
-msgstr ""
+msgstr "suljettu"
 
 msgid "Field"
-msgstr ""
+msgstr "Kenttä"
 
 msgid "Home"
 msgstr "Etusivu"
@@ -457,319 +459,319 @@ msgid "Saturday"
 msgstr "lauantai"
 
 msgid "High"
-msgstr ""
+msgstr "Korkein"
 
 msgid "Low"
-msgstr ""
+msgstr "Alin"
 
 msgid "Album"
-msgstr ""
+msgstr "Albumi"
 
 msgid "Artist"
-msgstr ""
+msgstr "Artisti"
 
 msgid "Add new"
-msgstr ""
+msgstr "Lisää uusi"
 
 msgid "Time"
-msgstr ""
+msgstr "Aika"
 
 msgid "Access"
-msgstr ""
+msgstr "Pääsy"
 
 msgid "View"
-msgstr ""
+msgstr "Näytä"
 
 msgid "Length"
-msgstr ""
+msgstr "Pituus"
 
 msgid "Format"
 msgstr "Muoto"
 
 msgid "History"
-msgstr ""
+msgstr "Historia"
 
 msgid "hidden"
-msgstr ""
+msgstr "piilotettu"
 
 msgid "File extensions"
-msgstr ""
+msgstr "Tiedostopäätteet"
 
 msgid "Modules"
-msgstr ""
+msgstr "Moduulit"
 
 msgid "Clear index"
-msgstr ""
+msgstr "Tyhjennä indeksi"
 
 msgid "General discussion"
-msgstr ""
+msgstr "Yleinen keskustelu"
 
 msgid "edit forum"
-msgstr ""
+msgstr "muokkaa foorumia"
 
 msgid "Forum name"
-msgstr ""
+msgstr "Foorumin nimi"
 
 msgid "forum"
-msgstr ""
+msgstr "foorumi"
 
 msgid "Refresh"
-msgstr ""
+msgstr "Päivitä"
 
 msgid "Region"
-msgstr ""
+msgstr "Alue"
 
 msgid "link"
-msgstr ""
+msgstr "linkki"
 
 msgid "Anchor"
-msgstr ""
+msgstr "Ankkuri"
 
 msgid "Display"
-msgstr ""
+msgstr "Näyttö"
 
 msgid "Advanced settings"
-msgstr ""
+msgstr "Edistyneet asetukset"
 
 msgid "GUID"
-msgstr ""
+msgstr "GUID"
 
 msgid "never"
-msgstr ""
+msgstr "ei koskaan"
 
 msgid "actions"
-msgstr ""
+msgstr "toimenpiteet"
 
 msgid "Theme"
-msgstr ""
+msgstr "Teema"
 
 msgid "Layout"
-msgstr ""
+msgstr "Ulkoasu"
 
 msgid "Select a layout"
-msgstr ""
+msgstr "Valitse taitto"
 
 msgid "aggregator"
-msgstr ""
+msgstr "syötteiden kerääjä"
 
 msgid "Update interval"
-msgstr ""
+msgstr "Päivitysväli"
 
 msgid "The fully-qualified URL of the feed."
-msgstr ""
+msgstr "Syötteen kokonainen osoite."
 
 msgid "Add forum"
-msgstr ""
+msgstr "Lisää foorumi"
 
 msgid "Add term"
-msgstr ""
+msgstr "Lisää termi"
 
 msgid "Search keywords"
-msgstr ""
+msgstr "Hakusanat"
 
 msgid "Timestamp"
-msgstr ""
+msgstr "Ajankohta"
 
 msgid "Keywords"
-msgstr ""
+msgstr "Avainsanat"
 
 msgid "Search Keywords"
-msgstr ""
+msgstr "Hakusanat"
 
 msgid "Preview comment"
-msgstr ""
+msgstr "Esikatsele kommenttia"
 
 msgid "Component"
-msgstr ""
+msgstr "Komponentti"
 
 msgid "Advanced search"
-msgstr ""
+msgstr "Tarkempi haku"
 
 msgid "You are not authorized to access this page."
-msgstr ""
+msgstr "Sinulla ei ole käyttöoikeuksia tälle sivulle."
 
 msgid "Unknown"
 msgstr "Tuntematon"
 
 msgid "States"
-msgstr ""
+msgstr "Tilat"
 
 msgid "n/a"
-msgstr ""
+msgstr "ei mitään"
 
 msgid "Upload image"
-msgstr ""
+msgstr "Lataa kuva"
 
 msgid "Taxonomy settings"
-msgstr ""
+msgstr "Luokittelun asetukset"
 
 msgid "Before"
-msgstr ""
+msgstr "Ennen"
 
 msgid "After"
-msgstr ""
+msgstr "Jälkeen"
 
 msgid "Database type"
-msgstr ""
+msgstr "Tietokannan tyyppi"
 
 msgid "action"
-msgstr ""
+msgstr "toiminto"
 
 msgid "Continue"
-msgstr ""
+msgstr "Jatka"
 
 msgid "Error"
-msgstr ""
+msgstr "Virhe"
 
 msgid "no"
 msgstr "ei"
 
 msgid "New user: %name %email."
-msgstr ""
+msgstr "Uusi käyttäjä: %name %email."
 
 msgid "Node"
-msgstr ""
+msgstr "Node"
 
 msgid "Sent email to %recipient"
-msgstr ""
+msgstr "Sähköposti lähetettiin (vastaanottajana %recipient)"
 
 msgid "The subject of the message."
-msgstr ""
+msgstr "Viestin aihe."
 
 msgid "Number of columns"
-msgstr ""
+msgstr "Sarakkeiden määrä"
 
 msgid "Data type"
-msgstr ""
+msgstr "Tietotyyppi"
 
 msgid "Separator"
-msgstr ""
+msgstr "Erotin"
 
 msgid "Include"
-msgstr ""
+msgstr "Sisällytä"
 
 msgid "Exclude"
-msgstr ""
+msgstr "Jätä pois"
 
 msgid "Horizontal"
-msgstr ""
+msgstr "Vaakasuora"
 
 msgid "Vertical"
-msgstr ""
+msgstr "Pystysuora"
 
 msgid "Open link in new window"
-msgstr ""
+msgstr "Avaa linkki uudessa ikkunassa"
 
 msgid "vocabularies"
-msgstr ""
+msgstr "sanastot"
 
 msgid "term"
-msgstr ""
+msgstr "termi"
 
 msgid "Expanded"
-msgstr ""
+msgstr "Laajennettu"
 
 msgid "Parent item"
-msgstr ""
+msgstr "Yläkohta"
 
 msgid "Add child page"
-msgstr ""
+msgstr "Lisää alasivu"
 
 msgid "Printer-friendly version"
-msgstr ""
+msgstr "Tulostettava sivu"
 
 msgid "Content type for child pages"
-msgstr ""
+msgstr "Alasivujen sisältötyyppi"
 
 msgid "Update options"
-msgstr ""
+msgstr "Päivitysvaihtoehdot"
 
 msgid "Remove from outline"
-msgstr ""
+msgstr "Poista kirjasta"
 
 msgid "Unknown export format."
-msgstr ""
+msgstr "Tuntematon vientimuoto."
 
 msgid "Done"
-msgstr ""
+msgstr "Tehty"
 
 msgid "Last post"
-msgstr ""
+msgstr "Uusin kirjoitus"
 
 msgid "Access denied"
-msgstr ""
+msgstr "Pääsy kielletty"
 
 msgid "Year"
-msgstr ""
+msgstr "Vuosi"
 
 msgid "Add content"
-msgstr ""
+msgstr "Lisää sisältöä"
 
 msgid "Area"
-msgstr ""
+msgstr "Alue"
 
 msgid "Override title"
-msgstr ""
+msgstr "Ohita otsikko"
 
 msgid "CSS class"
-msgstr ""
+msgstr "CSS-luokka"
 
 msgid "Add view"
-msgstr ""
+msgstr "Lisää näkymä"
 
 msgid "Pager ID"
-msgstr ""
+msgstr "Sivutuksen ID"
 
 msgid "View arguments"
-msgstr ""
+msgstr "Näytön argumentit"
 
 msgid "Configuration saved."
-msgstr ""
+msgstr "Asetukset talletettu."
 
 msgid "Logo"
-msgstr ""
+msgstr "Logo"
 
 msgid "Site name"
-msgstr ""
+msgstr "Sivuston nimi"
 
 msgid "Site slogan"
-msgstr ""
+msgstr "Sivuston iskulause"
 
 msgid "Good"
 msgstr "Hyvä"
 
 msgid "Node types"
-msgstr ""
+msgstr "Sisältötyypit"
 
 msgid "User settings"
-msgstr ""
+msgstr "Käyttäjäasetukset"
 
 msgid "Site"
-msgstr ""
+msgstr "Sivusto"
 
 msgid "Web Server"
-msgstr ""
+msgstr "Verkkopalvelin"
 
 msgid "Database"
-msgstr ""
+msgstr "Tietokanta"
 
 msgid "Drupal"
-msgstr ""
+msgstr "Drupal"
 
 msgid "Not found"
-msgstr ""
+msgstr "Ei löydy"
 
 msgid "Module"
-msgstr ""
+msgstr "Moduuli"
 
 msgid "Host"
-msgstr ""
+msgstr "Isäntä"
 
 msgid "Options"
-msgstr ""
+msgstr "Valinnat"
 
 msgid "Off"
-msgstr ""
+msgstr "Off"
 
 msgid "Picture"
 msgstr "Kuva"
@@ -778,92 +780,92 @@ msgid "RSS"
 msgstr "RSS"
 
 msgid "Teaser"
-msgstr ""
+msgstr "Teaser"
 
 msgid "Updated"
-msgstr ""
+msgstr "Updated"
 
 msgid "All"
-msgstr ""
+msgstr "All"
 
 msgid "Icon"
-msgstr ""
+msgstr "Icon"
 
 msgid "Files"
-msgstr ""
+msgstr "Files"
 
 msgid "Filename"
-msgstr ""
+msgstr "Filename"
 
 msgid "Menu"
 msgstr "Valikko"
 
 msgid "Archive"
-msgstr ""
+msgstr "Archive"
 
 msgid "Content type"
-msgstr ""
+msgstr "Content type"
 
 msgid "Attachment"
-msgstr ""
+msgstr "Attachment"
 
 msgid "Active"
 msgstr "Aktiivinen"
 
 msgid "Date format"
-msgstr ""
+msgstr "Päivämäärän muoto"
 
 msgid "file"
-msgstr ""
+msgstr "tiedosto"
 
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 msgid "Created"
-msgstr ""
+msgstr "Created"
 
 msgid "Page"
 msgstr "Sivu"
 
 msgid "Components"
-msgstr ""
+msgstr "Komponentit"
 
 msgid "Contact"
 msgstr "Ota yhteyttä"
 
 msgid "Upload"
-msgstr ""
+msgstr "Siirrä"
 
 msgid "Add"
-msgstr ""
+msgstr "Lisää"
 
 msgid "Create"
-msgstr ""
+msgstr "Luo"
 
 msgid "Manage"
-msgstr ""
+msgstr "Ylläpidä"
 
 msgid "Configure"
-msgstr ""
+msgstr "Määrittele"
 
 msgid "Views"
-msgstr ""
+msgstr "Näkymät"
 
 msgid "PHP"
-msgstr ""
+msgstr "PHP"
 
 msgid "Breadcrumb"
-msgstr ""
+msgstr "Murupolku"
 
 msgid "1 hour"
 msgid_plural "@count hours"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 tunti"
+msgstr[1] "@count tuntia"
 
 msgid "1 day"
 msgid_plural "@count days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 päivä"
+msgstr[1] "@count päivää"
 
 msgid "Friday"
 msgstr "perjantai"
@@ -878,2140 +880,2143 @@ msgid "Wednesday"
 msgstr "keskiviikko"
 
 msgid "Mail"
-msgstr ""
+msgstr "Sähköposti"
 
 msgid "Statistics"
-msgstr ""
+msgstr "Tilastot"
 
 msgid "Core"
-msgstr ""
+msgstr "Ydin"
 
 msgid "PostgreSQL"
-msgstr ""
+msgstr "PostgreSQL"
 
 msgid "Manual update check"
-msgstr ""
+msgstr "Päivitysten tarkistaminen käsin"
 
 msgid "Never"
-msgstr ""
+msgstr "Ei koskaan"
 
 msgid "Check manually"
-msgstr ""
+msgstr "Tarkista käsin"
 
 msgid "Update available"
-msgstr ""
+msgstr "Päivitys saatavilla"
 
 msgid "Out of date"
 msgstr "Vanhentunut"
 
 msgid "Header"
-msgstr ""
+msgstr "Ylätunniste"
 
 msgid "Left sidebar"
-msgstr ""
+msgstr "Vasen sivupalkki"
 
 msgid "Right sidebar"
-msgstr ""
+msgstr "Oikea sivupalkki"
 
 msgid "Inline"
-msgstr ""
+msgstr "Avoin"
 
 msgid "Recipients"
-msgstr ""
+msgstr "Vastaanottajat"
 
 msgid "Selected"
-msgstr ""
+msgstr "Valittu"
 
 msgid "Your name"
 msgstr "Nimesi"
 
 msgid "Aggregator feed"
-msgstr ""
+msgstr "Aggregointisyöte"
 
 msgid "Aggregator feed ID"
-msgstr ""
+msgstr "Aggregointisyötteen ID"
 
 msgid "Feed description"
-msgstr ""
+msgstr "Syötteen kuvaus"
 
 msgid "Aggregator item"
-msgstr ""
+msgstr "Aggregointiartikkeli"
 
 msgid "Aggregator item ID"
-msgstr ""
+msgstr "Aggregaattori-kohteen ID"
 
 msgid "Throttle"
-msgstr ""
+msgstr "Kiihdytys"
 
 msgid "Visibility"
-msgstr ""
+msgstr "Näkyvyys"
 
 msgid "Role ID"
-msgstr ""
+msgstr "Roolin ID"
 
 msgid "Hostname"
-msgstr ""
+msgstr "Verkkotunnus"
 
 msgid "Score"
-msgstr ""
+msgstr "Tulos"
 
 msgid "Signature"
-msgstr ""
+msgstr "Allekirjoitus"
 
 msgid "Cacheable"
-msgstr ""
+msgstr "Välimuistitettava"
 
 msgid "Location"
-msgstr ""
+msgstr "Sijainti"
 
 msgid "Locale"
-msgstr ""
+msgstr "Lokalisointi"
 
 msgid "Title field label"
-msgstr ""
+msgstr "Otsikkokentän nimi"
 
 msgid "Sticky at top of lists"
-msgstr ""
+msgstr "Kiinnitetään luetteloiden alkuun"
 
 msgid "Revisions"
-msgstr ""
+msgstr "Versiot"
 
 msgid "Log message"
-msgstr ""
+msgstr "Lokimerkintä"
 
 msgid "URL alias"
-msgstr ""
+msgstr "Osoitealias"
 
 msgid "File MIME type"
-msgstr ""
+msgstr "Tiedoston MIME tyypit"
 
 msgid "Node revision ID"
-msgstr ""
+msgstr "Solmun revision ID"
 
 msgid "Vocabulary name"
-msgstr ""
+msgstr "Sanaston nimi"
 
 msgid "Term"
-msgstr ""
+msgstr "Termi"
 
 msgid "User role"
-msgstr ""
+msgstr "Käyttäjärooli"
 
 msgid "Role name"
-msgstr ""
+msgstr "Roolin nimi"
 
 msgid "Time zone"
 msgstr "Aikavyöhyke"
 
 msgid "Field name"
-msgstr ""
+msgstr "Kentän nimi"
 
 msgid "Field type"
-msgstr ""
+msgstr "Kentän tyyppi"
 
 msgid "Global settings"
-msgstr ""
+msgstr "Sivuston laajuiset asetukset"
 
 msgid "Multiple values"
-msgstr ""
+msgstr "Useita arvoja"
 
 msgid "Widget type"
-msgstr ""
+msgstr "Widgetin tyyppi"
 
 msgid "Contains"
-msgstr ""
+msgstr "Sisältää"
 
 msgid "Does not contain"
-msgstr ""
+msgstr "Ei sisällä"
 
 msgid "Is less than"
-msgstr ""
+msgstr "On pienempi kuin"
 
 msgid "Is less than or equal to"
-msgstr ""
+msgstr "On pienempi tai yhtäsuuri kuin"
 
 msgid "Is equal to"
-msgstr ""
+msgstr "On yhtä kuin"
 
 msgid "Is greater than or equal to"
-msgstr ""
+msgstr "On suurempi tai yhtäsuuri kuin"
 
 msgid "Is greater than"
-msgstr ""
+msgstr "On suurempi kuin"
 
 msgid "Is not equal to"
-msgstr ""
+msgstr "Ei ole yhtä kuin"
 
 msgid "Average"
-msgstr ""
+msgstr "Keskimäärin"
 
 msgid "Overridden"
-msgstr ""
+msgstr "Ohitettu"
 
 msgid "Add action"
-msgstr ""
+msgstr "Lisää toimenpide"
 
 msgid "Set name"
-msgstr ""
+msgstr "Ryhmän nimi"
 
 msgid "Original image"
-msgstr ""
+msgstr "Alkuperäinen kuva"
 
 msgid "Link to URL"
-msgstr ""
+msgstr "Linkki URL:ään"
 
 msgid "Search settings"
-msgstr ""
+msgstr "Haun asetukset"
 
 msgid "Mode"
-msgstr ""
+msgstr "Tila"
 
 msgid "Warning"
-msgstr ""
+msgstr "Varoitus"
 
 msgid "blocked"
-msgstr ""
+msgstr "suljettu"
 
 msgid "active"
 msgstr "aktiivinen"
 
 msgid "N/A"
-msgstr ""
+msgstr "Ei saatavilla"
 
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 msgid "OPML feed"
-msgstr ""
+msgstr "OPML-syöte"
 
 msgid "Number of news items in block"
-msgstr ""
+msgstr "Lohkossa näytettävien aiheiden määrä"
 
 msgid "View this feed's recent news."
-msgstr ""
+msgstr "Näytä tämän syötteen uusimmat aiheet."
 
 msgid "Feed overview"
-msgstr ""
+msgstr "Syötteiden yleiskatsaus"
 
 msgid "Items"
-msgstr ""
+msgstr "Aiheet"
 
 msgid "Next update"
-msgstr ""
+msgstr "Seuraava päivitys"
 
 msgid "%time ago"
-msgstr ""
+msgstr "%time sitten"
 
 msgid "%time left"
-msgstr ""
+msgstr "%time jäljellä"
 
 msgid "Authored by"
-msgstr ""
+msgstr "Kirjoittanut"
 
 msgid "Processor"
-msgstr ""
+msgstr "Prosessori"
 
 msgid "The feed %feed has been updated."
-msgstr ""
+msgstr "Syöte %feed on päivitetty."
 
 msgid "Feed %feed added."
-msgstr ""
+msgstr "Syöte %feed lisätty."
 
 msgid "The feed %feed has been added."
-msgstr ""
+msgstr "Syöte %feed on lisätty."
 
 msgid "Disclaimer"
-msgstr ""
+msgstr "Vastuuvapausilmoitus"
 
 msgid "Sort order"
-msgstr ""
+msgstr "Lajittelujärjestys"
 
 msgid "Up"
-msgstr ""
+msgstr "Ylös"
 
 msgid "Textfield"
-msgstr ""
+msgstr "Tekstikenttä"
 
 msgid "Display options"
-msgstr ""
+msgstr "Näyttöasetukset"
 
 msgid "Maximum"
-msgstr ""
+msgstr "Suurin"
 
 msgid "Scale"
-msgstr ""
+msgstr "Skaalaa"
 
 msgid "Thumbnail"
-msgstr ""
+msgstr "Pienoiskuva"
 
 msgid "Medium"
-msgstr ""
+msgstr "Keskiverto"
 
 msgid "Sortable"
-msgstr ""
+msgstr "Lajiteltavissa"
 
 msgid "standard"
-msgstr ""
+msgstr "standardi"
 
 msgid "Month"
-msgstr ""
+msgstr "Kuukausi"
 
 msgid "Details"
-msgstr ""
+msgstr "Yksityiskohdat"
 
 msgid "Widget"
-msgstr ""
+msgstr "Widgetti"
 
 msgid "Last reply"
-msgstr ""
+msgstr "Viimeisin vastaus"
 
 msgid "Prev"
-msgstr ""
+msgstr "Edellinen"
 
 msgid "Domain"
-msgstr ""
+msgstr "Domain"
 
 msgid "Processors"
-msgstr ""
+msgstr "Prosessorit"
 
 msgid "Unlimited"
-msgstr ""
+msgstr "Rajoittamaton"
 
 msgid "Current"
-msgstr ""
+msgstr "Tämänhetkinen"
 
 msgid "State"
-msgstr ""
+msgstr "Tila"
 
 msgid "Filter by"
-msgstr ""
+msgstr "Suodata"
 
 msgid "Enter a valid username."
-msgstr ""
+msgstr "Syötä olemassaoleva käyttäjänimi."
 
 msgid "Recipient"
-msgstr ""
+msgstr "Vastaanottaja"
 
 msgid "OR"
-msgstr ""
+msgstr "TAI"
 
 msgid "Add a role to the selected users"
-msgstr ""
+msgstr "Lisää rooli valituille käyttäjille"
 
 msgid "Remove a role from the selected users"
-msgstr ""
+msgstr "Poista rooli valituilta käyttäjiltä"
 
 msgid "node"
-msgstr ""
+msgstr "solmu"
 
 msgid "Administer content"
-msgstr ""
+msgstr "Ylläpidä sisältöä"
 
 msgid "Directory"
-msgstr ""
+msgstr "Hakemisto"
 
 msgid "Method"
-msgstr ""
+msgstr "Tapa"
 
 msgid "Egypt"
-msgstr ""
+msgstr "Egypti"
 
 msgid "Namibia"
-msgstr ""
+msgstr "Namibia"
 
 msgid "To"
-msgstr ""
+msgstr "To"
 
 msgid "Comment"
 msgstr "Kommentti"
 
 msgid "Plain text"
-msgstr ""
+msgstr "Plain text"
 
 msgid "Footer"
-msgstr ""
+msgstr "Footer"
 
 msgid "Last access"
-msgstr ""
+msgstr "Last access"
 
 msgid "From"
-msgstr ""
+msgstr "From"
 
 msgid "Revision ID"
-msgstr ""
+msgstr "Version ID"
 
 msgid "Severity"
-msgstr ""
+msgstr "Severity"
 
 msgid "Published"
 msgstr "Julkaistu"
 
 msgid "Last update"
-msgstr ""
+msgstr "Last update"
 
 msgid "Roles"
-msgstr ""
+msgstr "Roles"
 
 msgid "Vocabulary"
-msgstr ""
+msgstr "Luokittelu"
 
 msgid "Fields"
-msgstr ""
+msgstr "Fields"
 
 msgid "Advanced"
-msgstr ""
+msgstr "Edistyneet"
 
 msgid ", "
-msgstr ""
+msgstr ", "
 
 msgid "Desc"
-msgstr ""
+msgstr "Desc"
 
 msgid "General"
-msgstr ""
+msgstr "Yleiset asetukset"
 
 msgid "Media"
-msgstr ""
+msgstr "Media"
 
 msgid "Performance"
-msgstr ""
+msgstr "Suorituskyky"
 
 msgid "System"
-msgstr ""
+msgstr "Järjestelmä"
 
 msgid "Available updates"
-msgstr ""
+msgstr "Saatavilla olevat päivitykset"
 
 msgid "Drupal core update status"
-msgstr ""
+msgstr "Drupalin ytimen päivitysten tila"
 
 msgid "Caching"
-msgstr ""
+msgstr "Välimuistin käyttö"
 
 msgid "Source string"
-msgstr ""
+msgstr "Lähdemerkkijono"
 
 msgid "Up to date"
 msgstr "Ajantasalla"
 
 msgid "Custom"
-msgstr ""
+msgstr "Oma"
 
 msgid "Israel"
-msgstr ""
+msgstr "Israel"
 
 msgid "Iran"
-msgstr ""
+msgstr "Iran"
 
 msgid "New Zealand"
-msgstr ""
+msgstr "Uusi-Seelanti"
 
 msgid "Tonga"
-msgstr ""
+msgstr "Tonga"
 
 msgid "Cuba"
-msgstr ""
+msgstr "Kuuba"
 
 msgid "Brazil"
-msgstr ""
+msgstr "Brasilia"
 
 msgid "Chile"
-msgstr ""
+msgstr "Chile"
 
 msgid "Paraguay"
-msgstr ""
+msgstr "Paraguay"
 
 msgid "Jamaica"
-msgstr ""
+msgstr "Jamaika"
 
 msgid "Japan"
-msgstr ""
+msgstr "Japani"
 
 msgid "Libya"
-msgstr ""
+msgstr "Libya"
 
 msgid "Poland"
-msgstr ""
+msgstr "Puola"
 
 msgid "Portugal"
-msgstr ""
+msgstr "Portugali"
 
 msgid "Singapore"
-msgstr ""
+msgstr "Singapore"
 
 msgid "Turkey"
-msgstr ""
+msgstr "Turkki"
 
 msgid "Day"
-msgstr ""
+msgstr "Päivä"
 
 msgid "Table"
 msgstr "Taulukko"
 
 msgid "Sat"
-msgstr ""
+msgstr "La"
 
 msgid "Sun"
-msgstr ""
+msgstr "Su"
 
 msgid "May"
-msgstr ""
+msgstr "Toukokuu"
 
 msgid "am"
-msgstr ""
+msgstr "am"
 
 msgid "pm"
-msgstr ""
+msgstr "pm"
 
 msgid "Start date"
-msgstr ""
+msgstr "Aloituspäivämäärä"
 
 msgid "End date"
-msgstr ""
+msgstr "Lopetuspäivämäärä"
 
 msgid "Forum"
-msgstr ""
+msgstr "Foorumi"
 
 msgid "Security"
-msgstr ""
+msgstr "Turvallisuus"
 
 msgid "Align"
-msgstr ""
+msgstr "Tasaa"
 
 msgid "Loop"
-msgstr ""
+msgstr "Kierros"
 
 msgid "Display title"
-msgstr ""
+msgstr "Näytä otsikko"
 
 msgid "Background color"
-msgstr ""
+msgstr "Taustaväri"
 
 msgid "Text color"
-msgstr ""
+msgstr "Tekstin väri"
 
 msgid "Navigation"
-msgstr ""
+msgstr "Navigaatio"
 
 msgid "Basic"
-msgstr ""
+msgstr "Perusasetukset"
 
 msgid "Color"
-msgstr ""
+msgstr "Väri"
 
 msgid "Link URL"
-msgstr ""
+msgstr "Linkin osoite"
 
 msgid "List type"
-msgstr ""
+msgstr "Listan tyyppi"
 
 msgid "Attributes"
-msgstr ""
+msgstr "Ominaisuudet"
 
 msgid "Select all"
-msgstr ""
+msgstr "Valitse kaikki"
 
 msgid "Allow"
-msgstr ""
+msgstr "Sallittu"
 
 msgid "Ignore"
-msgstr ""
+msgstr "Ohita"
 
 msgid "User data"
-msgstr ""
+msgstr "Käyttäjätiedot"
 
 msgid "User login"
-msgstr ""
+msgstr "Kirjautuminen"
 
 msgid "Updated URL for feed %title to %url."
-msgstr ""
+msgstr "Syötteen %title osoitteeksi on vaihdettu %url."
 
 msgid "Add new comment"
-msgstr ""
+msgstr "Lisää uusi kommentti"
 
 msgid "No terms available."
-msgstr ""
+msgstr "Yhtään termiä ei ole saatavilla."
 
 msgid "Counter"
-msgstr ""
+msgstr "Laskuri"
 
 msgid "String"
-msgstr ""
+msgstr "Merkkijono"
 
 msgid "Case"
-msgstr ""
+msgstr "Asia"
 
 msgid "Not installed"
-msgstr ""
+msgstr "Asentamatta"
 
 msgid "Referrer"
-msgstr ""
+msgstr "Viittaaja"
 
 msgid "Default front page"
-msgstr ""
+msgstr "Oletusetusivu"
 
 msgid "Button"
-msgstr ""
+msgstr "Nappi"
 
 msgid "Square"
-msgstr ""
+msgstr "Neliö"
 
 msgid "Both"
-msgstr ""
+msgstr "Molemmat"
 
 msgid "Maximum length"
-msgstr ""
+msgstr "Suurin pituus"
 
 msgid "Rows"
-msgstr ""
+msgstr "Rivejä"
 
 msgid "Cache"
-msgstr ""
+msgstr "Välimuisti"
 
 msgid "Argument"
-msgstr ""
+msgstr "Argumentti"
 
 msgid "Provider"
-msgstr ""
+msgstr "Sisältölähde"
 
 msgid "Save and edit"
-msgstr ""
+msgstr "Tallenna ja jatka muokkaamista"
 
 msgid "Edit view"
-msgstr ""
+msgstr "Muokkaa näkymää"
 
 msgid "Administer views"
-msgstr ""
+msgstr "Ylläpidä näkymiä"
 
 msgid "Ascending"
-msgstr ""
+msgstr "Nouseva"
 
 msgid "Descending"
-msgstr ""
+msgstr "Laskeva"
 
 msgid "Normal menu item"
-msgstr ""
+msgstr "Normaali valikkoelementti"
 
 msgid "Expose"
-msgstr ""
+msgstr "Näytä"
 
 msgid "Option"
-msgstr ""
+msgstr "Vaihtoehto"
 
 msgid "Operator"
-msgstr ""
+msgstr "Operaattori"
 
 msgid "Filters"
-msgstr ""
+msgstr "Suodattimet"
 
 msgid "Optional"
-msgstr ""
+msgstr "Valinnainen"
 
 msgid "Exposed Filters"
-msgstr ""
+msgstr "Paljastetut suodattimet"
 
 msgid "Order"
-msgstr ""
+msgstr "Järjestys"
 
 msgid "Views UI"
-msgstr ""
+msgstr "Näkymien hallintapaneeli"
 
 msgid "Uncategorized"
-msgstr ""
+msgstr "Katogorisoimattomat"
 
 msgid "Plain"
-msgstr ""
+msgstr "Puhdas"
 
 msgid "Position"
-msgstr ""
+msgstr "Sijoitus"
 
 msgid "Integer"
-msgstr ""
+msgstr "Kokonaisluku"
 
 msgid "Pattern"
-msgstr ""
+msgstr "Kuvio"
 
 msgid "The comment and all its replies have been deleted."
-msgstr ""
+msgstr "Kommentti ja kaikki sen vastaukset on poistettu."
 
 msgid "Cron settings"
-msgstr ""
+msgstr "Cron asertukset"
 
 msgid "Preformatted"
-msgstr ""
+msgstr "Esimuotoiltu"
 
 msgid "Anonymous users"
-msgstr ""
+msgstr "Anonyymit käyttäjät"
 
 msgid "Found"
-msgstr ""
+msgstr "Löydetty"
 
 msgid "fields"
-msgstr ""
+msgstr "kentät"
 
 msgid "Add group"
-msgstr ""
+msgstr "Lisää ryhmä"
 
 msgid "Save settings"
-msgstr ""
+msgstr "Tallenna asetukset"
 
 msgid "UID"
-msgstr ""
+msgstr "UID"
 
 msgid "Duration"
-msgstr ""
+msgstr "Kesto"
 
 msgid "Multiplier"
-msgstr ""
+msgstr "Kerroin"
 
 msgid "Session closed for %name."
-msgstr ""
+msgstr "Tunnuksen %name istunto on suljettu."
 
 msgid "Defaults"
-msgstr ""
+msgstr "Oletusasetukset"
 
 msgid "Your search yielded no results."
-msgstr ""
+msgstr "Hakusi ei tuottanut tuloksia."
 
 msgid "="
-msgstr ""
+msgstr "="
 
 msgid "Germany"
-msgstr ""
+msgstr "Saksa"
 
 msgid "Created date"
-msgstr ""
+msgstr "Luontipäivä"
 
 msgid "Updated date"
-msgstr ""
+msgstr "Päivitetty"
 
 msgid "comments"
-msgstr ""
+msgstr "kommentit"
 
 msgid "1 new"
 msgid_plural "@count new"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 uusi"
+msgstr[1] "@count uutta"
 
 msgid "Default language"
-msgstr ""
+msgstr "Oletuskieli"
 
 msgid "Condition"
-msgstr ""
+msgstr "Riippuvuus"
 
 msgid "Afghanistan"
-msgstr ""
+msgstr "Afganistan"
 
 msgid "Albania"
-msgstr ""
+msgstr "Albania"
 
 msgid "Algeria"
-msgstr ""
+msgstr "Algeria"
 
 msgid "American Samoa"
-msgstr ""
+msgstr "Amerikan Samoa"
 
 msgid "Angola"
-msgstr ""
+msgstr "Angola"
 
 msgid "Anguilla"
-msgstr ""
+msgstr "Anguilla"
 
 msgid "Antarctica"
-msgstr ""
+msgstr "Etelämanner"
 
 msgid "Antigua and Barbuda"
-msgstr ""
+msgstr "Antigua ja Barbuda"
 
 msgid "Argentina"
-msgstr ""
+msgstr "Argentiina"
 
 msgid "Armenia"
-msgstr ""
+msgstr "Armenia"
 
 msgid "Aruba"
-msgstr ""
+msgstr "Aruba"
 
 msgid "Australia"
-msgstr ""
+msgstr "Australia"
 
 msgid "Austria"
-msgstr ""
+msgstr "Itävalta"
 
 msgid "Azerbaijan"
-msgstr ""
+msgstr "Azerbaidzhan"
 
 msgid "Bahamas"
-msgstr ""
+msgstr "Bahama"
 
 msgid "Bahrain"
-msgstr ""
+msgstr "Bahrain"
 
 msgid "Bangladesh"
-msgstr ""
+msgstr "Bangladesh"
 
 msgid "Barbados"
-msgstr ""
+msgstr "Barbados"
 
 msgid "Belarus"
-msgstr ""
+msgstr "Valko-Venäjä"
 
 msgid "Belgium"
-msgstr ""
+msgstr "Belgia"
 
 msgid "Belize"
-msgstr ""
+msgstr "Belize"
 
 msgid "Benin"
-msgstr ""
+msgstr "Benin"
 
 msgid "Bermuda"
-msgstr ""
+msgstr "Bermuda"
 
 msgid "Bhutan"
-msgstr ""
+msgstr "Bhutan"
 
 msgid "Bolivia"
-msgstr ""
+msgstr "Bolivia"
 
 msgid "Bosnia and Herzegovina"
-msgstr ""
+msgstr "Bosnia ja Hertsegovina"
 
 msgid "Botswana"
-msgstr ""
+msgstr "Botswana"
 
 msgid "Bouvet Island"
-msgstr ""
+msgstr "Bouvet-saari"
 
 msgid "Brunei"
-msgstr ""
+msgstr "Brunei"
 
 msgid "Thu"
-msgstr ""
+msgstr "To"
 
 msgid "Anonymous"
 msgstr "Anonyymi"
 
 msgid "Full"
-msgstr ""
+msgstr "Full"
 
 msgid "Tracker"
-msgstr ""
+msgstr "Tracker"
 
 msgid "Recent comments"
-msgstr ""
+msgstr "Recent comments"
 
 msgid "Users"
-msgstr ""
+msgstr "Users"
 
 msgid "Role"
-msgstr ""
+msgstr "Role"
 
 msgid "Sort Criteria"
-msgstr ""
+msgstr "Sort Criteria"
 
 msgid "Log in"
 msgstr "Kirjaudu"
 
 msgid "External"
-msgstr ""
+msgstr "Ulkoinen"
 
 msgid "Sort by"
-msgstr ""
+msgstr "Sort by"
 
 msgid "Uninstall"
-msgstr ""
+msgstr "Asennuksen poisto"
 
 msgid "Install"
-msgstr ""
+msgstr "Asenna"
 
 msgid "Appearance"
-msgstr ""
+msgstr "Ulkoasu"
 
 msgid "Configuration"
-msgstr ""
+msgstr "Asetukset"
 
 msgid "Clear cache"
-msgstr ""
+msgstr "Puhdista välimuisti"
 
 msgid "Mon"
-msgstr ""
+msgstr "Ma"
 
 msgid "Fri"
-msgstr ""
+msgstr "Pe"
 
 msgid "Tue"
-msgstr ""
+msgstr "Ti"
 
 msgid "Wed"
-msgstr ""
+msgstr "Ke"
 
 msgid "Other"
-msgstr ""
+msgstr "Muu"
 
 msgid "Close"
-msgstr ""
+msgstr "Sulje"
 
 msgid "Bulgaria"
-msgstr ""
+msgstr "Bulgaria"
 
 msgid "Burkina Faso"
-msgstr ""
+msgstr "Burkina Faso"
 
 msgid "Burundi"
-msgstr ""
+msgstr "Burundi"
 
 msgid "Cambodia"
-msgstr ""
+msgstr "Kambodža"
 
 msgid "Cameroon"
-msgstr ""
+msgstr "Kamerun"
 
 msgid "Canada"
-msgstr ""
+msgstr "Kanada"
 
 msgid "Cape Verde"
-msgstr ""
+msgstr "Kap Verde"
 
 msgid "Cayman Islands"
-msgstr ""
+msgstr "Caymansaaret"
 
 msgid "Central African Republic"
-msgstr ""
+msgstr "Keski-Afrikka"
 
 msgid "Chad"
-msgstr ""
+msgstr "Chad"
 
 msgid "China"
-msgstr ""
+msgstr "Kiina"
 
 msgid "Christmas Island"
-msgstr ""
+msgstr "Joulusaari"
 
 msgid "Colombia"
-msgstr ""
+msgstr "Kolumbia"
 
 msgid "Comoros"
-msgstr ""
+msgstr "Komorit"
 
 msgid "Cook Islands"
-msgstr ""
+msgstr "Cookinsaaret"
 
 msgid "Costa Rica"
-msgstr ""
+msgstr "Costa Rica"
 
 msgid "Cyprus"
-msgstr ""
+msgstr "Kypros"
 
 msgid "Czech Republic"
-msgstr ""
+msgstr "Tsekki"
 
 msgid "Denmark"
-msgstr ""
+msgstr "Tanska"
 
 msgid "Djibouti"
-msgstr ""
+msgstr "Djibouti"
 
 msgid "Dominica"
-msgstr ""
+msgstr "Dominica"
 
 msgid "Dominican Republic"
-msgstr ""
+msgstr "Dominikaaninen Tasavalta"
 
 msgid "Ecuador"
-msgstr ""
+msgstr "Ecuador"
 
 msgid "El Salvador"
-msgstr ""
+msgstr "El Salvador"
 
 msgid "Equatorial Guinea"
-msgstr ""
+msgstr "Päiväntasaajan Guinea"
 
 msgid "Eritrea"
-msgstr ""
+msgstr "Eritrea"
 
 msgid "Estonia"
-msgstr ""
+msgstr "Viro"
 
 msgid "Ethiopia"
-msgstr ""
+msgstr "Etiopia"
 
 msgid "Faroe Islands"
-msgstr ""
+msgstr "Färsaaret"
 
 msgid "Finland"
-msgstr ""
+msgstr "Suomi"
 
 msgid "France"
-msgstr ""
+msgstr "Ranska"
 
 msgid "French Guiana"
-msgstr ""
+msgstr "Ranskan Guiana"
 
 msgid "French Polynesia"
-msgstr ""
+msgstr "Ranskan Polynesia"
 
 msgid "Gabon"
-msgstr ""
+msgstr "Gabon"
 
 msgid "Gambia"
-msgstr ""
+msgstr "Gambia"
 
 msgid "Georgia"
-msgstr ""
+msgstr "Georgia"
 
 msgid "Ghana"
-msgstr ""
+msgstr "Ghana"
 
 msgid "Gibraltar"
-msgstr ""
+msgstr "Gibraltar"
 
 msgid "Greece"
-msgstr ""
+msgstr "Kreikka"
 
 msgid "Greenland"
-msgstr ""
+msgstr "Grönlanti"
 
 msgid "Grenada"
-msgstr ""
+msgstr "Grenada"
 
 msgid "Guadeloupe"
-msgstr ""
+msgstr "Guadeloupe"
 
 msgid "Guam"
-msgstr ""
+msgstr "Guam"
 
 msgid "Guatemala"
-msgstr ""
+msgstr "Guatemala"
 
 msgid "Guinea"
-msgstr ""
+msgstr "Guinea"
 
 msgid "Guinea-Bissau"
-msgstr ""
+msgstr "Guinea-Bissau"
 
 msgid "Guyana"
-msgstr ""
+msgstr "Guyana"
 
 msgid "Haiti"
-msgstr ""
+msgstr "Haiti"
 
 msgid "Heard Island and McDonald Islands"
-msgstr ""
+msgstr "Heard- ja McDonaldinsaaret"
 
 msgid "Honduras"
-msgstr ""
+msgstr "Honduras"
 
 msgid "Hungary"
-msgstr ""
+msgstr "Unkari"
 
 msgid "Iceland"
-msgstr ""
+msgstr "Islanti"
 
 msgid "India"
-msgstr ""
+msgstr "Intia"
 
 msgid "Indonesia"
-msgstr ""
+msgstr "Indonesia"
 
 msgid "Iraq"
-msgstr ""
+msgstr "Irak"
 
 msgid "Ireland"
-msgstr ""
+msgstr "Irlanti"
 
 msgid "Italy"
-msgstr ""
+msgstr "Italia"
 
 msgid "Jordan"
-msgstr ""
+msgstr "Jordania"
 
 msgid "Kazakhstan"
-msgstr ""
+msgstr "Kazakstan"
 
 msgid "Kenya"
-msgstr ""
+msgstr "Kenia"
 
 msgid "Kiribati"
-msgstr ""
+msgstr "Kiribati"
 
 msgid "Kuwait"
-msgstr ""
+msgstr "Kuwait"
 
 msgid "Kyrgyzstan"
-msgstr ""
+msgstr "Kirgisia"
 
 msgid "Laos"
-msgstr ""
+msgstr "Laos"
 
 msgid "Latvia"
-msgstr ""
+msgstr "Latvia"
 
 msgid "Lebanon"
-msgstr ""
+msgstr "Libanon"
 
 msgid "Lesotho"
-msgstr ""
+msgstr "Lesotho"
 
 msgid "Liberia"
-msgstr ""
+msgstr "Liberia"
 
 msgid "Liechtenstein"
-msgstr ""
+msgstr "Liechtenstein"
 
 msgid "Lithuania"
-msgstr ""
+msgstr "Liettua"
 
 msgid "Luxembourg"
-msgstr ""
+msgstr "Luxemburg"
 
 msgid "Madagascar"
-msgstr ""
+msgstr "Madagaskar"
 
 msgid "Malawi"
-msgstr ""
+msgstr "Malawi"
 
 msgid "Malaysia"
-msgstr ""
+msgstr "Malesia"
 
 msgid "Maldives"
-msgstr ""
+msgstr "Malediivit"
 
 msgid "Mali"
-msgstr ""
+msgstr "Mali"
 
 msgid "Malta"
-msgstr ""
+msgstr "Malta"
 
 msgid "Marshall Islands"
-msgstr ""
+msgstr "Marshallinsaaret"
 
 msgid "Martinique"
-msgstr ""
+msgstr "Martinique"
 
 msgid "Mauritania"
-msgstr ""
+msgstr "Mauritania"
 
 msgid "Mauritius"
-msgstr ""
+msgstr "Mauritius"
 
 msgid "Mayotte"
-msgstr ""
+msgstr "Mayotte"
 
 msgid "Mexico"
-msgstr ""
+msgstr "Meksiko"
 
 msgid "Micronesia"
-msgstr ""
+msgstr "Mikronesia"
 
 msgid "Moldova"
-msgstr ""
+msgstr "Moldova"
 
 msgid "Monaco"
-msgstr ""
+msgstr "Monako"
 
 msgid "Mongolia"
-msgstr ""
+msgstr "Mongolia"
 
 msgid "Montserrat"
-msgstr ""
+msgstr "Montserrat"
 
 msgid "Morocco"
-msgstr ""
+msgstr "Marokko"
 
 msgid "Mozambique"
-msgstr ""
+msgstr "Mozambik"
 
 msgid "Nauru"
-msgstr ""
+msgstr "Nauru"
 
 msgid "Nepal"
-msgstr ""
+msgstr "Nepal"
 
 msgid "Netherlands"
-msgstr ""
+msgstr "Hollanti"
 
 msgid "Netherlands Antilles"
-msgstr ""
+msgstr "Alankomaiden Antillit"
 
 msgid "New Caledonia"
-msgstr ""
+msgstr "Uusi-Kaledonia"
 
 msgid "Nicaragua"
-msgstr ""
+msgstr "Nicaragua"
 
 msgid "Niger"
-msgstr ""
+msgstr "Niger"
 
 msgid "Nigeria"
-msgstr ""
+msgstr "Nigeria"
 
 msgid "Niue"
-msgstr ""
+msgstr "Niue"
 
 msgid "Norfolk Island"
-msgstr ""
+msgstr "Norfolkinsaari"
 
 msgid "North Korea"
-msgstr ""
+msgstr "Pohjois-Korea"
 
 msgid "Northern Mariana Islands"
-msgstr ""
+msgstr "Pohjois-Mariaanit"
 
 msgid "Norway"
-msgstr ""
+msgstr "Norja"
 
 msgid "Oman"
-msgstr ""
+msgstr "Oman"
 
 msgid "Pakistan"
-msgstr ""
+msgstr "Pakistan"
 
 msgid "Palau"
-msgstr ""
+msgstr "Palau"
 
 msgid "Panama"
-msgstr ""
+msgstr "Panama"
 
 msgid "Papua New Guinea"
-msgstr ""
+msgstr "Papua-Uusi-Guinea"
 
 msgid "Peru"
-msgstr ""
+msgstr "Peru"
 
 msgid "Philippines"
-msgstr ""
+msgstr "Filippiinit"
 
 msgid "Pitcairn Islands"
-msgstr ""
+msgstr "Pitcairn saaret"
 
 msgid "Puerto Rico"
-msgstr ""
+msgstr "Puerto Rico"
 
 msgid "Qatar"
-msgstr ""
+msgstr "Qatar"
 
 msgid "Romania"
-msgstr ""
+msgstr "Romania"
 
 msgid "Russia"
-msgstr ""
+msgstr "Venäjä"
 
 msgid "Rwanda"
-msgstr ""
+msgstr "Ruanda"
 
 msgid "Samoa"
-msgstr ""
+msgstr "Samoa"
 
 msgid "San Marino"
-msgstr ""
+msgstr "San Marino"
 
 msgid "Saudi Arabia"
-msgstr ""
+msgstr "Saudiarabia"
 
 msgid "Senegal"
-msgstr ""
+msgstr "Senegal"
 
 msgid "Seychelles"
-msgstr ""
+msgstr "Seychellit"
 
 msgid "Sierra Leone"
-msgstr ""
+msgstr "Sierra Leone"
 
 msgid "Slovakia"
-msgstr ""
+msgstr "Slovakia"
 
 msgid "Slovenia"
-msgstr ""
+msgstr "Slovenia"
 
 msgid "Solomon Islands"
-msgstr ""
+msgstr "Solomonsaaret"
 
 msgid "Somalia"
-msgstr ""
+msgstr "Somalia"
 
 msgid "South Africa"
-msgstr ""
+msgstr "Etelä-Afrikka"
 
 msgid "South Georgia and the South Sandwich Islands"
-msgstr ""
+msgstr "Etelä-Georgia ja Eteläiset Sandwichsaaret"
 
 msgid "Spain"
-msgstr ""
+msgstr "Espanja"
 
 msgid "Sri Lanka"
-msgstr ""
+msgstr "Sri Lanka"
 
 msgid "Sudan"
-msgstr ""
+msgstr "Sudan"
 
 msgid "Suriname"
-msgstr ""
+msgstr "Surinam"
 
 msgid "Svalbard and Jan Mayen"
-msgstr ""
+msgstr "Svalbard ja Jan Mayen"
 
 msgid "Swaziland"
-msgstr ""
+msgstr "Swazimaa"
 
 msgid "Sweden"
-msgstr ""
+msgstr "Ruotsi"
 
 msgid "Switzerland"
-msgstr ""
+msgstr "Sveitsi"
 
 msgid "Syria"
-msgstr ""
+msgstr "Syyria"
 
 msgid "Taiwan"
-msgstr ""
+msgstr "Taiwan"
 
 msgid "Tajikistan"
-msgstr ""
+msgstr "Tadžikistan"
 
 msgid "Tanzania"
-msgstr ""
+msgstr "Tansania"
 
 msgid "Thailand"
-msgstr ""
+msgstr "Thaimaa"
 
 msgid "Togo"
-msgstr ""
+msgstr "Togo"
 
 msgid "Tokelau"
-msgstr ""
+msgstr "Tokelau"
 
 msgid "Trinidad and Tobago"
-msgstr ""
+msgstr "Trinidad ja Tobago"
 
 msgid "Tunisia"
-msgstr ""
+msgstr "Tunisia"
 
 msgid "Turkmenistan"
-msgstr ""
+msgstr "Turkmenistan"
 
 msgid "Turks and Caicos Islands"
-msgstr ""
+msgstr "Turks- ja Caicossaaret"
 
 msgid "Tuvalu"
-msgstr ""
+msgstr "Tuvalu"
 
 msgid "Uganda"
-msgstr ""
+msgstr "Uganda"
 
 msgid "Ukraine"
-msgstr ""
+msgstr "Ukraina"
 
 msgid "United Arab Emirates"
-msgstr ""
+msgstr "Yhdistyneet arabiemiirikunnat"
 
 msgid "United Kingdom"
-msgstr ""
+msgstr "Yhdistynyt Kuningaskunta"
 
 msgid "United States"
-msgstr ""
+msgstr "Yhdysvallat"
 
 msgid "Uruguay"
-msgstr ""
+msgstr "Uruguay"
 
 msgid "Uzbekistan"
-msgstr ""
+msgstr "Uzbekistan"
 
 msgid "Vanuatu"
-msgstr ""
+msgstr "Vanuatu"
 
 msgid "Vatican City"
-msgstr ""
+msgstr "Vatikaani"
 
 msgid "Venezuela"
-msgstr ""
+msgstr "Venezuela"
 
 msgid "Wallis and Futuna"
-msgstr ""
+msgstr "Wallis ja Futuna"
 
 msgid "Yemen"
-msgstr ""
+msgstr "Jemen"
 
 msgid "Zambia"
-msgstr ""
+msgstr "Sambia"
 
 msgid "Zimbabwe"
-msgstr ""
+msgstr "Zimbabwe"
 
 msgid "Identity"
-msgstr ""
+msgstr "Identiteetti"
 
 msgid "Database username"
-msgstr ""
+msgstr "Tietokannan käyttäjätunnus"
 
 msgid "Database password"
-msgstr ""
+msgstr "Tietokannan salasana"
 
 msgid "Database name"
-msgstr ""
+msgstr "Tietokannan nimi"
 
 msgid "Add user"
-msgstr ""
+msgstr "Lisää käyttäjä"
 
 msgid "Port"
-msgstr ""
+msgstr "Portti"
 
 msgid "Regular expression"
-msgstr ""
+msgstr "Säännöllinen lauseke"
 
 msgid "Size of textfield"
-msgstr ""
+msgstr "Tekstikentän koko"
 
 msgid "Authoring information"
-msgstr ""
+msgstr "Julkaisutiedot"
 
 msgid "Authored on"
-msgstr ""
+msgstr "Luotu"
 
 msgid "Leave blank for %anonymous."
-msgstr ""
+msgstr "Jätä tyhjäksi käyttäjälle %anonymous."
 
 msgid "Hidden"
-msgstr ""
+msgstr "Piilotettu"
 
 msgid "Are you sure you want to delete %name?"
-msgstr ""
+msgstr "Oletko varma että haluat poistaa kategorian %name?"
 
 msgid "Undefined"
-msgstr ""
+msgstr "Määrittelemätön"
 
 msgid "Queued"
-msgstr ""
+msgstr "Jonossa"
 
 msgid "Syslog"
-msgstr ""
+msgstr "Syslog"
 
 msgid "Other queries"
-msgstr ""
+msgstr "Muut kyselyt"
 
 msgid "Key"
-msgstr ""
+msgstr "Avain"
 
 msgid "Link to node"
-msgstr ""
+msgstr "Linkitä solmuun"
 
 msgid "File Upload"
-msgstr ""
+msgstr "Tiedoston lataus palvelimelle"
 
 msgid "block"
-msgstr ""
+msgstr "lohko"
 
 msgid "Site language"
 msgstr "Sivuston kieli"
 
 msgid "Change"
-msgstr ""
+msgstr "Muuta"
 
 msgid "Spanish"
-msgstr ""
+msgstr "espanja"
 
 msgid "in"
-msgstr ""
+msgstr "sisällä"
 
 msgid "Messages"
-msgstr ""
+msgstr "Viestit"
 
 msgid "Edit term"
-msgstr ""
+msgstr "Muokkaa termiä"
 
 msgid "Switch"
-msgstr ""
+msgstr "Vaihda"
 
 msgid "Import OPML"
-msgstr ""
+msgstr "Lataa OPML"
 
 msgid "OPML File"
-msgstr ""
+msgstr "OPML tiedosto"
 
 msgid "Allowed HTML tags"
-msgstr ""
+msgstr "Sallitut HTML-tagit"
 
 msgid "Sources"
-msgstr ""
+msgstr "Lähteet"
 
 msgid "1 item"
 msgid_plural "@count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 aihe"
+msgstr[1] "@count aihetta"
 
 msgid "Feed items"
-msgstr ""
+msgstr "Syötteen kohteet"
 
 msgid "Add menu"
-msgstr ""
+msgstr "Lisää valikko"
 
 msgid "menu"
-msgstr ""
+msgstr "valikko"
 
 msgid "No items selected."
-msgstr ""
+msgstr "Yhtään kohdetta ei ole valittuna."
 
 msgid "The update has been performed."
-msgstr ""
+msgstr "Päivitys on suoritettu."
 
 msgid "Node title"
-msgstr ""
+msgstr "Solmun otsikko"
 
 msgid "Result"
-msgstr ""
+msgstr "Tulos"
 
 msgid "Browser"
-msgstr ""
+msgstr "Selain"
 
 msgid "View user profile."
-msgstr ""
+msgstr "Näytä käyttäjäprofiili."
 
 msgid "Titles only"
-msgstr ""
+msgstr "Vain otsikot"
 
 msgid "Full text"
-msgstr ""
+msgstr "Koko teksti"
 
 msgid "Feed settings"
-msgstr ""
+msgstr "Syotteen asetukset"
 
 msgid "Source"
-msgstr ""
+msgstr "Lähde"
 
 msgid "Add Block"
-msgstr ""
+msgstr "Lisää lohko"
 
 msgid "published"
-msgstr ""
+msgstr "julkaistu"
 
 msgid "The changes have been saved."
 msgstr "Muutokset tallennettiin."
 
 msgid "Undo"
-msgstr ""
+msgstr "Kumoa"
 
 msgid "@time ago"
-msgstr ""
+msgstr "@time sitten"
 
 msgid "No users selected."
-msgstr ""
+msgstr "Yhtään käyttäjää ei ole valittuna."
 
 msgid "Select all rows in this table"
-msgstr ""
+msgstr "Valitse kaikki taulukon rivit"
 
 msgid "Deselect all rows in this table"
-msgstr ""
+msgstr "Poista kaikkien rivien valinnat"
 
 msgid "User search"
-msgstr ""
+msgstr "Käyttäjähaku"
 
 msgid "Search results"
-msgstr ""
+msgstr "Hakutulokset"
 
 msgid "Please enter some keywords."
-msgstr ""
+msgstr "Ole hyvä, anna joitakin avainsanoja."
 
 msgid "Replacement patterns"
-msgstr ""
+msgstr "Korvauskuviot"
 
 msgid "Deleted"
-msgstr ""
+msgstr "Poistettu"
 
 msgid "Successful"
-msgstr ""
+msgstr "Onnistunut"
 
 msgid "Display name"
-msgstr ""
+msgstr "Näyttönimi"
 
 msgid "Topics"
-msgstr ""
+msgstr "Aiheet"
 
 msgid "Topic"
-msgstr ""
+msgstr "Aihe"
 
 msgid "Definition"
-msgstr ""
+msgstr "Määritelmä"
 
 msgid "Allowed values list"
-msgstr ""
+msgstr "Lista sallituista arvoista"
 
 msgid "Textfield size"
-msgstr ""
+msgstr "Tekstikentän koko"
 
 msgid "Today"
-msgstr ""
+msgstr "Tänään"
 
 msgid "Activity"
-msgstr ""
+msgstr "Aktiivisuus"
 
 msgid "Edit menu"
-msgstr ""
+msgstr "Muokkaa valikkoa"
 
 msgid "Delete menu"
-msgstr ""
+msgstr "Poista valikko"
 
 msgid "Publishing options"
-msgstr ""
+msgstr "Julkaisuasetukset"
 
 msgid "Create new revision"
-msgstr ""
+msgstr "Luo uusi versio"
 
 msgid "Lists"
-msgstr ""
+msgstr "Listat"
 
 msgid "Limit"
-msgstr ""
+msgstr "Rajoitus"
 
 msgid "Minimum height"
-msgstr ""
+msgstr "Vähimmäiskorkeus"
 
 msgid "Minimum width"
-msgstr ""
+msgstr "Vähimmäisleveys"
 
 msgid "Query"
-msgstr ""
+msgstr "Kysely"
 
 msgid "Locale settings"
 msgstr "Maa- ja kielikohtaiset asetukset"
 
 msgid "Search fields"
-msgstr ""
+msgstr "Hakukentät"
 
 msgid "Configure block"
-msgstr ""
+msgstr "Lohkon asetukset"
 
 msgid "Block name"
-msgstr ""
+msgstr "Lohkon nimi"
 
 msgid "How many content items to display in \"day\" list."
-msgstr ""
+msgstr "Kuinka monta kirjoitusta näytetään \"Tämänpäiväiset\" -listassa"
 
 msgid "Jan"
-msgstr ""
+msgstr "Tam"
 
 msgid "Feb"
-msgstr ""
+msgstr "Hel"
 
 msgid "Mar"
-msgstr ""
+msgstr "Maa"
 
 msgid "Apr"
-msgstr ""
+msgstr "Huh"
 
 msgid "Jun"
-msgstr ""
+msgstr "Kes"
 
 msgid "Jul"
-msgstr ""
+msgstr "Hei"
 
 msgid "Aug"
-msgstr ""
+msgstr "Elo"
 
 msgid "Sep"
-msgstr ""
+msgstr "Syy"
 
 msgid "Oct"
-msgstr ""
+msgstr "Lok"
 
 msgid "Nov"
-msgstr ""
+msgstr "Mar"
 
 msgid "Dec"
-msgstr ""
+msgstr "Jou"
 
 msgid "Hour"
-msgstr ""
+msgstr "Tunti"
 
 msgid "Minute"
-msgstr ""
+msgstr "Minuutti"
 
 msgid "Second"
-msgstr ""
+msgstr "Sekunti"
 
 msgid "Select list"
-msgstr ""
+msgstr "Valintalista"
 
 msgid "Text field"
-msgstr ""
+msgstr "Tekstikenttä"
 
 msgid "Granularity"
-msgstr ""
+msgstr "Rakeisuustaso"
 
 msgid "Posts"
-msgstr ""
+msgstr "Kirjoitukset"
 
 msgid "Map"
 msgstr "Kartta"
 
 msgid "Node settings"
-msgstr ""
+msgstr "Solmun asetukset"
 
 msgid "Alignment"
-msgstr ""
+msgstr "Tasaus"
 
 msgid "Randomize"
-msgstr ""
+msgstr "Satunnaista"
 
 msgid "Link label"
-msgstr ""
+msgstr "Linkin otsikko"
 
 msgid "author"
-msgstr ""
+msgstr "kirjoittaja"
 
 msgid "AND"
-msgstr ""
+msgstr "JA"
 
 msgid "Fixed"
-msgstr ""
+msgstr "Kiinteä"
 
 msgid "Revert"
-msgstr ""
+msgstr "Palauta käyttöön"
 
 msgid "Negate"
-msgstr ""
+msgstr "Käänteistä"
 
 msgid "Empty"
-msgstr ""
+msgstr "Tyhjä"
 
 msgid "Existing system path"
-msgstr ""
+msgstr "Olemassaoleva järjestelmäpolku"
 
 msgid "Path alias"
-msgstr ""
+msgstr "Polun alias"
 
 msgid "Greater than"
-msgstr ""
+msgstr "Suurempi kuin"
 
 msgid "Less than"
-msgstr ""
+msgstr "Pienempi kuin"
 
 msgid "Notice"
-msgstr ""
+msgstr "Huomio"
 
 msgid "Caption"
-msgstr ""
+msgstr "Kuvateksti"
 
 msgid "Number of day's top views to display"
-msgstr ""
+msgstr "Päivän suosituimpien määrä"
 
 msgid "Number of all time views to display"
-msgstr ""
+msgstr "Kaikkien aikojen suosituimpien määrä"
 
 msgid "Number of most recent views to display"
-msgstr ""
+msgstr "Viimeksi katsottujen määrä"
 
 msgid "characters"
-msgstr ""
+msgstr "merkit"
 
 msgid "Su"
-msgstr ""
+msgstr "Su"
 
 msgid "Mo"
-msgstr ""
+msgstr "Ma"
 
 msgid "Tu"
-msgstr ""
+msgstr "Ti"
 
 msgid "We"
-msgstr ""
+msgstr "Ke"
 
 msgid "Th"
-msgstr ""
+msgstr "To"
 
 msgid "Fr"
-msgstr ""
+msgstr "Pe"
 
 msgid "Sa"
-msgstr ""
+msgstr "La"
 
 msgid "First day of week"
-msgstr ""
+msgstr "Viikon ensimmäinen päivä"
 
 msgid "Add workflow"
-msgstr ""
+msgstr "Lisää työnkulku"
 
 msgid "Add state"
-msgstr ""
+msgstr "Lisää tila"
 
 msgid "Transition"
-msgstr ""
+msgstr "Sivunsiirto"
 
 msgid "Left"
-msgstr ""
+msgstr "Vasemmalla"
 
 msgid "Right"
-msgstr ""
+msgstr "Oikealla"
 
 msgid "Buttons"
-msgstr ""
+msgstr "Painikkeet"
 
 msgid "next ›"
 msgstr "seuraava >"
 
 msgid "Front page"
-msgstr ""
+msgstr "Front page"
 
 msgid "Entity"
-msgstr ""
+msgstr "Entity"
 
 msgid "Languages"
-msgstr ""
+msgstr "Languages"
 
 msgid "Member for"
-msgstr ""
+msgstr "Member for"
 
 msgid "Log out"
-msgstr ""
+msgstr "Kirjaudu ulos"
 
 msgid "Workflow"
-msgstr ""
+msgstr "Työnkulku"
 
 msgid "Modified"
 msgstr "Muokattu"
 
 msgid "Show"
-msgstr ""
+msgstr "Näytä"
 
 msgid "Configure permissions"
-msgstr ""
+msgstr "Säädä käyttöoikeuksia"
 
 msgid "Extend"
-msgstr ""
+msgstr "Laajenna"
 
 msgid "Create new account"
 msgstr "Luo uusi käyttäjätili"
 
 msgid "Seconds"
-msgstr ""
+msgstr "Sekunnit"
 
 msgid "role"
-msgstr ""
+msgstr "rooli"
 
 msgid "User registration"
-msgstr ""
+msgstr "Käyttäjän rekisteröityminen"
 
 msgid "Info"
-msgstr ""
+msgstr "Tieto"
 
 msgid "Created new term %term."
-msgstr ""
+msgstr "Luotiin uusi termi %term."
 
 msgid "Deleted term %name."
-msgstr ""
+msgstr "Termi %name poistettu."
 
 msgid "Notify user when account is activated"
-msgstr ""
+msgstr "Ilmoita käyttäjälle kun tili on aktivoitu"
 
 msgid "Notify user when account is blocked"
-msgstr ""
+msgstr "Ilmoita käyttäjälle kun tili on lukittu"
 
 msgid "Reference"
-msgstr ""
+msgstr "Viittaus"
 
 msgid "Enabled filters"
-msgstr ""
+msgstr "Käytössä olevat suodattimet"
 
 msgid "Updating"
-msgstr ""
+msgstr "Päivittäminen"
 
 msgid "or"
-msgstr ""
+msgstr "tai"
 
 msgid "Getting Started"
-msgstr ""
+msgstr "Näin aloitat"
 
 msgid "Convert"
-msgstr ""
+msgstr "Käännä"
 
 msgid "Binary"
-msgstr ""
+msgstr "Binääri"
 
 msgid "Delete term"
-msgstr ""
+msgstr "Poista termi"
 
 msgid "List terms"
-msgstr ""
+msgstr "Listaa termit"
 
 msgid ""
 "Deleting a term will delete all its children if there are any. This action "
 "cannot be undone."
 msgstr ""
+"Termin poistaminen poistaa myös kaikki sen mahdolliset alatermit. Tätä ei "
+"voi perua."
 
 msgid "Parent terms"
-msgstr ""
+msgstr "Ylemmän tason termit"
 
 msgid "Syndicate"
-msgstr ""
+msgstr "Syötteet"
 
 msgid "Books"
-msgstr ""
+msgstr "Kirjat"
 
 msgid "Style"
-msgstr ""
+msgstr "Tyyli"
 
 msgid "Forums"
-msgstr ""
+msgstr "Foorumit"
 
 msgid "Superscript"
-msgstr ""
+msgstr "Yläindeksi"
 
 msgid "Revisions for %title"
-msgstr ""
+msgstr "Kirjoituksen %title versiot"
 
 msgid "Revision"
-msgstr ""
+msgstr "Versio"
 
 msgid "The specified passwords do not match."
 msgstr "Salasanat eivät täsmää."
 
 msgid "Session"
-msgstr ""
+msgstr "Sessio"
 
 msgid "Missing"
-msgstr ""
+msgstr "Puuttuu"
 
 msgid "No forums defined"
-msgstr ""
+msgstr "Yhtään foorumia ei ole määritelty."
 
 msgid "This topic has been moved"
-msgstr ""
+msgstr "Tämä keskustelu on siirretty"
 
 msgid "roles"
-msgstr ""
+msgstr "roolit"
 
 msgid "Your settings have been saved."
-msgstr ""
+msgstr "Asetuksesi on tallennettu."
 
 msgid "Plugin"
-msgstr ""
+msgstr "Plugin"
 
 msgid "Link color"
-msgstr ""
+msgstr "Linkin väri"
 
 msgid "Duplicate"
-msgstr ""
+msgstr "Monista"
 
 msgid "Display label"
-msgstr ""
+msgstr "Näytä etiketti"
 
 msgid "Reverse"
-msgstr ""
+msgstr "Käänteinen järjestys"
 
 msgid "Testing"
-msgstr ""
+msgstr "Testaus"
 
 msgid "Standard"
-msgstr ""
+msgstr "Standardi"
 
 msgid "Interval"
-msgstr ""
+msgstr "Vaihteluväli"
 
 msgid "Ascension Island"
-msgstr ""
+msgstr "Ascension"
 
 msgid "Fiji"
-msgstr ""
+msgstr "Fidži"
 
 msgid "Falkland Islands"
-msgstr ""
+msgstr "Falklandsaaret"
 
 msgid "Saint Kitts and Nevis"
-msgstr ""
+msgstr "Saint Kitts ja Nevis"
 
 msgid "South Korea"
-msgstr ""
+msgstr "Etelä-Korea"
 
 msgid "Saint Lucia"
-msgstr ""
+msgstr "Saint Lucia"
 
 msgid "Saint Helena"
-msgstr ""
+msgstr "Saint Helena"
 
 msgid "French Southern Territories"
-msgstr ""
+msgstr "Ranskan eteläiset alueet"
 
 msgid "Saint Vincent and the Grenadines"
-msgstr ""
+msgstr "Saint Vincent ja Grenadiinit"
 
 msgid "U.S. Virgin Islands"
-msgstr ""
+msgstr "Amerikkalaiset Neitsytsaaret"
 
 msgid "Vietnam"
-msgstr ""
+msgstr "Vietnam"
 
 msgid "Guernsey"
-msgstr ""
+msgstr "Guernsey"
 
 msgid "Jersey"
-msgstr ""
+msgstr "Jersey"
 
 msgid "User name"
-msgstr ""
+msgstr "Käyttäjän nimi"
 
 msgid "Theme settings"
-msgstr ""
+msgstr "Teema-asetukset"
 
 msgid "Authentication"
-msgstr ""
+msgstr "Tunnistaminen"
 
 msgid "Not published"
-msgstr ""
+msgstr "Ei julkaistu"
 
 msgid "File settings"
-msgstr ""
+msgstr "Tiedostoasetukset"
 
 msgid "Menu settings"
-msgstr ""
+msgstr "Valikon asetukset"
 
 msgid "Color scheme"
-msgstr ""
+msgstr "Värivalikoima"
 
 msgid "width"
-msgstr ""
+msgstr "leveys"
 
 msgid "height"
-msgstr ""
+msgstr "korkeus"
 
 msgid "Unformatted"
-msgstr ""
+msgstr "Muokkaamaton"
 
 msgid "Formats"
-msgstr ""
+msgstr "Muodot"
 
 msgid "@type: deleted %title."
-msgstr ""
+msgstr "@type: poistettiin %title."
 
 msgid "RSS Feed"
-msgstr ""
+msgstr "RSS-syöte"
 
 msgid "Allowed file extensions"
-msgstr ""
+msgstr "Sallitut tiedostopäätteet"
 
 msgid "New comments"
-msgstr ""
+msgstr "Uudet kommentit"
 
 msgid "New"
 msgstr "Uusi"
 
 msgid "Redirect to URL"
-msgstr ""
+msgstr "Ohjaa osoitteeseen"
 
 msgid "Top left"
-msgstr ""
+msgstr "Vasemmalla ylhäällä"
 
 msgid "Top right"
-msgstr ""
+msgstr "Oikealla ylhäällä"
 
 msgid "Bottom right"
-msgstr ""
+msgstr "Alhaalla oikealla"
 
 msgid "Bottom left"
-msgstr ""
+msgstr "Alhaalla vasemmalla"
 
 msgid "Relationships"
-msgstr ""
+msgstr "Suhteet"
 
 msgid "Relationship"
-msgstr ""
+msgstr "Suhde"
 
 msgid "relationships"
-msgstr ""
+msgstr "suhteet"
 
 msgid "Migrate"
-msgstr ""
+msgstr "Muuta"
 
 msgid "The username %name has not been activated or is blocked."
 msgstr "Käyttäjän %name tiliä ei ole aktivoitu tai se on estetty."
 
 msgid "Login attempt failed for %user."
-msgstr ""
+msgstr "Käyttäjän %user kirjautumisyritys epäonnistui."
 
 msgid "Oldest first"
 msgstr "Vanhimmat ensin"
 
 msgid "Sort criteria"
-msgstr ""
+msgstr "Lajittelukriteerit"
 
 msgid "Base path"
-msgstr ""
+msgstr "Peruspolku"
 
 msgid "Revision of %title from %date"
-msgstr ""
+msgstr "Versio kirjoituksesta %title, julkaistu %date"
 
 msgid "Parent menu item"
-msgstr ""
+msgstr "Ylätason valikkoelementti"
 
 msgid "The username of the user to which you would like to assign ownership."
-msgstr ""
+msgstr "Sen käyttäjän tunnus, jolle haluat antaa omistuksen."
 
 msgid "Delete action"
-msgstr ""
+msgstr "Poista toimenpide"
 
 msgid "The action has been successfully saved."
-msgstr ""
+msgstr "Toimenpiteen tallentaminen onnistui."
 
 msgid "Themes"
-msgstr ""
+msgstr "Teemat"
 
 msgid "JPEG quality"
-msgstr ""
+msgstr "JPEG-kuvan laatu"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "Content options"
-msgstr ""
+msgstr "Sisällön vaihtoehdot"
 
 msgid "Last changed"
-msgstr ""
+msgstr "Viimeksi muokattu"
 
 msgid "not published"
-msgstr ""
+msgstr "ei julkaistu"
 
 msgid "Loading..."
-msgstr ""
+msgstr "Ladataan..."
 
 msgid "Protected"
-msgstr ""
+msgstr "Suojattu"
 
 msgid "Comment settings"
-msgstr ""
+msgstr "Kommentoinnin asetukset"
 
 msgid "Sticky"
-msgstr ""
+msgstr "Kiinnitetty"
 
 msgid "Default options"
-msgstr ""
+msgstr "Oletusasetukset"
 
 msgid "Ok"
-msgstr ""
+msgstr "Ok"
 
 msgid "Contact settings"
 msgstr "Yhteydenottoasetukset"
 
 msgid "Ban"
-msgstr ""
+msgstr "Ban"
 
 msgid "Processing"
-msgstr ""
+msgstr "Käsitellään"
 
 msgid "Temporary directory"
-msgstr ""
+msgstr "Väliaikainen hakemisto"
 
 msgid "File upload error. Could not move uploaded file."
 msgstr ""
+"Tiedoston siirto-ongelma. Tiedostoa ei voitu siirtää oikeaan hakemistoon."
 
 msgid "User status"
-msgstr ""
+msgstr "Käyttäjän tila"
 
 msgid "Shortcut"
-msgstr ""
+msgstr "Oikopolku"
 
 msgid "Default value"
-msgstr ""
+msgstr "Oletusarvo"
 
 msgid "Timezone"
-msgstr ""
+msgstr "Aikavyöhyke"
 
 msgid "Password strength:"
 msgstr "Salasanan vahvuus:"
@@ -3020,19 +3025,19 @@ msgid "Passwords match:"
 msgstr "Salasanat täsmäävät:"
 
 msgid "The name used to indicate anonymous users."
-msgstr ""
+msgstr "Tuntemattomasta käyttäjästä käytettävä nimi"
 
 msgid "Image crop"
-msgstr ""
+msgstr "Kuvan rajaus"
 
 msgid "@message"
-msgstr ""
+msgstr "@message"
 
 msgid "‹ Previous"
 msgstr "< Edellinen"
 
 msgid "comment"
-msgstr ""
+msgstr "kommentti"
 
 msgid "Anonymous user"
 msgstr "Anonyymi käyttäjä"
@@ -3044,748 +3049,763 @@ msgid "Published comments"
 msgstr "Julkaistut kommentit"
 
 msgid "Author Name"
-msgstr ""
+msgstr "Author Name"
 
 msgid "Unpublished"
 msgstr "Julkaisematon"
 
 msgid "Glossary"
-msgstr ""
+msgstr "Glossary"
 
 msgid "People"
-msgstr ""
+msgstr "People"
 
 msgid "Blocked"
-msgstr ""
+msgstr "Blocked"
 
 msgid "Output format"
-msgstr ""
+msgstr "Output format"
 
 msgid "Reset password"
 msgstr "Unohditko salasanasi?"
 
 msgid "Next page"
-msgstr ""
+msgstr "Seuraava sivu"
 
 msgid "Cron"
-msgstr ""
+msgstr "Cron"
 
 msgid "Shortcuts"
-msgstr ""
+msgstr "Oikopolut"
 
 msgid "Aggregate JavaScript files"
-msgstr ""
+msgstr "Yhdistä JavaScript-tiedostot"
 
 msgid "Changed"
-msgstr ""
+msgstr "Muuttunut"
 
 msgid "Multilingual"
-msgstr ""
+msgstr "Monikielinen"
 
 msgid "Installed"
-msgstr ""
+msgstr "Asennettu"
 
 msgid "Permissions"
-msgstr ""
+msgstr "Käyttöoikeudet"
 
 msgid "Enabled modules"
-msgstr ""
+msgstr "Aktivoidut moduulit"
 
 msgid "Not translated"
-msgstr ""
+msgstr "Kääntämättä"
 
 msgid "Select"
-msgstr ""
+msgstr "Valitse"
 
 msgid "Translatable"
-msgstr ""
+msgstr "Käännettävissä"
 
 msgid "Location of comment submission form"
-msgstr ""
+msgstr "Kommenttien lähetyslomakkeen sijainti"
 
 msgid "Show blocks"
-msgstr ""
+msgstr "Näytä elementit"
 
 msgid "Go to first page"
 msgstr "Ensimmäinen sivu"
 
 msgid "Enter the terms you wish to search for."
-msgstr ""
+msgstr "Kirjoita haluamasi hakusanat."
 
 msgid "Bold"
-msgstr ""
+msgstr "Lihavoitu"
 
 msgid "Underlined"
-msgstr ""
+msgstr "Alleviivattu"
 
 msgid "Variables"
-msgstr ""
+msgstr "Muuttujat"
 
 msgid "Tasks"
-msgstr ""
+msgstr "Tehtävät"
 
 msgid "Plugins"
-msgstr ""
+msgstr "Liitännäiset"
 
 msgid "Delete role"
-msgstr ""
+msgstr "Poista rooli"
 
 msgid "PHP Code"
-msgstr ""
+msgstr "PHP-koodi"
 
 msgid "Basic configuration"
-msgstr ""
+msgstr "Perusasetukset"
 
 msgid "Recipe"
-msgstr ""
+msgstr "Resepti"
 
 msgid "Ingredients"
-msgstr ""
+msgstr "Ainesosat"
 
 msgid "Recipes"
-msgstr ""
+msgstr "Reseptit"
 
 msgid "No caching"
-msgstr ""
+msgstr "Ei välimuistitusta"
 
 msgid "British Indian Ocean Territory"
-msgstr ""
+msgstr "Brittiläinen Intian valtameren alue"
 
 msgid "Croatia"
-msgstr ""
+msgstr "Kroatia"
 
 msgid "Macedonia"
-msgstr ""
+msgstr "Makedonia"
 
 msgid "Western Sahara"
-msgstr ""
+msgstr "Länsi-Sahara"
 
 msgid "Language switcher"
-msgstr ""
+msgstr "Kielen vaihtaja"
 
 msgid "Source field"
-msgstr ""
+msgstr "Lähdekenttä"
 
 msgid "Translation status"
-msgstr ""
+msgstr "Käännöksen tila"
 
 msgid "Blocks"
-msgstr ""
+msgstr "Lohkot"
 
 msgid "Delete block"
-msgstr ""
+msgstr "Poista lohko"
 
 msgid "Save blocks"
-msgstr ""
+msgstr "Tallenna lohkot"
 
 msgid "The block settings have been updated."
-msgstr ""
+msgstr "Lohkojen asetukset on tallennettu."
 
 msgid "Save block"
-msgstr ""
+msgstr "Tallenna lohko"
 
 msgid "The block configuration has been saved."
-msgstr ""
+msgstr "Lohkon asetukset on tallennettu."
 
 msgid "Any customizations will be lost. This action cannot be undone."
-msgstr ""
+msgstr "Kaikki mukautukset menetetään. Tätä ei voi perua."
 
 msgid "Add vocabulary"
-msgstr ""
+msgstr "Lisää sanasto"
 
 msgid "Edit vocabulary"
-msgstr ""
+msgstr "Muokkaa sanastoa"
 
 msgid "Created new vocabulary %name."
-msgstr ""
+msgstr "Uusi sanasto %name luotu."
 
 msgid "Updated vocabulary %name."
-msgstr ""
+msgstr "Sanasto %name päivitetty."
 
 msgid "Are you sure you want to delete the vocabulary %title?"
-msgstr ""
+msgstr "Haluatko varmasti poistaa sanaston %title?"
 
 msgid ""
 "Deleting a vocabulary will delete all the terms in it. This action cannot be"
 " undone."
 msgstr ""
+"Sanaston poistaminen tuhoaa myös kaikki sen sisältämät termit. Tätä ei voi "
+"perua."
 
 msgid "Deleted vocabulary %name."
-msgstr ""
+msgstr "Sanasto %name poistettu."
 
 msgid "Above"
-msgstr ""
+msgstr "Yläpuolella"
 
 msgid "@min and @max"
-msgstr ""
+msgstr "@min ja @max"
 
 msgid "Default time zone"
-msgstr ""
+msgstr "Oletusaikavyöhyke"
 
 msgid "Manage fields"
-msgstr ""
+msgstr "Hallitse kenttiä"
 
 msgid "Add field"
-msgstr ""
+msgstr "Lisää kenttä"
 
 msgid "Trimmed"
-msgstr ""
+msgstr "Trimmattu"
 
 msgid "Text area"
-msgstr ""
+msgstr "Tekstialue"
 
 msgid "Add a new field"
-msgstr ""
+msgstr "Lisää uusi kenttä"
 
 msgid "Save field settings"
-msgstr ""
+msgstr "Tallenna kentän asetukset"
 
 msgid "The update has encountered an error."
-msgstr ""
+msgstr "Päivityksessä tapahtui virhe."
 
 msgid "1 item successfully processed:"
 msgid_plural "@count items successfully processed:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 kohde käsiteltiin:"
+msgstr[1] "@count kohdetta käsiteltiin:"
 
 msgid "Provide a comma separated list of arguments to pass to the view."
-msgstr ""
+msgstr "Syötä pilkuin eroteltu lista näkymälle syötettävistä argumenteista."
 
 msgid "Decimal"
-msgstr ""
+msgstr "Desimaali"
 
 msgid "Float"
-msgstr ""
+msgstr "Liukuluku"
 
 msgid "Minimum"
-msgstr ""
+msgstr "Pienin"
 
 msgid "Precision"
-msgstr ""
+msgstr "Tarkkuus"
 
 msgid ""
 "The total number of digits to store in the database, including those to the "
 "right of the decimal."
 msgstr ""
+"Tietokantaan tallennettavien numeroiden kokonaismäärä, sisältäen "
+"desimaalipilkun oikealla puolella olevat numerot."
 
 msgid "The number of digits to the right of the decimal."
-msgstr ""
+msgstr "Numeroiden määrä desimaalin oikealla puolella."
 
 msgid "Decimal marker"
-msgstr ""
+msgstr "Desimaalimerkki"
 
 msgid "Check boxes/radio buttons"
-msgstr ""
+msgstr "Valintalaatikot/radionapit"
 
 msgid "Single on/off checkbox"
-msgstr ""
+msgstr "Yksittäinen valintaruutu"
 
 msgid "Text area (multiple rows)"
-msgstr ""
+msgstr "Tekstialue (useita rivejä)"
 
 msgid "Index"
-msgstr ""
+msgstr "Indeksi"
 
 msgid "Permalink"
-msgstr ""
+msgstr "Ikilinkki"
 
 msgid "Theme-engine-specific settings"
-msgstr ""
+msgstr "Teemamoottorikohtaiset asetukset"
 
 msgid "Form"
-msgstr ""
+msgstr "Kaavake"
 
 msgid "Debug"
-msgstr ""
+msgstr "Debuggaa"
 
 msgid "Exceptions"
-msgstr ""
+msgstr "Poikkeukset"
 
 msgid "The parent comment"
-msgstr ""
+msgstr "Isäntäkommentti"
 
 msgid "1 minute"
-msgstr ""
+msgstr "1 minuutti"
 
 msgid "@module module"
-msgstr ""
+msgstr "moduuli @module"
 
 msgid "More information"
-msgstr ""
+msgstr "Lisää tietoa"
 
 msgid "Grid"
 msgstr "Taulukko"
 
 msgid "Redo"
-msgstr ""
+msgstr "Toista"
 
 msgid "Italic"
-msgstr ""
+msgstr "Kursivoitu"
 
 msgid "Editor"
-msgstr ""
+msgstr "Editori"
 
 msgid "Date range"
-msgstr ""
+msgstr "Päivämäärän vaihteluväli"
 
 msgid "Anonymous commenting"
-msgstr ""
+msgstr "Anonyymi kommentointi"
 
 msgid "Anonymous posters may not enter their contact information"
-msgstr ""
+msgstr "Anonyymit kirjoittajat eivät voi jättää yhteystietojaan."
 
 msgid "Anonymous posters may leave their contact information"
-msgstr ""
+msgstr "Anonyymit kirjoittajat voivat jättää yhteystietonsa"
 
 msgid "Anonymous posters must leave their contact information"
-msgstr ""
+msgstr "Anonyymien kirjoittajien on jätettävä yhteystietonsa"
 
 msgid "Default comment setting"
-msgstr ""
+msgstr "Oletuskommenttiasetus"
 
 msgid ""
 "The content of this field is kept private and will not be shown publicly."
 msgstr ""
+"Tämän kentän sisältö pidetään yksityisenä eikä sitä näytetä julkisesti."
 
 msgid "parent"
-msgstr ""
+msgstr "isäntä"
 
 msgid "Date - newest first"
-msgstr ""
+msgstr "Päivämäärä - uusimmat ensin"
 
 msgid "Date - oldest first"
-msgstr ""
+msgstr "Päivämäärä - vanhimmat ensin"
 
 msgid "1 comment"
 msgid_plural "@count comments"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 kommentti"
+msgstr[1] "@count kommenttia"
 
 msgid "1 new comment"
 msgid_plural "@count new comments"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 uusi kommentti"
+msgstr[1] "@count uutta kommenttia"
 
 msgid "Save content type"
-msgstr ""
+msgstr "Tallenna sisältötyyppi"
 
 msgid "Show descriptions"
-msgstr ""
+msgstr "Näytä kuvaukset"
 
 msgid "Subtitle"
-msgstr ""
+msgstr "Alaotsikko"
 
 msgid "Copyright"
-msgstr ""
+msgstr "Tekijänoikeus"
 
 msgid "Not present"
-msgstr ""
+msgstr "Ei saatavilla"
 
 msgid "Source code"
-msgstr ""
+msgstr "Lähdekoodi"
 
 msgid "Contact link"
-msgstr ""
+msgstr "Yhteydenottolinkki"
 
 msgid "Edit container"
-msgstr ""
+msgstr "Muokkaa säiliötä"
 
 msgid "Plugin settings"
-msgstr ""
+msgstr "Lisäosan asetukset"
 
 msgid "Subscript"
-msgstr ""
+msgstr "Alaindeksi"
 
 msgid "Indent"
-msgstr ""
+msgstr "Suurenna sisennystä"
 
 msgid "Outdent"
-msgstr ""
+msgstr "Pienennä sisennystä"
 
 msgid "Unlink"
-msgstr ""
+msgstr "Poista linkki"
 
 msgid "Thread"
-msgstr ""
+msgstr "Ketjuta"
 
 msgid "Reply"
-msgstr ""
+msgstr "Vastaa"
 
 msgid "Hot topic threshold"
-msgstr ""
+msgstr "Suositun aiheen raja"
 
 msgid "Publish"
 msgstr "Julkaise"
 
 msgid "Apply"
-msgstr ""
+msgstr "Apply"
 
 msgid "Block description"
-msgstr ""
+msgstr "Block description"
 
 msgid "Used in"
-msgstr ""
+msgstr "Used in"
 
 msgid "Language code"
-msgstr ""
+msgstr "Language code"
 
 msgid "Translation"
-msgstr ""
+msgstr "Translation"
 
 msgid "Permission"
-msgstr ""
+msgstr "Permission"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Palauta luonnokseksi"
 
 msgid "Copy"
-msgstr ""
+msgstr "Kopioi"
 
 msgid "Global"
-msgstr ""
+msgstr "Global"
 
 msgid "Menu name"
-msgstr ""
+msgstr "Valikon nimi"
 
 msgid "Add another item"
-msgstr ""
+msgstr "Lisää uusi"
 
 msgid "Go to last page"
 msgstr "Viimeinen sivu"
 
 msgid "1 second"
 msgid_plural "@count seconds"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 sekunti"
+msgstr[1] "@count sekuntia"
 
 msgid ""
 "Configure what block content appears in your site's sidebars and other "
 "regions."
-msgstr ""
+msgstr "Valitse lohkot, jotka näytetään sivujen laidoilla ja muilla alueilla."
 
 msgid "Edit profile"
-msgstr ""
+msgstr "Muokkaa profiilia"
 
 msgid "Hide"
-msgstr ""
+msgstr "Piilossa"
 
 msgid "Text Editor"
-msgstr ""
+msgstr "Tekstieditori"
 
 msgid "Allows administrators to customize the site navigation menu."
-msgstr ""
+msgstr "Muokkaa navigaatiovalikoita."
 
 msgid ""
 "Defines selection, check box and radio button widgets for text and numeric "
 "fields."
 msgstr ""
+"Määrittää widgetin valintalistoja, valintaruutuja ja radionappeja varten "
+"sekä teksti- ja numeerisiä kenttiä varten."
 
 msgid "Defines simple text field types."
-msgstr ""
+msgstr "Määrittää yksinkertaiset tekstikenttätyypit."
 
 msgid "Please wait..."
 msgstr "Odota..."
 
 msgid "Topics per page"
-msgstr ""
+msgstr "Aiheita sivua kohden"
 
 msgid "Posts - most active first"
-msgstr ""
+msgstr "Aiheen mukaan - aktiivisimmat ensin"
 
 msgid "Posts - least active first"
-msgstr ""
+msgstr "Aiheen mukaan - vähiten aktiiviset ensin"
 
 msgid "URL path settings"
-msgstr ""
+msgstr "Polkujen asetukset"
 
 msgid "Title text"
-msgstr ""
+msgstr "Otsikkoteksti"
 
 msgid "Mapping"
-msgstr ""
+msgstr "Kartoitus"
 
 msgid "Are you sure you want to revert to the revision from %revision-date?"
 msgstr ""
+"Oletko varma, että haluat ottaa käyttöön version jonka päiväys on %revision-"
+"date?"
 
 msgid "Are you sure you want to delete the revision from %revision-date?"
-msgstr ""
+msgstr "Haluatko varmasti poistaa version, jonka päiväys on %revision-date?"
 
 msgid "Distinct"
-msgstr ""
+msgstr "Erilainen"
 
 msgid "Maximum upload size"
-msgstr ""
+msgstr "Suurin siirtokoko"
 
 msgid "Space"
-msgstr ""
+msgstr "Välilyönti"
 
 msgid "New forum topics"
-msgstr ""
+msgstr "Uusimmat foorumin aiheet"
 
 msgid "@type: deleted %title revision %revision."
-msgstr ""
+msgstr "@type: poistettiin %title versio %revision."
 
 msgid "Page not found"
-msgstr ""
+msgstr "Sivua ei löydy"
 
 msgid "More help"
-msgstr ""
+msgstr "Lisää apua"
 
 msgid "Bullet list"
-msgstr ""
+msgstr "Luettelomerkkilista"
 
 msgid "Account blocked"
-msgstr ""
+msgstr "Tilin käyttö estetty"
 
 msgid "Expand"
-msgstr ""
+msgstr "Laajenna"
 
 msgid "Change layout"
-msgstr ""
+msgstr "Muuta ulkoasua"
 
 msgid "Provided by"
-msgstr ""
+msgstr "Tarjoaa"
 
 msgid "Aggregate"
-msgstr ""
+msgstr "Aggregoi"
 
 msgid "Node access"
-msgstr ""
+msgstr "Solmun pääsy"
 
 msgid "Sizes"
-msgstr ""
+msgstr "Koot"
 
 msgid "Add terms"
-msgstr ""
+msgstr "Lisää termejä"
 
 msgid "Resize"
-msgstr ""
+msgstr "Muuta kokoa"
 
 msgid "Zip"
-msgstr ""
+msgstr "Zip"
 
 msgid "The directory %directory does not exist."
-msgstr ""
+msgstr "Hakemistoa %directory ei ole olemassa."
 
 msgid "Blockquote"
-msgstr ""
+msgstr "Kappalelainaus"
 
 msgid "Activate"
-msgstr ""
+msgstr "Aktivoi tilaus"
 
 msgid "empty"
-msgstr ""
+msgstr "tyhjä"
 
 msgid "Rebuild permissions"
-msgstr ""
+msgstr "Rakenna pääsyoikeudet uudelleen"
 
 msgid "@type: updated %title."
-msgstr ""
+msgstr "@type: päivitettiin %title."
 
 msgid "@type: added %title."
-msgstr ""
+msgstr "@type: lisättiin %title."
 
 msgid "Telephone"
-msgstr ""
+msgstr "Puhelin"
 
 msgid "Add role"
-msgstr ""
+msgstr "Lisää rooli"
 
 msgid "Path to custom logo"
-msgstr ""
+msgstr "Oman logon polku"
 
 msgid "Supported formats"
-msgstr ""
+msgstr "Tuetut muodot"
 
 msgid "Updated term %term."
-msgstr ""
+msgstr "Päivitettiin termi %term."
 
 msgid "- None selected -"
-msgstr ""
+msgstr "- Ei valittu -"
 
 msgid "Parser"
-msgstr ""
+msgstr "Parseri"
 
 msgid "Discard items older than"
-msgstr ""
+msgstr "Poista aiheet, jotka ovat vanhempia kuin"
 
 msgid "Aggregator"
-msgstr ""
+msgstr "Uutisten kerääjä"
 
 msgid "There is no new syndicated content from %site."
-msgstr ""
+msgstr "Sivustolla %site ei ole uutta sisältöä."
 
 msgid "There is new syndicated content from %site."
-msgstr ""
+msgstr "Sivustolla %site on uutta sisältöä."
 
 msgid "URL to the feed."
-msgstr ""
+msgstr "Syötteen osoite."
 
 msgid "Last time feed was checked for new items, as Unix timestamp."
-msgstr ""
+msgstr "Koska syötteestä viimeksi etsittiin uusia aiheita (UNIX-aikaleima)."
 
 msgid "An image representing the feed."
-msgstr ""
+msgstr "Kuva, joka edustaa syötettä."
 
 msgid "Entity tag HTTP response header, used for validating cache."
 msgstr ""
+"Kohteen HTTP-otsakkeen entity tag. Tätä käytetään välimuistin "
+"tarkistamiseen."
 
 msgid "When the feed was last modified, as a Unix timestamp."
-msgstr ""
+msgstr "Koska syötettä muokattiin viimeksi (UNIX-aikaleima)."
 
 msgid "Primary Key: Unique ID for feed item."
-msgstr ""
+msgstr "Pääavain: Syötteen aiheen ainutkertainen tunniste."
 
 msgid "Title of the feed item."
-msgstr ""
+msgstr "Aiheen otsikko."
 
 msgid "Link to the feed item."
-msgstr ""
+msgstr "Linkki syötteen aiheeseen."
 
 msgid "Author of the feed item."
-msgstr ""
+msgstr "Aiheen kirjoittaja."
 
 msgid "Body of the feed item."
-msgstr ""
+msgstr "Aiheen runko."
 
 msgid "Post date of feed item, as a Unix timestamp."
-msgstr ""
+msgstr "Syötteen aiheen kirjoitusaika (UNIX-aikaleima)."
 
 msgid "Unique identifier for the feed item."
-msgstr ""
+msgstr "Syötteen aiheen ainutkertainen tunniste."
 
 msgid "Alias"
-msgstr ""
+msgstr "Alias"
 
 msgid "Values"
-msgstr ""
+msgstr "Arvot"
 
 msgid "Enter your keywords"
-msgstr ""
+msgstr "Syötä hakusanat"
 
 msgid "Clean URLs"
-msgstr ""
+msgstr "Siistityt verkko-osoitteet"
 
 msgid "Number of topics"
-msgstr ""
+msgstr "Keskusteluiden määrä"
 
 msgid "Active forum topics"
-msgstr ""
+msgstr "Aktiiviset keskustelut"
 
 msgid "Read the latest forum topics."
-msgstr ""
+msgstr "Lue uusimmat keskustelut."
 
 msgid "HTTP authentication"
-msgstr ""
+msgstr "HTTP autentikointi"
 
 msgid "Attach to"
-msgstr ""
+msgstr "Liitä kohteeseen"
 
 msgid "Context"
-msgstr ""
+msgstr "Konteksti"
 
 msgid "Book navigation"
-msgstr ""
+msgstr "Kirjan navigaatio"
 
 msgid "Pager"
-msgstr ""
+msgstr "Sivutus"
 
 msgid "Identifier"
-msgstr ""
+msgstr "Tunnistin"
 
 msgid "Remove this item"
-msgstr ""
+msgstr "Poista"
 
 msgid "Keyword"
-msgstr ""
+msgstr "Avainsana"
 
 msgid "1 year"
 msgid_plural "@count years"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 vuosi"
+msgstr[1] "@count vuotta"
 
 msgid "1 week"
 msgid_plural "@count weeks"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 viikko"
+msgstr[1] "@count viikkoa"
 
 msgid "1 sec"
 msgid_plural "@count sec"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 s"
+msgstr[1] "@count s"
 
 msgid "Columns"
-msgstr ""
+msgstr "Palstat"
 
 msgid "Module name"
-msgstr ""
+msgstr "Moduulin nimi"
 
 msgid "Layout settings"
-msgstr ""
+msgstr "Ulkoasun asetukset"
 
 msgid "Page settings"
-msgstr ""
+msgstr "Sivuasetukset"
 
 msgid "Use pager"
-msgstr ""
+msgstr "Käytä sivutusta"
 
 msgid "Items to display"
-msgstr ""
+msgstr "Näytettävät elementit"
 
 msgid "More link"
-msgstr ""
+msgstr "\"Lisää\" linkki"
 
 msgid "More link text"
-msgstr ""
+msgstr "\"Lisää\" linkin teksti"
 
 msgid "Top level book"
-msgstr ""
+msgstr "Ylätason kirja"
 
 msgid "No temporary directories to remove."
-msgstr ""
+msgstr "Ei poistettavia tilapäiskansioita."
 
 msgid "German"
-msgstr ""
+msgstr "saksa"
 
 msgid "Link to file"
-msgstr ""
+msgstr "Linkki tiedostoon"
 
 msgid "contains"
-msgstr ""
+msgstr "sisältää"
 
 msgid "Send message"
 msgstr "Lähetä viesti"
 
 msgid "Allow Upscaling"
-msgstr ""
+msgstr "Salli ylöspäin skaalaus"
 
 msgid "Rotation angle"
-msgstr ""
+msgstr "Pyörityskulma"
 
 msgid ""
 "The number of degrees the image should be rotated. Positive numbers are "
 "clockwise, negative are counter-clockwise."
 msgstr ""
+"Kuinka monta astetta kuvaa käännetään. Positiiviiset luvut tarkoittavat "
+"myötäpäivään ja negatiiviset vastapäivään."
 
 msgid ""
 "Randomize the rotation angle for each image. The angle specified above is "
 "used as a maximum."
 msgstr ""
+"Satunnaista jokaisen kuvan kiertokulma. Yllämääritettyä kulmaa käytetään "
+"enimmäisarvona."
 
 msgid "Flush"
-msgstr ""
+msgstr "Tyhjennä"
 
 msgid "Print"
-msgstr ""
+msgstr "Tulosta"
 
 msgid "Field mapping"
-msgstr ""
+msgstr "Kenttien vastaavuuksien määrittely"
 
 msgid "The file could not be created."
-msgstr ""
+msgstr "Tiedoston luonti epäonnistui."
 
 msgid "Locked"
-msgstr ""
+msgstr "Lukittu"
 
 msgid "Password reset instructions mailed to %name at %email."
 msgstr ""
@@ -3793,1374 +3813,1423 @@ msgstr ""
 "%email."
 
 msgid "types"
-msgstr ""
+msgstr "tyypit"
 
 msgid "Data"
-msgstr ""
+msgstr "Data"
 
 msgid "Selection type"
-msgstr ""
+msgstr "Valintatyyppi"
 
 msgid "Any"
-msgstr ""
+msgstr "Mikä tahansa"
 
 msgid "Check for updates"
-msgstr ""
+msgstr "Tarkista päivitykset"
 
 msgid "All newer versions"
-msgstr ""
+msgstr "Kaikki uudemmat versiot"
 
 msgid "Only security updates"
-msgstr ""
+msgstr "Vain turvapäivitykset"
 
 msgid "No update data available"
-msgstr ""
+msgstr "Päivitystietoja ei ole saatavilla"
 
 msgid "Not secure!"
-msgstr ""
+msgstr "Turvaton!"
 
 msgid "Revoked!"
-msgstr ""
+msgstr "Peruttu!"
 
 msgid "Unsupported release"
-msgstr ""
+msgstr "Julkaisua ei tueta"
 
 msgid "Can not determine status"
-msgstr ""
+msgstr "Tilaa ei voida määritellä"
 
 msgid "(version @version available)"
-msgstr ""
+msgstr "(versio @version on saatavilla)"
 
 msgid "See the available updates page for more information:"
-msgstr ""
+msgstr "Lue lisää <em>Saatavilla olevat päivitykset</em> -sivulta:"
 
 msgid ""
 "There is a security update available for your version of Drupal. To ensure "
 "the security of your server, you should update immediately!"
 msgstr ""
+"Käyttämääsi Drupal-versioon on saatavilla turvapäivitys. Varmista "
+"palvelimesi turvallisuus päivittämällä välittömästi!"
 
 msgid "Display the depth of the comment if it is threaded."
-msgstr ""
+msgstr "Näytä kommentin syvyys jos kommentti on ketjutettuna."
 
 msgid "Taxonomy vocabulary"
-msgstr ""
+msgstr "Luokittelusanasto"
 
 msgid "No comments available."
-msgstr ""
+msgstr "No comments available."
 
 msgid "last »"
 msgstr "viimeinen »"
 
 msgid "Extension"
-msgstr ""
+msgstr "Tiedostopääte"
 
 msgid "Account settings"
-msgstr ""
+msgstr "Käyttäjätilin asetukset"
 
 msgid "« first"
 msgstr "« ensimmäinen"
 
 msgid "Machine name"
-msgstr ""
+msgstr "Machine name"
 
 msgid "Offset"
-msgstr ""
+msgstr "Offset"
 
 msgid "My account"
-msgstr ""
+msgstr "Oma käyttäjätilini"
 
 msgid "GD library"
-msgstr ""
+msgstr "GD-grafiikkakirjasto"
 
 msgid "1 min"
 msgid_plural "@count min"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 min"
+msgstr[1] "@count min"
 
 msgid "Defines a file field type."
-msgstr ""
+msgstr "Määrittelee kenttätyypin."
 
 msgid ""
 "Your version of Drupal has been revoked and is no longer available for "
 "download. Upgrading is strongly recommended!"
 msgstr ""
+"Käytössäsi oleva Drupalin versio on peruttu, eikä sitä voi enää ladata. "
+"Suosittelemme, että päivität Drupalin!"
 
 msgid ""
 "The installed version of at least one of your modules or themes has been "
 "revoked and is no longer available for download. Upgrading or disabling is "
 "strongly recommended!"
 msgstr ""
+"Ainakin yksi käyttämäsi moduuli tai teema on poistettu, eikä sitä tarjota "
+"enää. Suosittelemme että poistat tai päivität sen!"
 
 msgid ""
 "Your version of Drupal is no longer supported. Upgrading is strongly "
 "recommended!"
 msgstr ""
+"Käytössäsi olevaa Drupalin versiota ei enää tueta. Suosittelemme, että "
+"päivität Drupalin!"
 
 msgid ""
 "There are updates available for your version of Drupal. To ensure the proper"
 " functioning of your site, you should update as soon as possible."
 msgstr ""
+"Käyttämääsi Drupal-versioon on saatavilla päivitys. Varmista sivustosi "
+"toimivuus päivittämällä niin pian kuin mahdollista."
 
 msgid "Project not secure"
-msgstr ""
+msgstr "Projekti on turvaton"
 
 msgid ""
 "This project has been labeled insecure by the Drupal security team, and is "
 "no longer available for download. Immediately disabling everything included "
 "by this project is strongly recommended!"
 msgstr ""
+"Drupalin turvallisuusryhmä on merkinnyt tämän projektin turvattomaksi, eikä "
+"sitä voi enää ladata. Suosittelemme, että poistat välittömästi käytöstä "
+"kaiken tähän projektiin liittyvän!"
 
 msgid "Project revoked"
-msgstr ""
+msgstr "Projekti on peruttu"
 
 msgid ""
 "This project has been revoked, and is no longer available for download. "
 "Disabling everything included by this project is strongly recommended!"
 msgstr ""
+"Tämä projekti on peruttu, eikä sitä voi enää ladata. Suosittelemme, että "
+"poistat käytöstä kaiken tähän projektiin liittyvän!"
 
 msgid "Project not supported"
-msgstr ""
+msgstr "Projektia ei tueta"
 
 msgid ""
 "This project is no longer supported, and is no longer available for "
 "download. Disabling everything included by this project is strongly "
 "recommended!"
 msgstr ""
+"Tätä projektia ei enää tueta, eikä sitä voi enää ladata. Suosittelemme, että"
+" poistat käytöstä kaiken tähän projektiin liittyvän!"
 
 msgid "No available releases found"
-msgstr ""
+msgstr "Julkaisuja ei ole saatavilla"
 
 msgid "Release revoked"
-msgstr ""
+msgstr "Julkaisu on kumottu"
 
 msgid ""
 "Your currently installed release has been revoked, and is no longer "
 "available for download. Disabling everything included in this release or "
 "upgrading is strongly recommended!"
 msgstr ""
+"Käytössäsi oleva julkaisu on peruttu, eikä sitä voi enää ladata. "
+"Suosittelemme, että poistat kokonaan käytöstä tämän julkaisun tai päivität "
+"sen."
 
 msgid "Release not supported"
-msgstr ""
+msgstr "Julkaisua ei tueta"
 
 msgid ""
 "Your currently installed release is now unsupported, and is no longer "
 "available for download. Disabling everything included in this release or "
 "upgrading is strongly recommended!"
 msgstr ""
+"Käytössäsi olevaa julkaisua ei enää tueta, eikä sitä voi enää ladata. "
+"Suosittelemme, että poistat kokonaan käytöstä tämän julkaisun tai päivität "
+"sen."
 
 msgid "Invalid info"
-msgstr ""
+msgstr "Virheelliset tiedot"
 
 msgid "Security update required!"
-msgstr ""
+msgstr "Turvapäivitys vaaditaan!"
 
 msgid "Not supported!"
-msgstr ""
+msgstr "Ei tuettu!"
 
 msgid "Recommended version:"
-msgstr ""
+msgstr "Suositeltava versio:"
 
 msgid "Security update:"
-msgstr ""
+msgstr "Turvapäivitys:"
 
 msgid "Latest version:"
-msgstr ""
+msgstr "Uusin versio:"
 
 msgid "Development version:"
-msgstr ""
+msgstr "Kehitysversio:"
 
 msgid "Also available:"
-msgstr ""
+msgstr "Saatavilla myös:"
 
 msgid "No name"
-msgstr ""
+msgstr "Ei nimeä"
 
 msgid "File MIME"
-msgstr ""
+msgstr "Tiedoston MIME"
 
 msgid "User Role"
-msgstr ""
+msgstr "Käyttäjärooli"
 
 msgid "Search help"
-msgstr ""
+msgstr "Hakuohjeet"
 
 msgid "Field settings"
-msgstr ""
+msgstr "Kentän asetukset"
 
 msgid "Edit forum"
-msgstr ""
+msgstr "Muokkaa foorumia"
 
 msgid "Default order"
-msgstr ""
+msgstr "Oletusjärjestys"
 
 msgid ""
 "This is the designated forum vocabulary. Some of the normal vocabulary "
 "options have been removed."
 msgstr ""
+"Tämä sanasto määrittää foorumien rakenteen. Jotkin tavallisest sanastojen "
+"asetukset eivät ole käytettävissä."
 
 msgid "Leave shadow copy"
-msgstr ""
+msgstr "Jätä varjokopio"
 
 msgid ""
 "If you move this topic, you can leave a link in the old forum to the new "
 "forum."
 msgstr ""
+"Jos siirrät tätä keskustelua, vanhalle foorumille voidaan jättää uudelle "
+"foorumille ohjaava linkki eli <em>varjokopio</em>."
 
 msgid "Container name"
-msgstr ""
+msgstr "Säiliön nimi"
 
 msgid "forum container"
-msgstr ""
+msgstr "foorumisäiliö"
 
 msgid "Created new @type %term."
-msgstr ""
+msgstr "Luotu uusi @type %term."
 
 msgid "The @type %term has been updated."
-msgstr ""
+msgstr "Päivitetty @type %term."
 
 msgid "AJAX"
-msgstr ""
+msgstr "AJAX"
 
 msgid "Emails"
-msgstr ""
+msgstr "Sähköpostit"
 
 msgid "Favicon"
-msgstr ""
+msgstr "Favicon"
 
 msgid "Containing any of the words"
-msgstr ""
+msgstr "Sisältää minkä tahansa sanoista"
 
 msgid "Containing the phrase"
-msgstr ""
+msgstr "Sisältää lauseen"
 
 msgid "Containing none of the words"
-msgstr ""
+msgstr "Ei sisällä sanoja"
 
 msgid "Only of the type(s)"
-msgstr ""
+msgstr "Vain tyyppiä/tyyppejä"
 
 msgid "Content ranking"
-msgstr ""
+msgstr "Sisällön arvojärjestys"
 
 msgid "Keyword relevance"
-msgstr ""
+msgstr "Hakusanan osuvuus"
 
 msgid "Number of views"
-msgstr ""
+msgstr "Katselukerrat"
 
 msgid "Factor"
-msgstr ""
+msgstr "Tekijä"
 
 msgid "Content search"
-msgstr ""
+msgstr "Sisältöhaku"
 
 msgid "Expand layout to include descriptions."
-msgstr ""
+msgstr "Näytä väljempi ulkoasu, joka sisältää kuvaukset."
 
 msgid "Or"
-msgstr ""
+msgstr "TAI"
 
 msgid "Color set"
-msgstr ""
+msgstr "Värisarja"
 
 msgid "Underline"
-msgstr ""
+msgstr "Alleviivattu"
 
 msgid "Cut"
-msgstr ""
+msgstr "Leikkaa"
 
 msgid "Paste"
-msgstr ""
+msgstr "Liitä"
 
 msgid "Ordered list"
-msgstr ""
+msgstr "Järjestetty lista"
 
 msgid "Unordered list"
-msgstr ""
+msgstr "Järjestämätön lista"
 
 msgid "Case sensitive"
-msgstr ""
+msgstr "Kirjasinkokoriippuvainen"
 
 msgid "Maximum link text length"
-msgstr ""
+msgstr "Suurin linkkitekstin pituus"
 
 msgid ""
 "URLs longer than this number of characters will be truncated to prevent long"
 " strings that break formatting. The link itself will be retained; just the "
 "text portion of the link will be truncated."
 msgstr ""
+"Tätä merkkimäärää pidemmät URL:t lyhennetään, jolla estetään muotoilun "
+"rikkovat ylipitkät merkkijonot.  Itse linkki jää ennalleen; vain linkin "
+"tekstiosaa lyhennetään."
 
 msgid "Setting"
-msgstr ""
+msgstr "Asetus"
 
 msgid ""
 "If you don't have direct file access to the server, use this field to upload"
 " your logo."
 msgstr ""
+"Jos sinulla ei ole suoraa yhteyttä palvelimen tiedostojärjestelmään, käytä "
+"tätä kenttää logon siirtämiseen palvelimelle."
 
 msgid "Link class"
-msgstr ""
+msgstr "Linkin luokka"
 
 msgid "Install profile"
-msgstr ""
+msgstr "Asennusprofiili"
 
 msgid "%percentage of the site has been indexed."
-msgstr ""
+msgstr "%percentage sivustosta on indeksoitu."
 
 msgid "File directory"
-msgstr ""
+msgstr "Tiedostokansio"
 
 msgid "Default theme"
-msgstr ""
+msgstr "Oletusteema"
 
 msgid "Teaser length"
-msgstr ""
+msgstr "Yhteenvedon pituus"
 
 msgid "not set"
-msgstr ""
+msgstr "ei asetettuna"
 
 msgid "Memory limit"
-msgstr ""
+msgstr "Muistiraja"
 
 msgid "regex"
-msgstr ""
+msgstr "regex"
 
 msgid "Indexes"
-msgstr ""
+msgstr "Indeksit"
 
 msgid "Cardinality"
-msgstr ""
+msgstr "Mahtavuus"
 
 msgid "There is 1 item left to index."
 msgid_plural "There are @count items left to index."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Jäljellä on 1 indeksoitava kohde."
+msgstr[1] "Jäljellä on @count indeksoitavaa kohdetta."
 
 msgid "The content access permissions have been rebuilt."
-msgstr ""
+msgstr "Sisällön pääsyoikeudet on rakennettu uudelleen."
 
 msgid "Column"
-msgstr ""
+msgstr "Palsta"
 
 msgid "Default sort"
-msgstr ""
+msgstr "Oletusjärjestys"
 
 msgid "sort by @s"
-msgstr ""
+msgstr "Lajittele kentän @s mukaan"
 
 msgid "and"
-msgstr ""
+msgstr "ja"
 
 msgid "Manage actions"
-msgstr ""
+msgstr "Hallinnoi toimenpiteitä"
 
 msgid "Action type"
-msgstr ""
+msgstr "Toimenpiteen tyyppi"
 
 msgid "Display a message to the user"
-msgstr ""
+msgstr "Näytä käyttäjälle viesti"
 
 msgid "Unpublish comment containing keyword(s)"
-msgstr ""
+msgstr "Peru kommentin julkaisu, jos se sisältää avainsanan/sanoja"
 
 msgid "Page path"
-msgstr ""
+msgstr "Sivun polku"
 
 msgid "Banner image"
-msgstr ""
+msgstr "Bannerikuva"
 
 msgid "- Select -"
-msgstr ""
+msgstr "- Valitse -"
 
 msgid "Content language"
-msgstr ""
+msgstr "Sisällön kieli"
 
 msgid "Path prefix"
-msgstr ""
+msgstr "Polun etuliite"
 
 msgid "Auto-reply"
-msgstr ""
+msgstr "Automaattivastaus"
 
 msgid ""
 "Optional auto-reply. Leave empty if you do not want to send the user an "
 "auto-reply message."
 msgstr ""
+"Valinnainen automaattivastaus. Jätä tyhjäksi jos et halua lähettää "
+"käyttäjälle automaattista vastausviestiä."
 
 msgid "Add @type"
-msgstr ""
+msgstr "Lisää @type"
 
 msgid "Synchronize"
-msgstr ""
+msgstr "Synkronoi"
 
 msgid "Set as default"
-msgstr ""
+msgstr "Aseta oletukseksi"
 
 msgid "Not promoted"
-msgstr ""
+msgstr "Ei nostettu"
 
 msgid "Not sticky"
-msgstr ""
+msgstr "Ei kiinnitetty"
 
 msgid "Errors"
-msgstr ""
+msgstr "Virheet"
 
 msgid "Nid"
-msgstr ""
+msgstr "Nid"
 
 msgid "Parent comment"
-msgstr ""
+msgstr "Isäntäkommentti"
 
 msgid "Author's website"
-msgstr ""
+msgstr "Ylläpitäjän www-sivusto"
 
 msgid "Content ID"
-msgstr ""
+msgstr "Sisällön ID"
 
 msgid "Publish content"
-msgstr ""
+msgstr "Publish content"
 
 msgid "Node count"
-msgstr ""
+msgstr "Solmujen lukumäärä"
 
 msgid "Skip to main content"
-msgstr ""
+msgstr "Hyppää pääsisältöön"
 
 msgid "Reports"
-msgstr ""
+msgstr "Raportit"
 
 msgid "Web server"
-msgstr ""
+msgstr "Web-palvelin"
 
 msgid "Compress layout by hiding descriptions."
-msgstr ""
+msgstr "Näytä suppeampi ulkoasu, joka ei sisällä kuvauksia."
 
 msgid "Hide descriptions"
-msgstr ""
+msgstr "Kätke kuvaukset"
 
 msgid "Enables the categorization of content."
-msgstr ""
+msgstr "Luokittele sisältöä merkitsemällä kirjoituksiin termejä."
 
 msgid ""
 "Sort by the threaded order. This will keep child comments together with "
 "their parents."
 msgstr ""
+"Näytä vastaukset ketjutettuina. Tämä pitää alikommentit yhdessä isäntiensä "
+"kamssa."
 
 msgid "Provide a simple link to reply to the comment."
-msgstr ""
+msgstr "Tarjoa yksinkertainen linkki kommenttiin vastaamiseksi."
 
 msgid "Text to display"
-msgstr ""
+msgstr "Näytettävä teksti"
 
 msgid "UI settings"
-msgstr ""
+msgstr "UI asetukset"
 
 msgid "Newest first"
 msgstr "Uusimmat ensin"
 
 msgid "field"
-msgstr ""
+msgstr "kenttä"
 
 msgid "Update settings"
-msgstr ""
+msgstr "Päivitysasetukset"
 
 msgid "nodes"
-msgstr ""
+msgstr "solmut"
 
 msgid "Formatter"
-msgstr ""
+msgstr "Muokkaaja"
 
 msgid "Some required modules must be enabled"
 msgstr ""
+"Valitsemasi moduulit riippuvat muista moduuleista, jotka pitää myös ottaa "
+"käyttöön"
 
 msgid "New posts"
-msgstr ""
+msgstr "Uutta sisältöä"
 
 msgid "View settings"
-msgstr ""
+msgstr "Näkymän asetukset"
 
 msgid "Week @week"
-msgstr ""
+msgstr "Viikko @week"
 
 msgid "mm/dd/yy"
-msgstr ""
+msgstr "mm/dd/yy"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Poista näkymä"
 
 msgid "Accessibility features"
-msgstr ""
+msgstr "Saavutettavuus"
 
 msgid "Translation file"
-msgstr ""
+msgstr "Käännöstiedosto"
 
 msgid "File to import not found."
-msgstr ""
+msgstr "Tuotavaa tiedostoa ei löytynyt."
 
 msgid "Cache options"
-msgstr ""
+msgstr "Välimuistin optiot"
 
 msgid "Target"
-msgstr ""
+msgstr "Kohde"
 
 msgid "Time ago"
-msgstr ""
+msgstr "Aikaa sitten"
 
 msgid "Create @name"
-msgstr ""
+msgstr "Luo @name"
 
 msgid "Crop"
-msgstr ""
+msgstr "Rajaa"
 
 msgid "Not enabled"
-msgstr ""
+msgstr "Ei käytössä"
 
 msgid "Insert Image"
-msgstr ""
+msgstr "Lisää kuva"
 
 msgid ""
 "Instructions to present to the user below this field on the editing form.<br"
 " />Allowed HTML tags: @tags"
 msgstr ""
+"Tämän kentän alapuolella lomakkeella käyttäjälle näytettä ohjeteksti.<br "
+"/>Sallitut HTML-merkit: @tags"
 
 msgid "Sort direction"
-msgstr ""
+msgstr "Lajittelusuunta"
 
 msgid "Element"
-msgstr ""
+msgstr "Elementti"
 
 msgid "Radios"
-msgstr ""
+msgstr "Radionapit"
 
 msgid "Field options"
-msgstr ""
+msgstr "Kenttäasetukset"
 
 msgid "Save permissions"
-msgstr ""
+msgstr "Tallenna käyttöoikeudet"
 
 msgid "Effect"
-msgstr ""
+msgstr "Efekti"
 
 msgid "Route"
-msgstr ""
+msgstr "Reitti"
 
 msgid "Sequence"
-msgstr ""
+msgstr "Sekvenssi"
 
 msgid "starting from @count"
-msgstr ""
+msgstr "alkaen kohdasta @count"
 
 msgid "Embed"
-msgstr ""
+msgstr "Upota"
 
 msgid "Menu block"
-msgstr ""
+msgstr "Valikkolohko"
 
 msgid "Test settings"
-msgstr ""
+msgstr "Testausasetukset"
 
 msgid "Quick edit"
-msgstr ""
+msgstr "Pikamuokkaus"
 
 msgid "Change book (update list of parents)"
-msgstr ""
+msgstr "Vaihda kirjaa (päivittää yläsivujen listan)"
 
 msgid "Manage your site's book outlines."
-msgstr ""
+msgstr "Kokoa kirjoituksia kirjoiksi ja järjestele niiden sisältöä."
 
 msgid "For security reasons, your upload has been renamed to %filename."
 msgstr ""
+"Lähettämäsi tiedoston nimeksi on turvallisuussyistä vaihdettu %filename."
 
 msgid "vocabulary"
-msgstr ""
+msgstr "sanasto"
 
 msgid "Installed version"
-msgstr ""
+msgstr "Asennettu versio"
 
 msgid "Recommended version"
-msgstr ""
+msgstr "Suositeltu versio"
 
 msgid "User roles"
-msgstr ""
+msgstr "Käyttäjäroolit"
 
 msgid "Acronym"
-msgstr ""
+msgstr "Lyhenne"
 
 msgid "More link path"
-msgstr ""
+msgstr "\"Lisää\" linkin polku"
 
 msgid "No vocabularies available."
-msgstr ""
+msgstr "Yhtään sanastoa ei ole saatavilla."
 
 msgid "original"
-msgstr ""
+msgstr "alkuperäinen"
 
 msgid "Starting level"
-msgstr ""
+msgstr "Aloitustaso"
 
 msgid "Title only"
-msgstr ""
+msgstr "Vain otsikko"
 
 msgid "Notification settings"
-msgstr ""
+msgstr "Ilmoitusasetukset"
 
 msgid "Not defined"
-msgstr ""
+msgstr "Ei määriteltynä"
 
 msgid "Validator"
-msgstr ""
+msgstr "Validoija"
 
 msgid "Debugging"
-msgstr ""
+msgstr "Debuggaus"
 
 msgid "Inherit"
-msgstr ""
+msgstr "Peri"
 
 msgid "No preview"
-msgstr ""
+msgstr "Ei esikatselua"
 
 msgid "Save as"
-msgstr ""
+msgstr "Tallenna nimellä"
 
 msgid "Preview image"
-msgstr ""
+msgstr "Esikatselukuva"
 
 msgid "pixels"
-msgstr ""
+msgstr "pikseliä"
 
 msgid "Use default"
-msgstr ""
+msgstr "Käytä oletusarvoa"
 
 msgid "1 month"
 msgid_plural "@count months"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Yksi kuukausi"
+msgstr[1] "@count kuukautta"
 
 msgid "Parameter"
-msgstr ""
+msgstr "Parametri"
 
 msgid "done"
-msgstr ""
+msgstr "suoritettu"
 
 msgid "Display format"
-msgstr ""
+msgstr "Näyttömuoto"
 
 msgid "Current state"
-msgstr ""
+msgstr "Nykyinen tila"
 
 msgid "The date the node was last updated."
-msgstr ""
+msgstr "Solmun viimeisin päivityspäivämäärä."
 
 msgid "Direction"
-msgstr ""
+msgstr "Suunta"
 
 msgid "Drupal core"
-msgstr ""
+msgstr "Drupalin ydin"
 
 msgid "Book navigation block display"
-msgstr ""
+msgstr "Kirjojen navigaatiolohkon näyttäminen"
 
 msgid "Relations"
-msgstr ""
+msgstr "Suhteet"
 
 msgid "Invalid display id @display"
-msgstr ""
+msgstr "Epäkelpo sivun ID."
 
 msgid "Error: handler for @table > @field doesn't exist!"
-msgstr ""
+msgstr "Virhe: käsittelijää taulun @table kentälle @field ei löytynyt!"
 
 msgid "Do not use a relationship"
-msgstr ""
+msgstr "Älä käytä suhdetta"
 
 msgid "Password field is required."
 msgstr "Salasana-kenttä on pakollinen"
 
 msgid "Display type"
-msgstr ""
+msgstr "Näkymän tyyppi"
 
 msgid "Confirm password"
 msgstr "Vahvista salasana"
 
 msgid "button"
-msgstr ""
+msgstr "painike"
 
 msgid "Default display order"
-msgstr ""
+msgstr "Oletusärjestys"
 
 msgid "Administration theme"
-msgstr ""
+msgstr "Ylläpidon teema"
 
 msgid "The cache has been cleared."
-msgstr ""
+msgstr "Välimuisti on tyhjennetty."
 
 msgid "Isle of Man"
-msgstr ""
+msgstr "Man-saari"
 
 msgid "Montenegro"
-msgstr ""
+msgstr "Montenegro"
 
 msgid "Saint Pierre and Miquelon"
-msgstr ""
+msgstr "Saint Pierre ja Miquelon"
 
 msgid "Serbia"
-msgstr ""
+msgstr "Serbia"
 
 msgid "Uri"
-msgstr ""
+msgstr "Uri"
 
 msgid "Kosovo"
-msgstr ""
+msgstr "Kosovo"
 
 msgid "Diego Garcia"
-msgstr ""
+msgstr "Diego Garcia"
 
 msgid "Tristan da Cunha"
-msgstr ""
+msgstr "Tristan da Cunha"
 
 msgid "Role ID."
-msgstr ""
+msgstr "Roolin ID."
 
 msgid "Run cron"
-msgstr ""
+msgstr "Suorita cron-ajo"
 
 msgid "Run updates"
-msgstr ""
+msgstr "Suorita päivitykset"
 
 msgid "Combine"
-msgstr ""
+msgstr "Yhdistä"
 
 msgid "of"
-msgstr ""
+msgstr "/"
 
 msgid "Title field"
-msgstr ""
+msgstr "Otsikkokenttä"
 
 msgid "The file %file could not be saved. An unknown error has occurred."
-msgstr ""
+msgstr "Tiedostoa %file ei voitu tallentaa. Tapahtui tuntematon virhe."
 
 msgid "The specified file %name could not be uploaded."
-msgstr ""
+msgstr "Tiedoston %name siirtäminen palvelimelle epäonnistui."
 
 msgid "The file's name is empty. Please give a name to the file."
-msgstr ""
+msgstr "Tiedostoa ei voi jättää nimeämättä. Anna tiedostolle nimi."
 
 msgid "Only files with the following extensions are allowed: %files-allowed."
-msgstr ""
+msgstr "Vain seuraavat tiedostopäätteet ovat sallittuja: %files-allowed."
 
 msgid "The file is %filesize exceeding the maximum file size of %maxsize."
-msgstr ""
+msgstr "Tiedostokoko %filesize ylittää suurimman tiedostokoon rajan %maxsize."
 
 msgid "The file is %filesize which would exceed your disk quota of %quota."
 msgstr ""
+"Tiedoston koko on %filesize, mikä ylittää sinulle sallitun käyttörajan "
+"%quota."
 
 msgid ""
 "Upload error. Could not move uploaded file %file to destination "
 "%destination."
 msgstr ""
+"Virhe siirrettäessä tiedostoa palvelimelle. Tiedostoa %file ei voitu siirtää"
+" hakemistoon %destination."
 
 msgid "Add to book outline"
-msgstr ""
+msgstr "Lisää kirjaan"
 
 msgid "Stark"
-msgstr ""
+msgstr "Karu"
 
 msgid "New set"
-msgstr ""
+msgstr "Uusi ryhmä"
 
 msgid "No link"
-msgstr ""
+msgstr "Ei linkkiä"
 
 msgid "Add Link"
-msgstr ""
+msgstr "Lisää linkki"
 
 msgid "Edit Link"
-msgstr ""
+msgstr "Muokkaa linkkiä"
 
 msgid "outdated"
-msgstr ""
+msgstr "vanhentunut"
 
 msgid "Is not one of"
-msgstr ""
+msgstr "Ei ole yksikään"
 
 msgid "Re-index site"
-msgstr ""
+msgstr "Indeksoi sivusto uudelleen"
 
 msgid "Log searches"
-msgstr ""
+msgstr "Kirjaa haut"
 
 msgid "Are you sure you want to re-index the site?"
-msgstr ""
+msgstr "Oletko varma, että haluat indeksoida sivuston uudelleen?"
 
 msgid "cURL"
-msgstr ""
+msgstr "cURL"
 
 msgid "No test results to display."
-msgstr ""
+msgstr "Ei näytettäviä testituloksia"
 
 msgid "Save and continue"
-msgstr ""
+msgstr "Tallenna ja jatka"
 
 msgid "Dates"
-msgstr ""
+msgstr "Päivämäärät"
 
 msgid "Not applicable"
-msgstr ""
+msgstr "Not applicable"
 
 msgid "User account"
 msgstr "Käyttäjätili"
 
 msgid "Block type"
-msgstr ""
+msgstr "Block type"
 
 msgid "Entity type"
-msgstr ""
+msgstr "Entity type"
 
 msgid "Translate"
-msgstr ""
+msgstr "Translate"
 
 msgid "Custom format"
-msgstr ""
+msgstr "Mukautettu muoto"
 
 msgid "Web services"
-msgstr ""
+msgstr "Verkkopalvelut"
 
 msgid "@module (<span class=\"admin-disabled\">disabled</span>)"
-msgstr ""
+msgstr "@module (<span class=\"admin-disabled\">pois käytöstä</span>)"
 
 msgid "Admin menu"
-msgstr ""
+msgstr "Ylläpitovalikko"
 
 msgid "Tour"
-msgstr ""
+msgstr "Kierros"
 
 msgid "Save translations"
-msgstr ""
+msgstr "Talleta käännökset"
 
 msgid "Warning message"
-msgstr ""
+msgstr "Varoitusviesti"
 
 msgid "Error message"
 msgstr "Virhe viesti"
 
 msgid "Row"
-msgstr ""
+msgstr "Rivi"
 
 msgid "Date settings"
-msgstr ""
+msgstr "Päivämääräasetukset"
 
 msgid "Table name prefix"
-msgstr ""
+msgstr "Taulun nimen etuliite"
 
 msgid "Maximum height"
-msgstr ""
+msgstr "Maksimikorkeus"
 
 msgid "Maximum width"
-msgstr ""
+msgstr "Maksimileveys"
 
 msgid "Autocomplete matching"
-msgstr ""
+msgstr "Automaattinen täydennys"
 
 msgid "Starts with"
-msgstr ""
+msgstr "Alkaa"
 
 msgid "Link options"
-msgstr ""
+msgstr "Linkin asetukset"
 
 msgid "Timor-Leste"
-msgstr ""
+msgstr "Itä-Timor"
 
 msgid "Åland Islands"
-msgstr ""
+msgstr "Ahvenanmaa"
 
 msgid "Properties"
-msgstr ""
+msgstr "Ominaisuudet"
 
 msgid "Cached"
-msgstr ""
+msgstr "Välimuistissa"
 
 msgid "Autocomplete"
-msgstr ""
+msgstr "Automaattinen täydennys"
 
 msgid "Boolean"
-msgstr ""
+msgstr "Totuusarvo"
 
 msgid "Maximum image resolution"
-msgstr ""
+msgstr "Suurin kuvaresoluutio"
 
 msgid ""
 "An illegal choice has been detected. Please contact the site administrator."
-msgstr ""
+msgstr "Kelpaamaton valinta havaittu.  Ota yhteyttä sivuston ylläpitäjään."
 
 msgid "Tips"
-msgstr ""
+msgstr "Ohjeita"
 
 msgid "Bundles"
-msgstr ""
+msgstr "Paketit"
 
 msgid "Not writable"
-msgstr ""
+msgstr "Ei kirjoitettavissa"
 
 msgid "Bundle"
-msgstr ""
+msgstr "Paketti"
 
 msgid "Decimal point"
-msgstr ""
+msgstr "Desimaalipiste"
 
 msgid "Configuration name"
-msgstr ""
+msgstr "Asetusten nimi"
 
 msgid "Custom date format"
-msgstr ""
+msgstr "Mukautettu päivämäärämuoto"
 
 msgid "Drupal version"
-msgstr ""
+msgstr "Drupal-versio"
 
 msgid "Book outline"
-msgstr ""
+msgstr "Kirjan hierarkia"
 
 msgid "This will be the top-level page in this book."
-msgstr ""
+msgstr "Tästä tulee kirjan ylin sivu."
 
 msgid "Revision information"
-msgstr ""
+msgstr "Version tiedot"
 
 msgid "Notify user of new account"
-msgstr ""
+msgstr "Ilmoita käyttäjälle uudesta tilistä"
 
 msgid "Created timestamp"
-msgstr ""
+msgstr "Luotu-aikaleima"
 
 msgid "Is one of"
-msgstr ""
+msgstr "On yksi"
 
 msgid "View comment"
-msgstr ""
+msgstr "Näytä kommentti"
 
 msgid "Access will be granted to users with the specified permission string."
 msgstr ""
+"Käyttöoikeudet myönnetään tietyn käyttöoikeuden omaaville käyttäjille."
 
 msgid "Decimal value"
-msgstr ""
+msgstr "Desimaaliarvo"
 
 msgid "Comma"
-msgstr ""
+msgstr "Pilkku"
 
 msgid "Show All"
 msgstr "Näytä kaikki"
 
 msgid "Uses"
-msgstr ""
+msgstr "Käyttää"
 
 msgid "Path to custom icon"
-msgstr ""
+msgstr "Oman pikakuvakkeen polku"
 
 msgid "Your email address"
 msgstr "Sähköpostiosoitteesi"
 
 msgid "‹"
-msgstr ""
+msgstr "‹"
 
 msgid "›"
-msgstr ""
+msgstr "›"
 
 msgid "Users who have created accounts on your site."
-msgstr ""
+msgstr "Käyttäjät jotka ovat luoneet käyttäjätilit sivustollesi."
 
 msgid "Digest"
-msgstr ""
+msgstr "Digest"
 
 msgid "Default display mode"
-msgstr ""
+msgstr "Oletusnäkymä"
 
 msgid "Default comments per page"
-msgstr ""
+msgstr "Oletusmäärä sivua kohti"
 
 msgid "Comment controls"
-msgstr ""
+msgstr "Kommenttien näyttöasetukset"
 
 msgid "Comment subject field"
-msgstr ""
+msgstr "Kommentin otsikkokenttä"
 
 msgid ""
 "Any replies to this comment will be lost. This action cannot be undone."
-msgstr ""
+msgstr "Kaikki tämän kommentin vastaukset poistetaan. Tätä ei voi perua."
 
 msgid "Publish the selected comments"
-msgstr ""
+msgstr "Julkaise valitut kommentit"
 
 msgid "Unpublish the selected comments"
-msgstr ""
+msgstr "Peruuta valittujen kommenttien julkaisu"
 
 msgid "(No subject)"
-msgstr ""
+msgstr "(Ei aihetta)"
 
 msgid "!="
-msgstr ""
+msgstr "!="
 
 msgid "Is empty (NULL)"
-msgstr ""
+msgstr "On tyhjä (NULL)"
 
 msgid "not empty"
-msgstr ""
+msgstr "ei tyhjä"
 
 msgid "Access type"
-msgstr ""
+msgstr "Pääsytyyppi"
 
 msgid "Default image"
-msgstr ""
+msgstr "Oletuskuva"
 
 msgid "Add feed"
-msgstr ""
+msgstr "Lisää syöte"
 
 msgid "List links"
-msgstr ""
+msgstr "Listaa linkit"
 
 msgid "Text settings"
-msgstr ""
+msgstr "Tekstiasetukset"
 
 msgid "Ends with"
-msgstr ""
+msgstr "Päättyy merkkeihin"
 
 msgid "Toolbar"
-msgstr ""
+msgstr "Työkalupalkki"
 
 msgid ""
 "Comment: unauthorized comment submitted or comment submitted to a closed "
 "post %subject."
 msgstr ""
+"Kommentti: lisätty luvaton kommentti tai kommentti lisätty suljettuun "
+"kirjoitukseen %subject."
 
 msgid "Link this field to its user"
-msgstr ""
+msgstr "Linkitä kenttä käyttäjäänsä"
 
 msgid "Parent ID"
-msgstr ""
+msgstr "Isännän ID"
 
 msgid "Default style"
-msgstr ""
+msgstr "Vakiotyyli"
 
 msgid "The node ID of the node."
-msgstr ""
+msgstr "Solmun ID."
 
 msgid "Tab weight"
-msgstr ""
+msgstr "Välilehden painoarvo"
 
 msgid "Files directory"
-msgstr ""
+msgstr "Tiedostojen polku"
 
 msgid "Delete all revisions"
-msgstr ""
+msgstr "Poista kaikki versiot"
 
 msgid "No role"
-msgstr ""
+msgstr "Ei roolia"
 
 msgid "Block title."
-msgstr ""
+msgstr "Lohkon otsikko."
 
 msgid "1 view"
 msgid_plural "@count views"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 katselukerta"
+msgstr[1] "@count katselukertaa"
 
 msgid "The file's MIME type."
-msgstr ""
+msgstr "Tiedoston MIME-tyyppi."
 
 msgid "The size of the file."
-msgstr ""
+msgstr "Tiedoston koko."
 
 msgid "The MIME type of the file."
-msgstr ""
+msgstr "Tiedoston MIME-tyyppi."
 
 msgid "@type %title has been created."
-msgstr ""
+msgstr "@type %title on lisätty."
 
 msgid "@type %title has been updated."
-msgstr ""
+msgstr "@type %title on päivitetty."
 
 msgid "The post could not be saved."
-msgstr ""
+msgstr "Kirjoitusta ei voitu tallentaa."
 
 msgid "Menu link ID"
-msgstr ""
+msgstr "Valikkolinkin ID"
 
 msgid "1 character"
 msgid_plural "@count characters"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 merkki"
+msgstr[1] "@count merkkiä"
 
 msgid "Filter settings"
-msgstr ""
+msgstr "Suodattimien asetukset"
 
 msgid "You do not have any administrative items."
-msgstr ""
+msgstr "Sinulla ei ole ylläpidon tehtäviä."
 
 msgid "No help is available for module %module."
-msgstr ""
+msgstr "Moduulille %module ei ole ohjeita."
 
 msgid "@module administration pages"
-msgstr ""
+msgstr "Moduulin @module ylläpito"
 
 msgid "Filter the view to the currently logged in user."
-msgstr ""
+msgstr "Filtrera vyn till den nuvarande inloggade användaren."
 
 msgid "Save translation"
-msgstr ""
+msgstr "Tallenna käännös"
 
 msgid "Add language"
-msgstr ""
+msgstr "Lisää kieli"
 
 msgid "AM"
-msgstr ""
+msgstr "a.p."
 
 msgid "PM"
-msgstr ""
+msgstr "i.p."
 
 msgid "Comments per page"
-msgstr ""
+msgstr "Kommenttia sivua kohti"
 
 msgid "The file could not be uploaded."
-msgstr ""
+msgstr "Tiedoston lataaminen epäonnistui."
 
 msgid "Export configuration"
-msgstr ""
+msgstr "Vie asetukset"
 
 msgid "FTP"
-msgstr ""
+msgstr "FTP"
 
 msgid "Collaboration"
-msgstr ""
+msgstr "Kollaboraatio"
 
 msgid "Administration pages"
-msgstr ""
+msgstr "Hallintasivut"
 
 msgid "Capitalize first letter"
-msgstr ""
+msgstr "Capitalize first letter"
 
 msgid "Run tests"
-msgstr ""
+msgstr "Aja testit"
 
 msgid "Clean test environment"
-msgstr ""
+msgstr "Puhdista testiympäristö"
 
 msgid "Clean environment"
-msgstr ""
+msgstr "Puhdista ympäristö"
 
 msgid "No tests to display."
-msgstr ""
+msgstr "Ei näytettäviä testejä."
 
 msgid "Processing test @num of @max - %test."
-msgstr ""
+msgstr "Prosessoidaan testiä @num / @max - %test."
 
 msgid "Processed test @num of @max - %test."
-msgstr ""
+msgstr "Suoritettu testi @num / @max - %test."
 
 msgid "1 pass"
 msgid_plural "@count passes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 onnistunut suoritus"
+msgstr[1] "@count onnistunutta suoritusta"
 
 msgid "1 fail"
 msgid_plural "@count fails"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 epäonnistunut suoritus"
+msgstr[1] "@count epäonnistunutta suoritusta"
 
 msgid "1 exception"
 msgid_plural "@count exceptions"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 poikkeus"
+msgstr[1] "@count poikkeusta"
 
 msgid "User %name used one-time login link at time %timestamp."
 msgstr ""
+"Käyttäjä %name käytti kertakäyttöisen sisäänkirjautumislinkin %timestamp."
 
 msgid "Registration successful. You are now logged in."
-msgstr ""
+msgstr "Rekisteröityminen onnistui. Olet nyt kirjautunut sisään."
 
 msgid "Uid"
-msgstr ""
+msgstr "Uid"
 
 msgid "Custom text"
-msgstr ""
+msgstr "Muokattu teksti"
 
 msgid "Sum"
-msgstr ""
+msgstr "Summa"
 
 msgid "The comment body."
-msgstr ""
+msgstr "Kommentin sisältö."
 
 msgid "Default argument"
-msgstr ""
+msgstr "Oletusargumentti"
 
 msgid "Form mode"
-msgstr ""
+msgstr "Lomakemuoto"
 
 msgid "Secondary tabs"
-msgstr ""
+msgstr "Secondary tabs"
 
 msgid "Delete comment"
-msgstr ""
+msgstr "Delete comment"
 
 msgid "Publish comment"
-msgstr ""
+msgstr "Publish comment"
 
 msgid "Search index"
-msgstr ""
+msgstr "Search index"
 
 msgid "Posted in"
-msgstr ""
+msgstr "Posted in"
 
 msgid "Permanent"
-msgstr ""
+msgstr "Permanent"
 
 msgid "Upload date"
-msgstr ""
+msgstr "Upload date"
 
 msgid "No files available."
-msgstr ""
+msgstr "No files available."
 
 msgid "Frontpage"
 msgstr "Etusivu"
 
 msgid "Current user"
-msgstr ""
+msgstr "Tämänhetkinen käyttäjä"
 
 msgid "IP address"
-msgstr ""
+msgstr "IP osoite"
 
 msgid "Enter your @s username."
-msgstr ""
+msgstr "Syötä käyttäjätunnuksesi sivustolle @s."
 
 msgid "File system"
-msgstr ""
+msgstr "Tiedostojärjestelmä"
 
 msgid "Status report"
-msgstr ""
+msgstr "Tilanneraportti"
 
 msgid "PHP extensions"
-msgstr ""
+msgstr "PHP-lisäosat"
 
 msgid "RDF mapping"
-msgstr ""
+msgstr "RDF kartoitus"
 
 msgid "Migration"
-msgstr ""
+msgstr "Migraatio"
 
 msgid "Provides a framework for unit and functional testing."
-msgstr ""
+msgstr "Tarjoaa ympäristön yksikkö- ja funktionaaliseen testaukseen."
 
 msgid "sorted by"
-msgstr ""
+msgstr "lajiteltuna"
 
 msgid "Feed display options"
-msgstr ""
+msgstr "Syötteen näyttöasetukset"
 
 msgid "Available actions"
-msgstr ""
+msgstr "Saatavilla olevat toimenpiteet"
 
 msgid "Remove group"
-msgstr ""
+msgstr "Poista ryhmä"
 
 msgid "The comment ID."
-msgstr ""
+msgstr "Kommentin ID."
 
 msgid "Add link"
-msgstr ""
+msgstr "Lisää linkki"
 
 msgid "Link settings"
-msgstr ""
+msgstr "Linkkiasetukset"
 
 msgid "Numbered list"
-msgstr ""
+msgstr "Numeroitu lista"
 
 msgid "View comments"
-msgstr ""
+msgstr "Näytä kommentit"
 
 msgid "Not set"
-msgstr ""
+msgstr "Ei asetettu"
 
 msgid "Set password"
-msgstr ""
+msgstr "Aseta salasana"
 
 msgid "%name: this field cannot hold more than @count values."
-msgstr ""
+msgstr "%name: kentällä ei voi olla enempää arvoja kuin @count."
 
 msgid "No fields available."
-msgstr ""
+msgstr "Yhtään kenttää ei ole saatavilla."
 
 msgid "Content author"
-msgstr ""
+msgstr "Sisällön luoja"
 
 msgid "Vertical Tabs"
-msgstr ""
+msgstr "Pystyvälilehdet"
 
 msgid "Not in book"
-msgstr ""
+msgstr "Ei kirjasssa"
 
 msgid "New book"
-msgstr ""
+msgstr "Uusi kirja"
 
 msgid "By @name on @date"
-msgstr ""
+msgstr "@name päivänä @date"
 
 msgid "By @name"
-msgstr ""
+msgstr "@name"
 
 msgid "Not in menu"
-msgstr ""
+msgstr "Ei valikossa"
 
 msgid "Alias: @alias"
-msgstr ""
+msgstr "Alias: @alias"
 
 msgid "No alias"
-msgstr ""
+msgstr "Ei aliasta"
 
 msgid "Source language"
-msgstr ""
+msgstr "Lähdekieli"
 
 msgid "An error has occurred."
-msgstr ""
+msgstr "Tapahtui virhe."
 
 msgid "Your page will be a part of the selected book."
-msgstr ""
+msgstr "Sivusi lisätään valittuun kirjaan."
 
 msgid "Numeric"
-msgstr ""
+msgstr "Numeerinen"
 
 msgid "mobile"
-msgstr ""
+msgstr "mobiili"
 
 msgid "Media settings"
-msgstr ""
+msgstr "Media-asetukset"
 
 msgid "Custom URL"
-msgstr ""
+msgstr "Mukautettu URL"
 
 msgid "Notify user"
-msgstr ""
+msgstr "Ilmoita käyttäjälle"
 
 msgid "0 sec"
-msgstr ""
+msgstr "0 s"
 
 msgid "Submit button text"
-msgstr ""
+msgstr "Lähetyspainikkeen teksti"
 
 msgid "Card"
-msgstr ""
+msgstr "Kortti"
 
 msgid "Is published"
-msgstr ""
+msgstr "Julkaistu"
 
 msgid "Configure @block"
-msgstr ""
+msgstr "Muokkaa lohkoa @block"
 
 msgid "Filter log messages"
-msgstr ""
+msgstr "Suodata lokiviestit"
 
 msgid "You must select something to filter by."
-msgstr ""
+msgstr "Sinun on valittava suodatusehto."
 
 msgid "New revision"
-msgstr ""
+msgstr "Uusi versio"
 
 msgid "Callback"
-msgstr ""
+msgstr "Paluufunktio"
 
 msgid ""
 "To change the current user password, enter the new password in both fields."
@@ -5178,319 +5247,333 @@ msgid "This login can be used only once."
 msgstr "Tätä kirjautumista voi käyttää vain kerran."
 
 msgid "Add comment link"
-msgstr ""
+msgstr "Lisää kommenti -linkki"
 
 msgid "Strike-through"
-msgstr ""
+msgstr "Yliviivattu"
 
 msgid "Align left"
-msgstr ""
+msgstr "Tasaa vasen reuna"
 
 msgid "Align center"
-msgstr ""
+msgstr "Keskitä"
 
 msgid "Align right"
-msgstr ""
+msgstr "Tasaa oikea reuna"
 
 msgid "Justify"
-msgstr ""
+msgstr "Tasaa molemmat reunat"
 
 msgid "Horizontal rule"
-msgstr ""
+msgstr "Vaakaviiva"
 
 msgid "Paste Text"
-msgstr ""
+msgstr "Liitä teksti"
 
 msgid "Paste from Word"
-msgstr ""
+msgstr "Liitä Wordista"
 
 msgid "Remove format"
-msgstr ""
+msgstr "Poista muotoilu"
 
 msgid "Character map"
-msgstr ""
+msgstr "Merkkikartta"
 
 msgid "HTML block format"
-msgstr ""
+msgstr "HTML-kappaleen muotoilu"
 
 msgid "Font style"
-msgstr ""
+msgstr "Fonttityyli"
 
 msgid "Abbreviation"
-msgstr ""
+msgstr "Lyhennetty muoto"
 
 msgid "Inserted"
-msgstr ""
+msgstr "Lisätty"
 
 msgid "Provide a password for the new account in both fields."
-msgstr ""
+msgstr "Anna uuden käyttäjätilin salasana molempiin kenttiin."
 
 msgid "Changes cannot be made to a locked view."
-msgstr ""
+msgstr "Lukittua näkymää ei voi muokata."
 
 msgid "Broken/missing handler"
-msgstr ""
+msgstr "Rikkinäinen/puuttuva hallintakomento"
 
 msgid "Current node's creation time"
-msgstr ""
+msgstr "Tämän solmun luontiaika"
 
 msgid "Current node's update time"
-msgstr ""
+msgstr "Tämän solmun viimeisin päivitysaika"
 
 msgid "Do not display items with no value in summary"
-msgstr ""
+msgstr "Älä näytä yhteenvedossa argumentteja joilla ei ole arvoa"
 
 msgid "Invalid input"
-msgstr ""
+msgstr "Kielletty syöte"
 
 msgid "Fail basic validation if any argument is given"
-msgstr ""
+msgstr "Älä päästä validoinnista läpi jos argumentteja on syötetty"
 
 msgid ""
 "By checking this field, you can use this to make sure views with more "
 "arguments than necessary fail validation."
 msgstr ""
+"Aktivoimalla tämän ominaisuuden voit varmistaa että näkymät joissa on "
+"tarpeellista enemmän argumentteja eivät läpäise validointia."
 
 msgid "Glossary mode"
-msgstr ""
+msgstr "Sanalistamuoto"
 
 msgid "Character limit"
-msgstr ""
+msgstr "Kirjainmäärärajoitus"
 
 msgid "No transform"
-msgstr ""
+msgstr "Ei muunnosta"
 
 msgid "Upper case"
-msgstr ""
+msgstr "Isot kirjaimet"
 
 msgid "Lower case"
-msgstr ""
+msgstr "Pienet kirjaimet"
 
 msgid "Capitalize each word"
-msgstr ""
+msgstr "Muuta jokaisen sanan ensimmäinen kirjain isoksi kirjaimeksi"
 
 msgid "Case in path"
-msgstr ""
+msgstr "Isot / pienet kirjaimet polussa"
 
 msgid "Transform spaces to dashes in URL"
-msgstr ""
+msgstr "Muunna välilyönnit alaviivoiksi URLeissa"
 
 msgid "Exclude from display"
-msgstr ""
+msgstr "Piilota näkymässä"
 
 msgid "Link path"
-msgstr ""
+msgstr "Linkin polku"
 
 msgid ""
 "The Drupal path or absolute URL for this link. You may enter data from this "
 "view as per the \"Replacement patterns\" below."
 msgstr ""
+"Absoluuttinen Drupal-polku tälle linkille. Voit syöttää dataa tälle "
+"näkymälle allaolevien \"korvauskuvioiden\" pohjalta."
 
 msgid "The CSS class to apply to the link."
-msgstr ""
+msgstr "Linkissä käytettävät CSS-luokat."
 
 msgid "Prefix text"
-msgstr ""
+msgstr "Aloitusteksti"
 
 msgid "Suffix text"
-msgstr ""
+msgstr "Pääteteksti"
 
 msgid "Any text to display after this link. You may include HTML."
-msgstr ""
+msgstr "Linkin jälkeen esitettävä teksti. Teksti voi sisältää HTML:ää."
 
 msgid "Trim only on a word boundary"
-msgstr ""
+msgstr "Trimmaa vain sanojen välistä"
 
 msgid ""
 "If checked, this field be trimmed only on a word boundary. This is "
 "guaranteed to be the maximum characters stated or less. If there are no word"
 " boundaries this could trim a field to nothing."
 msgstr ""
+"Mikäli valittuna, kenttä rajataan ainoastaan sanojen välistä. Tämä on "
+"korkeintaan suurin määritelty kirjainmäärä. Jos sanojen rajoja ei ole, tämä "
+"voi trimmata kentän tyhjäksi."
 
 msgid "Strip HTML tags"
-msgstr ""
+msgstr "Poista HTML tagit"
 
 msgid "Field can contain HTML"
-msgstr ""
+msgstr "Kenttä voi sisältää HTML:ää"
 
 msgid "File size display"
-msgstr ""
+msgstr "Tiedostokoon näyttö"
 
 msgid "Formatted (in KB or MB)"
-msgstr ""
+msgstr "Formatoitu (Kilobitteinä tai Megabitteinä)"
 
 msgid "Raw bytes"
-msgstr ""
+msgstr "Raakabittejä"
 
 msgid "If checked, true will be displayed as false."
-msgstr ""
+msgstr "Mikäli valittuna, true näytetään falsena."
 
 msgid "Time ago (with \"ago\" appended)"
-msgstr ""
+msgstr "Aikaa sitten (menneen ajan kanssa)"
 
 msgid "Time span (with \"ago/hence\" appended)"
-msgstr ""
+msgstr "Aikaväli (lisättynä \"sitten/siten\")"
 
 msgid "Round"
-msgstr ""
+msgstr "Pyöristä"
 
 msgid "If checked, the number will be rounded."
-msgstr ""
+msgstr "Jos valittuna arvo pyöristetään."
 
 msgid "Specify how many digits to print after the decimal point."
-msgstr ""
+msgstr "Määrittele kuinka monta lukua näytetään desimaalipilkun jälkeen."
 
 msgid "What single character to use as a decimal point."
-msgstr ""
+msgstr "Mitä yksittäistä merkkiä käytetään desimaalipisteenä."
 
 msgid "What single character to use as the thousands separator."
-msgstr ""
+msgstr "Mitä merkkiä käytetään tuhatlukujen erottajana."
 
 msgid "Text to put before the number, such as currency symbol."
 msgstr ""
+"Numeroa ennen sijoitettava teksti, esimerkiksi valuuttayksikön merkki."
 
 msgid "Text to put after the number, such as currency symbol."
 msgstr ""
+"Numeron jälkeen sijoitettava teksti, esimerkiksi valuuttayksikön merkki."
 
 msgid "Simple separator"
-msgstr ""
+msgstr "Yksinkertainen erottaja"
 
 msgid "Display as link"
-msgstr ""
+msgstr "Näytä linkkinä"
 
 msgid "Operator identifier"
-msgstr ""
+msgstr "Operaattorin tunnistin"
 
 msgid "This will appear in the URL after the ? to identify this operator."
-msgstr ""
+msgstr "Tämä näytetään URLissa merkin ? jälkeen operaattorin tunnistamiseksi."
 
 msgid "Filter identifier"
-msgstr ""
+msgstr "Suodattimen tunnistin"
 
 msgid ""
 "This exposed filter is optional and will have added options to allow it not "
 "to be set."
 msgstr ""
+"Tämä suodatin on vaihtoehtoinen ja sillä on lisävalinta jonka avulla voidaan"
+" laittaa se asettamattomaan tilaan."
 
 msgid "Remember"
-msgstr ""
+msgstr "Muista"
 
 msgid "Remember the last setting the user gave this filter."
-msgstr ""
+msgstr "Muista käyttäjän viimeisin tälle suodattimelle valittu arvo."
 
 msgid "The identifier is required if the filter is exposed."
-msgstr ""
+msgstr "Tunnistin on pakollinen kentän ollessa näytettynä käyttäjille."
 
 msgid "This identifier is not allowed."
-msgstr ""
+msgstr "Tunnistin on kielletty."
 
 msgid "- Any -"
-msgstr ""
+msgstr "- Kaikki -"
 
 msgid "exposed"
-msgstr ""
+msgstr "näytetty"
 
 msgid "Value type"
-msgstr ""
+msgstr "Arvon tyyppi"
 
 msgid ""
 "A date in any machine readable format. CCYY-MM-DD HH:MM:SS is preferred."
 msgstr ""
+"Järjestelmän luettavassa muodossa oleva päivämäärä. Suositeltu muoto: CCYY-"
+"MM-DD HH:MM:SS"
 
 msgid "Invalid date format."
-msgstr ""
+msgstr "Epäkelpo päivämäärämuoto."
 
 msgid "Limit list to selected items"
-msgstr ""
+msgstr "Rajoita lista valittuihin vaihtoehtoihin"
 
 msgid "Delete the selected comments"
-msgstr ""
+msgstr "Poista valitut kommentit"
 
 msgid "Current date"
-msgstr ""
+msgstr "Tämänhetkinen päivämäärä"
 
 msgid ""
 "If checked, the only items presented to the user will be the ones selected "
 "here."
 msgstr ""
+"Mikäli valittuna, käyttäjille näytetään ainoastaan tässä valitut arvot."
 
 msgid "not in"
-msgstr ""
+msgstr "ei sisällä"
 
 msgid "<>"
-msgstr ""
+msgstr "<>"
 
 msgid "Is all of"
-msgstr ""
+msgstr "On kaikki"
 
 msgid "Is none of"
-msgstr ""
+msgstr "Ei ole yksikään"
 
 msgid "not"
-msgstr ""
+msgstr "ei"
 
 msgid "<"
-msgstr ""
+msgstr "<"
 
 msgid "<="
-msgstr ""
+msgstr "<="
 
 msgid ">="
-msgstr ""
+msgstr ">="
 
 msgid ">"
-msgstr ""
+msgstr ">"
 
 msgid "Is between"
-msgstr ""
+msgstr "On välillä"
 
 msgid "between"
-msgstr ""
+msgstr "välillä"
 
 msgid "Is not between"
-msgstr ""
+msgstr "Ei ole välillä"
 
 msgid "not between"
-msgstr ""
+msgstr "ei välillä"
 
 msgid "Min"
-msgstr ""
+msgstr "Min"
 
 msgid "And max"
-msgstr ""
+msgstr "Ja max"
 
 msgid "And"
-msgstr ""
+msgstr "Ja"
 
 msgid "Contains any word"
-msgstr ""
+msgstr "Sisältää minkä tahansa sanan"
 
 msgid "has word"
-msgstr ""
+msgstr "sisältää sanan"
 
 msgid "Contains all words"
-msgstr ""
+msgstr "Sisältää kaikki sanat"
 
 msgid "has all"
-msgstr ""
+msgstr "sisältää kaikki"
 
 msgid "begins"
-msgstr ""
+msgstr "alkaa"
 
 msgid "ends"
-msgstr ""
+msgstr "päättyy"
 
 msgid "!has"
-msgstr ""
+msgstr "!has"
 
 msgid "Require this relationship"
-msgstr ""
+msgstr "Vaadi riippuvuus"
 
 msgid "asc"
-msgstr ""
+msgstr "asc"
 
 msgid "desc"
-msgstr ""
+msgstr "desc"
 
 msgid ""
 "The granularity is the smallest unit to use when determining whether two "
@@ -5498,78 +5581,81 @@ msgid ""
 "dates in 1999, regardless of when they fall in 1999, will be considered the "
 "same date."
 msgstr ""
+"Pienin tarkkuus jota käytetään määrittelemään, ovatko päivämäärät samoja; "
+"esimerkiksi jos tarkkuus on \"Vuosi\", silloin kaikki vuoden 1999 "
+"päivämäärät tulkitaan samoiksi tarkemmasta päivämäärästä riippumatta."
 
 msgid "Broken"
-msgstr ""
+msgstr "Rikkinäinen"
 
 msgid "Displays"
-msgstr ""
+msgstr "Näytöt"
 
 msgid "These queries were run during view rendering:"
-msgstr ""
+msgstr "Nämä kyselyt suoritettiin näkymää renderöitäessä:"
 
 msgid "This display has no path."
-msgstr ""
+msgstr "Näyttöruudulla ei ole polkua."
 
 msgid "Query build time"
-msgstr ""
+msgstr "Kyselyn rakennusaika"
 
 msgid "@time ms"
-msgstr ""
+msgstr "@time ms"
 
 msgid "Query execute time"
-msgstr ""
+msgstr "Kyselyn suorittamisaika"
 
 msgid "View render time"
-msgstr ""
+msgstr "Näkymän renderöintiaika"
 
 msgid "No query was run"
-msgstr ""
+msgstr "Kyselyä ei suoritettu"
 
 msgid "Unable to preview due to validation errors."
-msgstr ""
+msgstr "Esikatselu ei onnistunut validointivirheistä johtuen."
 
 msgid "View name"
-msgstr ""
+msgstr "Näkymän nimi"
 
 msgid "Break lock"
-msgstr ""
+msgstr "Poista lukitus"
 
 msgid "The lock has been broken and you may now edit this view."
-msgstr ""
+msgstr "Lukitus on rikottu ja voit nyt muokata tätä näkymää."
 
 msgid "Go to the real page for this display"
-msgstr ""
+msgstr "Mene näkymän todelliselle sivulle"
 
 msgid "Missing style plugin"
-msgstr ""
+msgstr "Tyyliplugin puuttuu"
 
 msgid "Change settings for this style"
-msgstr ""
+msgstr "Muuta tyylin asetuksia"
 
 msgid "View analysis"
-msgstr ""
+msgstr "Näkymän analyysi"
 
 msgid "Rearrange @type"
-msgstr ""
+msgstr "Uudelleenjärjestä @type"
 
 msgid "Broken field @id"
-msgstr ""
+msgstr "Rikkinäinen kenttä @id"
 
 msgid "There are no @types available to add."
-msgstr ""
+msgstr "@types ei löytynyt lisättäväksi."
 
 msgid "Configure extra settings for @type %item"
-msgstr ""
+msgstr "Säädä lisäasetuksia @type %item"
 
 msgid "Clear Views' cache"
-msgstr ""
+msgstr "Tyhjennä Views välimuisti"
 
 msgid "Add Views signature to all SQL queries"
-msgstr ""
+msgstr "Lisää Views allekirjoitus kaikkiin SQL-kyselyihin"
 
 msgid "Disable views data caching"
-msgstr ""
+msgstr "Poista käytöstä näkymien tietojen välimuistitus"
 
 msgid ""
 "Views caches data about tables, modules and views available, to increase "
@@ -5577,368 +5663,405 @@ msgid ""
 "rebuild this data when needed. This can have a serious performance impact on"
 " your site."
 msgstr ""
+"Suorituskyvyn parantamiseksi Views tallentaa välimuistiin tietoa tauluista, "
+"moduuleista ja saatavilla olevista näkymistä. Valitsemalla tämän vaihtoehdon"
+" Views ohittaa tämän välimuistin ja rakentaa tiedon uudelleen aina "
+"tarvittaessa. Tällä voi olla merkittävää vaikutusta sivustosi "
+"suorituskykyyn."
 
 msgid "Show other queries run during render during live preview"
 msgstr ""
+"Näytä reaaliaikaisen esikatselun renderöinnin aikana ajetut "
+"tietokantakyselyt"
 
 msgid ""
 "Drupal has the potential to run many queries while a view is being rendered."
 " Checking this box will display every query run during view render as part "
 "of the live preview."
 msgstr ""
+"Drupal pystyy ajamaan useampia kyselyitä näkymän renderöinnin aikana. "
+"Valitse tämä vaihtoehto nähdäksesi kaikki reaaliaikaisen esikatselun aikana "
+"suoritetut kyselyt."
 
 msgid "View analysis can find nothing to report."
-msgstr ""
+msgstr "Näkymäanalyysi ei löytänyt raportoitavaa."
 
 msgid ""
 "This view has only a default display and therefore will not be placed "
 "anywhere on your site; perhaps you want to add a page or a block display."
 msgstr ""
+"Näkymällä on vain oletusnäyttöruutu minkä takia sitä ei voida sijoittaa "
+"mihinkään sivustollasi; haluat ehkä lisätä sivunäkymän tai lohkonäkymän."
 
 msgid "Reduce duplicates"
-msgstr ""
+msgstr "Vähennä duplikaatteja"
 
 msgid "Default settings for this view."
-msgstr ""
+msgstr "Näytön oletusasetukset."
 
 msgid "Display the view as a page, with a URL and menu links."
-msgstr ""
+msgstr "Näytä näkymä sivuna, sisältäen URLin ja valikkolinkit."
 
 msgid "Display the view as a block."
-msgstr ""
+msgstr "Näytä näkymä lohkona."
 
 msgid ""
 "Attachments added to other displays to achieve multiple views in the same "
 "view."
 msgstr ""
+"Muihin näyttöruutuihin liisätyt liitteet, tarkoituksena saada useampi näkymä"
+" yhden näkymän sisään."
 
 msgid "Display the view as a feed, such as an RSS feed."
-msgstr ""
+msgstr "Näytä näkymä syötteenä, kuten RSS syötteenä."
 
 msgid "Displays rows one after another."
-msgstr ""
+msgstr "Näyttää rivit toistensa jälkeen."
 
 msgid "HTML List"
-msgstr ""
+msgstr "HTML-lista"
 
 msgid "Displays rows in a grid."
-msgstr ""
+msgstr "Näyttää rivit ruudukkomuodossa."
 
 msgid "Displays rows in a table."
-msgstr ""
+msgstr "Näyttää rivit taulukkomuodossa."
 
 msgid "Displays the default summary as a list."
-msgstr ""
+msgstr "Näyttää oletustiivistelmän listana."
 
 msgid ""
 "Displays the summary unformatted, with option for one after another or "
 "inline."
 msgstr ""
+"Näyttää tiivistelmän muokkaamattomana sekä vaihtoehdon joko esittää se joko "
+"perätysten eri riveillä tai sisennettynä."
 
 msgid "Generates an RSS feed from a view."
-msgstr ""
+msgstr "Generoi RSS-syötteen näkymästä."
 
 msgid "Displays the fields with an optional template."
-msgstr ""
+msgstr "Näyttää kentät valinnallisella templatella."
 
 msgid "Will be available to all users."
-msgstr ""
+msgstr "Käytössä käyttäjille."
 
 msgid "Access will be granted to users with any of the specified roles."
-msgstr ""
+msgstr "Käyttöoikeudet myönnetään tietyn roolin omaaville käyttäjille."
 
 msgid "No caching of Views data."
-msgstr ""
+msgstr "Ei Views välimuistitusta."
 
 msgid "Time-based"
-msgstr ""
+msgstr "Aikapohjainen"
 
 msgid "Simple time-based caching of data."
-msgstr ""
+msgstr "Yksinkertainen aikapohjainen tiedon välimuistitus."
 
 msgid "sort criteria"
-msgstr ""
+msgstr "lajittelukriteerit"
 
 msgid "Sort criterion"
-msgstr ""
+msgstr "Lajittelukriteeri"
 
 msgid "sort criterion"
-msgstr ""
+msgstr "lajittelukriteeri"
 
 msgid "Aggregator items are imported from external RSS and Atom news feeds."
-msgstr ""
+msgstr "Aggregointiartikkelit haetaan ulkoisesta RSS ja Atom syötteestä."
 
 msgid "The title of the aggregator item."
-msgstr ""
+msgstr "Aggregointiartikkelin otsikko."
 
 msgid "The link to the original source URL of the item."
-msgstr ""
+msgstr "Artikkelin alkuperäisen lähteen URL."
 
 msgid "The author of the original imported item."
-msgstr ""
+msgstr "Alkuperäisen ladatun artikkelin kirjoittajan nimi."
 
 msgid "The actual content of the imported item."
-msgstr ""
+msgstr "Ladatun artikkelin sisältö."
 
 msgid ""
 "The date the original feed item was posted. (With some feeds, this will be "
 "the date it was imported.)"
 msgstr ""
+"Alkuperäisen syöteartikkelin kirjoituspäivämäärä. (Joissakin syötteissä tämä"
+" päivämäärä on sama kuin artikkelin latauspäivämäärä.)"
 
 msgid "Feed ID"
-msgstr ""
+msgstr "Syötteen ID"
 
 msgid "The unique ID of the aggregator feed."
-msgstr ""
+msgstr "Aggregointisyötteen yksilöllinen ID."
 
 msgid "The title of the aggregator feed."
-msgstr ""
+msgstr "Aggregointisyötteen otsikko."
 
 msgid "The link to the source URL of the feed."
-msgstr ""
+msgstr "Linkki syötteen lähdeosoitteeseen."
 
 msgid "The date the feed was last checked for new content."
 msgstr ""
+"Päivämäärä jolloin syöte viimeisimmäksi tarkistettiin uuden sisällön "
+"varalta."
 
 msgid "The description of the aggregator feed."
-msgstr ""
+msgstr "Syötteen kuvaus."
 
 msgid "Display the aggregator item using the data from the original source."
 msgstr ""
+"Näytä aggregointiartikkeli käyttäen alkuperäisestä lähteestä peräisin olevaa"
+" tietoa."
 
 msgid "The book the node is in."
-msgstr ""
+msgstr "Kirja johon solmu kuuluu"
 
 msgid "The weight of the book page."
-msgstr ""
+msgstr "Kirjasivun paino"
 
 msgid ""
 "The depth of the book page in the hierarchy; top level books have a depth of"
 " 1."
 msgstr ""
+"Kirjasivun hierarkinen syvyys; ensimmäisen tason kirjoilla on syvyys 1."
 
 msgid "The parent book node."
-msgstr ""
+msgstr "Kirjasolmun isäntäsolmu."
 
 msgid "The title of the comment."
-msgstr ""
+msgstr "Kommentin otsikko."
 
 msgid ""
 "The name of the comment's author. Can be rendered as a link to the author's "
 "homepage."
 msgstr ""
+"Kommentin kirjoittajan nimi. Voidaan renderöidä linkiksi kirjoittajan "
+"kotisivulle."
 
 msgid ""
 "The website address of the comment's author. Can be rendered as a link. Will"
 " be empty if the author is a registered user."
 msgstr ""
+"Kommentin kirjoittajan www-sivun osoite, Voidaan rederöidä linkkinä. Tyhjä "
+"mikäli käyttäjä on rekisteröitynyt."
 
 msgid "Post date"
-msgstr ""
+msgstr "Lähetetty"
 
 msgid "Node link"
-msgstr ""
+msgstr "Solmun linkki"
 
 msgid "The User ID of the comment's author."
-msgstr ""
+msgstr "Kommentin kirjoittajan käyttäjä ID."
 
 msgid "Parent CID"
-msgstr ""
+msgstr "Isäntä CID"
 
 msgid "Last comment time"
-msgstr ""
+msgstr "Viimeisimmän kommentin kellonaika"
 
 msgid "Date and time of when the last comment was posted."
-msgstr ""
+msgstr "Viimeisimmän kommentin lähetyspäivämäärä ja kellonaika."
 
 msgid "Last comment author"
-msgstr ""
+msgstr "Viimeisimmän kommentin kirjoittaja"
 
 msgid "The name of the author of the last posted comment."
-msgstr ""
+msgstr "Viimeisimmän kirjoitetun kommentin kirjoittajan nimi."
 
 msgid "The number of comments a node has."
-msgstr ""
+msgstr "Solmulla olevien kommenttien lukumäärä."
 
 msgid "Updated/commented date"
-msgstr ""
+msgstr "Päivitetty/kommentoitu -päivämäärä"
 
 msgid "The number of new comments on the node."
-msgstr ""
+msgstr "Solmun uusien kommenttien lukumäärä."
 
 msgid "User posted or commented"
-msgstr ""
+msgstr "Käyttäjä lähetti tai kommentoi"
 
 msgid "Display nodes only if a user posted the node or commented on the node."
 msgstr ""
+"Näytä solmut vain jos käyttäjä lähetti tai on kommentoinut kyseistä solmua."
 
 msgid "Display the comment as RSS."
-msgstr ""
+msgstr "Näytä kommentti RSS:nä."
 
 msgid "Provide a simple link to the user contact page."
-msgstr ""
+msgstr "Tarjoa yksinkertainen linkki käyttäjäkohtaiselle yhteydenottosivulle."
 
 msgid "Whether or not the node is published."
-msgstr ""
+msgstr "Onko solmu julkaistu vaiko ei."
 
 msgid "Created year + month"
-msgstr ""
+msgstr "Luontivuosi + kuukausi"
 
 msgid "Created year"
-msgstr ""
+msgstr "Luontivuosi"
 
 msgid "Created month"
-msgstr ""
+msgstr "Luontikuukausi"
 
 msgid "Created day"
-msgstr ""
+msgstr "Luontipäivä"
 
 msgid "Created week"
-msgstr ""
+msgstr "Luontiviikko"
 
 msgid "Updated year + month"
-msgstr ""
+msgstr "Päivitetty vuosi + kuukausi"
 
 msgid "Updated year"
-msgstr ""
+msgstr "Päivitetty vuosi"
 
 msgid "Updated month"
-msgstr ""
+msgstr "Päivitetty kuukausi"
 
 msgid "Updated day"
-msgstr ""
+msgstr "Päivitetty päivä"
 
 msgid "Updated week"
-msgstr ""
+msgstr "Päivitetty viikko"
 
 msgid "Provide a simple link to revert to the revision."
-msgstr ""
+msgstr "Tarjoaa yksinkertaisen linkin sisältöversion palauttamiseksi."
 
 msgid "Filter by access."
-msgstr ""
+msgstr "Suodata pääsyoikeuden perusteella."
 
 msgid "Has new content"
-msgstr ""
+msgstr "On uutta sisältöä"
 
 msgid ""
 "Display %display has no access control but does not contain a filter for "
 "published nodes."
 msgstr ""
+"Näyttöruudulla %display ei ole pääsysääntöjä mutta ei myöskään sisällä "
+"suodatinta suodattamaan julkaistua sisältöä."
 
 msgid ""
 "The score of the search item. This will not be used if the search filter is "
 "not also present."
-msgstr ""
+msgstr "Hakutulosten määrä. Tätä ei käytetä jos hakusuodatin ei ole käytössä."
 
 msgid "Total views"
-msgstr ""
+msgstr "Katselukertojen kokonaismäärä"
 
 msgid "The total number of times the node has been viewed."
-msgstr ""
+msgstr "Solmun lukukertojen kokonaismäärä."
 
 msgid "Views today"
-msgstr ""
+msgstr "Katsottu tänään"
 
 msgid "The total number of times the node has been viewed today."
-msgstr ""
+msgstr "Solmun lukukertojen määrä tänään."
 
 msgid "Most recent view"
-msgstr ""
+msgstr "Viimeisin katselukerta"
 
 msgid "The most recent time the node has been viewed."
-msgstr ""
+msgstr "Solmun viimeisimmän katselukerran ajankohta."
 
 msgid "Files maintained by Drupal and various modules."
-msgstr ""
+msgstr "Drupalin ja muiden moduulien ylläpitämät tiedostot."
 
 msgid "Taxonomy terms are attached to nodes."
-msgstr ""
+msgstr "Solmuihin linkitetyt luokittelutermit."
 
 msgid "Filter the results of \"Taxonomy: Term\" to a particular vocabulary."
-msgstr ""
+msgstr "Suodata \"Luokittelu: Termi\" -tulokset tietyn sanaston mukaan."
 
 msgid ""
 "Display all taxonomy terms associated with a node from specified "
 "vocabularies."
 msgstr ""
+"Näytä kaikki valituista sanastoista solmuun liitetyt luokittelutermit."
 
 msgid ""
 "The parent term of the term. This can produce duplicate entries if you are "
 "using a vocabulary that allows multiple parents."
 msgstr ""
+"Termin isäntätermi. Tämä voi tuottaa kaksoiskappaleita jos käytät sanastoa "
+"joka sallii useamman kuin yhden isäntätermin termiä kohden."
 
 msgid "The user ID"
-msgstr ""
+msgstr "Käyttäjän ID"
 
 msgid "The user or author name."
-msgstr ""
+msgstr "Käyttäjän tai kirjoittajan nimi."
 
 msgid ""
 "Email address for a given user. This field is normally not shown to users, "
 "so be cautious when using it."
 msgstr ""
+"Annetun käyttäjän sähköpostiosoite. Kenttää ei normaalisti näytetä "
+"käyttäjille joten ole varovainen sitä käyttäessäsi."
 
 msgid "User ID from URL"
-msgstr ""
+msgstr "Käyttäjän ID URLista"
 
 msgid "User ID from logged in user"
-msgstr ""
+msgstr "Käyttäjän ID kirjautuneelta käyttäjältä"
 
 msgid "Randomize the display order."
-msgstr ""
+msgstr "Sekoita näyttöjärjestys."
 
 msgid "Null"
-msgstr ""
+msgstr "Nolla"
 
 msgid "Provide custom text or link."
-msgstr ""
+msgstr "Tarjoa muokattua tekstiä tai linkki."
 
 msgid "View result counter"
-msgstr ""
+msgstr "Näkymän tuloslaskin"
 
 msgid "Displays the actual position of the view result"
-msgstr ""
+msgstr "Näyttää näkymän tuloslaskimen todellisen sijainnin"
 
 msgid "No user"
-msgstr ""
+msgstr "Ei  käyttäjää"
 
 msgid "Show teaser-style link"
-msgstr ""
+msgstr "Näytä teaserityyppinen linkki"
 
 msgid "Link this field to new comments"
-msgstr ""
+msgstr "Linkitä kenttä uusiin kommentteihin"
 
 msgid "contact"
-msgstr ""
+msgstr "yhteydenotto"
 
 msgid "Contact %user"
-msgstr ""
+msgstr "Ota yhteyttä %user"
 
 msgid "Unknown language"
-msgstr ""
+msgstr "Tuntematon kieli"
 
 msgid "Check for new comments as well"
-msgstr ""
+msgstr "Etsi myös uusia kommentteja"
 
 msgid "Alternative sort"
-msgstr ""
+msgstr "Vaihtoehtoinen lajittelu"
 
 msgid "Alternate sort order"
-msgstr ""
+msgstr "Vaihtoehtoinen lajittelujärjestys"
 
 msgid "On empty input"
-msgstr ""
+msgstr "Tyhjällä syötteellä"
 
 msgid "Show None"
-msgstr ""
+msgstr "Piilota kaikki"
 
 msgid ""
 "Search for either of the two terms with uppercase <strong>OR</strong>. For "
 "example, <strong>cats OR dogs</strong>."
 msgstr ""
+"Etsi joko kahta termiä isoilla kirjaimilla <strong>TAI</strong>. Esimerkiksi"
+" <strong>kissoja TAI koiria</strong>."
 
 msgid "Link this field to download the file"
-msgstr ""
+msgstr "Linkitä kenttä ladattavaan tiedostoon"
 
 msgid ""
 "The depth will match nodes tagged with terms in the hierarchy. For example, "
@@ -5948,134 +6071,146 @@ msgid ""
 "true; searching for \"apple\" will also pick up nodes tagged with \"fruit\" "
 "if depth is -1 (or lower)."
 msgstr ""
+"Syvyys vastaa hierarkiassa sijaitseviin termein merkittyihin solmuihin. "
+"Esimerkiksi jos sinulla on termi \"hedelmä\" ja alatermi \"omena\" "
+"syvyydellä 1 (tai suurempi), silloin suodatus termille \"hedelmä\" hakee "
+"kaikki solmut jotka on merkitty sanalla \"omena\" samoten kuin \"hedelmä\". "
+"Mikäli arvo on negatiivinen, käytetään käänteistä hakua eli haku termille "
+"\"omena\" palauttaa myös termillä \"hedelmä\" merkityt solmut mikäli paino "
+"on -1 tai matalampi."
 
 msgid "No vocabulary"
-msgstr ""
+msgstr "Ei sanastoa"
 
 msgid "Link this field to its term page"
-msgstr ""
+msgstr "Linkitä kenttä terminsä sivulle"
 
 msgid "Limit terms by vocabulary"
-msgstr ""
+msgstr "Rajoita termejä sanastoittain"
 
 msgid "Select which vocabulary to show terms for in the regular options."
-msgstr ""
+msgstr "Valitse minkä sanaston termit näytetään normaaleissa valinnoissa."
 
 msgid "Dropdown"
-msgstr ""
+msgstr "Alasvetovalikko"
 
 msgid "Show hierarchy in dropdown"
-msgstr ""
+msgstr "Näytä hierarkia alasvetovalikossa"
 
 msgid "An invalid vocabulary is selected. Please change it in the options."
-msgstr ""
+msgstr "Sanastoa ei ole valittuna. Muuta asetusta."
 
 msgid "Select terms from vocabulary @voc"
-msgstr ""
+msgstr "Valitse termit sanastosta @voc"
 
 msgid "Select terms"
-msgstr ""
+msgstr "Valitse termit"
 
 msgid "Is the logged in user"
-msgstr ""
+msgstr "Onko käyttäjä kirjautuneena"
 
 msgid "Usernames"
-msgstr ""
+msgstr "Käyttäjänimet"
 
 msgid "Enter a comma separated list of user names."
-msgstr ""
+msgstr "Syötä käyttäjänimet pilkuilla eroteltuina."
 
 msgid "Also look for a node and use the node author"
-msgstr ""
+msgstr "Etsi myös solmua ja käytä solmun luojaa"
 
 msgid "Restrict user based on role"
-msgstr ""
+msgstr "Rajoita käyttäjää roolipohjaisesti"
 
 msgid "Restrict to the selected roles"
-msgstr ""
+msgstr "Rajoita valittuihin rooleihin"
 
 msgid "If no roles are selected, users from any role will be allowed."
-msgstr ""
+msgstr "Kaikki roolit sallitaan mikäli rooleja ei ole valittuina."
 
 msgid "Unrestricted"
-msgstr ""
+msgstr "Rajoittamaton"
 
 msgid "No role(s) selected"
-msgstr ""
+msgstr "Rooleja ei ole valittuina."
 
 msgid "Multiple roles"
-msgstr ""
+msgstr "Useita rooleja"
 
 msgid "You must select at least one role if type is \"by role\""
 msgstr ""
+"Sinun on valittava vähintään yksi rooli jos käytät \"rooleittain\" asetusta."
 
 msgid "PHP validate code"
-msgstr ""
+msgstr "PHP validointikoodi"
 
 msgid "Never cache"
-msgstr ""
+msgstr "Älä käytä välimuistia"
 
 msgid "Query results"
-msgstr ""
+msgstr "Kyselyn tulokset"
 
 msgid "The length of time raw query results should be cached."
-msgstr ""
+msgstr "Kuinka kauan raakakyselyn tulokset säilytetään välimuistissa."
 
 msgid "Rendered output"
-msgstr ""
+msgstr "Ulosanti"
 
 msgid "The length of time rendered HTML output should be cached."
-msgstr ""
+msgstr "Kuinka pitkään HTML ulosanti tulee säilyttää välimuistissa."
 
 msgid "Broken field"
-msgstr ""
+msgstr "Rikkinäinen kenttä"
 
 msgid "Change the title that this display will use."
-msgstr ""
+msgstr "Vaihda näkymän käyttämää otsikkoa."
 
 msgid "Use AJAX"
-msgstr ""
+msgstr "Käytä AJAXia"
 
 msgid "Change whether or not this display will use AJAX."
-msgstr ""
+msgstr "Valitse käytetäänkö AJAXia vaiko ei."
 
 msgid "Mini"
-msgstr ""
+msgstr "Mini"
 
 msgid "Change this display's pager setting."
-msgstr ""
+msgstr "Muuta näkymän sivutusasetusta."
 
 msgid "Specify whether this display will provide a \"more\" link."
-msgstr ""
+msgstr "Valitse näytetäänkö näkymässä \"lisää\" linkki."
 
 msgid "Specify access control type for this display."
-msgstr ""
+msgstr "Määrittele näyttöruudun pääsysäännön tyyppi."
 
 msgid "Change settings for this access type."
-msgstr ""
+msgstr "Muuta pääsysäännön asetuksia."
 
 msgid "Specify caching type for this display."
-msgstr ""
+msgstr "Valitse näkymän välimuistitutstyyppi."
 
 msgid "Change settings for this caching type."
-msgstr ""
+msgstr "Muuta välimuistitustyypin asetusta."
 
 msgid "Link display"
-msgstr ""
+msgstr "Linkitettävä näkymä"
 
 msgid "Exposed form in block"
-msgstr ""
+msgstr "Näytä kaavake lohkossa"
 
 msgid "Allow the exposed form to appear in a block instead of the view."
 msgstr ""
+"Näytä käyttäjille paljastetut suodattimet sisältävä kaavake lohkossa näkymän"
+" sijaan."
 
 msgid "The title of this view"
-msgstr ""
+msgstr "Näkymän otsikko"
 
 msgid ""
 "This title will be displayed with the view, wherever titles are normally "
 "displayed; i.e, as the page title, block title, etc."
 msgstr ""
+"Otsikko näytetään näkymän yhteydessä paikassa missä otsikot normaalistikin "
+"näytetään; toisinsanoen sivun otsikko, lohkon otsikko jne."
 
 msgid ""
 "Unless you're experiencing problems with pagers related to this view, you "
@@ -6084,15 +6219,20 @@ msgid ""
 "array. Large values will add a lot of commas to your URLs, so avoid if "
 "possible."
 msgstr ""
+"On hyvä jättää tämä asetus arvoon 0 mikäli et havaitse ongelmia näkymän "
+"sivutuksen kanssa. Jos käytät useampia kuin yhtä sivutuselementtiä sivuilla,"
+" voi olla tarpeen asettaa tämä luku suuremmaksi jotta ne eivät törmää "
+"?page=array'n kanssa. Suuremmat luvut lisäävät paljon pilkkuja osoitteisiisi"
+" joten vältä jos mahdollista."
 
 msgid "Add a more link to the bottom of the display."
-msgstr ""
+msgstr "Näytä \"Lisää\" -linkki näkymän alaosassa."
 
 msgid "Create more link"
-msgstr ""
+msgstr "Luo \"lisää\" linkki"
 
 msgid "The text to display for the more link."
-msgstr ""
+msgstr "\"Lisää\" linkissä näytettävä teksti."
 
 msgid ""
 "This will make the view display only distinct items. If there are multiple "
@@ -6100,46 +6240,54 @@ msgid ""
 "and remove duplicates from a view, though it does not always work. Note that"
 " this can slow queries down, so use it with caution."
 msgstr ""
+"Tämä saa näkymän näyttämään ainoastaan yksilöityjä tuloksia. Jos sama tulos "
+"esiintyy useammin kuin kerran, tulos näytetään ainoastaan kertaalleen. Voit "
+"yrittää käyttää tätä poistamaan duplikaatit näkymistä vaikkakaan se ei aina "
+"toimi. Huomioi että tämä saattaa hidastaa tietokantakyselyitä joten käytä "
+"ominaisuutta varoen."
 
 msgid "Access restrictions"
-msgstr ""
+msgstr "Käyttöoikeudet"
 
 msgid "Access options"
-msgstr ""
+msgstr "Käytön ominaisuudet"
 
 msgid "Caching options"
-msgstr ""
+msgstr "Välimuistitustavat"
 
 msgid "Display even if view has no result"
-msgstr ""
+msgstr "Näytä vaikka näkymä ei palauta tuloksia"
 
 msgid "How should this view be styled"
-msgstr ""
+msgstr "Tapa jolla näkymä esitetään"
 
 msgid ""
 "If the style you choose has settings, be sure to click the settings button "
 "that will appear next to it in the View summary."
 msgstr ""
+"Valitsemallasi tyylillä on asetuksia, varmista että klikkaat Views "
+"yhteenvedon vieressä näkyvää asetusnappia."
 
 msgid "Style options"
-msgstr ""
+msgstr "Tyyliasetukset"
 
 msgid "Row style options"
-msgstr ""
+msgstr "Rivityylin asetukset"
 
 msgid "How should each row in this view be styled"
-msgstr ""
+msgstr "Kuinka kukin riveistä esitetään"
 
 msgid "Which display to use for path"
-msgstr ""
+msgstr "Mitä sivua käytetään polkuna"
 
 msgid ""
 "Which display to use to get this display's path for things like summary "
 "links, rss feed links, more links, etc."
 msgstr ""
+"Mitä sivua käytetään sivun polkuna esimerkiksi RSS-syötteen linkeissä jne."
 
 msgid "Put the exposed form in a block"
-msgstr ""
+msgstr "Aseta näkyviin määritetty kaavake lohkoon"
 
 msgid ""
 "If set, any exposed widgets will not appear with this view. Instead, a block"
@@ -6147,88 +6295,91 @@ msgid ""
 "exposed form will appear there. Note that this block must be enabled "
 "manually, Views will not enable it for you."
 msgstr ""
+"Jos valittu, suodattimet eivät näy tässä näkymässä, vaan ne näytetään "
+"lohkona Drupalin lohkojärjestelmässä. Huomaathan, että tämä lohko pitää "
+"ottaa käyttöön erikseen."
 
 msgid ""
 "Display \"@display\" uses fields but there are none defined for it or all "
 "are excluded."
-msgstr ""
+msgstr "Sivu \"@display\" käyttää kenttiä mutta kenttiä ei ole määritelty."
 
 msgid "Display \"@display\" uses a path but the path is undefined."
-msgstr ""
+msgstr "Sivu \"@display\" käyttää määrittämätöntä hakupolkua."
 
 msgid "Display \"@display\" has an invalid style plugin."
-msgstr ""
+msgstr "Sivulle \"@display\" määritettyä tyylilaajennusta ei löydy."
 
 msgid "Exposed form: @view-@display_id"
-msgstr ""
+msgstr "Näkyvä kaavake: @view-@display_id"
 
 msgid "Attachment settings"
-msgstr ""
+msgstr "Liiteasetukset"
 
 msgid "Inherit exposed filters"
-msgstr ""
+msgstr "Peri näkymään määritellyt suodattimet"
 
 msgid "Multiple displays"
-msgstr ""
+msgstr "Useita näyttöjä"
 
 msgid ""
 "Should this display inherit its exposed filter values from the parent "
 "display to which it is attached?"
-msgstr ""
+msgstr "Tuleeko sivun periä pääsivulle näkymään määritetyt suodatinarvot?"
 
 msgid "Attach before or after the parent display?"
-msgstr ""
+msgstr "Sijoita pääsivuin alkuun vai loppuun?"
 
 msgid "Select which display or displays this should attach to."
-msgstr ""
+msgstr "Valitse mihin sivuun tai sivuihin tämän tulisi liittyä."
 
 msgid "@view: @display"
-msgstr ""
+msgstr "@view: @display"
 
 msgid "Block admin description"
-msgstr ""
+msgstr "Lohkon kuvaus ylläpidossa"
 
 msgid "Using the site name"
-msgstr ""
+msgstr "Käyttää sivuston nimeä"
 
 msgid "Use the site name for the title"
-msgstr ""
+msgstr "Käytä sivuston nimeä otsikkona"
 
 msgid "The feed icon will be available only to the selected displays."
-msgstr ""
+msgstr "RSS-syötteen kuvake on tarjolla ainoastaan valituille näkymille."
 
 msgid "No menu"
-msgstr ""
+msgstr "Ei valikkoa"
 
 msgid "Normal: @title"
-msgstr ""
+msgstr "Normaali: @title"
 
 msgid "Tab: @title"
-msgstr ""
+msgstr "Välilehti: @title"
 
 msgid "Change settings for the parent menu"
-msgstr ""
+msgstr "Muuta ylätason valikkoelementin asetuksia"
 
 msgid "The menu path or URL of this view"
-msgstr ""
+msgstr "Näkymän valikon polku (URL)"
 
 msgid "Menu item entry"
-msgstr ""
+msgstr "Valikkoelementin syöttö"
 
 msgid "No menu entry"
-msgstr ""
+msgstr "Ei valikkoa"
 
 msgid "Normal menu entry"
-msgstr ""
+msgstr "Normaali valikkoelementti"
 
 msgid "Menu tab"
-msgstr ""
+msgstr "Valikkovälilehti"
 
 msgid "Default menu tab"
-msgstr ""
+msgstr "Oletusvalikkovälilehti"
 
 msgid "Default tab options"
-msgstr ""
+msgstr "Välilehtien perusasetukset"
 
 msgid ""
 "When providing a menu item as a tab, Drupal needs to know what the parent "
@@ -6238,79 +6389,95 @@ msgid ""
 "to this view is <em>foo/bar/baz</em>, the parent path would be "
 "<em>foo/bar</em>."
 msgstr ""
+"Kun tarjoat valikkon elementtiä välilehtenä, Drupalin on tiedettävä sen "
+"sijainti valikossa. Joskus sijainti on tiedossa kun taas joissakin "
+"tapauksissa joudut luomaan sen. Valikkohierarkiassa tämänhetkistä tasoa "
+"ylemmän valikkokohdan polku on aina sama kuin tämänhetkinen polku ilman "
+"viimeistä osaansa. Esimerkiksi jos näkymän polku on <em>foo/bar/baz</em>, "
+"sitä ylemmän tason valikkokohdan polku on <em>foo/bar</em>."
 
 msgid "Already exists"
-msgstr ""
+msgstr "On jo olemassa"
 
 msgid "If creating a parent menu item, enter the title of the item."
 msgstr ""
+"Jos olet luomassa ylätason valikkoelementtiä, syötä elementin otsikko."
 
 msgid "If creating a parent menu item, enter the description of the item."
-msgstr ""
+msgstr "Jos olet luomassa ylätason valikkoelementtiä, syötä elementin kuvaus."
 
 msgid "\"%\" may not be used for the first segment of a path."
-msgstr ""
+msgstr "\"%\" merkkiä ei voida käyttää polun ensimmäisenä osana."
 
 msgid "Views cannot create normal menu items for paths with a % in them."
-msgstr ""
+msgstr "Valikkoelementtiä ei voida luoda poluille jotka sisältävät merkin %."
 
 msgid "A display whose path ends with a % cannot be a tab."
-msgstr ""
+msgstr "Näkymä jonka polku päättyy prosenttimerkkiin ei voi olla välilehti."
 
 msgid "Title is required for this menu type."
-msgstr ""
+msgstr "Otsikko on pakollinen tämäntyyppiseen valikkoon."
 
 msgid "Inline fields"
-msgstr ""
+msgstr "Rinnakkaiset kentät"
 
 msgid ""
 "The separator may be placed between inline fields to keep them from "
 "squishing up next to each other. You can use HTML in this field."
 msgstr ""
+"Erotusmerkki voidaan sijoittaa sisennytettyjen kenttien väliin estämään "
+"niiden liimautumisen toisiinsa. Voit käyttää HTML:ää tässä kentässä."
 
 msgid ""
 "You may optionally specify a field by which to group the records. Leave "
 "blank to not group."
 msgstr ""
+"Voit vaihtoehtoisesti määritellä kentän jonka mukaan tulokset ryhmitellään, "
+"jätä tyhjäksi jos et halua ryhmittelyä."
 
 msgid "Style @style requires a row style but the row plugin is invalid."
-msgstr ""
+msgstr "Tyyli @style vaatii rivityylin mutta rivi-lisäosa ei ole aktivoituna."
 
 msgid ""
 "Horizontal alignment will place items starting in the upper left and moving "
 "right. Vertical alignment will place items starting in the upper left and "
 "moving down."
 msgstr ""
+"Vaakatason sisennys asettaa elementit ylävasemmalta yläoikealle. Psytytason "
+"sisennys sijoittaa elementit ylävasemmalta alkaen alaspäin."
 
 msgid "RSS description"
-msgstr ""
+msgstr "RSS-kuvaus"
 
 msgid "This will appear in the RSS feed itself."
-msgstr ""
+msgstr "Tämä näkyy itse RSS-syötteessä."
 
 msgid "Display record count with link"
-msgstr ""
+msgstr "Näytä osumien määrä linkin kanssa"
 
 msgid "Override number of items to display"
-msgstr ""
+msgstr "Ohita näytettävien elementtien määrä"
 
 msgid "Display items inline"
-msgstr ""
+msgstr "Näytä elementit rinnakkain"
 
 msgid ""
 "You need at least one field before you can configure your table settings"
 msgstr ""
+"Tarvitset vähintään yhden kentän ennen kuin voit muokata taulukon asetuksia"
 
 msgid "Override normal sorting if click sorting is used"
-msgstr ""
+msgstr "Ohita normaali lajittelu jos klikkaus-järjestely on valittuna"
 
 msgid "Enable Drupal style \"sticky\" table headers (Javascript)"
-msgstr ""
+msgstr "Aktivoi Drupal-tyyliset \"kiinteät\" taulunotsikot (JavaScript)"
 
 msgid ""
 "(Sticky header effects will not be active for preview below, only on live "
 "output.)"
 msgstr ""
+"(Kiinteät otsikot eivät näy alla olevassa esikatselussa, vaan ainoastaan "
+"varsinaisessa tulosteessa.)"
 
 msgid ""
 "Place fields into columns; you may combine multiple fields into the same "
@@ -6320,269 +6487,283 @@ msgid ""
 " sorted by default, if any. You may control column order and field labels in"
 " the fields section."
 msgstr ""
+"Siirrä kenttiä sarakkeisiin: voit yhdistää useampia kenttiä yhteen "
+"sarakkeeseen. Jos teet näin, kentät erotetaan toisistaan sarakkeelle "
+"määritellyllä erottimella. Valitse \"lajiteltava\"-ruutu tehdäksesi "
+"sarakkeesta lajiteltavan. Lisäksi valitse oletuslajittelu määritelläksesi "
+"minkä sarakkeen mukaan (jos mikään) lajitellaan lähtökohtaisesti. Voit "
+"hallita sarakkeiden järjestystä ja kenttien otsikoita kentät-osiossa."
 
 msgid "Parent link ID"
-msgstr ""
+msgstr "Isäntälinkin ID"
 
 msgid "Placeholder"
-msgstr ""
+msgstr "Paikkamerkki"
 
 msgid "Language settings"
 msgstr "Kieliasetukset"
 
 msgid "Attempting to re-run cron while it is already running."
-msgstr ""
+msgstr "Yritettiin uudelleenkäynnistää cron-ajo sen ollessa jo käynnissä."
 
 msgid "Cron run completed."
-msgstr ""
+msgstr "Cron-ajo valmis."
 
 msgid "Visitors"
-msgstr ""
+msgstr "Vierailijat"
 
 msgid "Allow multiple values"
-msgstr ""
+msgstr "Salli useampia arvoja kuin yksi"
 
 msgid "The maximum length of the field in characters."
-msgstr ""
+msgstr "Kentän maksimipituus merkkeinä."
 
 msgid "Module dependencies"
-msgstr ""
+msgstr "Moduuliriippuvuudet"
 
 msgid "Update translations"
-msgstr ""
+msgstr "Päivitä käännökset"
 
 msgid "Indexing throttle"
-msgstr ""
+msgstr "Indeksoinnin kiihdytys"
 
 msgid "Administration menu"
-msgstr ""
+msgstr "Ylläpitovalikko"
 
 msgid "››"
-msgstr ""
+msgstr "››"
 
 msgid "‹‹"
-msgstr ""
+msgstr "‹‹"
 
 msgid "- All -"
-msgstr ""
+msgstr "- All -"
 
 msgid "A boolean indicating whether this translation needs to be updated."
-msgstr ""
+msgstr "Totuusarvo joka osoittaa tarvitseeko tätä käännöstä päivittää."
 
 msgid "Publishing status"
-msgstr ""
+msgstr "Julkaisun tila"
 
 msgid "Edit language"
-msgstr ""
+msgstr "Muokkaa kieltä"
 
 msgid "External links only"
-msgstr ""
+msgstr "Vain ulkoiset linkit"
 
 msgid "Filter criteria"
-msgstr ""
+msgstr "Suodatinkriteerit"
 
 msgid "The content type %name has been updated."
-msgstr ""
+msgstr "Sisällön tyyppi %name on päivitetty."
 
 msgid "The content type %name has been added."
-msgstr ""
+msgstr "Sisällön tyyppi %name on lisätty."
 
 msgid "Drag to re-order"
-msgstr ""
+msgstr "Järjestele vetämällä"
 
 msgid "Block Content"
-msgstr ""
+msgstr "Lohkon sisältö"
 
 msgid "Blue Lagoon (default)"
-msgstr ""
+msgstr "Blue Lagoon (oletus)"
 
 msgid "The requested page could not be found."
-msgstr ""
+msgstr "Pyydettyä sivua ei löytynyt."
 
 msgid "Standard deviation"
-msgstr ""
+msgstr "Keskihajonta"
 
 msgid "The user account %id does not exist."
-msgstr ""
+msgstr "Käyttäjää id:llä %id ei löydy."
 
 msgid "Attempted to cancel non-existing user account: %id."
-msgstr ""
+msgstr "Yritettiin peruuttaa käyttäjätili jota ei ole olemassa: %id."
 
 msgid "Requirements problem"
-msgstr ""
+msgstr "Vaatimusongelma"
 
 msgid "Database configuration"
-msgstr ""
+msgstr "Tietokannan asetukset"
 
 msgid "Select an installation profile"
-msgstr ""
+msgstr "Valitse asennusprofiili"
 
 msgid "Choose language"
-msgstr ""
+msgstr "Valitse kieli"
 
 msgid "No profiles available"
-msgstr ""
+msgstr "Yhtään profiilia ei ole saatavilla."
 
 msgid "Drupal already installed"
-msgstr ""
+msgstr "Drupal on jo asennettu."
 
 msgid "Installing @drupal"
-msgstr ""
+msgstr "Asennetaan @drupal"
 
 msgid "The installation has encountered an error."
-msgstr ""
+msgstr "Asennusohjelma kohtasi virheen"
 
 msgid "Configure site"
-msgstr ""
+msgstr "Sivuston asetukset"
 
 msgid "Installed %module module."
-msgstr ""
+msgstr "Asennettiin %module moduuli."
 
 msgid "Choose profile"
-msgstr ""
+msgstr "Profiilin valitseminen"
 
 msgid "Verify requirements"
-msgstr ""
+msgstr "Vaatimuksien vahvistaminen"
 
 msgid "Set up database"
-msgstr ""
+msgstr "Tietokannan asetukset"
 
 msgid "Set up translations"
-msgstr ""
+msgstr "Käännösten valmistelu"
 
 msgid "Install site"
-msgstr ""
+msgstr "Sivuston asentaminen"
 
 msgid "Finish translations"
-msgstr ""
+msgstr "Käännösten viimeistely"
 
 msgid "Check for updates automatically"
-msgstr ""
+msgstr "Tarkista päivitykset automaattisesti"
 
 msgid "1 byte"
 msgid_plural "@count bytes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 tavu"
+msgstr[1] "@count tavua"
 
 msgid "Illegal choice %choice in %name element."
-msgstr ""
+msgstr "Laiton pyyntö %choice elementissä %name."
 
 msgid "GD2 image manipulation toolkit"
-msgstr ""
+msgstr "GD2-grafiikkakirjasto"
 
 msgid ""
 "Define the image quality for JPEG manipulations. Ranges from 0 to 100. "
 "Higher values mean better image quality but bigger files."
 msgstr ""
+"Valitse muunnettavien JPEG-kuvien laatu. Asteikko on 0-100. Korkeammat arvot"
+" merkitsevät parempaa kuvanlaatua mutta suurempia tiedostoja."
 
 msgid "Right to left"
-msgstr ""
+msgstr "Oikealta vasemmalle"
 
 msgid "Left to right"
-msgstr ""
+msgstr "Vasemmalta oikealle"
 
 msgid "Add custom language"
-msgstr ""
+msgstr "Lisää mukautettu kieli"
 
 msgid "Save language"
-msgstr ""
+msgstr "Tallenna kieli"
 
 msgid "Direction that text in this language is presented."
-msgstr ""
+msgstr "Kielen kirjoitussuunta."
 
 msgid "Languages not yet added"
-msgstr ""
+msgstr "Kielet, joita ei ole vielä lisätty"
 
 msgid "The language %language has been created."
-msgstr ""
+msgstr "Kieli %language on luotu."
 
 msgid "The submitted string contains disallowed HTML: %string"
-msgstr ""
+msgstr "Lähetetty merkkijono sisältää kiellettyä HTML:ää: %string"
 
 msgid "Importing interface translations"
-msgstr ""
+msgstr "Tuodaan käyttöliittymän käännöksiä"
 
 msgid "Error importing interface translations"
-msgstr ""
+msgstr "Virhe tuotaessa käyttöliittymän käännöksiä"
 
 msgid ""
 "Attempted submission of a translation string with disallowed HTML: %string"
 msgstr ""
+"Yritetty lähettää kiellettyä käännösmerkkijonoa kielletyllä HTML:llä %string"
 
 msgid "Updated JavaScript translation file for the language %language."
-msgstr ""
+msgstr "Kielen %language päivitetty JavaScript-käännöstiedosto."
 
 msgid "Created JavaScript translation file for the language %language."
-msgstr ""
+msgstr "Luotiin JavaScript-käännöstiedosto kielelle %language."
 
 msgid ""
 "An error occurred during creation of the JavaScript translation file for the"
 " language %language."
 msgstr ""
+"Tapahtui virhe luotaessa JavaScript-käännöstiedostoa kielelle %language."
 
 msgid "Standard PHP"
-msgstr ""
+msgstr "Standardi PHP"
 
 msgid "PHP Mbstring Extension"
-msgstr ""
+msgstr "PHP:n mbstring-laajennus"
 
 msgid "Could not convert XML encoding %s to UTF-8."
-msgstr ""
+msgstr "XML:n merkistöä %s ei voitu muuntaa UTF-8 -muotoon."
 
 msgid "The name of the feed (or the name of the website providing the feed)."
-msgstr ""
+msgstr "Syötteen nimi (tai sitä tarjoavan sivuston nimi)."
 
 msgid "Add a feed in RSS, RDF or Atom format. A feed may only have one entry."
-msgstr ""
+msgstr "Lisää syöte, joka on RSS-, RDF- tai Atom-muodossa."
 
 msgid "Update items"
-msgstr ""
+msgstr "Päivitä aiheet"
 
 msgid "No blocks in this region"
-msgstr ""
+msgstr "Tällä alueella ei ole lohkoja"
 
 msgid ""
 "The block %info was assigned to the invalid region %region and has been "
 "disabled."
-msgstr ""
+msgstr "Alue %region ei sovi lohkolle %info. Lohko on poistettu käytöstä."
 
 msgid ""
 "The content type for the %add-child link must be one of those selected as an"
 " allowed book outline type."
 msgstr ""
+"%add-child -linkin sisällön on oltava tyyppiä, jonka lisääminen kirjaan on "
+"sallittu."
 
 msgid ""
 "This book has been modified by another user, the changes could not be saved."
-msgstr ""
+msgstr "Toinen käyttäjä on muokannut kirjaa. Muutoksia ei voida tallentaa."
 
 msgid "Title changed from %original to %current."
-msgstr ""
+msgstr "Otsikko vaihdettiin muodosta %original muotoon %current."
 
 msgid "Updated book %title."
-msgstr ""
+msgstr "Kirja %title päivitetty."
 
 msgid "book: updated %title."
-msgstr ""
+msgstr "kirja: %title päivitetty."
 
 msgid "Update book outline"
-msgstr ""
+msgstr "Päivitä kirjan hierarkia"
 
 msgid "Remove from book outline"
-msgstr ""
+msgstr "Poista kirjasta"
 
 msgid "No changes were made"
-msgstr ""
+msgstr "Muutoksia ei tehty"
 
 msgid ""
 "The post has been added to the selected book. You may now position it "
 "relative to other pages."
 msgstr ""
+"Kirjoitus on lisätty valittuun kirjaan. Voit nyt säätää sen sijantia "
+"kirjassa."
 
 msgid "The book outline has been updated."
-msgstr ""
+msgstr "Kirjan hierarkia on päivitetty."
 
 msgid "There was an error adding the post to the book."
-msgstr ""
+msgstr "Kirjoituksen lisääminen kirjaan ei onnistunut."
 
 msgid ""
 "%title has associated child pages, which will be relocated automatically to "
@@ -6590,24 +6771,29 @@ msgid ""
 "before removing this page), %title may be added again using the Outline tab,"
 " and each of its former child pages will need to be relocated manually."
 msgstr ""
+"Sivulla %title on alasivuja, jotka siirretään automaattisesti jotta ne "
+"pysyvät mukana kirjassa. Luodaksesi hierarkian uudelleen (sellaisena kuin se"
+" oli ennen tämän sivun poistamista), lisää %title uudelleen kirjaan "
+"Hierarkia-välilehdestä, ja laita aiemmat alasivut takaisin paikalleen käsin."
 
 msgid "%title may be added to hierarchy again using the Outline tab."
 msgstr ""
+"Voit lisätä sivun %title takaisin kirjan hierarkiaan Hierarkia-välilehdeltä."
 
 msgid "Are you sure you want to remove %title from the book hierarchy?"
-msgstr ""
+msgstr "Haluatko varmasti poistaa sivun %name? tästä kirjasta?"
 
 msgid "The post has been removed from the book."
-msgstr ""
+msgstr "Kirjoitus on poistettu kirjasta."
 
 msgid "Show a printer-friendly version of this book page and its sub-pages."
-msgstr ""
+msgstr "Näytä tulostettava versio tästä kirjan sivusta ja sen alasivuista."
 
 msgid "Show block on all pages"
-msgstr ""
+msgstr "Näytä lohko kaikilla sivuilla"
 
 msgid "Show block only on book pages"
-msgstr ""
+msgstr "Näytä lohko ainoastaan kirjojen sivuilla"
 
 msgid ""
 "If <em>Show block on all pages</em> is selected, the block will contain the "
@@ -6618,72 +6804,81 @@ msgid ""
 "visibility settings</em> or other visibility settings can be used in "
 "addition to selectively display this block."
 msgstr ""
+"Jos valitset <em>Näytä lohko kaikilla sivuilla</em>, lohko sisältää kaikkien"
+" sivuston kirjojen automaattisesti luodut valikot. Jos valitset <em>Näytä "
+"lohko ainoastaan kirjojen sivuilla</em>, lohko sisältää ainoastaan "
+"parhaillaan luettavan kirjan valikon. Lohkoa ei tällöin näytetä, jos "
+"luettava sivu kuulu mihinkään kirjaan. Lohkon <em>sivukohtaisia "
+"näkyvyysasetuksia</em> ja muita näkyvyysasetuksia voi myös käyttää "
+"rajoittamaan, millä sivuilla lohko näkyy."
 
 msgid "This is the top-level page in this book."
-msgstr ""
+msgstr "Tämä on kirjan ylin sivu."
 
 msgid "No book selected."
-msgstr ""
+msgstr "Yhtään kirjaa ei ole valittuna."
 
 msgid ""
 "%title is part of a book outline, and has associated child pages. If you "
 "proceed with deletion, the child pages will be relocated automatically."
 msgstr ""
+"%title kuuluu kirjaan, ja sillä on alasivuja. Jos poistat sen, alasivut "
+"siirretään automaattisesti muualle kirjaan."
 
 msgid "Re-order book pages and change titles"
-msgstr ""
+msgstr "Järjestele kirjan sivuja ja muokkaa otsikoita"
 
 msgid "Book page"
-msgstr ""
+msgstr "Kirjan sivu"
 
 msgid "Contact form"
-msgstr ""
+msgstr "Yhteydenotto"
 
 msgid "Language name"
-msgstr ""
+msgstr "Language name"
 
 msgid "Who's new"
-msgstr ""
+msgstr "Who's new"
 
 msgid "Update notifications"
-msgstr ""
+msgstr "Päivitystiedotteet"
 
 msgid "Unicode library"
-msgstr ""
+msgstr "Unicode-kirjasto"
 
 msgid "String contains"
-msgstr ""
+msgstr "Merkkijono sisältää"
 
 msgid "Both translated and untranslated strings"
-msgstr ""
+msgstr "Sekä käännetyt että kääntämättömät merkkijonot"
 
 msgid "Only translated strings"
-msgstr ""
+msgstr "Vain käännetyt merkkijonot"
 
 msgid "Only untranslated strings"
-msgstr ""
+msgstr "Vain kääntämättömät merkkijonot"
 
 msgid "Search in"
-msgstr ""
+msgstr "Hae kielistä"
 
 msgid "Pagination"
-msgstr ""
+msgstr "Sivutus"
 
 msgid ""
 "Changes made in this table will not be saved until the form is submitted."
-msgstr ""
+msgstr "Muutokset otetaan käyttöön vasta kun valitset <em>tallenna</em>."
 
 msgid "Example: 'website feedback' or 'product information'."
-msgstr ""
+msgstr "Esimerkki: \"palaute\" tai \"tuotetiedot\"."
 
 msgid "No roles may use this format"
-msgstr ""
+msgstr "Mikään rooli eivät saa käyttää tätä muotoa"
 
 msgid "Allowed HTML tags: @tags"
-msgstr ""
+msgstr "Sallitut HTML-tagit: @tags"
 
 msgid "Anchors are used to make links to other pages."
-msgstr ""
+msgstr "Ankkureilla luodaan linkkejä muille sivuille."
 
 msgid ""
 "By default line break tags are automatically added, so use this tag to add "
@@ -6691,436 +6886,474 @@ msgid ""
 " open/close pair like all the others. Use the extra \" /\" inside the tag to"
 " maintain XHTML 1.0 compatibility"
 msgstr ""
+"Oletuksena rivinvaihdot lisätään automaattisesti, joten tätä tagia voidaan "
+"käyttää ylimääräisten rivinvaihtojen lisäämiseksi. Tagin käyttö eroaa "
+"normaalista koska sitä ei käytetä avaa/sulje -pareina niinkuin muita html-"
+"merkkauksia. Käytä merkkauksen sulkemiseksi ylimääräistä \"/\"-merkkiä "
+"merkkauksen sisällä säilyttääksesi XHTML 1.0 -yhteensopivuuden."
 
 msgid "Text with <br />line break"
-msgstr ""
+msgstr "Teksti <br />rivinvaihdolla"
 
 msgid ""
 "By default paragraph tags are automatically added, so use this tag to add "
 "additional ones."
 msgstr ""
+"Oletuksena kappalemerkkaukset lisätään automaattisesti, joten tätä "
+"merkkausta voidaan käyttää ylimääräisten kappaleiden lisäämiseksi."
 
 msgid "Paragraph one."
-msgstr ""
+msgstr "Kappale yksi"
 
 msgid "Paragraph two."
-msgstr ""
+msgstr "Kappale kaksi."
 
 msgid "Strong"
 msgstr "Vahva"
 
 msgid "Emphasized"
-msgstr ""
+msgstr "Korostettu"
 
 msgid "Cited"
-msgstr ""
+msgstr "Siteerattu"
 
 msgid "Coded text used to show programming source code"
 msgstr ""
+"Ohjelmointikielisen lähdekoodin näyttämiseen käytettävä koodimuotoinen "
+"teksti."
 
 msgid "Coded"
-msgstr ""
+msgstr "Koodattu"
 
 msgid "Bolded"
-msgstr ""
+msgstr "Lihavoitu"
 
 msgid "Italicized"
-msgstr ""
+msgstr "Kursivoitu"
 
 msgid "Superscripted"
-msgstr ""
+msgstr "Yläindeksi"
 
 msgid "<sup>Super</sup>scripted"
-msgstr ""
+msgstr "<sup>Ylä</sup>indeksi"
 
 msgid "Subscripted"
-msgstr ""
+msgstr "Alaindeksi"
 
 msgid "<sub>Sub</sub>scripted"
-msgstr ""
+msgstr "<sub>Ala</sub>indeksi"
 
 msgid "<abbr title=\"Abbreviation\">Abbrev.</abbr>"
-msgstr ""
+msgstr "<abbr title=\"Lyhennys\">Lyhenn.</abbr>"
 
 msgid "<acronym title=\"Three-Letter Acronym\">TLA</acronym>"
-msgstr ""
+msgstr "<acronym title=\"Kolmen kirjaimen lyhennesana\">KKL</acronym>"
 
 msgid "Block quoted"
-msgstr ""
+msgstr "Lohkolainaus"
 
 msgid "Quoted inline"
-msgstr ""
+msgstr "Välitön lainaus"
 
 msgid "Table header"
-msgstr ""
+msgstr "Taulukon otsikko"
 
 msgid "Table cell"
-msgstr ""
+msgstr "Taulukon solu"
 
 msgid "Ordered list - use the &lt;li&gt; to begin each list item"
-msgstr ""
+msgstr "Järjestetty lista - käytä &lt;li&gt;-merkkausta kunkin kohdan alussa."
 
 msgid "First item"
-msgstr ""
+msgstr "Ensimmäinen kohta"
 
 msgid "Second item"
-msgstr ""
+msgstr "Toinen kohta"
 
 msgid "Unordered list - use the &lt;li&gt; to begin each list item"
-msgstr ""
+msgstr "Järjestämätön lista - käytä &ltli&gt;-merkkausta kunkin kohdan alussa"
 
 msgid ""
 "Definition lists are similar to other HTML lists. &lt;dl&gt; begins the "
 "definition list, &lt;dt&gt; begins the definition term and &lt;dd&gt; begins"
 " the definition description."
 msgstr ""
+"Määrityslistat ovat samankaltaisia kuin muut HTML-listat. &lt;dl&gt; "
+"aloittaa listan, &lt;dt&gt; aloittaa määritystermin ja &lt;dd&gt; "
+"määrityskuvauksen."
 
 msgid "First term"
-msgstr ""
+msgstr "Ensimmäinen termi"
 
 msgid "First definition"
-msgstr ""
+msgstr "Ensimmäinen määritys"
 
 msgid "Second term"
-msgstr ""
+msgstr "Toinen termi"
 
 msgid "Second definition"
-msgstr ""
+msgstr "Toinen määritys"
 
 msgid "Subtitle three"
-msgstr ""
+msgstr "Alaotsikko kolme"
 
 msgid "Subtitle four"
-msgstr ""
+msgstr "Alaotsikko neljä"
 
 msgid "Subtitle five"
-msgstr ""
+msgstr "Alaotsikko viisi"
 
 msgid "Subtitle six"
-msgstr ""
+msgstr "Alaotsikko kuusi"
 
 msgid "Tag Description"
-msgstr ""
+msgstr "Koodin kuvaus"
 
 msgid "You Type"
-msgstr ""
+msgstr "Kun kirjoitat"
 
 msgid "You Get"
-msgstr ""
+msgstr "Näet seuraavaa"
 
 msgid "No help provided for tag %tag."
-msgstr ""
+msgstr "Tagille %tag ei löydy ohjetta."
 
 msgid "Ampersand"
-msgstr ""
+msgstr "&amp;-merkki"
 
 msgid "Quotation mark"
-msgstr ""
+msgstr "Lainausmerkki"
 
 msgid "Character Description"
-msgstr ""
+msgstr "Merkin kuvaus"
 
 msgid "Lines and paragraphs break automatically."
-msgstr ""
+msgstr "Rivit ja kappaleet päätetään automaattisesti."
 
 msgid "Compose tips"
-msgstr ""
+msgstr "Muotoiluvinkkejä"
 
 msgid "Short but meaningful name for this collection of threaded discussions."
-msgstr ""
+msgstr "Lyhyt mutta kuvaava nimi näille keskusteluille"
 
 msgid "Description and guidelines for discussions within this forum."
-msgstr ""
+msgstr "Tämän foorumin keskustelujen kuvaus ja ohjeet."
 
 msgid "Short but meaningful name for this collection of related forums."
-msgstr ""
+msgstr "Lyhyt mutta kuvaava nimi tälle foorumien kokoelmalle."
 
 msgid "Default number of forum topics displayed per page."
-msgstr ""
+msgstr "Kullakin sivulla näytettävien keskustelujen oletusmäärä."
 
 msgid "Default display order for topics."
-msgstr ""
+msgstr "Missä järjestyksessä keskustelut oletuksena näytetään?"
 
 msgid ""
 "Containers are usually placed at the top (root) level, but may also be "
 "placed inside another container or forum."
 msgstr ""
+"Säiliöt sijoitetaan tavallisesti ylimmälle tasolle (juuri), mutta ne voi "
+"myös sijoittaa toisen säiliön tai foorumin sisään."
 
 msgid ""
 "Forums may be placed at the top (root) level, or inside another container or"
 " forum."
 msgstr ""
+"Foorumin voi sijoittaa ylimmälle tasolle (juuri), tai toisen foorumin tai "
+"säiliön sisään."
 
 msgid "Forum topic"
-msgstr ""
+msgstr "Foorumin aihe"
 
 msgid "You are not allowed to post new content in the forum."
 msgstr ""
+"Sinulla ei ole oikeutta kirjoittaa uutta sisältöä keskustelupalstalle."
 
 msgid "Submission form settings"
-msgstr ""
+msgstr "Lähetyslomakkeen asetukset"
 
 msgid ""
 "The machine-readable name must contain only lowercase letters, numbers, and "
 "underscores."
 msgstr ""
+"Järjestelmää varten tarkoitettu nimi voi sisältää vain pieniä kirjaimia, "
+"numeroita ja alaviivoja."
 
 msgid "Added content type %name."
-msgstr ""
+msgstr "Lisätty sisältötyppi %name."
 
 msgid "Changed the content type of 1 post from %old-type to %type."
 msgid_plural ""
 "Changed the content type of @count posts from %old-type to %type."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 kirjoitus muutettiin tyypistä %old-type tyypiksi %type."
+msgstr[1] "@count kirjoitusta muutettiin tyypistä %old-type tyypiksi %type."
 
 msgid "Are you sure you want to rebuild the permissions on site content?"
-msgstr ""
+msgstr "Oletko varma, että haluat rakentaa sisällön pääsyoikeudet uudelleen?"
 
 msgid ""
 "This action rebuilds all permissions on site content, and may be a lengthy "
 "process. This action cannot be undone."
 msgstr ""
+"Tämä toiminto rakentaa kaikki sisällön pääsyoikeudet uudelleen, ja se voi "
+"kestää kauan. Tätä ei voi perua."
 
 msgid "language"
-msgstr ""
+msgstr "kieli"
 
 msgid "An error occurred and processing did not complete."
-msgstr ""
+msgstr "Tapahtui virhe; käsittelyä ei tehty loppuun."
 
 msgid "Copy of the revision from %date."
-msgstr ""
+msgstr "Kopio versiosta päivämäärältä %date."
 
 msgid "Revision from %revision-date of @type %title has been deleted."
 msgstr ""
+"Kirjoituksesta %title poistettiin versio, jonka tyyppi oli @type ja päiväys"
+"  %revision-date."
 
 msgid "@type: reverted %title revision %revision."
-msgstr ""
+msgstr "@type: palautettiin käyttöön %title versio %revision."
 
 msgid "The content access permissions need to be rebuilt."
-msgstr ""
+msgstr "Sisällön pääsyoikeudet pitää rakentaa uudelleen."
 
 msgid "Rebuilding content access permissions"
-msgstr ""
+msgstr "Rakennetaan sisällön pääsyoikeuksia uudelleen."
 
 msgid "Content permissions have been rebuilt."
-msgstr ""
+msgstr "Sisällön pääsyoikeudet on nyt rakennettu uudelleen."
 
 msgid "The content access permissions have not been properly rebuilt."
-msgstr ""
+msgstr "Sisällön pääsyoikeuksien uudelleen rakentaminen ei onnistunut."
 
 msgid "Add content type"
-msgstr ""
+msgstr "Lisää sisältötyyppi"
 
 msgid "Revert to earlier revision"
-msgstr ""
+msgstr "Palauta käyttöön aikaisempi versio"
 
 msgid "Delete earlier revision"
-msgstr ""
+msgstr "Poista aikaisempi versio"
 
 msgid "The alias %alias is already in use in this language."
-msgstr ""
+msgstr "Alias %alias on jo käytössä tällä kielellä."
 
 msgid "The alias has been saved."
-msgstr ""
+msgstr "Alias on tallennettu."
 
 msgid "Are you sure you want to delete path alias %title?"
-msgstr ""
+msgstr "Haluatko varmasti poistaa aliaksen %title?"
 
 msgid "Filter aliases"
-msgstr ""
+msgstr "Suodata aliaksia"
 
 msgid ""
 "Enter the path you wish to create the alias for, followed by the name of the"
 " new alias."
-msgstr ""
+msgstr "Anna polku, jolle haluat luoda aliaksen ja uuden aliaksen nimi."
 
 msgid "Edit alias"
-msgstr ""
+msgstr "Muokkaa aliasta"
 
 msgid "Delete alias"
-msgstr ""
+msgstr "Poista alias"
 
 msgid "Add alias"
-msgstr ""
+msgstr "Lisää alias"
 
 msgid "URL aliases"
-msgstr ""
+msgstr "Osoitealiakset"
 
 msgid "Top 'page not found' errors"
-msgstr ""
+msgstr "Tavallisimmat 'sivua ei löydy' -virheet"
 
 msgid "Top 'access denied' errors"
-msgstr ""
+msgstr "Tavallisimmat 'pääsy kielletty' -virheet"
 
 msgid "View events that have recently been logged."
-msgstr ""
+msgstr "Näytä lähiaikoina lokiin kirjatut tapahtumat"
 
 msgid "View 'access denied' errors (403s)."
-msgstr ""
+msgstr "Näytä 'pääsy kielletty' (403) -virheet."
 
 msgid "View 'page not found' errors (404s)."
-msgstr ""
+msgstr "Näytä 'sivua ei löydy' (404) -virheet."
 
 msgid "Allows users to comment on and discuss published content."
-msgstr ""
+msgstr "Keskustele sisällöstä kirjoittamalla kommentteja."
 
 msgid "Enables the use of both personal and site-wide contact forms."
 msgstr ""
+"Lähetä henkilökohtaisia viestejä muille käyttäjille. Voit myös luoda "
+"sivustolle palautelomakkeen."
 
 msgid "Logs and records system events to the database."
-msgstr ""
+msgstr "Kirjaa järjestelmätapahtumat tietokantaan."
 
 msgid "Manages the display of online help."
-msgstr ""
+msgstr "Lue ohjesivuja."
 
 msgid "Allows content to be submitted to the site and displayed on pages."
-msgstr ""
+msgstr "Julkaise ja katsele sisältöä."
 
 msgid "Allows users to rename URLs."
-msgstr ""
+msgstr "Muokkaa sivujen osoitteita."
 
 msgid "Number of items to index per cron run"
-msgstr ""
+msgstr "Yhden cron-ajon aikana indeksoitavien kohteiden määrä"
 
 msgid "Indexing settings"
-msgstr ""
+msgstr "Indeksoinnin asetukset"
 
 msgid "Minimum word length to index"
-msgstr ""
+msgstr "Indeksoitavien sanojen minimipituus"
 
 msgid "Simple CJK handling"
-msgstr ""
+msgstr "Yksinkertaistettu CJK-kielten käsittely"
 
 msgid ""
 "Whether to apply a simple Chinese/Japanese/Korean tokenizer based on "
 "overlapping sequences. Turn this off if you want to use an external "
 "preprocessor for this instead. Does not affect other languages."
 msgstr ""
+"Käytetäänkö yksinkertaistettua kiinan, japanin ja korean jäsennystä "
+"(tokenizer), joka perustuu päällekkäisin jaksoihin.  Käännä tämä pois päältä"
+" korvataksesi sen ulkoisella esikääntäjällä.  Tämä ei vaikuta muihin "
+"kieliin."
 
 msgid "Search form"
-msgstr ""
+msgstr "Hakulomake"
 
 msgid "Top search phrases"
-msgstr ""
+msgstr "Suosituimmat haut"
 
 msgid "View most popular search phrases."
-msgstr ""
+msgstr "Näytä suosituimmat haut."
 
 msgid "Content viewing counter settings"
-msgstr ""
+msgstr "Lukukertojen laskurin asetukset"
 
 msgid "Count content views"
-msgstr ""
+msgstr "Laske kirjoitusten lukukerrat"
 
 msgid "Increment a counter each time content is viewed."
-msgstr ""
+msgstr "Kasvata kirjoituksen laskuria joka kerta kun se luetaan."
 
 msgid "Popular content"
-msgstr ""
+msgstr "Suosituin sisältö"
 
 msgid "How many content items to display in \"all time\" list."
-msgstr ""
+msgstr "Montako kirjoitusta näytetään \"Kaikkiaan\"-listassa?"
 
 msgid "How many content items to display in \"recently viewed\" list."
-msgstr ""
+msgstr "Montako kirjoitusta näytetään \"Viimeksi katsottu\" -listassa?"
 
 msgid "Today's:"
-msgstr ""
+msgstr "Tämänpäiväiset:"
 
 msgid "All time:"
-msgstr ""
+msgstr "Kaikkiaan:"
 
 msgid "Last viewed:"
-msgstr ""
+msgstr "Viimeksi luettu:"
 
 msgid "User pictures in posts"
-msgstr ""
+msgstr "Käyttäjien kuvat kirjoituksissa"
 
 msgid "User pictures in comments"
-msgstr ""
+msgstr "Käyttäjien kuvat kommenteissa"
 
 msgid "Shortcut icon"
-msgstr ""
+msgstr "Pikakuvake (favicon)"
 
 msgid "Upload logo image"
-msgstr ""
+msgstr "Tallenna logokuva"
 
 msgid "Shortcut icon settings"
-msgstr ""
+msgstr "Pikakuvakkeen asetukset"
 
 msgid ""
 "If you don't have direct file access to the server, use this field to upload"
 " your shortcut icon."
 msgstr ""
+"Jos sinulla ei ole suoraa yhteyttä palvelimen tiedostojärjestelmään, käytä "
+"tätä kenttää kuvakkeen siirtämiseen palvelimelle."
 
 msgid "No modules selected."
-msgstr ""
+msgstr "Yhtään moduulia ei ole valittuna."
 
 msgid "Default 403 (access denied) page"
-msgstr ""
+msgstr "403 (pääsy kielletty) -sivu"
 
 msgid "Default 404 (not found) page"
-msgstr ""
+msgstr "404 (ei löydy) -sivu"
 
 msgid "Select an image processing toolkit"
-msgstr ""
+msgstr "Valitse kuvia käsiteltäessä käytettävä kirjasto"
 
 msgid "Number of items in each feed"
-msgstr ""
+msgstr "Kirjoitusten määrä kussakin syötteessä"
 
 msgid "Default number of items to include in each feed."
-msgstr ""
+msgstr "Syötteessä kerrallaan julkaistavien kirjoitusten määrä."
 
 msgid "Feed content"
-msgstr ""
+msgstr "Syötteen sisältö"
 
 msgid "Titles plus teaser"
-msgstr ""
+msgstr "Otsikot sekä lyhennelmä"
 
 msgid "Global setting for the default display of content items in each feed."
-msgstr ""
+msgstr "Kunkin syötteen sisällön näyttämistavan yleinen asetus."
 
 msgid "Formatting"
-msgstr ""
+msgstr "Muotoilu"
 
 msgid "Cron ran successfully."
-msgstr ""
+msgstr "Cron-ajo onnistui."
 
 msgid "Cron run failed."
-msgstr ""
+msgstr "Cron-ajo ei onnistunut."
 
 msgid "No modules are available to uninstall."
-msgstr ""
+msgstr "Ei moduuleita, joita voisi poistaa."
 
 msgid ""
 "This page shows you all available administration tasks for each module."
-msgstr ""
+msgstr "Tämä sivu näyttää kuhunkin moduuliin liittyvät ylläpitotoiminot."
 
 msgid ""
 "The <em>Powered by Drupal</em> block is an optional link to the home page of"
 " the Drupal project. While there is absolutely no requirement that sites "
 "feature this link, it may be used to show support for Drupal."
 msgstr ""
+"<em>Powered by Drupal</em> -lohko on linkki Drupal-projektin sivuille. Voit "
+"sen avulla kertoa suosivasi Drupalia, mutta sitä ei ole mikään pakko "
+"näyttää."
 
 msgid "Compact mode"
-msgstr ""
+msgstr "Tiivistetty tila"
 
 msgid "Date and time"
-msgstr ""
+msgstr "Aika ja päiväys"
 
 msgid "-1 (Unlimited)"
-msgstr ""
+msgstr "-1 (Rajoittamaton)"
 
 msgid ""
 "Consider increasing your PHP memory limit to %memory_minimum_limit to help "
 "prevent errors in the installation process."
 msgstr ""
+"PHP:n muistirajoitukseksi kannattaa asettaa %memory_minimum_limit. "
+"Rajoituksen korottaminen ehkäisee virheitä asennuksen aikana."
 
 msgid ""
 "Consider increasing your PHP memory limit to %memory_minimum_limit to help "
 "prevent errors in the update process."
 msgstr ""
+"PHP:n muistirajoitukseksi kannattaa asettaa %memory_minimum_limit. "
+"Rajoituksen korottaminen ehkäisee virheitä päivityksen aikana."
 
 msgid ""
 "Depending on your configuration, Drupal can run with a %memory_limit PHP "
@@ -7128,78 +7361,93 @@ msgid ""
 "recommended, especially if your site uses additional custom or contributed "
 "modules."
 msgstr ""
+"Asetuksista riippuen Drupal voi toimia, jos PHP:n muistirajoitus on "
+"%memory_limit. On kuitenkin suositeltavaa, että PHP:n muistirajoitus on "
+"%memory_minimum_limit, erityisesti jos sivustosi käyttää omia tai muiden "
+"kehittämiä moduuleja."
 
 msgid ""
 "Increase the memory limit by editing the memory_limit parameter in the file "
 "%configuration-file and then restart your web server (or contact your system"
 " administrator or hosting provider for assistance)."
 msgstr ""
+"Kasvata muistirajoitusta muokkaamalla memory_limit -parametria tiedostossa "
+"%configuration-file. Käynnistä web-palvelimesi sen jälkeen uudelleen (tai "
+"ota yhteyttä järjestelmän ylläpitäjään tai palveluntarjoajaan)."
 
 msgid ""
 "Contact your system administrator or hosting provider for assistance with "
 "increasing your PHP memory limit."
 msgstr ""
+"Pyydä palvelimen ylläpitäjältä tai palveluntarjoajalta apua PHP:n "
+"muistirajoituksen nostamisessa."
 
 msgid "Not protected"
-msgstr ""
+msgstr "Suojaamaton"
 
 msgid ""
 "The file %file is not protected from modifications and poses a security "
 "risk. You must change the file's permissions to be non-writable."
 msgstr ""
+"Tiedostoa %file ei ole suojattu muutoksilta, mikä aiheuttaa "
+"tietoturvaongelman. Kirjoitusoikeudet tiedostoon on poistettava."
 
 msgid "Cron has not run recently."
-msgstr ""
+msgstr "Cronia ei ole ajettu äskettäin."
 
 msgid "The directory %directory is not writable."
-msgstr ""
+msgstr "Hakemisto %directory ei ole kirjoitettavissa."
 
 msgid "Writable (<em>public</em> download method)"
-msgstr ""
+msgstr "Kirjoitettavissa (<em>julkinen</em> tiedostojen latausasetus)"
 
 msgid "Writable (<em>private</em> download method)"
-msgstr ""
+msgstr "Kirjoitettavissa (<em>yksityinen</em> tiedostojen latausasetus)"
 
 msgid "Reset to alphabetical"
-msgstr ""
+msgstr "Palauta aakkosjärjestys"
 
 msgid "Terms are displayed in ascending order by weight."
-msgstr ""
+msgstr "Termit näytetään nousevassa järjestyksessä painon mukaan."
 
 msgid "Weight value must be numeric."
-msgstr ""
+msgstr "Painoarvon täytyy olla numeerinen."
 
 msgid ""
 "Are you sure you want to reset the vocabulary %title to alphabetical order?"
-msgstr ""
+msgstr "Haluatko varmasti palauttaa sanaston %title aakkosjärjestykseen?"
 
 msgid ""
 "Resetting a vocabulary will discard all custom ordering and sort items "
 "alphabetically."
 msgstr ""
+"Sanaston palauttaminen aakkosjärjestykseen poistaa kaikki itse asetetut "
+"järjestykset, ja järjestää termit aakkosjärjestykseen."
 
 msgid "Reset vocabulary %name to alphabetical order."
-msgstr ""
+msgstr "Palauta sanasto %name aakkosjärjestykseen."
 
 msgid "Translation settings"
-msgstr ""
+msgstr "Kääntämisen asetukset"
 
 msgid "This translation needs to be updated"
-msgstr ""
+msgstr "Tämä käännös pitää päivittää"
 
 msgid "Unknown release date"
-msgstr ""
+msgstr "Tuntematon julkaisupäivämäärä"
 
 msgid "Last checked: never"
-msgstr ""
+msgstr "Ei tarkistettu koskaan"
 
 msgid "Includes: %includes"
-msgstr ""
+msgstr "Sisältää: %includes"
 
 msgid ""
 "Select how frequently you want to automatically check for new releases of "
 "your currently installed modules and themes."
 msgstr ""
+"Valitse, kuinka usein asennettujen moduulien ja teemojen päivitykset "
+"tarkistetaan."
 
 msgid ""
 "Here you can find information about available updates for your installed "
@@ -7207,74 +7455,85 @@ msgid ""
 " which may or may not have the same name, and might include multiple modules"
 " or themes within it."
 msgstr ""
+"Täältä löydät tietoja asennettuihin moduuleihin ja teemoihin saatavilla "
+"olevista päivityksistä. Huomaa, että jokainen moduuli ja teema kuuluu "
+"<em>projektiin</em>, johon saattaa kuulua useampia moduuleja tai teemoja."
 
 msgid ""
 "There are security updates available for one or more of your modules or "
 "themes. To ensure the security of your server, you should update "
 "immediately!"
 msgstr ""
+"Yhteen tai useampaan käyttämääsi moduuliin tai teemaan on saatavilla "
+"turvapäivitys. Varmista palvelimesi turvallisuus päivittämällä välittömästi!"
 
 msgid ""
 "There are updates available for one or more of your modules or themes. To "
 "ensure the proper functioning of your site, you should update as soon as "
 "possible."
 msgstr ""
+"Yhteen tai useampaan käyttämääsi moduuliin tai teemaan on saatavilla "
+"päivitys. Varmista sivustosi toimivuus päivittämällä niin pian kuin "
+"mahdollista."
 
 msgid "%name has been deleted."
-msgstr ""
+msgstr "%name on poistettu."
 
 msgid "Image toolkit"
-msgstr ""
+msgstr "Kuvatyökalut"
 
 msgid "RSS publishing"
-msgstr ""
+msgstr "RSS-julkaiseminen"
 
 msgid ""
 "Get a status report about available updates for your installed modules and "
 "themes."
 msgstr ""
+"Hae raportti asennettuihin moduuleihin ja teemoihin saatavilla olevista "
+"päivityksistä."
 
 msgid "Access to update.php"
-msgstr ""
+msgstr "Update.php:n käyttö"
 
 msgid "Database updates"
-msgstr ""
+msgstr "Tietokannan päivitykset"
 
 msgid "Cron maintenance tasks"
-msgstr ""
+msgstr "Cron-ajastetut ylläpitotoimenpiteet"
 
 msgid "PHP memory limit"
-msgstr ""
+msgstr "PHP:n muistiraja"
 
 msgid "Caches cleared."
-msgstr ""
+msgstr "Välimuistit tyhjennetty."
 
 msgid "Module and theme update status"
-msgstr ""
+msgstr "Moduulien ja teemojen päivitysten tila"
 
 msgid "Enables site-wide keyword searching."
-msgstr ""
+msgstr "Hae tekstiä kirjoituksista ja kommenteista."
 
 msgid "Logs and records system events to syslog."
-msgstr ""
+msgstr "Kirjaa järjestelmän tapahtumat lokitiedostoon."
 
 msgid "Handles general site configuration for administrators."
 msgstr ""
+"Huolehtii sivuston ylläpitäjille tarkoitetuista yleisistä asetuksista."
 
 msgid "@module (<span class=\"admin-missing\">missing</span>)"
-msgstr ""
+msgstr "@module (<span class=\"admin-missing\">puuttuu</span>)"
 
 msgid "Would you like to continue with uninstalling the above?"
-msgstr ""
+msgstr "Haluatko jatkaa yllä olevien osien poistamista?"
 
 msgid "Confirm uninstall"
-msgstr ""
+msgstr "Vahvista asennuksen poisto"
 
 msgid "The selected modules have been uninstalled."
-msgstr ""
+msgstr "Valitut moduulit on poistettu."
 
 msgid "You must enter a username."
-msgstr ""
+msgstr "Sinun on syötettävä käyttäjätunnus."
 
 msgid "The username cannot begin with a space."
 msgstr "Käyttäjänimi ei saa alkaa tyhjällä merkillä."
@@ -7294,59 +7553,62 @@ msgstr ""
 "merkkiä."
 
 msgid "Unblock the selected users"
-msgstr ""
+msgstr "Salli valittujen tunnusten käyttäminen"
 
 msgid "Block the selected users"
-msgstr ""
+msgstr "Estä valittujen tunnusten käyttäminen"
 
 msgid "Deleted user: %name %email."
-msgstr ""
+msgstr "Poistettu käyttäjä: %name %email."
 
 msgid "Edit role"
-msgstr ""
+msgstr "Muokkaa roolia"
 
 msgid "Language list"
-msgstr ""
+msgstr "Lista kielistä"
 
 msgid "File extension"
-msgstr ""
+msgstr "Tiedostopääte"
 
 msgid "wide"
-msgstr ""
+msgstr "laaja"
 
 msgid ""
 "The title is used as a tool tip when the user hovers the mouse over the "
 "image."
 msgstr ""
+"Otsikko on työkaluvihjeenä näytettävä teksti hiiren ollessa kuvan päällä."
 
 msgid "Progress indicator"
-msgstr ""
+msgstr "Edistymisentunnistin"
 
 msgid "Bar with progress meter"
-msgstr ""
+msgstr "Palkki edistymisentunnistimella"
 
 msgid "Throbber"
-msgstr ""
+msgstr "Throbber"
 
 msgid "Path settings"
-msgstr ""
+msgstr "Polkuasetukset"
 
 msgid "The file upload failed. %upload"
-msgstr ""
+msgstr "Tiedoston lataus epäonnistui. %upload"
 
 msgid "URL to file"
-msgstr ""
+msgstr "Tiedoston osoite"
 
 msgid ""
 "An unrecoverable error occurred. The uploaded file likely exceeded the "
 "maximum file size (@size) that this server supports."
 msgstr ""
+"Tapahtui peruuttamaton virhe. Tiedoston koko todennäköisesti ylitti "
+"palvelimen suurimman tuetun tiedostokoon (@size)."
 
 msgid "Starting upload..."
-msgstr ""
+msgstr "Aloitetaan lataus..."
 
 msgid "Uploading... (@current of @total)"
-msgstr ""
+msgstr "Ladataan... (@current / @total)"
 
 msgid ""
 "Your server is capable of displaying file upload progress using APC RFC1867."
@@ -7354,351 +7616,364 @@ msgid ""
 "the <a href=\"http://pecl.php.net/package/uploadprogress\">PECL "
 "uploadprogress library</a> if possible."
 msgstr ""
+"Palvelimesi pystyy näyttämään tiedoston latauksen etenemisen käyttäen APC "
+"RCF1867:ta. Huomaathan, että kirjasto tukee ainoastaan yhden latauksen "
+"esittämistä kerrallaan. On suositeltavaa käyttää <a "
+"href=\"http://pecl.php.net/package/uploadprogress\">PECL uploadprogress-"
+"kirjastoa</a>, mikäli mahdollista."
 
 msgid ""
 "Enabled (<a href=\"http://pecl.php.net/package/uploadprogress\">PECL "
 "uploadprogress</a>)"
 msgstr ""
+"Käytössä (<a href=\"http://pecl.php.net/package/uploadprogress\">PECL "
+"uploadprogress</a>)"
 
 msgid "Preferred language"
-msgstr ""
+msgstr "Ensisijainen kieli"
 
 msgid "Number field"
-msgstr ""
+msgstr "Numerokenttä"
 
 msgid "Styles"
-msgstr ""
+msgstr "Tyylit"
 
 msgid "Item ID"
-msgstr ""
+msgstr "Artikkelin ID"
 
 msgid "Posted on"
-msgstr ""
+msgstr "Julkaistu"
 
 msgid "The size of the file in bytes."
-msgstr ""
+msgstr "Tiedoston koko tavuina."
 
 msgid "Interface"
-msgstr ""
+msgstr "Käyttöliittymä"
 
 msgid "Thresholds"
-msgstr ""
+msgstr "Raja-arvot"
 
 msgid "@size KB"
-msgstr ""
+msgstr "@size KB"
 
 msgid "@size MB"
-msgstr ""
+msgstr "@size MB"
 
 msgid "@size GB"
-msgstr ""
+msgstr "@size GB"
 
 msgid "@size TB"
-msgstr ""
+msgstr "@size TB"
 
 msgid "@size PB"
-msgstr ""
+msgstr "@size PB"
 
 msgid "@size EB"
-msgstr ""
+msgstr "@size EB"
 
 msgid "@size ZB"
-msgstr ""
+msgstr "@size ZB"
 
 msgid "@size YB"
-msgstr ""
+msgstr "@size YB"
 
 msgid "All messages"
-msgstr ""
+msgstr "Kaikki viestit"
 
 msgid "Serialized"
-msgstr ""
+msgstr "Serialisoitu"
 
 msgid "Discard changes"
-msgstr ""
+msgstr "Hylkää muutokset"
 
 msgid "No new posts"
-msgstr ""
+msgstr "Ei uutta sisältöä"
 
 msgid "Sticky topic"
-msgstr ""
+msgstr "Kiinteä aihe"
 
 msgid "Emergency"
-msgstr ""
+msgstr "Hätätila"
 
 msgid "Sort descending"
-msgstr ""
+msgstr "Lajittele laskevasti"
 
 msgid "Sort ascending"
-msgstr ""
+msgstr "Lajittele nousevasti"
 
 msgid "The name of the site."
-msgstr ""
+msgstr "Sivuston nimi."
 
 msgid "The name of the term."
-msgstr ""
+msgstr "Termin nimi"
 
 msgid "Optional features"
-msgstr ""
+msgstr "Lisäominaisuudet"
 
 msgid "Administrative title"
-msgstr ""
+msgstr "Ylläpidollinen otsikko"
 
 msgid "Administrative description"
-msgstr ""
+msgstr "Ylläpidollinen kuvaus"
 
 msgid "Allow settings"
-msgstr ""
+msgstr "Salli asetukset"
 
 msgid "Title override"
-msgstr ""
+msgstr "Ohita otsikko"
 
 msgid "Style settings"
-msgstr ""
+msgstr "Tyylin asetukset"
 
 msgid "Views Block"
-msgstr ""
+msgstr "Näkymälohko"
 
 msgid "Alert"
-msgstr ""
+msgstr "Varoitus"
 
 msgid "Critical"
-msgstr ""
+msgstr "Kriittinen"
 
 msgid "Top center"
-msgstr ""
+msgstr "Ylhäällä keskellä"
 
 msgid "Bottom center"
-msgstr ""
+msgstr "Alhaalla keskellä"
 
 msgid "Content Translation"
-msgstr ""
+msgstr "Sisällön käännös"
 
 msgid "Warnings"
-msgstr ""
+msgstr "Varoitukset"
 
 msgid "Format string"
-msgstr ""
+msgstr "Muodon merkkijono"
 
 msgid "Add format"
-msgstr ""
+msgstr "Lisää muoto"
 
 msgid "Delete date format"
-msgstr ""
+msgstr "Poista päivämäärämuoto"
 
 msgid "Content type name"
-msgstr ""
+msgstr "Sisältötyypin nimi"
 
 msgid "Taxonomy Term"
-msgstr ""
+msgstr "Luokittelutermi"
 
 msgid "Slate"
-msgstr ""
+msgstr "Slate"
 
 msgid "Check settings"
-msgstr ""
+msgstr "Tarkista setukset"
 
 msgid "@field_name (Locked)"
-msgstr ""
+msgstr "@field_name (Lukittu)"
 
 msgid "- Select a field type -"
-msgstr ""
+msgstr "- Valitse kentän tyyppi -"
 
 msgid "- Select an existing field -"
-msgstr ""
+msgstr "– Valitse olemassaoleva kenttä –"
 
 msgid "Add new field: you need to provide a label."
-msgstr ""
+msgstr "Lisää uusi kenttä: sinun on annettava kentälle otsikko."
 
 msgid "The field %field is locked and cannot be edited."
-msgstr ""
+msgstr "Kenttä %field on lukittuna eikä sitä voi muokata."
 
 msgid "%name must be a number."
-msgstr ""
+msgstr "%namen on oltava numero."
 
 msgid "Field formatter"
-msgstr ""
+msgstr "Kentän muokkaaja"
 
 msgid "(first item is 0)"
-msgstr ""
+msgstr "(ensimmäinen elementti on 0)"
 
 msgid "(start from last values)"
-msgstr ""
+msgstr "(alkaen viimeisistä arvoista)"
 
 msgid "New group"
-msgstr ""
+msgstr "Uusi ryhmä"
 
 msgid "Content moderation"
-msgstr ""
+msgstr "Sisällön moderointi"
 
 msgid "Unsigned"
-msgstr ""
+msgstr "Merkitsemätön"
 
 msgid "Number of pages"
-msgstr ""
+msgstr "Sivujen lukumäärä"
 
 msgid "The weight of this term in relation to other terms."
-msgstr ""
+msgstr "Termin paino suhteessa muihin termeihin."
 
 msgid "Help text to display for the vocabulary."
-msgstr ""
+msgstr "Sanaston ohjeteksti."
 
 msgid ""
 "Whether or not related terms are enabled within the vocabulary. (0 = "
 "disabled, 1 = enabled)"
-msgstr ""
+msgstr "Ovatko sukulaistermit käytössä? (0 = ei, 1 = kyllä)"
 
 msgid ""
 "The type of hierarchy allowed within the vocabulary. (0 = disabled, 1 = "
 "single, 2 = multiple)"
 msgstr ""
+"Sallittu hierarkian tyyppi. (0 = ei käytössä, 1 = yksinkertainen, 2 = "
+"moninkertainen)"
 
 msgid ""
 "Whether or not multiple terms from this vocabulary may be assigned to a "
 "node. (0 = disabled, 1 = enabled)"
-msgstr ""
+msgstr "Voiko solmuun liittää useampia sanaston termejä? (0 = ei, 1 = kyllä)"
 
 msgid ""
 "Whether or not terms are required for nodes using this vocabulary. (0 = "
 "disabled, 1 = enabled)"
-msgstr ""
+msgstr "Onko solmuun liitettävä termi tästä sanastosta? (0 = ei, 1 = kyllä)"
 
 msgid ""
 "Whether or not free tagging is enabled for the vocabulary. (0 = disabled, 1 "
 "= enabled)"
-msgstr ""
+msgstr "Onko vapaa määrittely käytössä? (0 = ei, 1 = kyllä)"
 
 msgid "The weight of the vocabulary in relation to other vocabularies."
-msgstr ""
+msgstr "Sanaston paino suhteessa muihin sanastoihin."
 
 msgid "Views settings"
-msgstr ""
+msgstr "Näkymien asetukset"
 
 msgid "Rotate"
-msgstr ""
+msgstr "Kieritä"
 
 msgid "Relative date"
-msgstr ""
+msgstr "Suhteellinen päivämäärä"
 
 msgid "Remove selected"
-msgstr ""
+msgstr "Poista valitut"
 
 msgid "Facility"
-msgstr ""
+msgstr "Fasiliteetti"
 
 msgid "Page bottom"
-msgstr ""
+msgstr "Sivun alareuna"
 
 msgid "Show links"
-msgstr ""
+msgstr "Näytä linkit"
 
 msgid "Lock"
-msgstr ""
+msgstr "Lukitse"
 
 msgid "Limited"
-msgstr ""
+msgstr "Rajoitettu"
 
 msgid "Current revision"
-msgstr ""
+msgstr "Nykyinen versio"
 
 msgid " minutes"
-msgstr ""
+msgstr " minuuttia"
 
 msgid "Definitions"
-msgstr ""
+msgstr "Määritelmät"
 
 msgid "Drupal 6"
-msgstr ""
+msgstr "Drupal 6"
 
 msgid "Drupal 7"
-msgstr ""
+msgstr "Drupal 7"
 
 msgid "Regional settings"
-msgstr ""
+msgstr "Aluekohtaiset asetukset"
 
 msgid "Your virtual face or picture."
 msgstr "Valokuva tai muu yksilöivä kuva."
 
 msgid "Delete content"
-msgstr ""
+msgstr "Delete content"
 
 msgid "Author name"
 msgstr "Kirjoittajan nimi"
 
 msgid "Text format"
-msgstr ""
+msgstr "Tekstimuoto"
 
 msgid "Last »"
 msgstr "Viimeinen »"
 
 msgid "Who's online"
-msgstr ""
+msgstr "Who's online"
 
 msgid "Page count"
-msgstr ""
+msgstr "Sivujen lukumäärä"
 
 msgid "« First"
 msgstr "« Ensimmäinen"
 
 msgid "Upload progress"
-msgstr ""
+msgstr "Latausprosessi"
 
 msgid "Manages the user registration and login system."
-msgstr ""
+msgstr "Salli käyttäjien rekisteröityminen ja sisään kirjautuminen."
 
 msgid "Show description"
-msgstr ""
+msgstr "Näytä kuvaus"
 
 msgid "URL of the origin of the event."
-msgstr ""
+msgstr "Tapahtuman alkuperän osoite."
 
 msgid "Referer"
-msgstr ""
+msgstr "Viittaaja"
 
 msgid "Hostname of the user who triggered the event."
-msgstr ""
+msgstr "Tapahtuman aiheuttajan isäntänimi."
 
 msgid "Database is encoded in UTF-8"
-msgstr ""
+msgstr "Tietokannan koodaus on UTF-8"
 
 msgid ""
 "Drupal could not determine the encoding of the database was set to UTF-8"
 msgstr ""
+"Drupal ei pystynyt määrittelemään tietokannan koodausta joten arvoksi "
+"asetettiin UTF-8"
 
 msgid "PostgreSQL has initialized itself."
-msgstr ""
+msgstr "PostgreSQL tunnistautui."
 
 msgid "Workflows"
-msgstr ""
+msgstr "Työnkulut"
 
 msgid "Default values"
-msgstr ""
+msgstr "Oletusarvot"
 
 msgid "Saving"
-msgstr ""
+msgstr "Tallennus"
 
 msgid ""
 "Select the test(s) or test group(s) you would like to run, and click <em>Run"
 " tests</em>."
 msgstr ""
+"Valitse testit tai testiryhmät jotka haluat suorittaa ja klikkaa <em>Aja "
+"testit</em>."
 
 msgid "All (@count)"
-msgstr ""
+msgstr "Kaikki (@count)"
 
 msgid "Pass (@count)"
-msgstr ""
+msgstr "Läpäisi (@count)"
 
 msgid "Fail (@count)"
-msgstr ""
+msgstr "Ei läpäissyt (@count)"
 
 msgid "Return to list"
-msgstr ""
+msgstr "Palaa listaan"
 
 msgid "Clear results after each complete test suite run"
-msgstr ""
+msgstr "Puhdista tulokset jokaisen täyden testiajon jälkeen"
 
 msgid "Provide verbose information when running tests"
-msgstr ""
+msgstr "Näytä tietoa testien kulusta"
 
 msgid ""
 "The verbose data will be printed along with the standard assertions and is "
@@ -7706,124 +7981,133 @@ msgid ""
 "suite run. The verbose data output is very detailed and should only be used "
 "when debugging."
 msgstr ""
+"Tämä tieto näytetään normaalin debuggaustiedon oheessa. Tieto poistetaan "
+"jokaisen testiajon päätyttyä. Tieto on hyvin yksityiskohtaista ja sitä "
+"suositellaan käytettävän ainoastaan debuggauksen yhteydessä."
 
 msgid ""
 "HTTP auth settings to be used by the SimpleTest browser during testing. "
 "Useful when the site requires basic HTTP authentication."
 msgstr ""
+"HTTP autentikointiasetukset käytettäväksi SimpleTest selaimella testauksen "
+"aikana. Hyödyllistä kun sivusto vaatii yksinkertaisen HTTP autentikoinnin."
 
 msgid "The test run did not successfully finish."
-msgstr ""
+msgstr "Testiajon suoritus epäonnistui."
 
 msgid ""
 "Clear results is disabled and the test results table will not be cleared."
 msgstr ""
+"\"Puhdista tulokset\" ominaisuus on poissa käytöstä joten testitulosten "
+"taulua ei puhdisteta."
 
 msgid "No leftover tables to remove."
-msgstr ""
+msgstr "Ei poistattavia ylimääräisiä tauluja."
 
 msgid "1 debug message"
 msgid_plural "@count debug messages"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 muokkausviesti"
+msgstr[1] "@count muokkausviestiä"
 
 msgid "Removed 1 test result."
 msgid_plural "Removed @count test results."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Poistettiin 1 testitulos."
+msgstr[1] "Poistettiin @count testitulosta."
 
 msgid "Removed 1 leftover table."
 msgid_plural "Removed @count leftover tables."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Poistettiin 1 jäännöstaulu."
+msgstr[1] "Poistettiin @count jäännöstaulua."
 
 msgid "Removed 1 temporary directory."
 msgid_plural "Removed @count temporary directories."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Poistetettiin 1 tilapäiskansio."
+msgstr[1] "Poistettiin @count tilapäiskansiota."
 
 msgid "Test result"
-msgstr ""
+msgstr "Testin tulos"
 
 msgid "Node status"
-msgstr ""
+msgstr "Solmun tilanne"
 
 msgid "Edit style"
-msgstr ""
+msgstr "Muokkaa tyyliä"
 
 msgid "All content"
-msgstr ""
+msgstr "Kaikki sisältö"
 
 msgid "Maximum file size"
-msgstr ""
+msgstr "Suurin sallittu tiedostokoko"
 
 msgid "Machine name:"
-msgstr ""
+msgstr "Koneluettava nimi:"
 
 msgid "Content statistics"
-msgstr ""
+msgstr "Sisällön tilastotiedot"
 
 msgid "Translation files"
-msgstr ""
+msgstr "Käännöstiedostot"
 
 msgid "Upgrade"
-msgstr ""
+msgstr "Päivitä"
 
 msgid "Delete items"
-msgstr ""
+msgstr "Poista artikkeleita"
 
 msgid "Fetcher"
-msgstr ""
+msgstr "Hakija"
 
 msgid "This permission is inherited from the authenticated user role."
-msgstr ""
+msgstr "Oikeus on periytetty käyttäjäroolista \"autentikoitu käyttäjä\"."
 
 msgid "Seven"
-msgstr ""
+msgstr "Seitsemän"
 
 msgid "Filter format"
-msgstr ""
+msgstr "Suodatinmuoto"
 
 msgid "Pager type"
-msgstr ""
+msgstr "Sivutuksen tyyppi"
 
 msgid ""
 "Target of the link, such as _blank, _parent or an iframe's name. This field "
 "is rarely used."
 msgstr ""
+"Linkin kohde kuten _blank, _parent tai iframen nimi.\r\n"
+"Kenttää käytetään harvoin."
 
 msgid "@argument title"
-msgstr ""
+msgstr "@argument otsikko"
 
 msgid "@argument input"
-msgstr ""
+msgstr "@argument syöte"
 
 msgid "Count the number 0 as empty"
-msgstr ""
+msgstr "Laske numero 0 tyhjäksi"
 
 msgid "Hide if empty"
-msgstr ""
+msgstr "Piilota mikäli tyhjä"
 
 msgid "Starting value"
-msgstr ""
+msgstr "Aloitusarvo"
 
 msgid "Specify the number the counter should start at."
-msgstr ""
+msgstr "Määrittele mistä numerosta laskuri alkaa."
 
 msgid "Does not start with"
-msgstr ""
+msgstr "Ei ala merkeillä"
 
 msgid "not_begins"
-msgstr ""
+msgstr "ei_ala"
 
 msgid "Does not end with"
-msgstr ""
+msgstr "Ei pääty merkkeihin"
 
 msgid "not_ends"
-msgstr ""
+msgstr "ei_pääty"
 
 msgid "The view %name has been saved."
-msgstr ""
+msgstr "Näkymä nimellä %name on tallennettu."
 
 msgid ""
 "This filter can cause items that have more than one of the selected options "
@@ -7833,585 +8117,630 @@ msgid ""
 "caution. Shouldn't be set on single-value fields, as it may cause values to "
 "disappear from display, if used on an incompatible field."
 msgstr ""
+"Tämä suodatin voi aiheuttaa kaksoiskappaleita tuloksissa jotka täyttävät "
+"useamman kuin yhden valituista vaihtoehdoista. Jos suodatin aiheuttaa "
+"tulosten monistumista, tämä valintaruutu voi vähentää monistumista. Käytä "
+"tätä varoen koska mitä useampia termejä haet, sitä raskaammaksi kysely "
+"muuttuu. Ei tule asettaa yksiarvoisille kentille koska sen seurauksena arvot"
+" voivat kadota ruudulta mikäli sitä käytetään yhteensopimattomaan kenttään."
 
 msgid ""
 "Email of user that posted the comment. Will be empty if the author is a "
 "registered user."
 msgstr ""
+"Kommentin lähettäneen käyttäjän sähköpostiosoite. On tyhjä jos kirjoittaja "
+"on kirjautunut käyttäjä."
 
 msgid "The taxonomy term ID for the term."
-msgstr ""
+msgstr "Termin luokittelu-ID."
 
 msgid "The taxonomy term name for the term."
-msgstr ""
+msgstr "Termin luokitteluterminimi."
 
 msgid "The name for the vocabulary the term belongs to."
-msgstr ""
+msgstr "Mihin sanastoon termi kuuluu."
 
 msgid ""
 "Choose which vocabularies you wish to relate. Remember that every term found"
 " will create a new record, so this relationship is best used on just one "
 "vocabulary that has only one term per node."
 msgstr ""
+"Valitse mihin sanastoihin haluat liittää. Muista että jokainen löydetty "
+"termi luo uuden tuloksen joten valintaa kannattaa käyttää ainoastaan "
+"tapauksissa joissa yhdelle sanastolle on liitetty ainoastaan yksi termi per "
+"solmu."
 
 msgid "The name of the role."
-msgstr ""
+msgstr "Roolin nimi."
 
 msgid "Hide empty fields"
-msgstr ""
+msgstr "Piilota tyhjät kentät"
 
 msgid "Do not display fields, labels or markup for fields that are empty."
-msgstr ""
+msgstr "Piilota tyhjien kenttien koodi ja etiketti."
 
 msgid "Title of the feed."
-msgstr ""
+msgstr "Syötteen nimi."
 
 msgid "Language select"
-msgstr ""
+msgstr "Kielivalinta"
 
 msgid "Site email address"
-msgstr ""
+msgstr "Sivuston sähköpostiosoite"
 
 msgid ""
 "The <em>From</em> address in automated emails sent during registration and "
 "new password requests, and other notifications. (Use an address ending in "
 "your site's domain to help prevent this email being flagged as spam.)"
 msgstr ""
+"<em>Lähettäjä</em>-osoite automatisoiduissa sähköposteissa jotka lähetetään "
+"rekisteröinnin, salasanan palautuksien ja muussa yhteydessä. (Käytä "
+"osoitetta joka päättyy sivustosi verkkotunnukseen jotta sähköpostisi ei "
+"merkitä roskapostiksi.)"
 
 msgid "Administer forums"
-msgstr ""
+msgstr "Foorumeiden ylläpito"
 
 msgid "Length is shorter than"
-msgstr ""
+msgstr "Pituus on vähemmän kuin"
 
 msgid "shorter than"
-msgstr ""
+msgstr "vähemmän_kuin"
 
 msgid "Length is longer than"
-msgstr ""
+msgstr "Pituus on enemmän kuin"
 
 msgid "longer than"
-msgstr ""
+msgstr "enemmän kuin"
 
 msgid "SQL Query"
-msgstr ""
+msgstr "SQL kysely"
 
 msgid "Query will be generated and run using the Drupal database API."
-msgstr ""
+msgstr "Kysely luodaan ja suoritetaan käyttäen Drupalin tietokanta-APIa."
 
 msgid "revision user"
-msgstr ""
+msgstr "version käyttäjä"
 
 msgid "Exposed form"
-msgstr ""
+msgstr "Käyttäjille näytettävä kaavake"
 
 msgid "Cancel account"
-msgstr ""
+msgstr "Poista käyttäjätili"
 
 msgid "Maximum number of characters"
-msgstr ""
+msgstr "Merkkien enimmäismäärä"
 
 msgid "Current Theme"
-msgstr ""
+msgstr "Nykyinen teema"
 
 msgid "Dependencies"
-msgstr ""
+msgstr "Riippuvuudet"
 
 msgid "Administrator role"
-msgstr ""
+msgstr "Ylläpitäjä rooli"
 
 msgid "Inherit pager"
-msgstr ""
+msgstr "Peri sivunvalitsin"
 
 msgid "Render pager"
-msgstr ""
+msgstr "Renderöi sivunvalitsin"
 
 msgid "Render"
-msgstr ""
+msgstr "Renderöi"
 
 msgid "Image scale"
-msgstr ""
+msgstr "Kuvan skaala"
 
 msgid "No revision"
-msgstr ""
+msgstr "Ei versiota"
 
 msgid "Requires a title"
-msgstr ""
+msgstr "Vaatii otsikon"
 
 msgid "CKEditor"
-msgstr ""
+msgstr "CKEditor"
 
 msgid "Filter value"
-msgstr ""
+msgstr "Suodattimen arvo"
 
 msgid "Entities"
-msgstr ""
+msgstr "Entiteetit"
 
 msgid "Private files"
-msgstr ""
+msgstr "Yksityiset tiedostot"
 
 msgid "Not restricted"
-msgstr ""
+msgstr "Ei rajoitettu"
 
 msgid "Operations links"
-msgstr ""
+msgstr "Toimenpidelinkit"
 
 msgid "Choose a block"
-msgstr ""
+msgstr "Valitse lohko"
 
 msgid "Toolbar buttons"
-msgstr ""
+msgstr "Tykalupalkin painikkeet"
 
 msgid "Book ID"
-msgstr ""
+msgstr "Kirjan ID"
 
 msgid "The unique ID of the comment."
-msgstr ""
+msgstr "Kommentin yksilöllinen ID."
 
 msgid "The IP address of the computer the comment was posted from."
-msgstr ""
+msgstr "IP-osoite josta kommentti lähetettiin."
 
 msgid "The email address left by the comment author."
-msgstr ""
+msgstr "Kommentin jättäjän lähetyksen yhteydessä antama sähköpostiosoite."
 
 msgid "The home page URL left by the comment author."
-msgstr ""
+msgstr "Kommentin jättäjän lähetyksen yhteydessä antama kotisivun URL."
 
 msgid "The formatted content of the comment itself."
-msgstr ""
+msgstr "Itse kommentin formatoitu sisältö."
 
 msgid "The URL of the comment."
-msgstr ""
+msgstr "Kommentin URL"
 
 msgid "Base table"
-msgstr ""
+msgstr "Perustaulukko"
 
 msgid "Published status"
-msgstr ""
+msgstr "Published status"
 
 msgid "Structure"
-msgstr ""
+msgstr "Rakenne"
 
 msgid "The URL of the comment's edit page."
-msgstr ""
+msgstr "Kommentin muokkaussivun osoite."
 
 msgid "The date the comment was posted."
-msgstr ""
+msgstr "Kommentin lähetyspäivämäärä."
 
 msgid "The comment's parent, if comment threading is active."
-msgstr ""
+msgstr "Kommentin isäntä jos kommenttien ketjutus on kytkettynä päälle."
 
 msgid "The unique ID of the node's latest revision."
-msgstr ""
+msgstr "Solmun viimeisimmän version yksilöllinen ID."
 
 msgid "The human-readable name of the node type."
-msgstr ""
+msgstr "Sisältötyypin selkokielinen nimi."
 
 msgid "The URL of the node."
-msgstr ""
+msgstr "Solmun osoite."
 
 msgid "The URL of the node's edit page."
-msgstr ""
+msgstr "Solmun muokkaussivun osoite."
 
 msgid "The date the node was most recently updated."
-msgstr ""
+msgstr "Solmun viimeisin päivityspäivämäärä."
 
 msgid "The number of visitors who have read the node."
-msgstr ""
+msgstr "Solmun lukeneiden vierailijoiden lukumäärä."
 
 msgid "The number of visitors who have read the node today."
-msgstr ""
+msgstr "Kuinka moni käyttäjä on lukenut solmun tänään."
 
 msgid "Last view"
-msgstr ""
+msgstr "Viimeisin katselukerta"
 
 msgid "The date on which a visitor last read the node."
-msgstr ""
+msgstr "Solmun viimeisimmän lukukerran päivämäärä."
 
 msgid "The slogan of the site."
-msgstr ""
+msgstr "Sivuston iskulause."
 
 msgid "The administrative email address for the site."
-msgstr ""
+msgstr "Sivun ylläpidollinen sähköpostiosoite."
 
 msgid "The URL of the site's front page."
-msgstr ""
+msgstr "Sivuston etusivun URL."
 
 msgid "The URL of the site's login page."
-msgstr ""
+msgstr "Sivuston kirjautumissivun osoite (URL)."
 
 msgid "The unique ID of the uploaded file."
-msgstr ""
+msgstr "Ladatun tiedoston yksilöllinen ID."
 
 msgid "The name of the file on disk."
-msgstr ""
+msgstr "Tiedoston nimi järjestelmässä."
 
 msgid "The web-accessible URL for the file."
-msgstr ""
+msgstr "Tiedoston www-osoite (URL)."
 
 msgid "The date the file was most recently changed."
-msgstr ""
+msgstr "Päivämäärä jolloin tiedostoa viimeksi muutettiin."
 
 msgid "The user who originally uploaded the file."
-msgstr ""
+msgstr "Käyttäjä joka alunperin lataso tiedoston."
 
 msgid "The unique ID of the taxonomy term."
-msgstr ""
+msgstr "Luokittelutermin yksilöllinen ID."
 
 msgid "The name of the taxonomy term."
-msgstr ""
+msgstr "Luokittelutermin nimi."
 
 msgid "The optional description of the taxonomy term."
-msgstr ""
+msgstr "Luokittelutermin valinnainen kuvaus."
 
 msgid "The number of nodes tagged with the taxonomy term."
-msgstr ""
+msgstr "Niiden solmujen lukumäärä jotka liittyvät luokittelutermiin."
 
 msgid "The URL of the taxonomy term."
-msgstr ""
+msgstr "Luokittelutermin URL."
 
 msgid "The vocabulary the taxonomy term belongs to."
-msgstr ""
+msgstr "Sen luokittelun nimi johon luokittelutermi kuuluu."
 
 msgid "The parent term of the taxonomy term, if one exists."
-msgstr ""
+msgstr "Termin ylätermi jos olemassa."
 
 msgid "The unique ID of the taxonomy vocabulary."
-msgstr ""
+msgstr "Sanaston yksilöllinen ID."
 
 msgid "The name of the taxonomy vocabulary."
-msgstr ""
+msgstr "Sanaston nimi."
 
 msgid "The optional description of the taxonomy vocabulary."
-msgstr ""
+msgstr "Sanaston vaihtoehtoinen kuvaus."
 
 msgid ""
 "The number of nodes tagged with terms belonging to the taxonomy vocabulary."
 msgstr ""
+"Luokittelusanastoon kuuluvalla termillä merkittyjen solmujen lukumäärä."
 
 msgid "The number of terms belonging to the taxonomy vocabulary."
-msgstr ""
+msgstr "Luokitteluun kuuluvien termien lukumäärä."
 
 msgid "The unique ID of the user account."
-msgstr ""
+msgstr "Käyttäjätilin yksilöllinen ID."
 
 msgid "The login name of the user account."
-msgstr ""
+msgstr "Käyttäjänimi."
 
 msgid "The email address of the user account."
-msgstr ""
+msgstr "Käyttäjätilin sähköpostiosoite."
 
 msgid "The URL of the account profile page."
-msgstr ""
+msgstr "Käyttäjätilin profiilin sivun osoite."
 
 msgid "The date the user last logged in to the site."
-msgstr ""
+msgstr "Päivä jolloin käyttäjä viimeksi kirjautui sivuille."
 
 msgid "The date the user account was created."
-msgstr ""
+msgstr "Käyttäjätilin luontipäivämäärä."
 
 msgid "Review log"
-msgstr ""
+msgstr "Tarkista logi"
 
 msgid "Sender name"
-msgstr ""
+msgstr "Lähettäjän nimi"
 
 msgid "Sender email"
-msgstr ""
+msgstr "Lähettäjän sähköposti"
 
 msgid "Time zone settings"
-msgstr ""
+msgstr "Aikavyöhykkeen asetukset"
 
 msgid "Content Moderation"
-msgstr ""
+msgstr "Sisällön moderointi"
 
 msgid "You are not allowed to access this page."
-msgstr ""
+msgstr "Sinulla ei ole oikeuksia tarkastella tätä sivua."
 
 msgid "Authorize file system changes"
-msgstr ""
+msgstr "Valtuuta tiedostojärjestelmän muutokset"
 
 msgid "It appears you have reached this page in error."
-msgstr ""
+msgstr "Todennäköisesti olet saapunut tälle sivulle erehdyksessä."
 
 msgid "authorize.php"
-msgstr ""
+msgstr "authorize.php"
 
 msgid "Cron could not run because an invalid key was used."
-msgstr ""
+msgstr "Cronia ei voitu ajaa virheellisestä avaimesta johtuen."
 
 msgid "Cron could not run because the site is in maintenance mode."
-msgstr ""
+msgstr "Cronia ei voitu ajaa, koska sivusto on huoltotilassa."
 
 msgid "Default country"
-msgstr ""
+msgstr "Oletusmaa"
 
 msgid ""
 "In your %settings_file file you have configured @drupal to use a %driver "
 "server, however your PHP installation currently does not support this "
 "database type."
 msgstr ""
+"%settings_file-tiedostossa olet määrittänyt, että @drupal käyttää %driver-"
+"palvelinta, mutta PHP-asennuksesi ei tue tätä tietokantatyyppiä."
 
 msgid ""
 "We were unable to find any installation profiles. Installation profiles tell"
 " us what modules to enable and what schema to install in the database. A "
 "profile is necessary to continue with the installation process."
 msgstr ""
+"Yhtään asennusprofiilia ei löytynyt. Asennusprofiilit kertovat, mitkä "
+"moduulit otetaan käyttöön ja mitä mallia tietokanta käyttää. Profiili "
+"vaaditaan, jotta asennusta voidaan jatkaa."
 
 msgid "Congratulations, you installed @drupal!"
-msgstr ""
+msgstr "Onnittelut, @drupal asennettiin onnistuneesti!"
 
 msgid "Settings file"
-msgstr ""
+msgstr "Asetukset-tiedosto"
 
 msgid "Site maintenance account"
-msgstr ""
+msgstr "Sivuston ylläpitotili"
 
 msgid "No pending updates."
-msgstr ""
+msgstr "Ei odottavia päivityksiä."
 
 msgid "1 pending update"
 msgid_plural "@count pending updates"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Yksi päivitys saatavilla."
+msgstr[1] "@count päivitystä saatavilla."
 
 msgid "Unable to continue, no available methods of file transfer"
-msgstr ""
+msgstr "Ei voitu jatkaa, koska käytettävissä ei ollut tiedostonsiirtotapoja"
 
 msgid "To continue, provide your server connection details"
-msgstr ""
+msgstr "Syötä palvelinyhteyden tiedot jatkaaksesi"
 
 msgid "Connection method"
-msgstr ""
+msgstr "Yhdistämistapa"
 
 msgid "Enter connection settings"
-msgstr ""
+msgstr "Syötä yhteyden asetukset"
 
 msgid "@backend connection settings"
-msgstr ""
+msgstr "@backend yhteyden asetukset"
 
 msgid "Change connection type"
-msgstr ""
+msgstr "Vaihda yhteystapaa"
 
 msgid "No active batch."
-msgstr ""
+msgstr "Ei aktiivista eräajoa."
 
 msgid "Site under maintenance"
-msgstr ""
+msgstr "Sivustoa päivitetään"
 
 msgid "Archivers can only operate on local files: %file not supported"
 msgstr ""
+"Arkistoijat voivat hyödyntää vain paikallisia tiedostoja: %file ei ole "
+"tuettu."
 
 msgid ""
 "The file %source could not be uploaded because a file by that name already "
 "exists in the destination %directory."
 msgstr ""
+"Tiedostoa %source ei voitu siirtää palvelimelle koska samanniminen tiedosto "
+"on jo olemassa kohteessa %directory."
 
 msgid ""
 "The file's name exceeds the 240 characters limit. Please rename the file and"
 " try again."
 msgstr ""
+"Tiedoston nimi ylittää 240 merkin maksimirajan. Uudelleennimeä tiedosto ja "
+"yritä uudelleen."
 
 msgid "The file permissions could not be set on %uri."
-msgstr ""
+msgstr "Tiedosto-oikeuksien asettaminen kohteelle %uri epäonnistui."
 
 msgid "Completed @current of @total."
-msgstr ""
+msgstr "@current / @total valmiina."
 
 msgid ""
 "Failed to run all tasks against the database server. The task %task wasn't "
 "found."
 msgstr ""
+"Kaikkien tehtävien suorittaminen tietokantapalvelimella epäonnistui. "
+"Tehtävää %task ei löydetty."
 
 msgid "Failed to modify %settings. Verify the file permissions."
 msgstr ""
+"%settings tiedoston muokkaaminen epäonnistui. Varmista ltiedoston luku- ja "
+"kirjoitusoikeudet."
 
 msgid "Failed to open %settings. Verify the file permissions."
 msgstr ""
+"%settings tiedoston avaaminen epäonnistui. Varmista ltiedoston luku- ja "
+"kirjoitusoikeudet."
 
 msgid "Required modules"
-msgstr ""
+msgstr "Vaaditut moduulit"
 
 msgid "Required modules not found."
-msgstr ""
+msgstr "Tarvittavia moduuleita ei löytynyt."
 
 msgid "%module module uninstalled."
-msgstr ""
+msgstr "Moduulin %module asennus poistettu."
 
 msgid "Saint Barthélemy"
-msgstr ""
+msgstr "Saint Barthélemy"
 
 msgid "No strings available."
-msgstr ""
+msgstr "Merkkijonoja ei saatavilla."
 
 msgid "JavaScript translation file %file.js was lost."
-msgstr ""
+msgstr "JavaScript käännöstiedosto %file.js hukattiin."
 
 msgid "Operating in maintenance mode."
-msgstr ""
+msgstr "Sivusto on huoltotilassa."
 
 msgid "Unable to determine the type of the source directory."
-msgstr ""
+msgstr "Lähdekansion tyypin määrittely epäonnistui."
 
 msgid "Cannot determine the type of project."
-msgstr ""
+msgstr "Projektin tyypin määrittely epäonnistui."
 
 msgid ""
 "Fatal error in update, cowardly refusing to wipe out the install directory."
-msgstr ""
+msgstr "Päivitys epäonnistui, asennuskansiota ei voida poistaa."
 
 msgid "Unable to create %directory due to the following: %reason"
-msgstr ""
+msgstr "Kansion %directory luominen epäonnistui: %reason"
 
 msgid "New comment count"
-msgstr ""
+msgstr "Uusien kommenttien lukumäärä"
 
 msgid "Field types"
-msgstr ""
+msgstr "Kenttätyypit"
 
 msgid "Path: !uri"
-msgstr ""
+msgstr "Polku: !uri"
 
 msgid "StatusText: !statusText"
-msgstr ""
+msgstr "Tilanneteksti: !statusText"
 
 msgid "(active tab)"
-msgstr ""
+msgstr "(aktiivinen välilehti)"
 
 msgid "HTTP Result Code: !status"
-msgstr ""
+msgstr "HTTP koodi: !status"
 
 msgid "Status message"
-msgstr ""
+msgstr "Tilanneviesti"
 
 msgid "An AJAX HTTP request terminated abnormally."
-msgstr ""
+msgstr "AJAX-HTTP-pyyntö keskeytyi odottamatta."
 
 msgid "An AJAX HTTP error occurred."
-msgstr ""
+msgstr "Tapahtui AJAX HTTP virhe."
 
 msgid "Debugging information follows."
-msgstr ""
+msgstr "Seuraavassa virhetiedot."
 
 msgid "Upload an OPML file containing a list of feeds to be imported."
-msgstr ""
+msgstr "Lataa siirrettävät syötteet sisältävä OPML tiedosto."
 
 msgid "OPML Remote URL"
-msgstr ""
+msgstr "OPML etäosoite"
 
 msgid ""
 "Enter the URL of an OPML file. This file will be downloaded and processed "
 "only once on submission of the form."
 msgstr ""
+"Syötä OPML-tiedoston URL. Tiedosto ladataan ja käsitellään vain kerran "
+"lomakkeen lähettämisen jälkeen."
 
 msgid "No new feed has been added."
-msgstr ""
+msgstr "Uutta syötettä ei lisätty."
 
 msgid "The URL %url is invalid."
-msgstr ""
+msgstr "URL %url ei ole kelvollinen."
 
 msgid "A feed named %title already exists."
-msgstr ""
+msgstr "Syöte nimellä %title löytyy jo järjestelmästä."
 
 msgid "A feed with the URL %url already exists."
-msgstr ""
+msgstr "Syöte URLilla %url löytyy jo järjestelmästä."
 
 msgid ""
 "Fetchers download data from an external source. Choose a fetcher suitable "
 "for the external source you would like to download from."
 msgstr ""
+"Hakijat hakevat tietoa ulkopuolisesta lähteestä. Valitse sopivin hakija "
+"haluamallesi ulkopuoliselle tietolähteelle."
 
 msgid ""
 "Parsers transform downloaded data into standard structures. Choose a parser "
 "suitable for the type of feeds you would like to aggregate."
 msgstr ""
+"Parserit muuttavat ladatun datan standardiin muotoon. Valitse syötteellesi "
+"sopivin parseri."
 
 msgid ""
 "Processors act on parsed feed data, for example they store feed items. "
 "Choose the processors suitable for your task."
 msgstr ""
+"Prosessorit toimivat haetun syötedatan perusteella, esimerkiksi ne voivat "
+"tallentaa syötteissä olevia artikkeleita solmuiksi järjestelmään. Valitse "
+"tehtävääsi varten sopivin prosessori."
 
 msgid "For most aggregation tasks, the default settings are fine."
-msgstr ""
+msgstr "Perusasetukset ovat riittäviä useimmille aggregointitehtäville."
 
 msgid "Default fetcher"
-msgstr ""
+msgstr "Oletushakija"
 
 msgid "Downloads data from a URL using Drupal's HTTP request handler."
-msgstr ""
+msgstr "Lataa tietoa URLista käyttäen Drupalin HTTP kutsujen käsittelijää."
 
 msgid "Default parser"
-msgstr ""
+msgstr "Oletusparseri"
 
 msgid "Default processor"
-msgstr ""
+msgstr "Oletusprosessori"
 
 msgid "Creates lightweight records from feed items."
-msgstr ""
+msgstr "Luo solmuja RSS syötteiden sisällöstä."
 
 msgid "Default processor settings"
-msgstr ""
+msgstr "Oletusprosessorin asetukset"
 
 msgid "Number of items shown in listing pages"
-msgstr ""
+msgstr "Tulosten määrä listaussivuilla"
 
 msgid "Length of trimmed description"
-msgstr ""
+msgstr "Trimmatun kuvauksen pituus"
 
 msgid ""
 "The maximum number of characters used in the trimmed version of content."
-msgstr ""
+msgstr "Merkkien enimmäismäärä trimmatussa sisällössä."
 
 msgid "Viewing feeds"
-msgstr ""
+msgstr "Näytetään syötteet"
 
 msgid "Adding, editing, and deleting feeds"
-msgstr ""
+msgstr "Syötteiden lisäys, poisto ja muokkaus"
 
 msgid "Configuring cron"
-msgstr ""
+msgstr "Säädetään cronia"
 
 msgid "Administer news feeds"
-msgstr ""
+msgstr "Ylläpidä uutissyötteitä"
 
 msgid "View news feeds"
-msgstr ""
+msgstr "Näytä uutissyötteet"
 
 msgid "Controlling visibility"
-msgstr ""
+msgstr "Näkyvyyden säätö"
 
 msgid "Creating custom blocks"
-msgstr ""
+msgstr "Kustmoitujen lohkojen luonti"
 
 msgid "Demonstrate block regions (@theme)"
-msgstr ""
+msgstr "Esitä lohkoalueet (@theme)"
 
 msgid "Administer blocks"
-msgstr ""
+msgstr "Lohkojen ylläpito"
 
 msgid "Restricted to certain pages"
-msgstr ""
+msgstr "Rajoitettu tiettyihin sivuihin"
 
 msgid "The block cannot be placed in this region."
-msgstr ""
+msgstr "Lohkoa ei voi asettaa tähän alueeseen."
 
 msgid "No books available."
-msgstr ""
+msgstr "Kirjoja ei saatavilla."
 
 msgid "Content types allowed in book outlines"
-msgstr ""
+msgstr "Kirjojen kehyksissä sallitut sisältötyypit"
 
 msgid "Users with the %outline-perm permission can add all content types."
 msgstr ""
+"Käyttäjät joilla on %outline-perm käyttöoikeudet voivat lisätä "
+"kaikentyyppistä sisältöä."
 
 msgid "Administer book outlines"
-msgstr ""
+msgstr "Ylläpidä kirjojen  hierarkiaa"
 
 msgid "Adding and managing book content"
-msgstr ""
+msgstr "Kirjassisällön lisääminen ja muokkaus"
 
 msgid "Printing books"
-msgstr ""
+msgstr "Kirjojen tulostus"
 
 msgid ""
 "Users with the <em>View printer-friendly books</em> permission can select "
@@ -8419,6 +8748,10 @@ msgid ""
 "page's content to generate a printer-friendly display of the page and all of"
 " its subsections."
 msgstr ""
+"Käyttäjät joilla on käyttöoikeus <em>katso tulostinystävällistä kirjaa<em> "
+"voivat valita <em>tulostinystävällisen version</em> sivun alareunassa "
+"näkyvästä linkistä. Tämän linkin kautta kirjasivusta luodaan "
+"tulostinystävällinen versio sisältäen sivu ja sen eri osat."
 
 msgid ""
 "The book module offers a means to organize a collection of related content "
@@ -8426,280 +8759,329 @@ msgid ""
 " displays links to adjacent book pages, providing a simple navigation system"
 " for creating and reviewing structured content."
 msgstr ""
+"Book moduuli tarjoaa tavan organisoida sivuihin liittyvää sisältöä kirjan "
+"muotoon. Kun kirjaa tarkastellaan, se näyttää automaattisesti linkit siihen "
+"liittyviin kirjasivuihin rakenteessa navigointia varten."
 
 msgid "Create new books"
-msgstr ""
+msgstr "Luo uusia kirjoja"
 
 msgid "View printer-friendly books"
-msgstr ""
+msgstr "Näytä tulostinystävälliset kirjat"
 
 msgid ""
 "View a book page and all of its sub-pages as a single document for ease of "
 "printing. Can be performance heavy."
 msgstr ""
+"Näytä kirjasivu ja kaikki sen alisivut tulostamisen helpottamiseksi. Tämä "
+"voi heikentää suorituskykyä."
 
 msgid ""
 "<em>Books</em> have a built-in hierarchical navigation. Use for handbooks or"
 " tutorials."
 msgstr ""
+"<em>Kirjoilla</em> on sisäänrakennettu hierarkinen navigaatio. Käytä "
+"ohjeissa tai ohjekirjoissa."
 
 msgid "Changing colors"
-msgstr ""
+msgstr "Värien muuttaminen"
 
 msgid "Select one or more comments to perform the update on."
-msgstr ""
+msgstr "Valitse yksi tai useampi päivitettävä kommentti."
 
 msgid "Deleted comment @cid and its replies."
-msgstr ""
+msgstr "Poistettu kommentti @cid ja sen vastaukset."
 
 msgid "Comment approved."
-msgstr ""
+msgstr "Kommentti hyväksytty."
 
 msgid "Tokens for comments posted on the site."
-msgstr ""
+msgstr "Lähetettyjä kommentteja varten käytettävissä olevia tokeneja."
 
 msgid "Unapproved comments (@count)"
-msgstr ""
+msgstr "Hyväksymättömät kommentit (@count)"
 
 msgid "Administer comments and comment settings"
-msgstr ""
+msgstr "Ylläpidä kommentoinnin ja kommenttien asetuksia"
 
 msgid "Edit own comments"
-msgstr ""
+msgstr "Muokkaa omia kommentteja"
 
 msgid "Threading"
-msgstr ""
+msgstr "Ketjutettu"
 
 msgid "Show comment replies in a threaded list."
-msgstr ""
+msgstr "Näytä kommentin vastaukset ketjutettuna listana."
 
 msgid "Allow comment title"
-msgstr ""
+msgstr "Salli kommentin otsikko"
 
 msgid "Show reply form on the same page as comments"
-msgstr ""
+msgstr "Näytä vastauslomake samalla sivulla kuin kommentit"
 
 msgid "Users with the \"Post comments\" permission can post comments."
 msgstr ""
+"Käyttäjät joilla on tarvittavat käyttöoikeudet (lähetä kommentteja) voivat "
+"jättää kommenttinsa."
 
 msgid "Users cannot post comments, but existing comments will be displayed."
 msgstr ""
+"Käyttäjät eivät voi jättää kommentteja mutta olemassaolevat kommentit "
+"näytetään."
 
 msgid "Comments are hidden from view."
-msgstr ""
+msgstr "Kommentit piilotetaan näkymästä."
 
 msgid ""
 "Your comment has been queued for review by site administrators and will be "
 "published after approval."
 msgstr ""
+"Kommenttisi on jonoutettu moderointia varten ja julkaistaan hyväksynnän "
+"jälkeen."
 
 msgid "Your comment has been posted."
-msgstr ""
+msgstr "Kommenttisi on lähetetty."
 
 msgid ""
 "The comment will be unpublished if it contains any of the phrases above. Use"
 " a case-sensitive, comma-separated list of phrases. Example: funny, bungee "
 "jumping, \"Company, Inc.\""
 msgstr ""
+"Kommentti muutetaan julkaisemattomaan tilaan jos se sisältää jonkin "
+"ylläolevista sanoista tai virkkeistä. Syötä listaan kirjainkoosta "
+"riippuvaisia, pilkuin eroteltuja virkkeitä. Esimerkkejä: hauska, benji-"
+"hyppy, \"Yritys Oy\""
 
 msgid ""
 "You cannot send more than %limit messages in @interval. Try again later."
 msgstr ""
+"Voit lähettää enintään %limit viestiä @interval aikana. Yritä myöhemmin "
+"uudelleen."
 
 msgid "Contact @username"
-msgstr ""
+msgstr "Ota yhteyttä käyttäjään @username"
 
 msgid "Administer contact forms and contact form settings"
 msgstr ""
+"Ylläpidä yhteydenottokaavakkeita ja yhteydenottokaavakkeiden asetuksia"
 
 msgid "Use the site-wide contact form"
-msgstr ""
+msgstr "Käytä sivustonlaajuista yhteydenottolomaketta"
 
 msgid "Use users' personal contact forms"
-msgstr ""
+msgstr "Käytä käyttäjäkohtaisia yhteydenottokaavakkeita"
 
 msgid "Changing this setting will not affect existing users."
-msgstr ""
+msgstr "Tämän asetuksen muuttaminen ei vaikuta olemassaoleviin käyttäjiin."
 
 msgid "Displaying contextual links"
-msgstr ""
+msgstr "Asiayhteyteen liittyvien linkkien esittäminen"
 
 msgid "Use contextual links"
-msgstr ""
+msgstr "Käytä asiayhteyteen liittyviä linkkejä"
 
 msgid "Contextual links"
-msgstr ""
+msgstr "Asiayhteyteen liittyvät linkit"
 
 msgid "Database log cleared."
-msgstr ""
+msgstr "Tietokantalogit siivottu."
 
 msgid "Monitoring your site"
-msgstr ""
+msgstr "Sivustosi monitorointi"
 
 msgid "Debugging site problems"
-msgstr ""
+msgstr "Sivuston ongelmien debuggaus"
 
 msgid "Allowed HTML tags in labels: @tags"
-msgstr ""
+msgstr "Etiketeissä sallitut HTML-merkit: @tags"
 
 msgid ""
 "The value of this field is being determined by the %function function and "
 "may not be changed."
 msgstr ""
+"Kentän arvo määrittyy funktion %function avulla eikä sitä voi muuttaa."
 
 msgid "Allowed values list: each key must be a valid integer or decimal."
 msgstr ""
+"Sallitut arvot: kaikkien arvojen on oltava numeerisia tai desimaaleja."
 
 msgid ""
 "Allowed values list: each key must be a string at most 255 characters long."
 msgstr ""
+"Sallitut arvot: kaikkien avainten on oltava merkkijonoja, enimmäispituus 255"
+" merkkiä."
 
 msgid "Allowed values list: keys must be integers."
-msgstr ""
+msgstr "Lista sallituista arvoista: avainten on oltava muuttujia."
 
 msgid "Allows users to create and organize related content in an outline."
 msgstr ""
+"Antaa käyttäjien luoda ja organisoida kirjamaista ja hierarkiaalista "
+"sisältöä."
 
 msgid "Unapproved comments"
-msgstr ""
+msgstr "Unapproved comments"
 
 msgid "ResponseText: !responseText"
-msgstr ""
+msgstr "Vastausteksti: !responseText"
 
 msgid "Allows administrators to change the color scheme of compatible themes."
-msgstr ""
+msgstr "Sallii ylläpitäjien muuttaa yhteensopivien teemojen väriskaalaa."
 
 msgid ""
 "Provides contextual links to perform actions related to elements on a page."
 msgstr ""
+"Tarjoaa asiayhteyteen liittyvät linkit jotta voit suorittaa sivun "
+"elementteihin liittyviä toimintoja."
 
 msgid "Provides discussion forums."
-msgstr ""
+msgstr "Tarjoaa keskustelufoorumeita."
 
 msgid "List (text)"
-msgstr ""
+msgstr "Lista (teksti)"
 
 msgid "ReadyState: !readyState"
-msgstr ""
+msgstr "ReadyState: !readyState"
 
 msgid "This field stores a number in the database as an integer."
-msgstr ""
+msgstr "Kenttä tallentaa numeron tietokantaan kokonaislukuna."
 
 msgid "This field stores a number in the database in a fixed decimal format."
-msgstr ""
+msgstr "Kenttä tallentaa numeron tietokantaan kiinteässä desimaalimuodossa."
 
 msgid "This field stores a number in the database in a floating point format."
-msgstr ""
+msgstr "Kenttä tallentaa numeron tietokantaan reaalilukuna."
 
 msgid ""
 "The minimum value that should be allowed in this field. Leave blank for no "
 "minimum."
 msgstr ""
+"Syötä pienin sallittu arvo kentässä. Jätä tyhjäksi jos et halua asettaa "
+"pienintä arvoa."
 
 msgid ""
 "The maximum value that should be allowed in this field. Leave blank for no "
 "maximum."
 msgstr ""
+"Syötä suurin sallittu arvo kentässä. Jätä tyhjäksi jos et halua asettaa "
+"suurinta arvoa."
 
 msgid ""
 "Define a string that should be prefixed to the value, like '$ ' or '&euro; "
 "'. Leave blank for none. Separate singular and plural values with a pipe "
 "('pound|pounds')."
 msgstr ""
+"Määrittele merkkijono joka liitetään etuliitteeksi arvoon, esimerkiksi '$' "
+"tai '&euro;'. Jätä tyhjäksi jos et halua käyttää etuliittettä. Erottele "
+"yksikkö- ja monikkomuodot putkimerkillä ('pauna|paunaa')."
 
 msgid "Summary input"
-msgstr ""
+msgstr "Yhteenveto"
 
 msgid ""
 "This allows authors to input an explicit summary, to be displayed instead of"
 " the automatically trimmed text when using the \"Summary or trimmed\" "
 "display type."
 msgstr ""
+"Tämä sallii kirjoittajien syöttää yhteenveto joka näytetään trimmatun "
+"tekstin sijaan käytettäessä \"Yhteenveto tai trimmattu\" esitystapaa."
 
 msgid "Summary or trimmed"
-msgstr ""
+msgstr "Yhteenveto tai trimmattu"
 
 msgid "Text area with a summary"
-msgstr ""
+msgstr "Tekstialue yhteenvedolla"
 
 msgid "Leave blank to use trimmed value of full text as the summary."
 msgstr ""
+"Jätä tyhjäksi käyttääksesi kokonaistekstin trimmattua arvoa yhteenvetona."
 
 msgid "Hide summary"
-msgstr ""
+msgstr "Piilota yhteenveto"
 
 msgid "Edit summary"
-msgstr ""
+msgstr "Muokkaa yhteenvetoa"
 
 msgid "Edit field settings."
-msgstr ""
+msgstr "Muokkaa kentän asetuksia."
 
 msgid ""
 "These settings apply to the %field field everywhere it is used. These "
 "settings impact the way that data is stored in the database and cannot be "
 "changed once data has been created."
 msgstr ""
+"Nämä asetukset vaikuttavat kenttään %field kaikkialla, missä sitä käytetään."
+" Asetukset vaikuttavat sen tallennustapaan tietokannassa, eikä niitä voi "
+"muuttaa sen jälkeen kun kenttään on tallennettu tietoa."
 
 msgid "Updated field %label field settings."
-msgstr ""
+msgstr "Päivitettiin kentän %label asetukset."
 
 msgid "Attempt to update field %label failed: %message."
-msgstr ""
+msgstr "Kentän %label päivitys epäonnistui: %message."
 
 msgid "The field %field has been deleted from the %type content type."
-msgstr ""
+msgstr "Kenttä %field on poistettu sisältötyypistä %type."
 
 msgid "There was a problem removing the %field from the %type content type."
-msgstr ""
+msgstr "Kentän %field poistaminen sisältötyypistä %type epäonnistui."
 
 msgid "Required field"
-msgstr ""
+msgstr "Pakollinen kenttä"
 
 msgid "The default value for this field, used when creating new content."
-msgstr ""
+msgstr "Kentän oletusarvo luotaessa uutta sisältöä."
 
 msgid "Saved %label configuration."
-msgstr ""
+msgstr "Tallennettu %label asetukset."
 
 msgid "This list shows all fields currently in use for easy reference."
 msgstr ""
+"Lista näyttää kaikki käytössäolevat kentät viittauksien helpottamiseksi."
 
 msgid "Manage display"
-msgstr ""
+msgstr "Ylläpidä näkymää"
 
 msgid "Field UI"
-msgstr ""
+msgstr "Field UI"
 
 msgid "This field stores the ID of a file as an integer value."
-msgstr ""
+msgstr "Kenttä tallentaa tiedoston ID:n kokonaislukuna."
 
 msgid "Enable <em>Display</em> field"
-msgstr ""
+msgstr "Ota käyttöön <em>Näytä</em>-kenttä"
 
 msgid ""
 "The display option allows users to choose if a file should be shown when "
 "viewing the content."
 msgstr ""
+"Tämä vaihtoehto antaa valita, näytetäänkö tiedosto vai ei sisältöä "
+"luettaessa."
 
 msgid "Files displayed by default"
-msgstr ""
+msgstr "Tiedostot näytetään oletusarvoisesti"
 
 msgid "This setting only has an effect if the display option is enabled."
-msgstr ""
+msgstr "Tämä asetus on voimassa vain, jos Näytä-kenttä on otettu käyttöön."
 
 msgid "Upload destination"
-msgstr ""
+msgstr "Tallennuskohde"
 
 msgid ""
 "Select where the final files should be stored. Private file storage has "
 "significantly more overhead than public files, but allows restricted access "
 "to files within this field."
 msgstr ""
+"Valitse mihin lopulliset tiedostot tallennetaan. Yksityinen tiedostojen "
+"tallentaminen on huomattavasti raskaampaa mutta tarjoaa mahdollisuuden "
+"rajata pääsyä tässä kentässä oleviin tiedostoihin."
 
 msgid ""
 "Optional subdirectory within the upload destination where files will be "
 "stored. Do not include preceding or trailing slashes."
 msgstr ""
+"Vaihtoehtoinen alakansio latauskohteessa johon tiedostot tallennetaan. Älä "
+"sisällytä edeltävää tai seuraavaa \"/\" merkkiä."
 
 msgid ""
 "Enter a value like \"512\" (bytes), \"80 KB\" (kilobytes) or \"50 MB\" "
@@ -8707,89 +9089,103 @@ msgid ""
 "file sizes will be limited only by PHP's maximum post and file upload sizes "
 "(current limit <strong>%limit</strong>)."
 msgstr ""
+"Syötä arvo muotoa \"512\" (tavua), \"80 KB\" (kilotavua) tai \"50 MB\" "
+"(megatavua) rajoittaaksesi sallittua kokoa. Jos jätät tämän tyhjäksi, "
+"tiedostojen koon rajoittamiseen käytetään ainoastaan PHP:n omia "
+"enimmäiskokoasetuksia (tämänhetkinen raja <strong>%limit</strong>)."
 
 msgid "Enable <em>Description</em> field"
-msgstr ""
+msgstr "Ota käyttöön <em>Kuvaus</em>-kenttä"
 
 msgid ""
 "The description field allows users to enter a description about the uploaded"
 " file."
-msgstr ""
+msgstr "Kuvauskenttään käyttäjä voi syöttää kuvauksen ladatusta tiedostosta."
 
 msgid ""
 "The list of allowed extensions is not valid, be sure to exclude leading dots"
 " and to separate extensions with a comma or space."
 msgstr ""
+"Sallittujen tiedostopäätteiden lista ei ole validi. Varmista ettet ole "
+"syöttänyt päätteen nimeä edeltäviä pisteitä ja olet erotellut päätteiden "
+"nimet pilkuilla tai välilyönneillä."
 
 msgid "Generic file"
-msgstr ""
+msgstr "Geneerinen tiedosto"
 
 msgid "Table of files"
-msgstr ""
+msgstr "Tiedostotaulukko"
 
 msgid "Add a new file"
-msgstr ""
+msgstr "Lisää uusi tiedosto"
 
 msgid "Include file in display"
-msgstr ""
+msgstr "Sisällytä tiedosto näkymään"
 
 msgid "The description may be used as the label of the link to the file."
-msgstr ""
+msgstr "Kuvausta voidaan käyttää tiedostolinkin etikettinä."
 
 msgid "All roles may use this format"
-msgstr ""
+msgstr "Kaikki roolit saavat käyttää tätä muotoa"
 
 msgid "The text format ordering has been saved."
-msgstr ""
+msgstr "Tekstimuotojen tärkeysjärjestys on tallennettu."
 
 msgid "Add text format"
-msgstr ""
+msgstr "Lisää tekstimuoto"
 
 msgid "All roles for this text format must be enabled and cannot be changed."
 msgstr ""
+"Kaikki roolit syöttömuotoa varten on aktivoitava eikä niitä voi muuttaa."
 
 msgid "Filter processing order"
-msgstr ""
+msgstr "Suodattimien prosessointijärjestys"
 
 msgid "Text format names must be unique. A format named %name already exists."
 msgstr ""
+"Tekstimuodon nimen on oltava yksilöllinen. Muoto nimellä %name on jo "
+"olemassa."
 
 msgid "Added text format %format."
-msgstr ""
+msgstr "Lisättiin tekstimuoto %format."
 
 msgid "The text format %format has been updated."
-msgstr ""
+msgstr "Tekstimuoto %format on päivitetty."
 
 msgid "Text formats"
-msgstr ""
+msgstr "Tekstimuodot"
 
 msgid "Choosing a text format"
-msgstr ""
+msgstr "Tekstimuodon valinta"
 
 msgid ""
 "Warning: This permission may have security implications depending on how the"
 " text format is configured."
 msgstr ""
+"Varoitus: Tällä käyttöoikeudella voi olla tietoturvaan vaikuttavia "
+"vaikutuksia tekstimuodon asetuksista riippuen."
 
 msgid ""
 "Convert line breaks into HTML (i.e. <code>&lt;br&gt;</code> and "
 "<code>&lt;p&gt;</code>)"
 msgstr ""
+"Muuta rivinvaihdot HTML-tageiksi (l. <code>&lt;br&gt;</code> ja "
+"<code>&lt;p&gt;</code>)"
 
 msgid "Convert URLs into links"
-msgstr ""
+msgstr "Muuta osoitteet linkeiksi"
 
 msgid "Correct faulty and chopped off HTML"
-msgstr ""
+msgstr "Korjaa rikkinäinen HTML"
 
 msgid "Display any HTML as plain text"
-msgstr ""
+msgstr "Näytä HTML puhtaana tekstinä"
 
 msgid "Display basic HTML help in long filter tips"
-msgstr ""
+msgstr "Näytä yksinkertaista HTML:ää pidemmissä suodatinohjeissa."
 
 msgid "Add rel=\"nofollow\" to all links"
-msgstr ""
+msgstr "Lisää kaikkiin linkkeihin rel=\"nofollow\""
 
 msgid ""
 "This site allows HTML content. While learning all of HTML may feel "
@@ -8797,21 +9193,26 @@ msgid ""
 " \"tags\" is very easy. This table provides examples for each tag that is "
 "enabled on this site."
 msgstr ""
+"Sivusto sallii HTML sisällön. Kaikkien HTML tagien opiskelu voi vaikuttaa "
+"turhalta joten voit opetella niistä vain yksinkertaisimmat. Tämä taulukko "
+"tarjoaa esimerkkejä jokaisesta sivustolla sallitusta HTML tagista."
 
 msgid "Most unusual characters can be directly entered without any problems."
-msgstr ""
+msgstr "Suurin osa erikoismerkeistä voidaan syöttää suoraan ilman ongelmia."
 
 msgid "No HTML tags allowed."
-msgstr ""
+msgstr "HTML-merkit ovat kiellettyjä."
 
 msgid "The number of replies a topic must have to be considered \"hot\"."
 msgstr ""
+"Kuinka monta vastausta keskusteluaiheessa on oltava jotta se tulkitaan "
+"\"kuumaksi\"."
 
 msgid "Starting a discussion"
-msgstr ""
+msgstr "Keskustelun aloitus"
 
 msgid "Moving forum topics"
-msgstr ""
+msgstr "Foorumin otsikoiden siirtäminen"
 
 msgid ""
 "A forum topic (and all of its comments) may be moved between forums by "
@@ -8819,9 +9220,13 @@ msgid ""
 " topic between forums, the <em>Leave shadow copy</em> option creates a link "
 "in the original forum pointing to the new location."
 msgstr ""
+"Foorumin aihe ja kaikki sen sisältämät kommentit voidaan siirtää foorumeiden"
+" välillä valitsemalla eri foorumi keskusteluaihetta muokattaessa. Kun "
+"siirrät foorumin eri foorumiin, <em>Jätä varjokopio</em> linkki luo linkin "
+"alkuperäisestä foorumista uuteen."
 
 msgid "Locking and disabling comments"
-msgstr ""
+msgstr "Kommenttien lukitseminen ja käytöstä poistaminen"
 
 msgid ""
 "Selecting <em>Closed</em> under <em>Comment settings</em> while editing a "
@@ -8829,199 +9234,237 @@ msgid ""
 "<em>Hidden</em> under <em>Comment settings</em> while editing a forum topic "
 "will hide all existing comments on the thread, and prevent new ones."
 msgstr ""
+"Valitsemalla <em>Suljettu</em> tilan <em>Kommenttiasetusten</em> alla estät "
+"kommenttien lisäämisen viestiketjuun. Jos valitset <em>Piilotettu</em> tilan"
+" <em>Kommentointiasetusten</em> alla muokatessasi foorumin otsikkoa, saat "
+"piilotettua kaikki olemassaolevat kommentit ja estettyä uusien kommenttien "
+"lisäämisen."
 
 msgid "Forums contain forum topics. Use containers to group related forums."
 msgstr ""
+"Foorumit sisältävät aiheita. Käytä säiliöitä foorumeiden ryhmittelyyn."
 
 msgid "Use containers to group related forums."
-msgstr ""
+msgstr "Käytä säiliöitä foorumeiden ryhmittelyyn."
 
 msgid "A forum holds related forum topics."
-msgstr ""
+msgstr "Foorumi sisältää listan liittyvistä foorumin otsikoista."
 
 msgid "Add new @node_type"
-msgstr ""
+msgstr "Lisää uusi sisältötyyppi @node_type"
 
 msgid ""
 "The item %forum is a forum container, not a forum. Select one of the forums "
 "below instead."
 msgstr ""
+"%forum on foorumisäiliö eikä yksittäinen foorumi. Valitse sen sijaan yksi "
+"allaolevista foorumeista."
 
 msgid "A <em>forum topic</em> starts a new discussion thread within a forum."
 msgstr ""
+"<em>Foorumin keskusteluaihe</em> aloittaa keskusteluketjun foorumin sisällä."
 
 msgid "Control forum hierarchy settings."
-msgstr ""
+msgstr "Foorumin hierarkian ylläpito"
 
 msgid "Forum navigation vocabulary"
-msgstr ""
+msgstr "Foorumin navigointiin käytettävä sanasto"
 
 msgid "Filters content in preparation for display."
-msgstr ""
+msgstr "Suodattaa sisällön esikatselutilassa."
 
 msgid "Follow these steps to set up and start using your website:"
 msgstr ""
+"Uutta sivustoa käyttöönotettaessa kannattaa yleensä tehdä seuraavat toimet:"
 
 msgid "Providing a help reference"
-msgstr ""
+msgstr "Aputekstiin viittaaminen"
 
 msgid "Image style name"
-msgstr ""
+msgstr "Kuvan tyylin nimi"
 
 msgid "Select a new effect"
-msgstr ""
+msgstr "Valitse uusi efekti"
 
 msgid "Select an effect to add."
-msgstr ""
+msgstr "Valitse lisättävä efekti."
 
 msgid "The image effect was successfully applied."
-msgstr ""
+msgstr "Kuvan efekti otettu onnistuneesti käyttöön."
 
 msgid "Style name"
-msgstr ""
+msgstr "Tyylin nimi"
 
 msgid "Create new style"
-msgstr ""
+msgstr "Luo uusi tyyli"
 
 msgid "Style %name was created."
-msgstr ""
+msgstr "Tyyli nimellä %name on luotu."
 
 msgid "Replacement style"
-msgstr ""
+msgstr "Korvaava tyyli"
 
 msgid "Optionally select a style before deleting %style"
-msgstr ""
+msgstr "Vaihtoehtoisesti valitse tyyli ennenkuin poistat tyylin %style"
 
 msgid "Edit %label effect"
-msgstr ""
+msgstr "Muokkaa efektiä %label"
 
 msgid "Add %label effect"
-msgstr ""
+msgstr "Lisää efekti %label"
 
 msgid "Update effect"
-msgstr ""
+msgstr "Päivitä efektiä"
 
 msgid ""
 "Are you sure you want to delete the @effect effect from the %style style?"
-msgstr ""
+msgstr "Oletko varma että haluat poistaa efektin @effect tyylistä %style ?"
 
 msgid "The image effect %name has been deleted."
-msgstr ""
+msgstr "Kuvan efekti %name on poistettu."
 
 msgid "Width and height can not both be blank."
-msgstr ""
+msgstr "Määrittele joko korkeus tai leveys tai molemmat."
 
 msgid "The part of the image that will be retained during the crop."
-msgstr ""
+msgstr "Leikkauksen jälkeen kuvasta säilytettävä osa."
 
 msgid ""
 "The background color to use for exposed areas of the image. Use web-style "
 "hex colors (#FFFFFF for white, #000000 for black). Leave blank for "
 "transparency on image types that support it."
 msgstr ""
+"Kuvan läpinäkyvien alueiden kohdalla käytettävä taustaväri. Käytä web-"
+"tyylisiä heksavärejä (#FFFFFF valkoiselle, #000000 mustalle). Jätä tyhjäksi "
+"jos haluat säilyttää näytettävien kuvien läpinäkyvyyden."
 
 msgid ""
 "There are currently no effects in this style. Add one by selecting an option"
 " below."
 msgstr ""
+"Tälle tyylille ei vielä ole määritettynä efektejä. Lisää efekti valitsemalla"
+" vaihtoehto allaolevasta listasta."
 
 msgid "view actual size"
-msgstr ""
+msgstr "näytä todellinen koko"
 
 msgid "Sample original image"
-msgstr ""
+msgstr "Alkuperäisen kuvan kuvakaappaus"
 
 msgid "Sample modified image"
-msgstr ""
+msgstr "Muokatun kuvan kuvakaappaus"
 
 msgid ""
 "Resizing will make images an exact set of dimensions. This may cause images "
 "to be stretched or shrunk disproportionately."
 msgstr ""
+"Kuvien koon muuttaminen tekee kuvista ennaltamäärätyn kokoisia. Tämä voi "
+"aiheuttaa kuvien venymistä."
 
 msgid ""
 "Scaling will maintain the aspect-ratio of the original image. If only a "
 "single dimension is specified, the other dimension will be calculated."
 msgstr ""
+"Skaalaus säilyttää kuvan alkuperäisen kuvasuhteen. Jos vain yksi ulottuvuus "
+"on määritettynä, järjestelmä laskee toisen ulottuvuuden automaattisesti."
 
 msgid "Scale and crop"
-msgstr ""
+msgstr "Skaalaa ja leikkaa"
 
 msgid ""
 "Scale and crop will maintain the aspect-ratio of the original image, then "
 "crop the larger dimension. This is most useful for creating perfectly square"
 " thumbnails without stretching the image."
 msgstr ""
+"Skaala ja leikkaa toiminto säilyttää kuvan alkuperäisen kuvasuhteen "
+"leikkaamalla pois alkuperäisen kuvasuhteen ylittävän osuuden kuvasta. Tämä "
+"on käytännöllistä kun halutaan luoda täsmälleen neliön muotoisia "
+"pikakuvakkeita venyttämättä itse kuvaa."
 
 msgid "Desaturate"
-msgstr ""
+msgstr "Poista kyllästys"
 
 msgid "Desaturate converts an image to grayscale."
-msgstr ""
+msgstr "\"Poista kyllästys\" toiminto muuttaa kuvan mustavalkoiseksi."
 
 msgid ""
 "Rotating an image may cause the dimensions of an image to increase to fit "
 "the diagonal."
 msgstr ""
+"Kuvan kierittäminen voi vaikuttaa niin että kuvan mitat kasvavat täyttämään "
+"sille määritetyn alueen."
 
 msgid ""
 "Image resize failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Kuvakoon muuttaminen käyttäen %toolkit polussa %path epäonnistui (%mimetype,"
+" %dimensions)"
 
 msgid ""
 "Image scale failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Kuvan skaalaaminen käyttäen %toolkit polussa %path epäonnistui (%mimetype, "
+"%dimensions)"
 
 msgid ""
 "Image crop failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Kuvan leikkaus työkalulla %toolkit polussa %path epäonnistui (%mimetype, "
+"%dimensions)"
 
 msgid ""
 "Image scale and crop failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Kuvan leikkaus aalaus työkalulla %toolkit polussa %path epäonnistui "
+"(%mimetype, %dimensions)ja sk"
 
 msgid ""
 "Image desaturate failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Kuvan leikkaus työkalulla %toolkit polussa %path epäonnistui (%mimetype, "
+"%dimensions)"
 
 msgid ""
 "Image rotate failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Kyllästyksen poisto työkalulla %toolkit polussa %path epäonnistui "
+"(%mimetype, %dimensions)"
 
 msgid "This field stores the ID of an image file as an integer value."
-msgstr ""
+msgstr "Kenttä tallentaa kuvan ID:n kokonaislukuna tietokantaan."
 
 msgid "If no image is uploaded, this image will be shown on display."
-msgstr ""
+msgstr "Jos kuvaa ei ole ladattuna, sen sijasta näytetään tämä kuva."
 
 msgid "Minimum image resolution"
-msgstr ""
+msgstr "Kuvan pienin resoluutio"
 
 msgid "Enable <em>Alt</em> field"
-msgstr ""
+msgstr "Ota käyttöön <em>alt</em>-kenttä"
 
 msgid "Enable <em>Title</em> field"
-msgstr ""
+msgstr "Ota käyttöön <em>Otsikko</em>-kenttä"
 
 msgid ""
 "The title attribute is used as a tooltip when the mouse hovers over the "
 "image."
 msgstr ""
+"Otsikko on työkaluvihjeenä näytettävä teksti hiiren ollessa kuvan päällä."
 
 msgid "Preview image style"
-msgstr ""
+msgstr "Esikatsele kuvan tyyliä"
 
 msgid "no preview"
-msgstr ""
+msgstr "ei esikatselua"
 
 msgid "The preview image will be shown while editing the content."
-msgstr ""
+msgstr "Esikatselukuva näytetään sisältöä muokattaessa."
 
 msgid ""
 "Image styles commonly provide thumbnail sizes by scaling and cropping "
@@ -9029,84 +9472,95 @@ msgid ""
 "an image is displayed with a style, a new file is created and the original "
 "image is left unchanged."
 msgstr ""
+"Kuvatyylit yleensä tarjoavat pikkukuvien kokoisia kuvia skaalamalla ja "
+"kroppaamalla kuvia mutta ne voivat myös lisätä lukuisia kuvaefektejä kuviin "
+"ennen esitystä. Kun kuvaa näytetään kuvatyylillä, uusi tiedosto lisätään ja "
+"alkuperäinen kuva jätetään muuttumattomaksi."
 
 msgid "Administer image styles"
-msgstr ""
+msgstr "Ylläpidä kuvien tyylejä"
 
 msgid "No defined styles"
-msgstr ""
+msgstr "Ei määriteltyjä tyylejä"
 
 msgid "Image generation in progress. Try again shortly."
-msgstr ""
+msgstr "Kuvanluonti käynnissä. Yritä uudelleen hetken kuluttua."
 
 msgid "Error generating image."
-msgstr ""
+msgstr "Virhe kuvan luonnissa."
 
 msgid "Unable to generate the derived image located at %path."
-msgstr ""
+msgstr "Muokatun kuvan lataaminen osoitteesta %path epäonnistui."
 
 msgid "Failed to create style directory: %directory"
-msgstr ""
+msgstr "Tyylikansion %directory luonti epäonnistui"
 
 msgid ""
 "Cached image file %destination already exists. There may be an issue with "
 "your rewrite configuration."
 msgstr ""
+"Välimuistitettu kuva %destination on jo olemassa. Sinulla voi olla ongelma "
+"uudelleenkirjoitussääntöjesi kanssa."
 
 msgid "Edit image effect"
-msgstr ""
+msgstr "Muokkaa kuvan efektejä"
 
 msgid "Delete image effect"
-msgstr ""
+msgstr "Poista kuvan efekti"
 
 msgid "Add image effect"
-msgstr ""
+msgstr "Lisää kuvan efekti"
 
 msgid "Detection method"
-msgstr ""
+msgstr "Tunnistustapa"
 
 msgid "Part of the URL that determines language"
-msgstr ""
+msgstr "Kielen määrittelevä URLin osa"
 
 msgid "Request/session parameter"
-msgstr ""
+msgstr "Pyyntö/sessio parametri"
 
 msgid ""
 "Name of the request/session parameter used to determine the desired "
 "language."
-msgstr ""
+msgstr "Kielen määrittelemiseen käytetyn kutsu/sessio muuttujan parametri."
 
 msgid "Date type"
-msgstr ""
+msgstr "Tietotyyppi"
 
 msgid ""
 "Determine the language from a request/session parameter. Example: "
 "\"http://example.com?language=de\" sets language to German based on the use "
 "of \"de\" within the \"language\" parameter."
 msgstr ""
+"Määrittele kieli kutsu/sessio parametrista. Esimerkki: "
+"\"http://example.com?language=de\" asettaa kieleksi \"saksa\" pohjautuen "
+"\"de\" määreeseen \"language\" parametrissa."
 
 msgid "Administer languages"
-msgstr ""
+msgstr "Ylläpidä kieliä"
 
 msgid ""
 "Order of language detection methods for content. If a version of content is "
 "available in the detected language, it will be displayed."
 msgstr ""
+"Sisällön kielentunnistustapojen järjestys. Jos sisältöä on olemassa "
+"tunnistetulle kielelle se näytetään."
 
 msgid "Follow the user's language preference."
-msgstr ""
+msgstr "Seuraa käyttäjän oletus-kielivalintaa."
 
 msgid "Language switcher (@type)"
-msgstr ""
+msgstr "Kielen valitsin (@type)"
 
 msgid "Detection and selection"
-msgstr ""
+msgstr "Automaattinen asettaminen ja valitseminen"
 
 msgid "URL language detection configuration"
-msgstr ""
+msgstr "Osoitepohjaisen kielentunnistuksen asetukset"
 
 msgid "Session language detection configuration"
-msgstr ""
+msgstr "Sessiokohtaiset kielentunnistuksen asetukset"
 
 msgctxt "Long month name"
 msgid "January"
@@ -9153,47 +9607,50 @@ msgid "December"
 msgstr "joulukuu"
 
 msgid "The text to be used for this link in the menu."
-msgstr ""
+msgstr "Linkin teksti valikossa käytettäväksi."
 
 msgid "Menu links that are not enabled will not be listed in any menu."
-msgstr ""
+msgstr "Käytöstä poistettuja valikkolinkkejä ei näytetä missään valikossa."
 
 msgid ""
 "If selected and this menu link has children, the menu will always appear "
 "expanded."
 msgstr ""
+"Mikäli valittuna, valikot joilla on alivalikoita esitetään aina "
+"laajennettuina."
 
 msgid "Parent link"
-msgstr ""
+msgstr "Isäntälinkki"
 
 msgid "Add to shortcuts"
-msgstr ""
+msgstr "Lisää oikopolkuihin"
 
 msgid "Add effect"
-msgstr ""
+msgstr "Lisää efekti"
 
 msgid "Image styles"
-msgstr ""
+msgstr "Kuvatyylit"
 
 msgid ""
 "Configure styles that can be used for resizing or adjusting images on "
 "display."
 msgstr ""
+"Aseta tyylit joita voidaan käyttää kuvien koon ja muotoilun asetuksissa."
 
 msgid "Filter translatable strings"
-msgstr ""
+msgstr "Suodata käännettävät merkkijonot"
 
 msgid "The menu link %title has been deleted."
-msgstr ""
+msgstr "Valikon linkki %title on poistettu."
 
 msgid "Are you sure you want to reset the link %item to its default values?"
-msgstr ""
+msgstr "Oletko varma että haluat alustaa linkin %item oletusarvoihinsa?"
 
 msgid "The menu link was reset to its default settings."
-msgstr ""
+msgstr "Valikon linkki palautettiin oletusasetuksiinsa."
 
 msgid "Deleted custom menu %title and all its menu links."
-msgstr ""
+msgstr "Poistettiin kustomoitu valikko %title ja kaikki sen valikkolinkit."
 
 msgid ""
 "<strong>Warning:</strong> There is currently 1 menu link in %title. It will "
@@ -9202,122 +9659,139 @@ msgid_plural ""
 "<strong>Warning:</strong> There are currently @count menu links in %title. "
 "They will be deleted (system-defined links will be reset)."
 msgstr[0] ""
+"<strong>Varoitus:</strong> Valikossa %title on tällä hetkellä yksi linkki. "
+"Se poistetaan (järjestelmän määrittelemät linkit palautetaan "
+"oletusasetuksiinsa)."
 msgstr[1] ""
+"<strong>Varoitus:</strong> Valikossa %title on tällä hetkellä @count "
+"linkkiä. Se poistetaan (järjestelmän määrittelemät linkit palautetaan "
+"oletusasetuksiinsa)."
 
 msgid "Managing menus"
-msgstr ""
+msgstr "Valikoiden ylläpito"
 
 msgid "Administer menus and menu items"
-msgstr ""
+msgstr "Ylläpidä valikoita ja valikkolinkkejä"
 
 msgid "Provide a menu link"
-msgstr ""
+msgstr "Näytä sivu valikossa"
 
 msgid "Available menus"
-msgstr ""
+msgstr "Käytettävissä olevat valikot"
 
 msgid "The menus available to place links in for this content type."
-msgstr ""
+msgstr "Tätä sisältötyyppiä varten käytettävissä olevat valikot."
 
 msgid "Default parent item"
-msgstr ""
+msgstr "Oletus- valikossa ylemmän tason valikkokohta"
 
 msgid ""
 "Choose the menu item to be the default parent for a new link in the content "
 "authoring form."
 msgstr ""
+"Valitse se valikkokohta, joka on oletuksena valikkokohdan ylätasona sisällön"
+" luontilomakkeessa."
 
 msgid "Edit menu link"
-msgstr ""
+msgstr "Muokkaa valikkolinkkiä"
 
 msgid "Reset menu link"
-msgstr ""
+msgstr "Palauta valikkolinkki oletusasetuksiin"
 
 msgid "Delete menu link"
-msgstr ""
+msgstr "Poista valikkolinkki"
 
 msgid "Preview before submitting"
-msgstr ""
+msgstr "Esikatsele ennen tallennusta"
 
 msgid ""
 "This text will be displayed at the top of the page when creating or editing "
 "content of this type."
 msgstr ""
+"Tämä teksti näytetään sivun yläreunassa kun tämäntyyppistä sisältöä luodaan "
+"tai muokataan."
 
 msgid ""
 "Users with the <em>Administer content</em> permission will be able to "
 "override these options."
 msgstr ""
+"Käyttäjät joilla on <em>oikeus ylläpitää sisältöä</em> voivat ohittaa nämä "
+"valinnat."
 
 msgid "Author username and publish date will be displayed."
-msgstr ""
+msgstr "Käyttäjän nimi ja julkaisupäivä näytetään."
 
 msgid "Invalid machine-readable name. Enter a name other than %invalid."
-msgstr ""
+msgstr "Epäkelpo koneluettava nimi. Syötä jokin muu nimi kuin %invalid."
 
 msgid "Publish selected content"
-msgstr ""
+msgstr "Julkaise valitut sisällöt"
 
 msgid "Unpublish selected content"
-msgstr ""
+msgstr "Peru valittujen sisältöjen julkaisu"
 
 msgid "Promote selected content to front page"
-msgstr ""
+msgstr "Näytä valitut sisällöt etusivulla"
 
 msgid "Demote selected content from front page"
-msgstr ""
+msgstr "Poista valitut sisällöt etusivulta"
 
 msgid "Make selected content sticky"
-msgstr ""
+msgstr "Kiinnitä valitut sisällöt listojen alkuun"
 
 msgid "Make selected content not sticky"
-msgstr ""
+msgstr "Irroita valitut sisällöt listojen alusta"
 
 msgid "Are you sure you want to delete this item?"
 msgid_plural "Are you sure you want to delete these items?"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Oletko varma että haluat poistaa tämän elementin?"
+msgstr[1] "Oletko varma että haluat poistaa nämä elementit?"
 
 msgid "<em>Edit @type</em> @title"
-msgstr ""
+msgstr "<em>Muokataan @type</em> @title"
 
 msgid "Tokens related to individual content items, or \"nodes\"."
-msgstr ""
+msgstr "Yksittäiseen sisältöön (\"solmut\") liittyvät merkit."
 
 msgid "The unique ID of the content item, or \"node\"."
-msgstr ""
+msgstr "Sisällön elementin tai solmun yksilöllinen ID."
 
 msgid "The main body text of the node."
-msgstr ""
+msgstr "Solmun sisältö"
 
 msgid "The summary of the node's main body text."
-msgstr ""
+msgstr "Solmun rungon tiivistelmä."
 
 msgid "Creating content"
-msgstr ""
+msgstr "Sisällön luominen"
 
 msgid "Creating custom content types"
-msgstr ""
+msgstr "Omien sisältötyyppien lisääminen"
 
 msgid "Administering content"
-msgstr ""
+msgstr "Sisällönhallinta"
 
 msgid "Creating revisions"
-msgstr ""
+msgstr "Versioiden luonti"
 
 msgid ""
 "The Node module also enables you to create multiple versions of any content,"
 " and revert to older versions using the <em>Revision information</em> "
 "settings."
 msgstr ""
+"Node moduuli sallii sinun luoda useita versioita mistä tahansa sisällöstä ja"
+" palata takaisin vanhempaan versioon käyttäen <em>Versiotiedot</em> "
+"asetuksia."
 
 msgid "User permissions"
-msgstr ""
+msgstr "Käyttöoikeudet"
 
 msgid ""
 "Individual content types can have different fields, behaviors, and "
 "permissions assigned to them."
 msgstr ""
+"Eri sisältötyypit voivat sisältää eri kenttiä, käyttäytymismalleja ja "
+"kullekin voidaan asettaa yksilölliset käyttöoikeudet."
 
 msgid ""
 "Content items can be displayed using different view modes: Teaser, Full "
@@ -9325,186 +9799,203 @@ msgid ""
 "typically used in lists of multiple content items. <em>Full content</em> is "
 "typically used when the content is displayed on its own page."
 msgstr ""
+"Sisällön osia voidaan näyttää eri esitystiloissa: Lyhennelmä, Koko sisältö, "
+"Tulostus, RSS jne. <em>Lyhennelmä</em> on lyhyt muoto jota useimmiten "
+"käytetään listattaessa useaa sisältöartikkelia. <em>Koko sisältö</em> muotoa"
+" käytetään esitettäessä sisältöä omalla sivullaan."
 
 msgid ""
 "Here, you can define which fields are shown and hidden when %type content is"
 " displayed in each view mode, and define how the fields are displayed in "
 "each view mode."
 msgstr ""
+"Tässä voit määritellä, mitkä kentät näytetään ja mitkä piilotetaan "
+"esitettäessä sisältöä jonka tyyppi on %type, lisäksi voit määritellä kuinka "
+"kentät esitetään eri esitystavoissa."
 
 msgid "Administer content types"
-msgstr ""
+msgstr "Ylläpidä sisältötyyppejä"
 
 msgid ""
 "Warning: Give to trusted roles only; this permission has security "
 "implications."
 msgstr ""
+"Varoitus: Aseta vain luotetuille rooleille; tällä oikeusmäärityksellä on "
+"vaikutuksia turvallisuuteen."
 
 msgid "View published content"
-msgstr ""
+msgstr "Näytä julkaistu sisältö"
 
 msgid "Bypass content access control"
-msgstr ""
+msgstr "Ohita sisällön pääsysäännöt"
 
 msgid "View own unpublished content"
-msgstr ""
+msgstr "Näytä oma julkaisematon sisältö"
 
 msgid "Content is sticky at top of lists"
-msgstr ""
+msgstr "Sisältö liimataan listojen yläosaan"
 
 msgid "Content is promoted to the front page"
-msgstr ""
+msgstr "Sisältö nostetaan etusivulle"
 
 msgid "No front page content has been created yet."
-msgstr ""
+msgstr "Etusivun sisältöä ei ole vielä luotu."
 
 msgid "Change the author of content"
-msgstr ""
+msgstr "Muuta sisällön luojan tiedot"
 
 msgid "Unpublish content containing keyword(s)"
-msgstr ""
+msgstr "Peru niiden sisältöjen julkaisu, jotka sisältävät avainsanat"
 
 msgid ""
 "The content will be unpublished if it contains any of the phrases above. Use"
 " a case-sensitive, comma-separated list of phrases. Example: funny, bungee "
 "jumping, \"Company, Inc.\""
 msgstr ""
+"Sisältö muutetaan ei-julkaistuksi jos se sisältää minkä tahansa yllä "
+"listatuista sanoista tai lauseista. Merkitse sanat tai lauseet pilkuilla "
+"eroteltuina pienillä kirjaimilla. Esimerkki: hauska, benji-hyppy, \"Yritys "
+"Oy\""
 
 msgid "One permission in use"
 msgid_plural "@count permissions in use"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Yksi sääntö käytössä"
+msgstr[1] "@count sääntöä käytössä"
 
 msgid "Don't display post information"
-msgstr ""
+msgstr "Älä näytä lähetyksen tietoja"
 
 msgid "Creating aliases"
-msgstr ""
+msgstr "Luo aliaksia"
 
 msgid "Managing aliases"
-msgstr ""
+msgstr "Aliaksien ylläpito"
 
 msgid ""
 "An alias defines a different name for an existing URL path - for example, "
 "the alias 'about' for the URL path 'node/1'. A URL path can have multiple "
 "aliases."
 msgstr ""
+"Alias määrittelee uuden nimen olemassa olevalle osoitteelle. Esimerkiksi "
+"alias 'about' polulle 'node/1'. Osoitteella voi olla useampia aliaksia."
 
 msgid "Administer URL aliases"
-msgstr ""
+msgstr "Ylläpidä osoitealiaksia"
 
 msgid "Create and edit URL aliases"
-msgstr ""
+msgstr "Muokkaa ja luo osoitealiaksia"
 
 msgid "The alias is already in use."
-msgstr ""
+msgstr "Alias on jo käytössä."
 
 msgid "Searched %type for %keys."
-msgstr ""
+msgstr "Haettiin %type hakusanoilla %keys."
 
 msgid "Administer search"
-msgstr ""
+msgstr "Ylläpidä hakutoimintoa"
 
 msgid "Use search"
-msgstr ""
+msgstr "Käytä hakutoimintoa"
 
 msgid "Choose a set of shortcuts to use"
-msgstr ""
+msgstr "Valitse käytettävät oikopolut"
 
 msgid "Choose a set of shortcuts for this user"
-msgstr ""
+msgstr "Valitse oikopolkuryhmä tälle käyttäjälle"
 
 msgid ""
 "%user is now using a new shortcut set called %set_name. You can edit it from"
 " this page."
 msgstr ""
+"Käyttäjä %user käyttää nyt oikopolkuryhmää %set_name. Voit muokata sitä "
+"tällä sivulla."
 
 msgid "You are now using the %set_name shortcut set."
-msgstr ""
+msgstr "Käytät nyt oikopolkuryhmää %set_name."
 
 msgid "%user is now using the %set_name shortcut set."
-msgstr ""
+msgstr "Käyttäjä %user käyttää nyt oikopolkuryhmää %set_name."
 
 msgid "Change set"
-msgstr ""
+msgstr "Muuta ryhmää"
 
 msgid "The shortcut set has been updated."
-msgstr ""
+msgstr "Oikopolkuryhmä on päivitetty."
 
 msgid "The name of the shortcut."
-msgstr ""
+msgstr "Oikopolun nimi."
 
 msgid "The shortcut %link has been updated."
-msgstr ""
+msgstr "Oikopolku %link on päivitetty."
 
 msgid "Added a shortcut for %title."
-msgstr ""
+msgstr "Lisättiin oikopolku osoitteelle %title."
 
 msgid "The shortcut %title has been deleted."
-msgstr ""
+msgstr "Oikopolku %title on poistettu."
 
 msgid "Unable to add a shortcut for %title."
-msgstr ""
+msgstr "Oikopolun lisääminen osoitteelle %title epäonnistui."
 
 msgid "Adding and removing shortcuts"
-msgstr ""
+msgstr "Oikopolkujen lisäys ja poisto"
 
 msgid "Displaying shortcuts"
-msgstr ""
+msgstr "Oikopolkujen näyttäminen"
 
 msgid "Administer shortcuts"
-msgstr ""
+msgstr "Ylläpidä oikopolkuja"
 
 msgid "Revision log message"
-msgstr ""
+msgstr "Version viesti"
 
 msgid "Make content unsticky"
-msgstr ""
+msgstr "Make content unsticky"
 
 msgid "Promote content to front page"
-msgstr ""
+msgstr "Promote content to front page"
 
 msgid "Save content"
-msgstr ""
+msgstr "Save content"
 
 msgid "Unpublish content"
-msgstr ""
+msgstr "Unpublish content"
 
 msgid "Find and manage content."
-msgstr ""
+msgstr "Find and manage content."
 
 msgid "Recent content"
 msgstr "Tuore sisältö"
 
 msgid "Node Access Permissions"
-msgstr ""
+msgstr "Solmujen pääsyoikeudet"
 
 msgid "Add to %shortcut_set shortcuts"
-msgstr ""
+msgstr "Lisää oikopolkuryhmään %shortcut_set"
 
 msgid "Use advanced search"
 msgstr "Käytä laajennettua hakua"
 
 msgid "Remove from %shortcut_set shortcuts"
-msgstr ""
+msgstr "Poista oikopolkuryhmästä %shortcut_set"
 
 msgid "Remove from shortcuts"
-msgstr ""
+msgstr "Poista oikopoluista"
 
 msgid "Add shortcut"
-msgstr ""
+msgstr "Lisää oikopolku"
 
 msgid "GSS negotiate"
-msgstr ""
+msgstr "GSS vaihto"
 
 msgid "NTLM"
-msgstr ""
+msgstr "NTLM"
 
 msgid "Any safe"
-msgstr ""
+msgstr "Mikä tahansa turvallinen"
 
 msgid "Running tests"
-msgstr ""
+msgstr "Testien suorittaminen"
 
 msgid ""
 "After the tests run, a message will be displayed next to each test group "
@@ -9516,70 +10007,87 @@ msgid ""
 " exceptions will be indicated in red or pink rows. You can then use these "
 "results to refine your code and tests, until all tests pass."
 msgstr ""
+"Testin päätyttyä järjestelmä näyttää viestin kunkin testiryhmän perässä "
+"kertoen suoritettiinko testi onnistuneesti vai epäonnistuiko testi vai "
+"suoritettiinko se huomautuksin. Onnistuneesti suoritettu tarkoittaa että "
+"testi tuotti odotetut tulokset kun taas epäonnistunut normaalisti merkitsee "
+"virhettä koodissa kuten PHP-virhe tai huomautus. Jos testit epäonnistuivat "
+"tai ne suoritettiin huomautuksin, tulokset laajennetaan näyttämään "
+"yksityiskohdat testistä ja epäonnistuneet testit esitetään vaaleanpunaisilla"
+" tai punaisilla riveillä. Voit tämän jälkeen käyttää tuloksia tarkistaaksesi"
+" koodisi ja testisi kunnes kaikki testit on suoritettu onnistuneesti."
 
 msgid "Administer tests"
-msgstr ""
+msgstr "Ylläpidä testejä"
 
 msgid "The test run finished in @elapsed."
-msgstr ""
+msgstr "Testiajo suoritettu @elapsed ajassa."
 
 msgid ""
 "Use the <em>Clean environment</em> button to clean-up temporary files and "
 "tables."
 msgstr ""
+"Käytä <em>Puhdista ympäristö</em> nappia poistaaksesi tilapäiset taulut ja "
+"tiedostot."
 
 msgid "PHP open_basedir restriction"
-msgstr ""
+msgstr "PHP open_basedir rajoitus"
 
 msgid "Displaying popular content"
-msgstr ""
+msgstr "Suositun sisällön näyttäminen"
 
 msgid "Page view counter"
-msgstr ""
+msgstr "Sivun katselukertojen laskuri"
 
 msgid "Administer statistics"
-msgstr ""
+msgstr "Ylläpidä tilastoja"
 
 msgid "View content hits"
-msgstr ""
+msgstr "Näytä sisällön katselukerrat"
 
 msgid "Logging for UNIX, Linux, and Mac OS X"
-msgstr ""
+msgstr "Loggaus UNIXille, Linuxille ja Mac OS X:lle"
 
 msgid "Logging for Microsoft Windows"
-msgstr ""
+msgstr "Loggaus Windowsilla"
 
 msgid ""
 "On Microsoft Windows, messages are always sent to the Event Log using the "
 "code <code>LOG_USER</code>."
 msgstr ""
+"Windowsilla viestit lähtetään aina tapahtumalogiin koodilla "
+"<code>LOG_USER</code>."
 
 msgid "Syslog facility"
-msgstr ""
+msgstr "Syslog-ominaisuus"
 
 msgid ""
 "Depending on the system configuration, Syslog and other logging tools use "
 "this code to identify or filter messages from within the entire system log."
 msgstr ""
+"Järjestelmäsi asetuksista riippuen Syslog ja muut loggaustyökalut käyttävät "
+"tätä koodia viestien tunnistamiseen ja suodattamiseen järjestelmälogista."
 
 msgid ""
 "The image %file could not be rotated because the imagerotate() function is "
 "not available in this PHP installation."
 msgstr ""
+"Kuvan %file kääntäminen ei onnistunut koska käyttämäsi PHP-asennus ei tue "
+"funktiota imagerotate()."
 
 msgid "default theme"
-msgstr ""
+msgstr "oletusteema"
 
 msgid ""
 "Choose \"Default theme\" to always use the same theme as the rest of the "
 "site."
-msgstr ""
+msgstr "Valitse \"oletusteema\" käyttääksesi samaa teemaa koko muulle sivustolle."
 
 msgid "Use the administration theme when editing or creating content"
-msgstr ""
+msgstr "Käytä ylläpidon teemaa silloin kun muokataan tai luodaan sisältöä."
 
 msgid "The %theme theme was not found."
-msgstr ""
+msgstr "Teemaa %theme ei löytynyt."
 
 msgid ""
 "Please note that the administration theme is still set to the %admin_theme "
@@ -9587,208 +10095,230 @@ msgid ""
 "administrative sections of the site, however, will show the selected "
 "%selected_theme theme by default."
 msgstr ""
+"Huomaa että ylläpidon teema on %admin_theme. Tästä syystä tämän sivun teema "
+"säilyi muuttumattomana. Sivuston kaikilla muilla sivuilla kuin "
+"ylläpitosivuilla käytetään oletuksena teemaa %selected_theme."
 
 msgid "%theme is now the default theme."
-msgstr ""
+msgstr "Teema %theme on nyt oletusteema."
 
 msgid "User verification status in comments"
-msgstr ""
+msgstr "Käyttäjän varmennuksen tila kommenteissa"
 
 msgid ""
 "These settings only exist for the themes based on the %engine theme engine."
 msgstr ""
+"Nämä asetukset esiintyvät ainoastaan teemoille jotka ovat riippuvaisia "
+"%engine teemasta."
 
 msgid "The custom logo path is invalid."
-msgstr ""
+msgstr "Oman logon polku ei kelpaa."
 
 msgid "The custom favicon path is invalid."
-msgstr ""
+msgstr "Oman faviconin polku ei kelpaa."
 
 msgid "Would you like to continue with the above?"
-msgstr ""
+msgstr "Haluatko jatkaa yllämainittua?"
 
 msgid "Enter a valid IP address."
-msgstr ""
+msgstr "Syötä käypä IP osoite."
 
 msgid "The IP address %ip was deleted."
-msgstr ""
+msgstr "IP-osoite %ip on poistettu."
 
 msgid "How this is used depends on your site's theme."
-msgstr ""
+msgstr "Tämän käyttö riippuu sivustosi teemasta."
 
 msgid ""
 "This page is displayed when the requested document is denied to the current "
 "user. Leave blank to display a generic \"access denied\" page."
 msgstr ""
+"Tämä sivu näytetään, kun käyttäjällä ei ole oikeuksia tarkastella pyydettyä "
+"sivua. Jätä tyhjäksi käyttääksesi oletus-virhesivua."
 
 msgid ""
 "This page is displayed when no other content matches the requested document."
 " Leave blank to display a generic \"page not found\" page."
 msgstr ""
+"Tämä sivu näytetään, kun pyydettyä sivua ei löydy. Jätä tyhjäksi "
+"käyttääksesi oletus-virhesivua."
 
 msgid "Errors and warnings"
-msgstr ""
+msgstr "Virheet ja varoitukset"
 
 msgid "Public file system path"
-msgstr ""
+msgstr "Julkinen tiedostojärjestelmän polku"
 
 msgid "Private file system path"
-msgstr ""
+msgstr "Yksityinen tiedostojärjestelmän polku"
 
 msgid ""
 "A local file system path where temporary files will be stored. This "
 "directory should not be accessible over the web."
 msgstr ""
+"Paikallisen tiedostojärjestelmän polku johon tilapäistiedostot tallennetaan."
+" Hakemiston ei pidä olla käytettävissä verkon yli."
 
 msgid "Default download method"
-msgstr ""
+msgstr "Oletus-lataustapa"
 
 msgid ""
 "This setting is used as the preferred download method. The use of public "
 "files is more efficient, but does not provide any access control."
 msgstr ""
+"Tämä asetus määrittää ensisijaisen lataustavan. Julkisten tiedostojen "
+"käyttäminen on tehokkaampaa, mutta niihin pääsyn rajoittaminen ei ole "
+"mahdollista."
 
 msgid "Description of your site, included in each feed."
-msgstr ""
+msgstr "Sivustosi kuvaus, joka sisältyy kaikkiin sivuston syötteisiin."
 
 msgid "Time zones"
-msgstr ""
+msgstr "Aikavyöhykkeet"
 
 msgid "Only applied if users may set their own time zone."
-msgstr ""
+msgstr "Käytetään vain jos käyttäjät voivat itse asettaa aikavyöhykkeensä."
 
 msgid "Time zone for new users"
-msgstr ""
+msgstr "Uusien käyttäjien aikavyöhyke"
 
 msgid "Put site into maintenance mode"
-msgstr ""
+msgstr "Vaihda sivusto huoltotilaan."
 
 msgid "Displayed as %date"
-msgstr ""
+msgstr "Näytetään muodossa %date"
 
 msgid "Save format"
-msgstr ""
+msgstr "Tallenna muoto"
 
 msgid "Custom date format updated."
-msgstr ""
+msgstr "Oma päivämäärämuoto päivitetty."
 
 msgid "Custom date format added."
-msgstr ""
+msgstr "Oma päivämäärämuoto lisätty."
 
 msgid "Available actions:"
-msgstr ""
+msgstr "Tarjolla olevat toiminnot:"
 
 msgid "Create an advanced action"
-msgstr ""
+msgstr "Luo laajennettu toiminto"
 
 msgid "Deleted %ip"
-msgstr ""
+msgstr "Poistettu %ip"
 
 msgid "You must enable the @required module to install @module."
 msgid_plural "You must enable the @required modules to install @module."
 msgstr[0] ""
+"Sinun on otettava käyttöön moduuli @required asentaaksesi moduulin @module."
 msgstr[1] ""
+"Sinun on otettava käyttöön moduulit @required asentaaksesi moduulin @module."
 
 msgid "Tokens for site-wide settings and other global information."
 msgstr ""
+"Sivuston laajuisten asetusten ja muun sivuston laajuisen tiedon tokenit."
 
 msgid "Tokens related to times and dates."
-msgstr ""
+msgstr "Aikoihin ja päivämääriin liittyvät tokenit."
 
 msgid "Tokens related to uploaded files."
-msgstr ""
+msgstr "Ladattuihin tiedostoihin liittyvät tokenit."
 
 msgid "The URL of the site's front page without the protocol."
-msgstr ""
+msgstr "Sivuston etusivun osoite (URL) ilman protokollaa."
 
 msgid "A date in 'short' format. (%date)"
-msgstr ""
+msgstr "Päivämäärä 'lyhyessä' muodossa (%date)"
 
 msgid "A date in 'medium' format. (%date)"
-msgstr ""
+msgstr "Päivämäärä 'keskipitkässä' muodossa (%date)"
 
 msgid "A date in 'long' format. (%date)"
-msgstr ""
+msgstr "Päivämäärä 'pitkässä' muodossa (%date)"
 
 msgid "A date in UNIX timestamp format (%date)"
-msgstr ""
+msgstr "Päivämäärä UNIX-aikaleimana (%date)"
 
 msgid "Managing modules"
-msgstr ""
+msgstr "Moduulien hallinta"
 
 msgid "Managing themes"
-msgstr ""
+msgstr "Teemojen hallinta"
 
 msgid "Configuring basic site settings"
-msgstr ""
+msgstr "Järjestelmän perusasetukset"
 
 msgid "Administer modules"
-msgstr ""
+msgstr "Ylläpidä moduuleita"
 
 msgid "Administer site configuration"
-msgstr ""
+msgstr "Ylläpidä sivuston asetuksia"
 
 msgid "Administer themes"
-msgstr ""
+msgstr "Ylläpidä teemoja"
 
 msgid "Administer actions"
-msgstr ""
+msgstr "Ylläpidä toimintoja"
 
 msgid "Use the administration pages and help"
-msgstr ""
+msgstr "Käytä ylläpito- ja ohjesivuja"
 
 msgid "Use the site in maintenance mode"
-msgstr ""
+msgstr "Käytä sivustoa huoltotilassa"
 
 msgid "View site reports"
-msgstr ""
+msgstr "Näytä sivuston raportit"
 
 msgid "Public files"
-msgstr ""
+msgstr "Julkiset tiedostot"
 
 msgid "Public local files served by the webserver."
-msgstr ""
+msgstr "Julkiset palvelimen jakelemat tiedostot."
 
 msgid "Private local files served by Drupal."
-msgstr ""
+msgstr "Yksityiset Drupalin jakamat tiedostot."
 
 msgid "Temporary files"
-msgstr ""
+msgstr "Tilapäistiedostot"
 
 msgid "Temporary local files for upload and previews."
 msgstr ""
+"Esikatseluun ja tiedostojen lataamiseen käytettävät tilapäistiedostot."
 
 msgid "Update modules"
-msgstr ""
+msgstr "Päivitä moduulit"
 
 msgid "Update themes"
-msgstr ""
+msgstr "Päivitä teemat"
 
 msgid "SSH"
-msgstr ""
+msgstr "SSH"
 
 msgid ""
 "Your password is not saved in the database and is only used to establish a "
 "connection."
 msgstr ""
+"Salasanaasi ei tallenneta tietokantaan ja sitä käytetään ainoastaan "
+"tietokantaan yhdistämisessä."
 
 msgid "Edit shortcuts"
-msgstr ""
+msgstr "Muokkaa oikopolkuja"
 
 msgid "Clear all caches"
-msgstr ""
+msgstr "Tyhjennä kaikki välimuistit"
 
 msgid "Bandwidth optimization"
-msgstr ""
+msgstr "Kaistanleveyden optimointi"
 
 msgid "Allows users to manage customizable lists of shortcut links."
-msgstr ""
+msgstr "Salli käyttäjien ylläpitää mukautettavia listoja oikopoluista."
 
 msgid ""
 "The connection will be created between your web server and the machine "
 "hosting the web server files. In the vast majority of cases, this will be "
 "the same machine, and \"localhost\" is correct."
 msgstr ""
+"Yhteys luodaan www-palvelimesi ja tiedostot sisältävän palvelimen välille. "
+"Useimmiten tämä on sama kone jolloin oikea asetus on \"localhost\"."
 
 msgid ""
 "Select the desired local time and time zone. Dates and times throughout this"
@@ -9798,331 +10328,357 @@ msgstr ""
 "valitsemasi aikavyöhykkeen mukaan."
 
 msgid "The directory %directory does not exist and could not be created."
-msgstr ""
+msgstr "Hakemistoa %directory ei löytynyt ja sen luominen epäonnistui."
 
 msgid ""
 "The directory %directory exists but is not writable and could not be made "
 "writable."
 msgstr ""
+"Hakemisto %directory löytyi mutta ei ole kirjoituskelpoinen ja sen "
+"kirjoituskelpoiseksi tekeminen epäonnistui."
 
 msgid "Delete IP address"
-msgstr ""
+msgstr "Poista IP-osoite"
 
 msgid "Edit date format"
-msgstr ""
+msgstr "Muokkaa päivämäärämuotoja"
 
 msgid "%profile_name (%profile-%version)"
-msgstr ""
+msgstr "%profile_name (%profile-%version)"
 
 msgid "Tokens related to taxonomy terms."
-msgstr ""
+msgstr "Luokittelutermeihin liittyvät tokenit."
 
 msgid "Tokens related to taxonomy vocabularies."
-msgstr ""
+msgstr "Luokittelusanastoihin liittyvät tokenit."
 
 msgid ""
 "Taxonomy is for categorizing content. Terms are grouped into vocabularies. "
 "For example, a vocabulary called \"Fruit\" would contain the terms \"Apple\""
 " and \"Banana\"."
 msgstr ""
+"Luokittelua käytetään sisällön lajitteluun. Termit ryhmitellään sanastoihin."
+" Esimerkiksi sanasto nimeltä \"Hedelmä\" voisi sisältää termit \"Omena\" ja "
+"\"Banaani\"."
 
 msgid ""
 "You can reorganize the terms in %capital_name using their drag-and-drop "
 "handles, and group terms under a parent term by sliding them under and to "
 "the right of the parent."
 msgstr ""
+"Voit uudelleenlajitella termejä ylätason %capital_name alla käyttämällä "
+"vetokäyttöliittymää ja ryhmitellä termejä ylätason alle liu'uttamalla ne "
+"isäntätermin alle ja oikealle."
 
 msgid ""
 "%capital_name contains terms grouped under parent terms. You can reorganize "
 "the terms in %capital_name using their drag-and-drop handles."
 msgstr ""
+"%capital_name sisältää termit jotka on ryhmitelty isäntätermin alle. Voit "
+"järjestellä niitä uudelleen käyttäen vedä-pudota toimintoa."
 
 msgid "Administer vocabularies and terms"
-msgstr ""
+msgstr "Ylläpidä luokitteluja ja sanastoja"
 
 msgid "Tracking new and updated site content"
-msgstr ""
+msgstr "Uuden ja päivitetyn sisällön jäljittäminen"
 
 msgid "Tracking user-specific content"
-msgstr ""
+msgstr "Käyttäjäkohtaisen sisällön jäljittäminen"
 
 msgid "My recent content"
-msgstr ""
+msgstr "Oma viimeisin sisältöni"
 
 msgid "Translating content"
-msgstr ""
+msgstr "Sisällön kääntäminen"
 
 msgid "Installing updates"
-msgstr ""
+msgstr "Asennetaan päivityksiä"
 
 msgid "Preparing to update your site"
-msgstr ""
+msgstr "Valmistellaan sivuston päivitystä"
 
 msgid "Installing %project"
-msgstr ""
+msgstr "Asennetaan %project"
 
 msgid "Preparing to install"
-msgstr ""
+msgstr "Aloitetaan asennusta"
 
 msgid "Error installing / updating"
-msgstr ""
+msgstr "Virhe asennuksessa / päivityksessä"
 
 msgid "Installed %project_name successfully"
-msgstr ""
+msgstr "Projekti %project_name asennettu onnistuneesti"
 
 msgid ""
 "Update was completed successfully. Your site has been taken out of "
 "maintenance mode."
-msgstr ""
+msgstr "Päivitys suoritettu. Sivusto on otettu pois huoltotilasta."
 
 msgid "Update was completed successfully."
-msgstr ""
+msgstr "Päivitys suoritettu onnistuneesti."
 
 msgid "Update failed! See the log below for more information."
-msgstr ""
+msgstr "Päivitys epäonnistui! Lisätietoa saat allaolevista logitiedoista."
 
 msgid ""
 "Update failed! See the log below for more information. Your site is still in"
 " maintenance mode."
 msgstr ""
+"Päivitys epäonnistui! Lisätietoa saat alla olevasta lokitiedostosta. Sivusto"
+" on edelleen huoltotilassa."
 
 msgid ""
 "Installation was completed successfully. Your site has been taken out of "
 "maintenance mode."
-msgstr ""
+msgstr "Asennus onnistui. Sivusto on otettu pois huoltotilasta."
 
 msgid "Installation was completed successfully."
-msgstr ""
+msgstr "Asennus suoritettu onnistuneesti."
 
 msgid "Installation failed! See the log below for more information."
-msgstr ""
+msgstr "Asennus epäonnistui! Lisätietoa saat allaolevista logitiedoista."
 
 msgid ""
 "Installation failed! See the log below for more information. Your site is "
 "still in maintenance mode."
 msgstr ""
+"Asennus epäonnistui! Lisätietoa saat allaolevasta lokitiedostosta. Sivusto "
+"on edelleen huoltotilassa."
 
 msgid "No available update data"
-msgstr ""
+msgstr "Päivitystietoja ei ole saatavilla"
 
 msgid "Checking available update data"
-msgstr ""
+msgstr "Tarkistetaan päivitystiedot"
 
 msgid "Trying to check available update data ..."
-msgstr ""
+msgstr "Haetaan päivitystietoja..."
 
 msgid "Error checking available update data."
-msgstr ""
+msgstr "Päivitystietojen tarkistaminen epäonnistui."
 
 msgid "Checking available update data ..."
-msgstr ""
+msgstr "Haetaan päivitystietoja..."
 
 msgid "Checked available update data for %title."
-msgstr ""
+msgstr "Tarkistettiin päivitystiedot projektille %title."
 
 msgid "Failed to check available update data for %title."
-msgstr ""
+msgstr "Päivitystietojen tarkistaminen %title epäonnistui."
 
 msgid "An error occurred trying to get available update data."
-msgstr ""
+msgstr "Virhe haettaessa päivitystietoja."
 
 msgid "Checked available update data for one project."
 msgid_plural "Checked available update data for @count projects."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Tarkistettiin yhden moduulin päivitystiedot."
+msgstr[1] "Tarkistettiin @count moduulin päivitystiedot."
 
 msgid "Failed to get available update data for one project."
 msgid_plural "Failed to get available update data for @count projects."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Päivitystietojen hakeminen yhdelle projektille epäonnistui."
+msgstr[1] "Päivitystietojen hakeminen @count projektille epäonnistui."
 
 msgid "There was a problem getting update information. Try again later."
-msgstr ""
+msgstr "Päivitystietojen haku epäonnistui. Yritä myöhemmin uudelleen."
 
 msgid "(Theme)"
-msgstr ""
+msgstr "(Teema)"
 
 msgid "(Security update)"
-msgstr ""
+msgstr "(Turvallisuuspäivitys)"
 
 msgid "(Unsupported)"
-msgstr ""
+msgstr "(Ei tuettu)"
 
 msgid "All of your projects are up to date."
-msgstr ""
+msgstr "Sivusto on ajantasalla ja eikä vaadi päivitystä."
 
 msgid "Download these updates"
-msgstr ""
+msgstr "Lataa päivitykset"
 
 msgid "Manual updates required"
-msgstr ""
+msgstr "Käsin päivitettävät"
 
 msgid "You must select at least one project to update."
-msgstr ""
+msgstr "Sinun on valittava vähintään yksi päivitettävä projekti."
 
 msgid "Downloading updates"
-msgstr ""
+msgstr "Ladataan päivityksiä"
 
 msgid "Preparing to download selected updates"
-msgstr ""
+msgstr "Valmistaudutaan lataamaan päivityksiä"
 
 msgid "Downloading updates failed:"
-msgstr ""
+msgstr "Päivitysten lataaminen epäonnistui:"
 
 msgid "Updates downloaded successfully."
-msgstr ""
+msgstr "Päivitykset ladattu onnistuneesti."
 
 msgid "Fatal error trying to download."
-msgstr ""
+msgstr "Kriittinen  virhe ladattaessa."
 
 msgid "Perform updates with site in maintenance mode (strongly recommended)"
-msgstr ""
+msgstr "Suorita päivitykset sivuston ollessa huoltotilassa (suositellaan)"
 
 msgid "Install from a URL"
-msgstr ""
+msgstr "Asenna URL-osoitteesta"
 
 msgid "For example: %url"
-msgstr ""
+msgstr "Esimerkiksi: %url"
 
 msgid "Upload a module or theme archive to install"
-msgstr ""
+msgstr "Lataa moduuli tai teema joka asennetaan"
 
 msgid "For example: %filename from your local computer"
-msgstr ""
+msgstr "Esimerkiksi: %filename paikallisella tietokoneellasi"
 
 msgid "You must either provide a URL or upload an archive file to install."
 msgstr ""
+"Sinun täytyy tarjota joko osoite tai ladata asennuksen sisältävä "
+"arkistotiedosto."
 
 msgid "Unable to retrieve Drupal project from %url."
-msgstr ""
+msgstr "Drupal projektin haku osoitteesta %url epäonnistui."
 
 msgid "Provided archive contains no files."
-msgstr ""
+msgstr "Tarjottu arkistotiedosto ei sisällä tiedostoja."
 
 msgid "Unable to determine %project name."
-msgstr ""
+msgstr "%project nimen määritys ei onnistunut."
 
 msgid "%project is already installed."
-msgstr ""
+msgstr "%project on jo asennettu."
 
 msgid "Cannot extract %file, not a valid archive."
 msgstr ""
+"Tiedoston %file purkaminen epäonnistui, tiedosto ei ole sallittua muotoa"
 
 msgid "Downloading %project"
-msgstr ""
+msgstr "Ladataan %project"
 
 msgid "Failed to download %project from %url"
-msgstr ""
+msgstr "%project lataus osoitteesta %url epäonnistui"
 
 msgid "Includes:"
-msgstr ""
+msgstr "Sisältää:"
 
 msgid "Enabled: %includes"
-msgstr ""
+msgstr "Käytössä: %includes"
 
 msgid "Disabled: %disabled"
-msgstr ""
+msgstr "Poissa käytöstä: %disabled"
 
 msgid "Checking for available updates"
-msgstr ""
+msgstr "Uusien päivitysten haku"
 
 msgid ""
 "You can automatically install your missing updates using the Update manager:"
 msgstr ""
+"Voit asentaa puutuvat päivityksesi automaattisesti Päivitystyökalun avulla."
 
 msgid ""
 "The installed version of at least one of your modules or themes is no longer"
 " supported. Upgrading or disabling is strongly recommended. See the project "
 "homepage for more details."
 msgstr ""
+"Yhtä tai useampaa asentamaasi moduulin tai teeman versiota ei enää tueta. "
+"Suosittelemme päivittämään tai poistamaan moduulin käytöstä. Katso "
+"lisätietoja moduulin kotisivulta."
 
 msgid "Ready to update"
-msgstr ""
+msgstr "Valmiina päivittämään"
 
 msgid "Update manager"
-msgstr ""
+msgstr "Päivitystenhallinta"
 
 msgid ""
 "This role will be automatically assigned new permissions whenever a module "
 "is enabled. Changing this setting will not affect existing permissions."
 msgstr ""
+"Tälle roolille annetaan automaattisesti uudet oikeudet kun jokin moduuli "
+"otetaan käyttöön. Tämän asetuksen muuttaminen ei vaikuta olemassaoleviin "
+"oikeuksiin."
 
 msgid "Registration and cancellation"
-msgstr ""
+msgstr "Rekisteröinti ja peruutus"
 
 msgid "Maintenance mode"
-msgstr ""
+msgstr "Huoltotila"
 
 msgid "No people available."
-msgstr ""
+msgstr "No people available."
 
 msgid "Logging and errors"
-msgstr ""
+msgstr "Loggaus ja virheet"
 
 msgid "Regional and language"
-msgstr ""
+msgstr "Alue ja kieli"
 
 msgid "Search and metadata"
-msgstr ""
+msgstr "Haku ja metadata"
 
 msgid "Content authoring"
-msgstr ""
+msgstr "Sisällön luonti"
 
 msgid "more information"
-msgstr ""
+msgstr "lisää tietoa"
 
 msgid "Failed to get available update data."
-msgstr ""
+msgstr "Päivitystietojen lataus epäonnistui."
 
 msgid "Enables tracking of recent content for users."
-msgstr ""
+msgstr "Mahdollistaa sisällön jäljittämisen käyttäjille."
 
 msgid ""
 "Checks for available updates, and can securely install or update modules and"
 " themes via a web interface."
 msgstr ""
+"Tarkistaa päivitykset ja kykenee asentamaan tai päivittämään moduuleja ja "
+"teemoja turvallisesti web-käyttöliittymän kautta."
 
 msgid "Who can register accounts?"
-msgstr ""
+msgstr "Kuka voi rekisteröidä käyttäjätilejä?"
 
 msgid "Administrators only"
-msgstr ""
+msgstr "Vain ylläpitäjät"
 
 msgid "Visitors, but administrator approval is required"
-msgstr ""
+msgstr "Vierailijat mutta ylläpitäjän hyväksyntä vaaditaan"
 
 msgid "When cancelling a user account"
-msgstr ""
+msgstr "Kun käyttäjätunnus peruutetaan"
 
 msgid "Select method for cancelling account"
-msgstr ""
+msgstr "Valitse tunnuksen sulkemistapa"
 
 msgid "Administer users"
-msgstr ""
+msgstr "Hallitse käyttäjiä"
 
 msgid "Welcome (new user created by administrator)"
-msgstr ""
+msgstr "Tervetuloa (uusi ylläpidon luoma käyttäjä)"
 
 msgid "Welcome (awaiting approval)"
-msgstr ""
+msgstr "Tervetuloa (odottaa hyväksyntää)"
 
 msgid "Welcome (no approval required)"
-msgstr ""
+msgstr "Tervetuloa (erillistä hyväksyntää ei vaadita)"
 
 msgid "Password recovery"
-msgstr ""
+msgstr "Salasanan palautus"
 
 msgid "Account activation"
-msgstr ""
+msgstr "Tilin aktivointi"
 
 msgid "Account cancellation confirmation"
-msgstr ""
+msgstr "Tilin sulkemisen vahvistaminen"
 
 msgid "Account canceled"
-msgstr ""
+msgstr "Tili suljettu"
 
 msgid "The one-time login link you clicked is invalid."
-msgstr ""
+msgstr "Käyttämääsi linkkiä ei löydy."
 
 msgid ""
 "You have just used your one-time login link. It is no longer necessary to "
@@ -10148,86 +10704,95 @@ msgstr ""
 "alla olevan lomakkeen avulla. "
 
 msgid "When cancelling your account"
-msgstr ""
+msgstr "Peruuttaessasi käyttäjätilisi"
 
 msgid "When cancelling the account"
-msgstr ""
+msgstr "Käyttäjätiliä peruutettaessa"
 
 msgid "Are you sure you want to cancel your account?"
-msgstr ""
+msgstr "Oletko varma että haluat peruuttaa käyttäjätilisi?"
 
 msgid "Are you sure you want to cancel the account %name?"
-msgstr ""
+msgstr "Oletko varma että haluat peruuttaa käyttäjän %name?"
 
 msgid "Select the method to cancel the account above."
-msgstr ""
+msgstr "Valitse käyttäjätilin peruutustapa."
 
 msgid ""
 "Your account will be blocked and you will no longer be able to log in. All "
 "of your content will be hidden from everyone but administrators."
 msgstr ""
+"Tilisi lukitaan etkä pysty kirjautumaan sisään. Kaikki luomasi sisältö "
+"piilotetaan muilta käyttäjiltä paitsi ylläpitäjiltä."
 
 msgid ""
 "Your account will be removed and all account information deleted. All of "
 "your content will be assigned to the %anonymous-name user."
 msgstr ""
+"Käyttäjätilisi ja kaikki siihen liittyvät tiedot poistetaan. Kaikki "
+"kirjoittamasi sisältö merkitään %anonymous käyttäjän kirjoittamaksi."
 
 msgid ""
 "Your account will be removed and all account information deleted. All of "
 "your content will also be deleted."
 msgstr ""
+"Käyttäjätilisi ja kaikki tietosi poistetaan. Myöskin luomasi sisältö "
+"poistetaan."
 
 msgid ""
 "You have tried to use an account cancellation link that has expired. Please "
 "request a new one using the form below."
 msgstr ""
+"Yritit käyttää vanhentunutta käyttäjätilin peruutuslinkkiä. Ole hyvä ja "
+"pyydä uusi allaolevalla kaavakkeella."
 
 msgid "Sent account cancellation request to %name %email."
-msgstr ""
+msgstr "Lähetetty käyttäjätilin peruutuspyyntö osoitteeseen %name %email."
 
 msgid "Tokens related to individual user accounts."
-msgstr ""
+msgstr "Yksittäisiin käyttäjätileihin liittyvät tokenit."
 
 msgid "Tokens related to the currently logged in user."
-msgstr ""
+msgstr "Tällä hetkellä kirjautuneena olevaan käyttäjään liittyvät tokenit."
 
 msgid "Creating and managing users"
-msgstr ""
+msgstr "Käyttäjien ylläpito ja luonti"
 
 msgid ""
 "This form lets administrators configure how fields should be displayed when "
 "rendering a user profile page."
 msgstr ""
+"Tässä näkymässä valitset miten käyttäjäprofiili-sivulla kentät esitetään."
 
 msgid "Administer permissions"
-msgstr ""
+msgstr "Ylläpidä oikeuksia"
 
 msgid "Change own username"
-msgstr ""
+msgstr "Muuta omaa käyttäjänimeä"
 
 msgid "Cancel own user account"
-msgstr ""
+msgstr "Peru oma käyttötilisi"
 
 msgid "Cancelling account"
-msgstr ""
+msgstr "Käyttäjätilin peruuttaminen"
 
 msgid "Cancelling user account"
-msgstr ""
+msgstr "Käyttäjätilin peruutus"
 
 msgid "%name has been disabled."
-msgstr ""
+msgstr "%name on poistettu käytöstä."
 
 msgid "Cancel the selected user accounts"
-msgstr ""
+msgstr "Peruuta valitut käyttäjätilit"
 
 msgid "When cancelling these accounts"
-msgstr ""
+msgstr "Peruutettaessa näitä käyttäjätilejä"
 
 msgid "Are you sure you want to cancel these user accounts?"
-msgstr ""
+msgstr "Oletko varma että haluat peruuttaa nämä käyttäjätilit?"
 
 msgid "Cancel accounts"
-msgstr ""
+msgstr "Peruuta käyttäjätilejä"
 
 msgid "Add lowercase letters"
 msgstr "Lisää pieniä kirjaimia"
@@ -10242,7 +10807,7 @@ msgid "Add punctuation"
 msgstr "Lisää erikoismerkkejä"
 
 msgid "Make it different from your username"
-msgstr ""
+msgstr "Tee siitä eri kuin käyttäjänimesi"
 
 msgid "Weak"
 msgstr "Heikko"
@@ -10251,103 +10816,109 @@ msgid "Fair"
 msgstr "Keskiverto"
 
 msgid "Blocked user: %name %email."
-msgstr ""
+msgstr "Estetty käyttäjä: %name %email."
 
 msgid "Confirm account cancellation"
-msgstr ""
+msgstr "Vahvista käyttäjätilin peruutus."
 
 msgid "Minimal"
-msgstr ""
+msgstr "Minimaalinen"
 
 msgid "Install with commonly used features pre-configured."
-msgstr ""
+msgstr "Asenna useimmiten käytetyillä perusasetuksilla."
 
 msgid "Flood control"
-msgstr ""
+msgstr "Tulvan ehkäisy"
 
 msgid "Exposed"
-msgstr ""
+msgstr "Näytetään käyttäjille"
 
 msgid "Remove this display"
-msgstr ""
+msgstr "Poista sivu"
 
 msgid "Operator to use on all groups"
-msgstr ""
+msgstr "Kaikkiin ryhmiin käytettävä operaattori"
 
 msgid ""
 "Either \"group 0 AND group 1 AND group 2\" or \"group 0 OR group 1 OR group "
 "2\", etc"
 msgstr ""
+"Joko \"group 0 AND group 1 AND group 2\" tai \"group 0 OR group 1 OR group "
+"2\", jne"
 
 msgid "Remove group @group"
-msgstr ""
+msgstr "Poista ryhmä @group"
 
 msgid "Default group"
-msgstr ""
+msgstr "Oletusryhmä"
 
 msgid "Group @group"
-msgstr ""
+msgstr "Ryhmä @group"
 
 msgid "Ungroupable filters"
-msgstr ""
+msgstr "Ryhmittelykelvottomat suodattimet"
 
 msgid "Basic exposed form"
-msgstr ""
+msgstr "Yksinkertainen näytetty kaavake"
 
 msgid "Input required"
-msgstr ""
+msgstr "Pakollinen syöte"
 
 msgid ""
 "An exposed form that only renders a view if the form contains user input."
 msgstr ""
+"Käyttäjälle näytetty kaavake joka renderöi näkymän vain jos kaavake sisältää"
+" käyttäjäsyötettä."
 
 msgid "Display all items"
-msgstr ""
+msgstr "Näytä kaikki tulokset"
 
 msgid "Display a specified number of items"
-msgstr ""
+msgstr "Näytä tietty määrä tuloksia"
 
 msgid "Display a limited number items that this view might find."
-msgstr ""
+msgstr "Näytä rajoitettu määrä näkymän tuloksia."
 
 msgid "Paged output, full pager"
-msgstr ""
+msgstr "Sivutettu tulostus, täysi sivutus"
 
 msgid "Paged output, full Drupal style"
-msgstr ""
+msgstr "Sivutettu tulostus, täysi Drupal tyyli"
 
 msgid "Paged output, mini pager"
-msgstr ""
+msgstr "Sivutettu tulostus, minisivutus"
 
 msgid "Name (raw)"
-msgstr ""
+msgstr "Nimi (raakamuodossa)"
 
 msgid "Provide markup text for the area."
-msgstr ""
+msgstr "Tarjoa markup-tekstiä tekstialueelle."
 
 msgid "Machine Name"
-msgstr ""
+msgstr "Koneluettava nimi"
 
 msgid "Change the machine name of this display."
-msgstr ""
+msgstr "Muuta näyttöruudun koneluettava nimi."
 
 msgid "Change settings for this pager type."
-msgstr ""
+msgstr "Muuta sivutustyypin asetuksia."
 
 msgid "Allow grouping and aggregation (calculation) of fields."
-msgstr ""
+msgstr "Mahdollista kenttien ryhmittely ja aggregointi (laskenta)."
 
 msgid "Exposed form style"
-msgstr ""
+msgstr "Näytetyn lomakkeen tyyli"
 
 msgid "Select the kind of exposed filter to use."
-msgstr ""
+msgstr "Valitse käyttäjille näytettävän suodattimen tyyppi."
 
 msgid "Exposed form settings for this exposed form style."
 msgstr ""
+"Käyttäjille näytetyn kaavakkeen asetukset tälle käyttäjille näytetyn "
+"kaavakkeen tyylille."
 
 msgid "The machine name of this display"
-msgstr ""
+msgstr "Näkymän koneluettava nimi"
 
 msgid ""
 "If enabled, some fields may become unavailable. All fields that are selected"
@@ -10356,113 +10927,118 @@ msgid ""
 "them. For example, you can group nodes on title and count the number of nids"
 " in order to get a list of duplicate titles."
 msgstr ""
+"Mikäli valittuna, jotkut kentät eivät ole käytettävissä. Kaikki valitut "
+"kentät ryhmitellään niin että ainoastaan yksilöidyt arvot näytetään. Muut "
+"keräymää varten määritellyt kentät käyvät läpi saman funktion. Esimerkiksi "
+"voit ryhmitellä solmut otsikoiden mukaan ja laskea nidien (solmu idt) määrä "
+"saadaksesi listan useammin kuin kerran esiintyvistä otsikoista."
 
 msgid "Exposed Form"
-msgstr ""
+msgstr "Avoimet kaavakkeet"
 
 msgid "Exposed form options"
-msgstr ""
+msgstr "Avointen kaavakkeiden asetukset"
 
 msgid "Pager options"
-msgstr ""
+msgstr "Sivutusasetukset"
 
 msgid "Display id should be unique."
-msgstr ""
+msgstr "Näyttöruudun ID:n on oltava yksilöllinen."
 
 msgid "Include reset button"
-msgstr ""
+msgstr "Lisää palautusnappi"
 
 msgid "Reset button label"
-msgstr ""
+msgstr "Palautusnapin etiketti"
 
 msgid "Text to display in the reset button of the exposed form."
-msgstr ""
+msgstr "Palauta-napissa näytettävä teksti."
 
 msgid "Exposed sorts label"
-msgstr ""
+msgstr "Käyttäjille näytettyjen lajitteluiden etiketti"
 
 msgid "Select any filter and click on Apply to see results"
-msgstr ""
+msgstr "Valitse mikä tahansa suodatin ja klikkaa Suorita nähdäksesi tulokset"
 
 msgid "Image style"
-msgstr ""
+msgstr "Kuvan tyyli"
 
 msgid "Use tags to group articles on similar topics into categories."
-msgstr ""
+msgstr "Use tags to group articles on similar topics into categories."
 
 msgid "An administrator created an account for you at [site:name]"
-msgstr ""
+msgstr "An administrator created an account for you at [site:name]"
 
 msgid "Find and manage people interacting with your site."
-msgstr ""
+msgstr "Find and manage people interacting with your site."
 
 msgid "Entity ID"
-msgstr ""
+msgstr "Entiteetin ID"
 
 msgid "Contact forms"
-msgstr ""
+msgstr "Yhteydenottolomakkeet"
 
 msgid "Text on demand"
-msgstr ""
+msgstr "Tekstiä pyynnöstä"
 
 msgid "Exposed options"
-msgstr ""
+msgstr "Käyttäjille näytettävät vaihtoehdot"
 
 msgid "Items per page label"
-msgstr ""
+msgstr "\"Tulosta sivua kohti\" -etiketti"
 
 msgid "Exposed items per page options"
-msgstr ""
+msgstr "Sivukohtaisten käyttäjille näytettävien vaihtoehtojen asetukset"
 
 msgid "Expose Offset"
-msgstr ""
+msgstr "Näytä offset käyttäjille"
 
 msgid "Offset label"
-msgstr ""
+msgstr "Offsetin etiketti"
 
 msgid "Mini pager, @count item, skip @skip"
 msgid_plural "Mini pager, @count items, skip @skip"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Pieni sivutus, @count tulos, ohita @skip"
+msgstr[1] "Pieni sivutus, @count tulosta, ohita @skip"
 
 msgid "Mini pager, @count item"
 msgid_plural "Mini pager, @count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Pieni sivutus, @count tulos"
+msgstr[1] "Pieni sivutus, @count tulosta"
 
 msgid "All items, skip @skip"
-msgstr ""
+msgstr "Kaikki itemit, ohita @skip"
 
 msgid "All items"
-msgstr ""
+msgstr "Kaikki itemit"
 
 msgid "@count item, skip @skip"
 msgid_plural "@count items, skip @skip"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count tulos, ohita @skip"
+msgstr[1] "@count tulosta, ohita @skip"
 
 msgid "@count item"
 msgid_plural "@count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count tulos"
+msgstr[1] "@count tulosta"
 
 msgid "Group results together"
-msgstr ""
+msgstr "Ryhmitä tulokset"
 
 msgid "Unlock"
-msgstr ""
+msgstr "Avaa lukitus"
 
 msgid "Bundle ID"
-msgstr ""
+msgstr "Paketin ID"
 
 msgid "Add custom block"
-msgstr ""
+msgstr "Lisää kustomoitu lohko"
 
 msgid "Internet"
-msgstr ""
+msgstr "Internet"
 
 msgid "Alt"
-msgstr ""
+msgstr "Alt"
 
 msgid ""
 "1 pending update (@number_applied to be applied, @number_incompatible "
@@ -10471,21 +11047,27 @@ msgid_plural ""
 "@count pending updates (@number_applied to be applied, @number_incompatible "
 "skipped)"
 msgstr[0] ""
+"1 uusi päivitys (@number_applied soveltuvaa, @number_incompatible "
+"ohitettiin)"
 msgstr[1] ""
+"@count uutta päivitystä (@number_applied soveltuvaa, @number_incompatible "
+"ohitettiin)"
 
 msgid "Author textfield"
-msgstr ""
+msgstr "\"Kommentin jättäjän nimi\"-tekstikenttä"
 
 msgid "Error messages to display"
-msgstr ""
+msgstr "Näytettävät virheviestit"
 
 msgid ""
 "It is recommended that sites running on production environments do not "
 "display any errors."
 msgstr ""
+"On suositeltavaa että tuotantokäytössä olevat sivustot eivät näytä "
+"virheilmoituksia."
 
 msgid "Cannot open %file_path"
-msgstr ""
+msgstr "Tiedostopolun %file_path avaaminen epäonnistui"
 
 msgid "Current password"
 msgstr "Nykyinen salasanasi"
@@ -10497,93 +11079,98 @@ msgstr ""
 "Nykyinen salasanasi puuttuu tai on virheellinen; sinun täytyy vaihtaa %name."
 
 msgid "Terminology"
-msgstr ""
+msgstr "Sanasto"
 
 msgid "Last login timestamp"
-msgstr ""
+msgstr "Viimeisimmän kirjautumisen aikaleima"
 
 msgid "Forum settings"
-msgstr ""
+msgstr "Foorum-asetukset"
 
 msgid "Maximize"
-msgstr ""
+msgstr "Maksimoi"
 
 msgid "Update preview"
-msgstr ""
+msgstr "Päivitä esikatselu"
 
 msgid "No media available."
-msgstr ""
+msgstr "Ei mediaa saatavilla."
 
 msgid "Administer media"
-msgstr ""
+msgstr "Ylläpidä mediaa"
 
 msgid "View media"
-msgstr ""
+msgstr "Näytä media"
 
 msgid "Remove block"
-msgstr ""
+msgstr "Poista lohko"
 
 msgid "all languages"
-msgstr ""
+msgstr "kaikki kielet"
 
 msgid "%module module installed."
-msgstr ""
+msgstr "Moduuli %module on asennettu."
 
 msgid "@node_type comment"
-msgstr ""
+msgstr "@node_type kommentti"
 
 msgid "Administer text formats and filters"
-msgstr ""
+msgstr "Ylläpidä tekstimuotoja ja suodattimia"
 
 msgid "@type language detection"
-msgstr ""
+msgstr "@type kielen tunnistaminen"
 
 msgid "Use the detected interface language."
-msgstr ""
+msgstr "Käytä automaattisesti löydettyä käyttöliittymän kieltä"
 
 msgid ""
 "The new set is created by copying items from your default shortcut set."
-msgstr ""
+msgstr "Uusi ryhmä luodaan kopioimalla oletus-oikopolkuryhmä."
 
 msgid "The new set is created by copying items from the %default set."
-msgstr ""
+msgstr "Uusi ryhmä luodaan kopioimalla ryhmä %default."
 
 msgid "You are currently using the %set-name shortcut set."
-msgstr ""
+msgstr "Käytät tällä hetkellä oikopolkuryhmää %set-name."
 
 msgid "Create new set"
-msgstr ""
+msgstr "Luo uusi ryhmä"
 
 msgid ""
 "The %set_name shortcut set has been created. You can edit it from this page."
-msgstr ""
+msgstr "Oikopolkuryhmä %set_name on luotu. Voit muokata sitä tältä sivulta."
 
 msgid "Updated set name to %set-name."
-msgstr ""
+msgstr "Ryhmän nimeksi päivitettiin %set-name."
 
 msgid ""
 "If you have chosen this shortcut set as the default for some or all users, "
 "they may also be affected by deleting it."
 msgstr ""
+"Jos olet valinnut tämän oikopolkuryhmän oletukseksi joillekin tai kaikille "
+"käyttäjille, ryhmän poistaminen saattaa vaikuttaa myöskin heidän "
+"käyttäjätileihinsä."
 
 msgid "1 user has chosen or been assigned to this shortcut set."
 msgid_plural "@count users have chosen or been assigned to this shortcut set."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 käyttäjä on valinnut käyttävänsä tätä oikopolkusarjaa."
+msgstr[1] "@count käyttäjää on valinnut käyttävänsä tätä oikopolkusarjaa."
 
 msgid "Administering shortcuts"
-msgstr ""
+msgstr "Oikopolkuryhmien ylläpito"
 
 msgid "Choosing shortcut sets"
-msgstr ""
+msgstr "Oikopolkuryhmien valitseminen"
 
 msgid ""
 "Users with permission to switch shortcut sets can choose a shortcut set to "
 "use from the Shortcuts tab of their user account page."
 msgstr ""
+"Käyttäjät, joilla on oikeudet vaihtaa oikopolkuryhmäänsä, voivat valita "
+"ryhmän Oikopolut-välilehdeltä käyttäjäprofiilissaan."
 
 msgid "Edit current shortcut set"
-msgstr ""
+msgstr "Muokkaa nykyistä oikopolkuryhmää"
 
 msgid ""
 "Editing the current shortcut set will affect other users if that set has "
@@ -10591,323 +11178,352 @@ msgid ""
 "set\" permission along with this permission will grant permission to edit "
 "any shortcut set."
 msgstr ""
+"Oikopolkuryhmien muokkaaminen vaikuttaa toisiin käyttäjiin, mikäli se on "
+"määritelty heille käyttöön. Oikeuden \"Valitse mikä tahansa oikopolkuryhmä\""
+" myöntäminen yhdessä tämän oikeuden kanssa antaa oikeudet muokata mitä "
+"tahansa oikopolkuryhmää."
 
 msgid "Select any shortcut set"
-msgstr ""
+msgstr "Valitse mikä tahansa oikopolkuryhmä"
 
 msgid ""
 "From all shortcut sets, select one to be own active set. Without this "
 "permission, an administrator selects shortcut sets for users."
 msgstr ""
+"Valitse oma käytössä oleva oikopolkuryhmä. Mikäli tätä oikeutta ei ole "
+"määritelty, ainoastaan ylläpitäjä voi valita oikopolkuryhmät käyttäjille."
 
 msgid "Add shortcut set"
-msgstr ""
+msgstr "Lisää oikopolkuryhmä"
 
 msgid "Edit set name"
-msgstr ""
+msgstr "Muokkaa sarjan nimeä"
 
 msgid "Delete shortcut set"
-msgstr ""
+msgstr "Poista oikopolkusarja"
 
 msgid "@remote could not be saved to @path."
-msgstr ""
+msgstr "@remote ei voitu tallentaa polkuun @path."
 
 msgid "Database support"
-msgstr ""
+msgstr "Tietokantatuki"
 
 msgid "Cache type"
-msgstr ""
+msgstr "Välimuistin tyyppi"
 
 msgid "Is not empty (NOT NULL)"
-msgstr ""
+msgstr "Ei ole tyhjä (NOT NULL)"
 
 msgid ""
 "Display %display has set node/% as path. This will not produce what you "
 "want. If you want to have multiple versions of the node view, use panels."
 msgstr ""
+"Näyttöruutu on asettanut poluksi node/%. Tämä ei välttämättä tuota haluttuja"
+" tuloksia. Jos sinulla on useampi kuin yksi versio solmunäkymästä, on "
+"suositeltavaa käyttää paneeleita."
 
 msgid "Use absolute link (begins with \"http://\")"
-msgstr ""
+msgstr "Käytä absoluuttista polkua (alkaa \"http://\")"
 
 msgid "Output machine name"
-msgstr ""
+msgstr "Näytä koneluettava nimi"
 
 msgid "Change the CSS class name(s) that will be added to this display."
-msgstr ""
+msgstr "Muuta näytettävien CSS luokkien nimeä/nimiä."
 
 msgid "CSS classes must be alphanumeric or dashes only."
-msgstr ""
+msgstr "CSS luokkien on oltava alphanumeerisia tai vain heittopilkkuja"
 
 msgid ""
 "Set between which values the user can choose when determining the items per "
 "page. Separated by comma."
 msgstr ""
+"Valitse arvot sen mukaan kuinka monta osumaa haluat käyttäjien voivan "
+"näyttää sivua kohden. Erottele luvut pilkuilla."
 
 msgid "Update @name"
-msgstr ""
+msgstr "Päivitä @name"
 
 msgid "Link field"
-msgstr ""
+msgstr "Linkkikenttä"
 
 msgid "Attachment before"
-msgstr ""
+msgstr "Liite ennen"
 
 msgid "Attachment after"
-msgstr ""
+msgstr "Liite jälkeen"
 
 msgid "Feed icon"
-msgstr ""
+msgstr "Syötekuvake"
 
 msgid "Cache configuration"
-msgstr ""
+msgstr "Välimuistin asetukset"
 
 msgid "Editing"
-msgstr ""
+msgstr "Muokkaaminen"
 
 msgid "The date the comment was most recently updated."
-msgstr ""
+msgstr "Päivämäärä jolloin kommenttia viimeksi muokattiin."
 
 msgid "Comment posted: %subject."
-msgstr ""
+msgstr "Kommentti lähetetty: %subject."
 
 msgid ""
 "This field has been disabled because you do not have sufficient permissions "
 "to edit it."
 msgstr ""
+"Kenttä on pois käytöstä koska käyttöoikeutesi eivät oikeuta muokkaamaan sen "
+"sisältöä."
 
 msgid ""
 "View, edit and delete all content regardless of permission restrictions."
 msgstr ""
+"Näytä, muokkaa ja poista sisältöä riippumatta käyttöoikeusrajoituksista."
 
 msgid "Syslog format"
-msgstr ""
+msgstr "Järjestelmälogin muoto"
 
 msgid "A date in 'time-since' format. (%date)"
-msgstr ""
+msgstr "Päivämäärä muodossa 'aikaa sitten'. (%date)"
 
 msgid "The location of the file relative to Drupal root."
-msgstr ""
+msgstr "Tiedoston sijainti suhteessa Drupalin juureen"
 
 msgid "Your modules have been downloaded and updated."
-msgstr ""
+msgstr "Moduulipäivitykset ladattu ja moduulit päivitetty onnistuneesti."
 
 msgid ""
 "The selected file %filename cannot be uploaded. Only files with the "
 "following extensions are allowed: %extensions."
 msgstr ""
+"Tiedostoa %filename ei voida ladata. Sallitut tiedostopäätteet: %extensions."
 
 msgid "Bartik"
-msgstr ""
+msgstr "Bartik"
 
 msgid "Highlighted"
-msgstr ""
+msgstr "Korostettu"
 
 msgid "Main background"
-msgstr ""
+msgstr "Pää-taustaväri/kuva"
 
 msgid "Sidebar background"
-msgstr ""
+msgstr "Sivupalkin tausta"
 
 msgid "Current page"
 msgstr "Nykyinen sivu"
 
 msgid "Configure user accounts."
-msgstr ""
+msgstr "Säädä käyttäjätilejä."
 
 msgid "Add and modify shortcut sets."
-msgstr ""
+msgstr "Lisää ja muokkaa oikopolkuryhmiä."
 
 msgid "Overview of fields on all entity types."
-msgstr ""
+msgstr "Lista kentistä kaikissa entiteettityypeissä."
 
 msgid "GD library PNG support"
-msgstr ""
+msgstr "GD-kirjaston PNG-tuki"
 
 msgid "Translation update status"
-msgstr ""
+msgstr "Käännösten päivitystilanne"
 
 msgid "Filter modules"
-msgstr ""
+msgstr "Suodata moduuleja"
 
 msgid "Field API to add fields to entities like nodes and users."
-msgstr ""
+msgstr "Field API lisää kenttiä entiteetteihin kuten solmut tai käyttäjät."
 
 msgid "Collapse"
-msgstr ""
+msgstr "Pienennä"
 
 msgid "Sidebar borders"
-msgstr ""
+msgstr "Sivupalkin reunat"
 
 msgid "Footer background"
-msgstr ""
+msgstr "Alatunnisteen tausta"
 
 msgid "Plum"
-msgstr ""
+msgstr "Luumu"
 
 msgid "Site logo"
-msgstr ""
+msgstr "Sivuston logo"
 
 msgid "Title link"
-msgstr ""
+msgstr "Otsikkolinkki"
 
 msgid ""
 "A space-separated list of HTML tags allowed in the content of feed items. "
 "Disallowed tags are stripped from the content."
 msgstr ""
+"Välilyönnein eroteltu lista syötteissä sallituista HTML-tageista. Kaikki "
+"kielletyt tagit poistetaan."
 
 msgid "%field cannot contain any markup."
-msgstr ""
+msgstr "Kenttä %field ei voi sisältää markuppia."
 
 msgid ""
 "These options control the display settings for the %name theme. When your "
 "site is displayed using this theme, these settings will be used."
 msgstr ""
+"Nämä asetukset säätävät teeman %name näyttöasetuksia. Näitä asetuksia "
+"käytetään aina, kun sivustoa katsellaan tällä teemalla."
 
 msgid "Administer software updates"
-msgstr ""
+msgstr "Ylläpidä ohjelmistopäivityksiä"
 
 msgid "@required_name (Missing)"
-msgstr ""
+msgstr "@required_name (Puuttuva)"
 
 msgid "@required_name (Version @compatibility required)"
-msgstr ""
+msgstr "@required_name (Versio @compatibility vaaditaan)"
 
 msgid "@name requires at least PHP @version."
-msgstr ""
+msgstr "@name vaatii vähintään PHP version  @version"
 
 msgid "Unresolved dependency"
-msgstr ""
+msgstr "Ratkaisematon riippuvuus"
 
 msgid "@name requires this module."
-msgstr ""
+msgstr "@name vaatii tämän moduulin"
 
 msgid ""
 "@name requires this module and version. Currently using @required_name "
 "version @version"
 msgstr ""
+"@name vaatii tämän moduulin ja version. Tällä hetkellä käytössä "
+"@required_name versio @version"
 
 msgid "Previous page"
-msgstr ""
+msgstr "Edellinen sivu"
 
 msgid "Fetch settings"
-msgstr ""
+msgstr "Nouda asetukset"
 
 msgid "Site details"
-msgstr ""
+msgstr "Sivuston tiedot"
 
 msgid "The email address %mail is not valid."
-msgstr ""
+msgstr "Sähköpostiosoite %mail ei kelpaa."
 
 msgid "Add media"
-msgstr ""
+msgstr "Lisää mediatiedosto"
 
 msgid "Interfaces"
-msgstr ""
+msgstr "Rajapinnat"
 
 msgid "Title and slogan"
-msgstr ""
+msgstr "Otsikko ja iskulause"
 
 msgid "Firehouse"
-msgstr ""
+msgstr "Palolaitos"
 
 msgid "Ice"
-msgstr ""
+msgstr "Jää"
 
 msgid ""
 "The database table prefix you have entered, %prefix, is invalid. The table "
 "prefix can only contain alphanumeric characters, periods, or underscores."
 msgstr ""
+"Syöttämäsi tietokannan etuliite ei kelpaa. Taulujen etuliite voi sisältää "
+"vain numeroita, kirjaimia, pisteitä tai alaviivoja."
 
 msgid "Default settings file"
-msgstr ""
+msgstr "Oletusasetustiedosto"
 
 msgid "The default settings file does not exist."
-msgstr ""
+msgstr "Oletusasetustiedostoa ei löydy."
 
 msgid ""
 "The @drupal installer requires that the %default-file file not be modified "
 "in any way from the original download."
 msgstr ""
+"@drupal-asennusohjelma edellyttää, ettei %default-tiedostoa ole millään "
+"tavoin muutettu lataamisen jälkeen."
 
 msgid "Show row weights"
-msgstr ""
+msgstr "Näytä rivien painokertoimet"
 
 msgid "Hide row weights"
-msgstr ""
+msgstr "Piilota rivien painokertoimet"
 
 msgid "%name: the value may be no less than %min."
-msgstr ""
+msgstr "%name: arvo eri voi olla pienempi kuin %min."
 
 msgid "%name: the value may be no greater than %max."
-msgstr ""
+msgstr "%name: arvo eri voi olla suurempi kuin %max."
 
 msgid "Custom display settings"
-msgstr ""
+msgstr "Mukautetut näyttöasetukset"
 
 msgid ""
 "Separate extensions with a space or comma and do not include the leading "
 "dot."
 msgstr ""
+"Erottele tiedostopäätteet pilkuin eroteltuina ilman tiedostopäätettä "
+"edeltävää pistettä."
 
 msgid "Node module element"
-msgstr ""
+msgstr "Node-moduulin elementti"
 
 msgid "not yet assigned"
-msgstr ""
+msgstr "ei vielä asetettu"
 
 msgid "not yet created"
-msgstr ""
+msgstr "ei vielä luotu"
 
 msgid "Edit permissions"
-msgstr ""
+msgstr "Muokkaa käyttöoikeuksia"
 
 msgid "None (original image)"
-msgstr ""
+msgstr "Ei mitään (alkuperäinen kuva)"
 
 msgid "Row class"
-msgstr ""
+msgstr "Rivin luokka"
 
 msgid "Latest version"
-msgstr ""
+msgstr "Uusin versio"
 
 msgid "The URL of the account edit page."
-msgstr ""
+msgstr "Käyttäjätilin muokkaussivun osoite."
 
 msgid "Edit translations"
-msgstr ""
+msgstr "Muokkaa käännöksiä"
 
 msgid "- Use default -"
-msgstr ""
+msgstr "- Käytä oletusta -"
 
 msgid "Query type"
-msgstr ""
+msgstr "Kyselyn tyyppi"
 
 msgid "Search pages"
-msgstr ""
+msgstr "Hakusivut"
 
 msgid "Add search page"
-msgstr ""
+msgstr "Lisää hakusivu"
 
 msgid "Redirect path"
-msgstr ""
+msgstr "Uudelleenohjauspolku"
 
 msgid "Unknown content type"
-msgstr ""
+msgstr "Tuntematon sisältötyyppi"
 
 msgid "Drupal Upgrade"
-msgstr ""
+msgstr "Drupalin päivitys"
 
 msgid "Summary options"
-msgstr ""
+msgstr "Tiivistelmän asetukset"
 
 msgid "Never (manually)"
-msgstr ""
+msgstr "Ei koskaan (manuaalisesti)"
 
 msgid ""
 "The data could not be saved because the destination %destination is invalid."
 " This may be caused by improper use of file_save_data() or a missing stream "
 "wrapper."
 msgstr ""
+"Tietoa ei voitu tallentaa koska kohdetta %destination ei löytynyt. Tämä voi "
+"olla seurausta funktion file_save_data() virheellisestä käytöstä."
 
 msgid ""
 "Failed to connect to your database server. The server reports the following "
@@ -10916,696 +11532,800 @@ msgid ""
 " you entered the correct username and password?</li><li>Have you entered the"
 " correct database hostname?</li></ul>"
 msgstr ""
+"Yhdistäminen tietokantapalvelimellesi epäonnistui. Palvelin palautti "
+"seuraavan viestin: %error.<ul><li>Onko tietokantapalvelin "
+"toiminnassa?</li><li>Onko tietokanta olemassa ja oletko syöttänyt oikean "
+"tietokannan nimen?</li><li>Oletko syöttänyt oikean käyttäjätunnuksen ja "
+"salasanan?</li><li>Oletko syöttänyt oikean tietokannan osoitteen?</li></ul>"
 
 msgid "Exit block region demonstration"
-msgstr ""
+msgstr "Poistu lohkoalueiden esityksestä"
 
 msgid "Database log messages to keep"
-msgstr ""
+msgstr "Tietokantalogin säilytettävät viestit"
 
 msgid ""
 "Define a string that should be suffixed to the value, like ' m', ' kb/s'. "
 "Leave blank for none. Separate singular and plural values with a pipe "
 "('pound|pounds')."
 msgstr ""
+"Määrittele merkkijono, jota käytetään arvon päätteenä; esimerkiksi 'm' tai "
+"'kb/s'. Voit jättää myös tyhjäksi. Erota yksikkö- ja monikkomuodot "
+"putkimerkillä ('metri|metriä'.)"
 
 msgid "Thousand marker"
-msgstr ""
+msgstr "Tuhat-merkki"
 
 msgid "Display prefix and suffix."
-msgstr ""
+msgstr "Näytä etu- ja jälkiliite."
 
 msgid "Display with prefix and suffix."
-msgstr ""
+msgstr "Näytä etuliitteen ja päätteen kanssa."
 
 msgid "- Select a value -"
-msgstr ""
+msgstr "- Aseta arvo -"
 
 msgid "Trim length"
-msgstr ""
+msgstr "Trimmauspituus"
 
 msgid "No field is displayed."
-msgstr ""
+msgstr "Kenttiä ei näytetä."
 
 msgid "No field is hidden."
-msgstr ""
+msgstr "Kenttiä ei ole piilotettu."
 
 msgid "Format settings:"
-msgstr ""
+msgstr "Muotoiluasetukset:"
 
 msgid ""
 "Text formats are presented on content editing pages in the order defined on "
 "this page. The first format available to a user will be selected by default."
 msgstr ""
+"Tekstimuodot näytetään sisällönmuokkaussivuilla ennakkoon määritetyssä "
+"järjestyksessä. Ensimmäinen käytettävissä oleva muoto valitaan aina "
+"oletuksena."
 
 msgid "Link image to"
-msgstr ""
+msgstr "Linkitä kuva"
 
 msgid "Image style: @style"
-msgstr ""
+msgstr "Kuvan tyyli: @style"
 
 msgid "Linked to content"
-msgstr ""
+msgstr "Linkitetty sisältöön"
 
 msgid "Linked to file"
-msgstr ""
+msgstr "Linkitetty tiedostoon"
 
 msgid "Shown when hovering over the menu link."
-msgstr ""
+msgstr "Näytetään vietäessä hiirtä linkin yli."
 
 msgid ""
 "Format: %time. The date format is YYYY-MM-DD and %timezone is the time zone "
 "offset from UTC. Leave blank to use the time of form submission."
 msgstr ""
+"Muoto: %time. Päivämäärä on muotoa YYYY-MM-DD ja %timezone on aikasiirtymä "
+"suhteessa UTC. Jätä tyhjäksi jos haluat käyttää kaavakkeen lähetysaikaa."
 
 msgid "Syslog identity"
-msgstr ""
+msgstr "Syslog identiteetti"
 
 msgid ""
 "A string that will be prepended to every message logged to Syslog. If you "
 "have multiple sites logging to the same Syslog log file, a unique identity "
 "per site makes it easy to tell the log entries apart."
 msgstr ""
+"Merkkijono joka liitetään jokaiseen syslog merkinnän eteen. Jos sinulla on "
+"useampia sivustoja, yksilöllinen tunnistin helpottaa tunnistamaan viestit "
+"sivustokohtaisesti."
 
 msgid "Error pages"
-msgstr ""
+msgstr "Virhesivut"
 
 msgid "Run cron every"
-msgstr ""
+msgstr "Cronin ajoväli"
 
 msgid "Weight for added term"
-msgstr ""
+msgstr "Lisätyn termin painokerroin"
 
 msgid ""
 "Minimal profile for running tests. Includes absolutely required modules "
 "only."
 msgstr ""
+"Vähimmäisprofiili testausta varten. Sisältää vain ainoastaan pakolliset "
+"moduulit."
 
 msgid "Administrative name"
-msgstr ""
+msgstr "Ylläpidollinen nimi"
 
 msgid "Saint Martin"
-msgstr ""
+msgstr "Saint Martin"
 
 msgid "Invalid merge query: no conditions"
-msgstr ""
+msgstr "Epästandardi liitoskysely: ehdot puuttuvat"
 
 msgid "Weight for @block block"
-msgstr ""
+msgstr "Lohkon @block painoarvo"
 
 msgid "Region for @block block"
-msgstr ""
+msgstr "Lohkon @block sisältöalue"
 
 msgid "Post comments"
-msgstr ""
+msgstr "Lähetä kommentteja"
 
 msgid "Skip comment approval"
-msgstr ""
+msgstr "Ohita kommentin hyväksyntä"
 
 msgid "Are you sure you want to disable the text format %format?"
-msgstr ""
+msgstr "Oletko varma että haluat poistaa käytöstä tesktimuodon %format?"
 
 msgid ""
 "Disabled text formats are completely removed from the administrative "
 "interface, and any content stored with that format will not be displayed. "
 "This action cannot be undone."
 msgstr ""
+"Käytöstäpoistetut tekstimuodot poistetaan kokonaan näkyvistä "
+"käyttöliittymästä ja mitään niillä tallennettua sisältöä ei näytetä. Tätä "
+"toimintoa ei voi peruuttaa."
 
 msgid "Disabled text format %format."
-msgstr ""
+msgstr "Poistettu käytöstä tekstimuoto %format."
 
 msgid "Text Formats"
-msgstr ""
+msgstr "Tekstimuodot"
 
 msgid "Disable text format"
-msgstr ""
+msgstr "Poista käytöstä tekstimuoto"
 
 msgid "Comment type"
-msgstr ""
+msgstr "Kommentin tyyppi"
 
 msgid "Bulk update"
-msgstr ""
+msgstr "Bulk update"
 
 msgid "Search page"
-msgstr ""
+msgstr "Hakusivu"
 
 msgid "View mode"
-msgstr ""
+msgstr "Näyttötila"
 
 msgid "UUID"
-msgstr ""
+msgstr "UUID"
 
 msgid "Subscribe to @title"
-msgstr ""
+msgstr "Tilaa aihepiirin @title RSS-syöte"
 
 msgid "Back to site"
-msgstr ""
+msgstr "Palaa sivustolle"
 
 msgid "Configuration files"
-msgstr ""
+msgstr "Asetustiedostot"
 
 msgid "@module"
-msgstr ""
+msgstr "@module"
 
 msgid "User interface for the Field API."
-msgstr ""
+msgstr "Field API:n käyttöliittymä"
 
 msgid "Hot topic, new comments"
-msgstr ""
+msgstr "Kuuma aihe, uudet kommentit"
 
 msgid "Hot topic"
-msgstr ""
+msgstr "Kuuma aihe"
 
 msgid "Normal topic"
-msgstr ""
+msgstr "Normaali aihe"
 
 msgid "Closed topic"
-msgstr ""
+msgstr "Suljettu aihe"
 
 msgid "Configure @module permissions"
-msgstr ""
+msgstr "Säädä moduulin @module käyttöoikeuksia"
 
 msgid "Install new module or theme"
-msgstr ""
+msgstr "Asenna uusi moduuli tai teema"
 
 msgid "Install new theme"
-msgstr ""
+msgstr "Asenna uusi teema"
 
 msgid "Nothing"
-msgstr ""
+msgstr "Ei mitään"
 
 msgid "Update @title"
-msgstr ""
+msgstr "Päivitä @title"
 
 msgid ""
 "A unique machine-readable name. Can only contain lowercase letters, numbers,"
 " and underscores."
 msgstr ""
+"Uniikki koneellisesti luettava nimi. Saa sisältää vain pieniä kirjaimia, "
+"numeroita ja alaviivoja."
 
 msgid "The machine-readable name must contain unique characters."
-msgstr ""
+msgstr "Koneellisesti luettavan nimen tulee sisältää uniikkeja merkkejä."
 
 msgid ""
 "The machine-readable name must contain only lowercase letters, numbers, and "
 "hyphens."
 msgstr ""
+"Koneellisesti luettava nimi saa sisältää vain pieniä kirjaimia, numeroita ja"
+" tavuviivoja."
 
 msgid "The machine-readable name is already in use. It must be unique."
-msgstr ""
+msgstr "Koneellisesti luettava nimi on jo käytössä. Sen pitää olla uniikki."
 
 msgid "Weight for @title"
-msgstr ""
+msgstr "Paino kentälle @title"
 
 msgid "Weight for row @number"
-msgstr ""
+msgstr "Paino riville @number"
 
 msgid "Label display for @title"
-msgstr ""
+msgstr "Etiketti kentälle @title"
 
 msgid "Formatter for @title"
-msgstr ""
+msgstr "Kentän @title muotoiluasetukset"
 
 msgid "Parents for @title"
-msgstr ""
+msgstr "Kentän @title isännät"
 
 msgid ""
 "There is data for this field in the database. The field settings can no "
 "longer be changed."
 msgstr ""
+"Tälle kentälle on tallennettuna tietoa tietokantaan. Kentän asetuksia ei voi"
+" enää muuttaa."
 
 msgid "Weight for new file"
-msgstr ""
+msgstr "Uuden tiedoston paino"
 
 msgid "Choose a file"
-msgstr ""
+msgstr "Valitse tiedosto"
 
 msgid "Weight for new effect"
-msgstr ""
+msgstr "Painokerroin uudelle efektille"
 
 msgid "Enable @title menu link"
-msgstr ""
+msgstr "Ota käyttöön valikkolinkki @title"
 
 msgid ""
 "A unique name to construct the URL for the menu. It must only contain "
 "lowercase letters, numbers and hyphens."
 msgstr ""
+"Valikon URL-osoitteen muodostamiseen käytettävä yksilöllinen nimi. Nimi saa "
+"sisältää ainoastaan pieniä kirjaimia, numeroita ja väliviivoja."
 
 msgid "Schema version"
-msgstr ""
+msgstr "Skeemaversio"
 
 msgid "Number of servings"
-msgstr ""
+msgstr "Annosten määrä"
 
 msgid "Theme name"
-msgstr ""
+msgstr "Teeman nimi"
 
 msgid "URL fallback"
-msgstr ""
+msgstr "Paluuosoite"
 
 msgid "Use an already detected language for URLs if none is found."
-msgstr ""
+msgstr "Käytä aiemmin tunnistettua kieltä URLeissa jos kieltä ei löydy."
 
 msgid "%type_name: Create new content"
-msgstr ""
+msgstr "%type_name: Luo uutta sisältöä"
 
 msgid "%type_name: Edit own content"
-msgstr ""
+msgstr "%type_name: Muokkaa omaa sisältöä"
 
 msgid "%type_name: Edit any content"
-msgstr ""
+msgstr "%type_name: Muokkaa mitä tahansa sisältöä"
 
 msgid "%type_name: Delete own content"
-msgstr ""
+msgstr "%type_name: Poista omaa sisältöä"
 
 msgid "%type_name: Delete any content"
-msgstr ""
+msgstr "%type_name: Poista mitä tahansa sisältöä"
 
 msgid "New object was not saved, no error provided"
-msgstr ""
+msgstr "Uutta objektia ei tallennettu, ei virheilmoitusta"
 
 msgid "The published status of a comment. (0 = Published, 1 = Not Published)"
-msgstr ""
+msgstr "Kommentin julkaisustatus (0 = julkaistu, 1 = ei julkaistu)"
 
 msgid "The comment author's name."
-msgstr ""
+msgstr "Kommentin kirjoittajan nimi."
 
 msgid "Next steps"
-msgstr ""
+msgstr "Seuraavat vaiheet"
 
 msgid "@driver_name settings"
-msgstr ""
+msgstr "@driver_name asetukset"
 
 msgid "SQLite"
-msgstr ""
+msgstr "SQLite"
 
 msgid "Database file"
-msgstr ""
+msgstr "Tietokantatiedosto"
 
 msgid ""
 "The absolute path to the file where @drupal data will be stored. This must "
 "be writable by the web server and should exist outside of the web root."
 msgstr ""
+"Absoluuttinen polku tiedostoon, johon @drupal data tallennetaan. Tiedoston "
+"on oltava palvelimen kirjoitettavissa ja sen tulee sijaita www-juuren "
+"ulkopuolella."
 
 msgid "No fields are present yet."
-msgstr ""
+msgstr "Kenttiä ei ole vielä lisättynä."
 
 msgctxt "Font weight"
 msgid "Strong"
-msgstr ""
+msgstr "Lihavoitu"
 
 msgid "Enable newly added modules"
-msgstr ""
+msgstr "Ota käyttöön uudet moduulit"
 
 msgid "View the administration theme"
-msgstr ""
+msgstr "Näytä ylläpitoteema"
 
 msgid "Indexed %count content items for tracking."
-msgstr ""
+msgstr "Indeksoitiin %count elementtiä jäljitystä varten."
 
 msgid "Release notes for @project_title"
-msgstr ""
+msgstr "Julkaisutiedot projektille @project_title"
 
 msgid "The role settings have been updated."
-msgstr ""
+msgstr "Roolin asetukset on päivitetty."
 
 msgid "Disable the account and keep its content."
-msgstr ""
+msgstr "Poista käyttäjä käytöstä ja säilytä käyttäjän syöttämä sisältö."
 
 msgid "Disable the account and unpublish its content."
 msgstr ""
+"Poista käyttäjä käytöstä ja muuta käyttäjän luoma sisältö julkaisemattomaan "
+"tilaan."
 
 msgid ""
 "Delete the account and make its content belong to the %anonymous-name user."
 msgstr ""
+"Poista käyttäjä ja siirrä käyttäjän luoma sisältö käyttäjän %anonymous-name "
+"alle. Huomaa että jatkossa kuka tahansa käyttäjä voi muokata kyseisiä sivuja"
+" mikäli et siirrä niitä jonkin rajoitetun käyttäjän luomiksi."
 
 msgid "Delete the account and its content."
-msgstr ""
+msgstr "Poista käyttäjä ja käyttäjän luoma sisältö."
 
 msgid "Drupal system listing compatible test"
-msgstr ""
+msgstr "Drupal-järjestelmä listaa yhteensopivaa testiä"
 
 msgid "Support module for testing the drupal_system_listing function."
-msgstr ""
+msgstr "Tukimoduuli drupal_system_listing funktion testaamiseksi."
 
 msgid "Fixed value"
-msgstr ""
+msgstr "Kiinteä arvo"
 
 msgid "String settings"
-msgstr ""
+msgstr "Merkkijonon asetukset"
 
 msgid "Use field label instead of the \"On value\" as label"
-msgstr ""
+msgstr "Käytä etikettinä kentän etikettiä \"On value\" sijaan."
 
 msgid "List (integer)"
-msgstr ""
+msgstr "Lista (kokonaisluku)"
 
 msgid ""
 "This field stores integer values from a list of allowed 'value => label' "
 "pairs, i.e. 'Lifetime in days': 1 => 1 day, 7 => 1 week, 31 => 1 month."
 msgstr ""
+"Kenttä tallentaa tekstiarvoja sallitut 'arvo => etiketti' parit sisältävästä"
+" listasta, esimerkiksi 'Yhdysvaltain osavaltiot': IL => Illinois, IA => "
+"Iowa, IN => Indiana."
 
 msgid "List (float)"
-msgstr ""
+msgstr "Lista (reaaliluku)"
 
 msgid ""
 "This field stores float values from a list of allowed 'value => label' "
 "pairs, i.e. 'Fraction': 0 => 0, .25 => 1/4, .75 => 3/4, 1 => 1."
 msgstr ""
+"Kenttä tallentaa kelluvia arvoja sallitut 'arvo => etiketti' parit "
+"sisältävästä listasta, esimerkiksi 'Murtoluku': 0 => 0, .25 => 1/4, .75 => "
+"3/4, 1 => 1."
 
 msgid ""
 "This field stores text values from a list of allowed 'value => label' pairs,"
 " i.e. 'US States': IL => Illinois, IA => Iowa, IN => Indiana."
 msgstr ""
+"Kenttä tallentaa tekstiarvoja sallitut 'arvo => etiketti' parit sisältävästä"
+" listasta, esimerkiksi 'Yhdysvaltain osavaltiot': IL => Illinois, IA => "
+"Iowa, IN => Indiana."
 
 msgid ""
 "The possible values this field can contain. Enter one value per line, in the"
 " format key|label."
 msgstr ""
+"Lista kentälle sallittavista arvoista. Syötä yksi arvo riviä kohden muodossa"
+" avain|etiketti (engl. key|label)."
 
 msgid ""
 "The key is the stored value, and must be numeric. The label will be used in "
 "displayed values and edit forms."
 msgstr ""
+"Avain on tallennettu arvo ja sen on oltava numeerinen. Etikettiä käytetään "
+"näytetyissä arvoissa ja muokkauskaavakkeissa."
 
 msgid ""
 "The label is optional: if a line contains a single number, it will be used "
 "as key and label."
 msgstr ""
+"Etiketti on valinnainen vaihtoehto: jos rivi sisältää yksittäisen luvun sitä"
+" käytetään sekä avaimena että etikettinä."
 
 msgid ""
 "Lists of labels are also accepted (one label per line), only if the field "
 "does not hold any values yet. Numeric keys will be automatically generated "
 "from the positions in the list."
 msgstr ""
+"Voit syöttää etiketit myös listana (yksi riviä kohti), tämä on mahdollista "
+"vain jos kentässä ei ole entuudestaan tallennettuja arvoja.  Järjestelmä luo"
+" etiketeille numeeriset avaimet sen perusteella missä kohtaa listaa se "
+"sijaitsee."
 
 msgid ""
 "The key is the stored value. The label will be used in displayed values and "
 "edit forms."
 msgstr ""
+"Avain on tallennettu arvo. Etikettiä käytetään näytetyissä arvoissa ja "
+"muokkauskaavakkeissa."
 
 msgid ""
 "The label is optional: if a line contains a single string, it will be used "
 "as key and label."
 msgstr ""
+"Etiketti on valinnainen vaihtoehto: jos rivi sisältää yksittäisen "
+"merkkijonon sitä käytetään sekä avaimena että etikettinä."
 
 msgid "Allowed values list: invalid input."
-msgstr ""
+msgstr "Lista sallituista arvoista: kielletty syöte."
 
 msgid ""
 "Allowed values list: some values are being removed while currently in use."
 msgstr ""
+"Sallitut arvot: jotkut arvot poistetaan niiden ollessa tällä hetkellä "
+"käytössä."
 
 msgid "The entity type."
-msgstr ""
+msgstr "Entiteetin tyyppi."
 
 msgid "Center left"
-msgstr ""
+msgstr "Keskitä vasemmalle"
 
 msgid "Center right"
-msgstr ""
+msgstr "Keskitä oikealle"
 
 msgid "Unable to parse info file: %info_file."
-msgstr ""
+msgstr "Info-tiedoston lukeminen epäonnistui: %info-file."
 
 msgid "Custom blocks"
-msgstr ""
+msgstr "Kustomoidut lohkot"
 
 msgid "HTML element"
-msgstr ""
+msgstr "HTML-elementti"
 
 msgid "Label HTML element"
-msgstr ""
+msgstr "Etiketin HTML-elementti"
 
 msgid "Place a colon after the label"
-msgstr ""
+msgstr "Sijoita kaksoispiste etiketin perään"
 
 msgid "Wrapper HTML element"
-msgstr ""
+msgstr "Ympäröivä HTML-elementti"
 
 msgid "Wrapper class"
-msgstr ""
+msgstr "Ympäröivän elementin luokka"
 
 msgid "Add default classes"
-msgstr ""
+msgstr "Lisää oletusluokkia"
 
 msgid ""
 "Use default Views classes to identify the field, field label and field "
 "content."
 msgstr ""
+"Käytä Views moduulin oletusluokkia kentän, kentän etiketin ja kentän "
+"sisällön tunnistamiseen."
 
 msgid "Use absolute path"
-msgstr ""
+msgstr "Käytä absoluuttista polkua"
 
 msgid "Rel Text"
-msgstr ""
+msgstr "Rel teksti"
 
 msgid ""
 "Include Rel attribute for use in lightbox2 or other javascript utility."
 msgstr ""
+"Sisällytä Rel attribuutti käytettäväksi lightbox2'n ja muiden javascript-"
+"toimintojen kanssa."
 
 msgid "Preserve certain tags"
-msgstr ""
+msgstr "Säilytä tietyt tagit"
 
 msgid "Specify validation criteria"
-msgstr ""
+msgstr "Määrittele validointikriteerit"
 
 msgid "Representative sort order"
-msgstr ""
+msgstr "Edustava lajittelujärjestys"
 
 msgid "Hash"
-msgstr ""
+msgstr "Hash"
 
 msgid "Administer settings."
-msgstr ""
+msgstr "Ylläpidä asetuksia."
 
 msgid "Changed date"
-msgstr ""
+msgstr "Changed date"
 
 msgid "Asc"
-msgstr ""
+msgstr "Asc"
 
 msgid "View reports, updates, and errors."
-msgstr ""
+msgstr "Tarkastele raportteja, saatavilla olevia päivityksiä ja virheitä."
 
 msgid "Reference for usage, configuration, and modules."
-msgstr ""
+msgstr "Viittaus käyttöä varten, asetuksille ja moduuleille."
 
 msgid "Database system version"
-msgstr ""
+msgstr "Tietokantajärjestelmän versio"
 
 msgid "Database system"
-msgstr ""
+msgstr "Tietokantajärjestelmä"
 
 msgid "Install new module"
-msgstr ""
+msgstr "Asenna uusi moduuli"
 
 msgid "Uninstall @module module"
-msgstr ""
+msgstr "Poista moduulin @module asennus"
 
 msgid ""
 "List the tags that need to be preserved during the stripping process. "
 "example &quot;&lt;p&gt; &lt;br&gt;&quot; which will preserve all p and br "
 "elements"
 msgstr ""
+"Listaa tagit jotka tulee säilyttää. Esimerkiksi &quot;&lt;p&gt; "
+"&lt;br&gt;&quot; säilyttää kaikki p ja br elementit."
 
 msgid "Format plural"
-msgstr ""
+msgstr "Formatoi monikko"
 
 msgid "If checked, special handling will be used for plurality."
-msgstr ""
+msgstr "Mikäli valittuna, monikon määrittelyyn käytetään erityistä toimintoa."
 
 msgid "Singular form"
-msgstr ""
+msgstr "Yksikkömuoto"
 
 msgid "Plural form"
-msgstr ""
+msgstr "Monikkomuoto"
 
 msgid ""
 "Text to use for the plural form, @count will be replaced with the value."
-msgstr ""
+msgstr "Monikkomuodossa käytettävä teksti, @count korvataan arvolla."
 
 msgid ""
 "A unique machine-readable name for this View. It must only contain lowercase"
 " letters, numbers, and underscores."
 msgstr ""
+"Näkymän yksilöllinen koneluettava nimi. Nimi voi sisältää ainoastaan pieniä "
+"kirjaimia, numeroita ja alaviivoja."
 
 msgid "Weight for @display"
-msgstr ""
+msgstr "Paino sivulle @display"
 
 msgid ""
 "This title will be displayed on the views edit page instead of the default "
 "one. This might be useful if you have the same item twice."
 msgstr ""
+"Tämä otsikko näytetään näkymän muokkaussivulla oletusotsikon sijaan. Tämä "
+"voi olla hyödyllistä jos näkymässäsi on useampi kuin yksi samantyyppinen "
+"näyttöruutu."
 
 msgid "The unique ID of the aggregator item."
-msgstr ""
+msgstr "Aggregointiartikkelin yksilöllinen ID."
 
 msgid "The guid of the original imported item."
-msgstr ""
+msgstr "Ladatun alkuperäisen artikkelin GUID."
 
 msgid "Date and time of when the comment was created."
-msgstr ""
+msgstr "Kommentin luontipäivämäärä ja kellonaika."
 
 msgid "Date and time of when the comment was last updated."
-msgstr ""
+msgstr "Kommentin viimeisin muokkauspäivämäärä ja kellonaika."
 
 msgid "Whether the comment is approved (or still in the moderation queue)."
 msgstr ""
+"Onko kommentti hyväksytty vai odottaako se hyväksyntää moderointijonossa."
 
 msgid "Last comment CID"
-msgstr ""
+msgstr "Viimeisimmän kommentin CID"
 
 msgid "Last Comment"
-msgstr ""
+msgstr "Viimeisin kommentti"
 
 msgid ""
 "Some roles lack permission to access content, but display %display has no "
 "access control."
 msgstr ""
+"Joillakin käyttäjärooleillla ei ole pääsyä sisältöön mutta näyttöruudulla "
+"%display ei ole pääsysääntöjä."
 
 msgid "The extension of the file."
-msgstr ""
+msgstr "Tiedostopääte."
 
 msgid "File Usage"
-msgstr ""
+msgstr "Tiedoston käyttö"
 
 msgid ""
 "A file that is associated with this node, usually because it is in a field "
 "on the node."
 msgstr ""
+"Tähän solmuun liittyvä tiedosto, useimmiten koska tiedoston on solmun "
+"kentässä."
 
 msgid ""
 "A user that is associated with this file, usually because this file is in a "
 "field on the user."
 msgstr ""
+"Tiedostoon liittyvä käyttäjä, useimmiten koska tiedosto on käyttäjän "
+"käyttäjäprofiilin kentässä."
 
 msgid ""
 "A file that is associated with this user, usually because it is in a field "
 "on the user."
 msgstr ""
+"Tähän käyttäjään liittyvä tiedosto, useimmiten koska tiedosto on käyttäjän "
+"käyttäjäprofiilin kentässä."
 
 msgid ""
 "A comment that is associated with this file, usually because this file is in"
 " a field on the comment."
 msgstr ""
+"Tiedostoon liittyvä kommentti, useimmiten koska tiedosto on ladattu "
+"kommenttikenttien kautta."
 
 msgid ""
 "A file that is associated with this comment, usually because it is in a "
 "field on the comment."
 msgstr ""
+"Kommenttiin  liitetty tiedosto, useimmiten koska se on jossakin kommentin "
+"kentistä."
 
 msgid ""
 "A taxonomy term that is associated with this file, usually because this file"
 " is in a field on the taxonomy term."
 msgstr ""
+"Tiedostoon liitetty luokittelutermi, useimmiten koska se on jossakin "
+"luokittelutermin kentässä."
 
 msgid ""
 "A file that is associated with this taxonomy term, usually because it is in "
 "a field on the taxonomy term."
 msgstr ""
+"Tiedostoon liitetty luokittelutermi, useimmiten koska se on jossakin "
+"luokittelutermin kentässä."
 
 msgid "The module managing this file relationship."
-msgstr ""
+msgstr "Tiedostosuhdetta ylläpitävän moduulin nimi."
 
 msgid "The type of entity that is related to the file."
-msgstr ""
+msgstr "Tiedostoon liitetyn entiteetin tyyppi."
 
 msgid "The number of times the file is used by this entity."
-msgstr ""
+msgstr "Kuinka monta kertaa entiteetti on käyttänyt tiedostoa."
 
 msgid ""
 "Used by Style: Table to determine the actual column to click sort the field "
 "on. The default is usually fine."
 msgstr ""
+"Tyylin käytössä: Taulu joka määrittelee lajittelua varten klikattavan "
+"sarakkeen kentän. Oletusarvo on useimmiten riittävä."
 
 msgid "Group column"
-msgstr ""
+msgstr "Ryhmittelysarake"
 
 msgid ""
 "Select the column of this field to apply the grouping function selected "
 "above."
 msgstr ""
+"Valitse mihin kentän sarakkeeseen valittua ryhmittelyfunktiota käytetään."
 
 msgid "Group columns (additional)"
-msgstr ""
+msgstr "Ryhmittelysarakkeet (lisä)"
 
 msgid ""
 "Select any additional columns of this field to include in the query and to "
 "group on."
 msgstr ""
+"Valitse kyselyyn sisällytettävät ja ryhmittelyn perusteena käytettävät "
+"kentän lisäsarakkeet."
 
 msgid "Display download path instead of file storage URI"
-msgstr ""
+msgstr "Näytä latauspolku tiedoston polun sijaan"
 
 msgid "The machine name for the vocabulary the term belongs to."
-msgstr ""
+msgstr "Termin sisältävän sanaston koneluettava nimi."
 
 msgid "Display error message"
-msgstr ""
+msgstr "Näytä virheilmoitus"
 
 msgid "Comment or document this display."
-msgstr ""
+msgstr "Kommentoi tai dokumentoi näyttöruutua."
 
 msgid "Query settings"
-msgstr ""
+msgstr "Kyselyasetukset"
 
 msgid "Allow to set some advanced settings for the query plugin"
-msgstr ""
+msgstr "Salli lisäasetusten asettaminen kyselypluginille"
 
 msgid "The name and the description of this display"
-msgstr ""
+msgstr "Näyttöruudun nimi ja kuvaus"
 
 msgid "Query options"
-msgstr ""
+msgstr "Kyselyvaihtoehdot"
 
 msgid "Display name must be letters, numbers, or underscores only."
 msgstr ""
+"Näyttöruudun otsikko voi sisältää ainoastaan kirjaimia, numeroita ja "
+"alaviivoja."
 
 msgid ""
 "Should this display inherit its paging values from the parent display to "
 "which it is attached?"
 msgstr ""
+"Periikö näyttöruutu sivutuksensa arvot isäntäruudusta johon se on liitetty?"
 
 msgid ""
 "Should this display render the pager values? This is only meaningful if "
 "inheriting a pager."
 msgstr ""
+"Näyttääkö näyttöruutu sivutuksen renderöidyt arvot? Tämä on merkityksellistä"
+" vain sivutusta periytettäessä."
 
 msgid ""
 "This will appear as the name of this block in administer >> structure >> "
 "blocks."
-msgstr ""
+msgstr "Tämä näytetään lohkon nimenä lohkojen hallintasivulla."
 
 msgid ""
 "Text to display instead of results until the user selects and applies an "
 "exposed filter."
 msgstr ""
+"Tulosten sijaan näytettävä teksti kunnes käyttäjä valitsee ja ottaa käyttöön"
+" käyttäjälle näytetyn suodattimen."
 
 msgid "Include all items option"
-msgstr ""
+msgstr "\"Sisällytä kaikki tulokset\" vaihtoehto"
 
 msgid "All items label"
-msgstr ""
+msgstr "Kaikkien tulosten etiketti"
 
 msgid "Disable SQL rewriting"
-msgstr ""
+msgstr "Ota pois käytöstä SQL uudelleenkirjoitus"
 
 msgid "The class to provide on each row."
-msgstr ""
+msgstr "Jokaiselle riville asetettava CSS-luokka."
 
 msgid ""
 "You may use field tokens from as per the \"Replacement patterns\" used in "
 "\"Rewrite the output of this field\" for all fields."
 msgstr ""
+"Voit käyttää korvausmerkkejä \"korvauskuvioita kohden\", näitä käytetään "
+"kaikille kentille kohdassa \"uudelleenkirjoita näkymässä\"."
 
 msgid "The class to provide on the wrapper, outside the list."
-msgstr ""
+msgstr "Listan ulkopuolelle asetettavan ympäröivän elementin CSS-luokka."
 
 msgid "List class"
-msgstr ""
+msgstr "Listan luokka"
 
 msgid "The class to provide on the list element itself."
-msgstr ""
+msgstr "Lista-elementin luokka"
 
 msgid ""
 "Define the base path for links in this summary\n"
@@ -11614,595 +12334,671 @@ msgid ""
 "        is empty, views will use the first path found as the base path,\n"
 "        in page displays, or / if no path could be found."
 msgstr ""
+"Näytä tämän yhteenvetonäkymän linkkien peruspolut, esimerkiksi tapaan http://example.com/<strong>nakyman_polku/arkisto</strong>.\r\n"
+"Älä sisällytä alkavaa ja päättävää kauttaviivaa. Jos arvo on tyhjä, views käyttää ensimmäistä löydettyä polkua peruspolkuna sivunäkymissä tai jos / jos polkua ei löydy."
 
 msgid "Content access"
-msgstr ""
+msgstr "Sisällön pääsysäännöt"
 
 msgctxt "ampm"
 msgid "am"
-msgstr ""
+msgstr "am"
 
 msgctxt "ampm"
 msgid "pm"
-msgstr ""
+msgstr "pm"
 
 msgid "Sticky status"
-msgstr ""
+msgstr "Listojen alussa näytön tila"
 
 msgid "RSS category"
-msgstr ""
+msgstr "RSS-luokitus"
 
 msgid "RSS enclosure"
-msgstr ""
+msgstr "RSS liite"
 
 msgid "Paste your configuration here"
-msgstr ""
+msgstr "Kopioi asetuksesi tähän"
 
 msgid "Import configuration"
-msgstr ""
+msgstr "Tuo asetukset"
 
 msgid "5 minute"
-msgstr ""
+msgstr "5 minuuttia"
 
 msgid "15 minute"
-msgstr ""
+msgstr "15 minuuttia"
 
 msgid "URL to image"
-msgstr ""
+msgstr "Kuvan URL-osoite"
 
 msgid "Content revisions"
-msgstr ""
+msgstr "Sisältöversiot"
 
 msgid "%time hence"
-msgstr ""
+msgstr "%time siten"
 
 msgid "Language selection"
-msgstr ""
+msgstr "Kielen valinta"
 
 msgid "Delete all translations"
-msgstr ""
+msgstr "Poista kaikki käännökset"
 
 msgid "No Access"
-msgstr ""
+msgstr "Ei pääsyä"
 
 msgid "Search page path"
-msgstr ""
+msgstr "Hakusivun polku"
 
 msgid "Many to one"
-msgstr ""
+msgstr "Monta yhteen"
 
 msgid "All Day"
-msgstr ""
+msgstr "Koko päivä"
 
 msgid "Upscale"
-msgstr ""
+msgstr "Skaalaa ylös"
 
 msgid "Logo settings"
-msgstr ""
+msgstr "Logon asetukset"
 
 msgid "Delete field."
-msgstr ""
+msgstr "Poista kenttä."
 
 msgid "No results behavior"
-msgstr ""
+msgstr "Toiminta jos tuloksia ei löydy"
 
 msgid "Edit @section"
-msgstr ""
+msgstr "Muokkaa @section"
 
 msgid "View to insert"
-msgstr ""
+msgstr "Sisällytettävä näkymä"
 
 msgid "The view to insert into this area."
-msgstr ""
+msgstr "Tälle alueelle sisällytettävä näkymä"
 
 msgid "Inherit contextual filters"
-msgstr ""
+msgstr "Periytä kontekstiriippuvaiset suodattimet"
 
 msgid ""
 "If checked, this view will receive the same contextual filters as its "
 "parent."
 msgstr ""
+"Mikäli valittuna, tämä näkymä saa samat kontekstiriippuvaiset suodattimet "
+"kuin isäntänsä."
 
 msgid "Recursion detected in view @view display @display."
-msgstr ""
+msgstr "Rekursio löydetty näkymässä @view ruudussa @display."
 
 msgid "When the filter value is <em>NOT</em> in the URL"
-msgstr ""
+msgstr "Kun suodatinarvo <em>EI</em> ole URLissa"
 
 msgid "Exception value"
-msgstr ""
+msgstr "Poikkeuksen arvo"
 
 msgid "If this value is received, the filter will be ignored; i.e, \"all values\""
-msgstr ""
+msgstr "Jos arvo on vastaanotettu, suodatin ohitetaan; ts. \"kaikki arvot\""
 
 msgid "When the filter value <em>IS</em> in the URL or a default is provided"
-msgstr ""
+msgstr "Kun suodatinarvo <em>ON</em> URLissa tai suodattimella on oletusarvo"
 
 msgid "Provide title"
-msgstr ""
+msgstr "Tarjoa otsikko"
 
 msgid "Custom block"
-msgstr ""
+msgstr "Kustomoitu lohko"
 
 msgid "Action to take if filter value does not validate"
-msgstr ""
+msgstr "Toiminto joka suoritetaan jos suodatettu arvo ei validoidu"
 
 msgid "Display all results for the specified field"
-msgstr ""
+msgstr "Näytä määritetyn kentän kaikki arvot"
 
 msgid "Provide default value"
-msgstr ""
+msgstr "Tarjoa oletusarvo"
 
 msgid "Show \"Page not found\""
-msgstr ""
+msgstr "Näytä \"Sivua ei löytynyt\""
 
 msgid "Display a summary"
-msgstr ""
+msgstr "Näytä tiivistelmä"
 
 msgid "Display contents of \"No results found\""
-msgstr ""
+msgstr "Näytä sisältö \"Ei tuloksia\""
 
 msgid "Skip default argument for view URL"
-msgstr ""
+msgstr "Ohita näkymän URLin oletusargumentti"
 
 msgid ""
 "Select whether to include this default argument when constructing the URL "
 "for this view. Skipping default arguments is useful e.g. in the case of "
 "feeds."
 msgstr ""
+"Valitse sisällytetäänkö tämä oletusargumentti näkymän URLiin. Oletusarvon "
+"ohittaminen on hyödyllistä esimerkiksi syötteiden kohdalla."
 
 msgid "Number of records"
-msgstr ""
+msgstr "Osumien lukumäärä"
 
 msgctxt "Sort order"
 msgid "Default sort"
-msgstr ""
+msgstr "Oletuslajittelu"
 
 msgctxt "Sort order"
 msgid "Date"
-msgstr ""
+msgstr "Päivämäärä"
 
 msgctxt "Sort order"
 msgid "Numerical"
-msgstr ""
+msgstr "Numeerinen"
 
 msgid ""
 "If selected, users can enter multiple values in the form of 1+2+3 (for OR) "
 "or 1,2,3 (for AND)."
 msgstr ""
+"Mikäli valittuna, käyttäjät voivat syöttää useita arvoja muodossa 1+2+3 (OR "
+"toiminnolle) tai 1,2,3 (AND toiminnolle)."
 
 msgid ""
 "If selected, multiple instances of this filter can work together, as though "
 "multiple values were supplied to the same filter. This setting is not "
 "compatible with the \"Reduce duplicates\" setting."
 msgstr ""
+"Mikäli valittuna, useat tämän suodattimen käyttökerrat voivat toimia yhdessä"
+" aivan kuin suodattimelle olisi annettu useampia kuin yksi arvo. Tämä asetus"
+" ei ole yhteensopiva \"Vähennä kaksoiskappaleita\" asetuksen kanssa."
 
 msgid ""
 "If selected, the numbers entered for the filter will be excluded rather than"
 " limiting the view."
 msgstr ""
+"Mikäli valittuna, syötetyt arvot jätetään pois pikemmin kuin että näkymää "
+"rajoitetaan niiden mukaisesti."
 
 msgid ""
 "Glossary mode applies a limit to the number of characters used in the filter"
 " value, which allows the summary view to act as a glossary."
 msgstr ""
+"Sanastotila ottaa käyttöön rajoituksen merkkien määrälle suodattimen "
+"arvossa. Tämä mahdollistaa tiivistelmänäkymän toimimisen sanastona."
 
 msgid ""
 "How many characters of the filter value to filter against. If set to 1, all "
 "fields starting with the first letter in the filter value would be matched."
 msgstr ""
+"Kuinka montaa suodattimen arvon merkkiä vasten suodatetaan. Mikäli 1, "
+"suodatetaan kaikki kentät jotka alkavat suodattimen arvon ensimmäisellä "
+"kirjaimella."
 
 msgid ""
 "When printing the title and summary, how to transform the case of the filter"
 " value."
 msgstr ""
+"Miten suodatinarvon merkit muunnetaan tulostettaessa otsikkoa ja "
+"tiivistelmää."
 
 msgctxt "Sort order"
 msgid "Alphabetical"
-msgstr ""
+msgstr "Aakkosellinen"
 
 msgid "Create a label"
-msgstr ""
+msgstr "Luo etiketti"
 
 msgid ""
 "Enable to load this field as hidden. Often used to group fields, or to use "
 "as token in another field."
 msgstr ""
+"Ota käyttöön ladataksesi kenttä piilotettuna. Käytetään usein tiedon "
+"ryhmittelyssä tai korvauskuvioina toisissa kentissä."
 
 msgid "Choose the HTML element to wrap around this field, e.g. H1, H2, etc."
 msgstr ""
+"Valitse kentän ympäröivänä elementtinä käytettävä HTML-elementti, "
+"esimerkiksi H1, H2 jne."
 
 msgid "Create a CSS class"
-msgstr ""
+msgstr "Luo CSS-luokka"
 
 msgid "Choose the HTML element to wrap around this label, e.g. H1, H2, etc."
 msgstr ""
+"Valitse etiketin ympärille asetettava HTML-elementti, esim. H1, H2, jne."
 
 msgid "Rewrite results"
-msgstr ""
+msgstr "Uudelleenkirjoita näkymässä"
 
 msgid "Replace spaces with dashes"
-msgstr ""
+msgstr "Korvaa välilyönnit väliviivoilla"
 
 msgid "External server URL"
-msgstr ""
+msgstr "Ulkoisen palvelimen URL"
 
 msgid ""
 "Links to an external server using a full URL: e.g. 'http://www.example.com' "
 "or 'www.example.com'."
 msgstr ""
+"Linkittää ulkopuoliseen palveluun käyttäen kokonaista URLia: esimerkiksi "
+"'http://www.example.com' tai 'www.example.com'."
 
 msgid "Convert newlines to HTML &lt;br&gt; tags"
-msgstr ""
+msgstr "Muunna rivinvaihdot &lt;br&gt;-HTML-tageiksi"
 
 msgid "No results text"
-msgstr ""
+msgstr "Teksti joka näytetään jos näkymällä ei ole tuloksia"
 
 msgid ""
 "Enable to display the \"no results text\" if the field contains the number "
 "0."
-msgstr ""
+msgstr "Ota käyttöön \"ei tuloksia teksti\" jos kenttä sisältää numeron 0."
 
 msgid "Time hence"
-msgstr ""
+msgstr "Aikaa siten"
 
 msgid "Time hence (with \"hence\" appended)"
-msgstr ""
+msgstr "Aikaa siten (\"siten\" lisättynä)"
 
 msgid "Time span (future dates have \"-\" prepended)"
-msgstr ""
+msgstr "Aikaväli (tulevilla päivämäärillä on \"-\" takaliitteenä)"
 
 msgid "Time span (past dates have \"-\" prepended)"
-msgstr ""
+msgstr "Aikaväli (menneillä päivämäärillä on \"-\" etuliitteenä)"
 
 msgid ""
 "How should the serialized data be displayed. You can choose a custom "
 "array/object key or a print_r on the full output."
 msgstr ""
+"Sarjoitettu tiedon esitystapa. Voit valita kustomoidun arrayn/objektin "
+"avaimen tai käyttää print_r tulostaaksesi koko tuloksen."
 
 msgid "Full data (unserialized)"
-msgstr ""
+msgstr "Kaikki tieto (serialisoimaton)"
 
 msgid "A certain key"
-msgstr ""
+msgstr "Tietty avain"
 
 msgid "Which key should be displayed"
-msgstr ""
+msgstr "Minkä avaimen haluat näytettävän"
 
 msgid "You have to enter a key if you want to display a key of the data."
-msgstr ""
+msgstr "Sinun on määriteltävä avain jos haluat näyttää tiedon avaimen."
 
 msgid "How many different units to display in the string."
-msgstr ""
+msgstr "Kuinka monta yksikköä näytetään merkkijonossa."
 
 msgid "This filter is not exposed. Expose it to allow the users to change it."
 msgstr ""
+"Suodatinta ei näytetä kävijöille. Muuta sen asetuksia salliaksesi käyttäjien"
+" muuttaa sen arvoa."
 
 msgid "Expose filter"
-msgstr ""
+msgstr "Näytä suodatin"
 
 msgid ""
 "This filter is exposed. If you hide it, users will not be able to change it."
 msgstr ""
+"Suodatin näytetään käyttäjille. Jos piilotat sen käyttäjät eivät pysty "
+"muuttamaan sitä."
 
 msgid "Hide filter"
-msgstr ""
+msgstr "Piilota suodatin"
 
 msgid "Expose operator"
-msgstr ""
+msgstr "Näytä operaattori"
 
 msgid "Allow the user to choose the operator."
-msgstr ""
+msgstr "Salli käyttäjän valita operaattori."
 
 msgid "Allow multiple selections"
-msgstr ""
+msgstr "Salli monivalinta"
 
 msgid "Enable to allow users to select multiple items."
-msgstr ""
+msgstr "Ota käyttöön mahdollistaaksesi monivalinta."
 
 msgid "Remember the last selection"
-msgstr ""
+msgstr "Muista viimeisin valinta"
 
 msgid "Enable to remember the last selection made by the user."
-msgstr ""
+msgstr "Ota käyttöön muistaaksesi käyttäjän tekemä viimeisin valinta."
 
 msgid "You must select a value unless this is an non-required exposed filter."
 msgstr ""
+"Sinun on valittava arvo paitsi jos suodatin on käyttjille näkyvä ei-"
+"pakollinen suodatin."
 
 msgid "Enable to hide items that do not contain this relationship"
-msgstr ""
+msgstr "Piilota tulokset jotka eivät sisällä tätä riippuvuutta"
 
 msgid "This sort is not exposed. Expose it to allow the users to change it."
 msgstr ""
+"Lajittelua ei näytetä käyttäjille. Paljasta se mahdollistaaksesi sen "
+"muuttamisen."
 
 msgid "Expose sort"
-msgstr ""
+msgstr "Käyttäjille näytettävä lajittelu"
 
 msgid ""
 "This sort is exposed. If you hide it, users will not be able to change it."
 msgstr ""
+"Lajittelua ei näytetä käyttäjille. Jos piilotat sen, käyttäjät eivät voi "
+"muuttaa sitä."
 
 msgid "Hide sort"
-msgstr ""
+msgstr "Piilota lajittelu"
 
 msgid "Provide description"
-msgstr ""
+msgstr "Tarjoa kuvaus"
 
 msgid "Update \"@title\" choice"
-msgstr ""
+msgstr "Päivitä \"@title\" valinta"
 
 msgid "Update \"@title\" choice (@number)"
-msgstr ""
+msgstr "Päivitä \"@title\" valinta (@number)"
 
 msgid "Auto preview"
-msgstr ""
+msgstr "Automaattinen esikatselu"
 
 msgid "Preview with contextual filters:"
-msgstr ""
+msgstr "Esikatsele sisältöriippuvaisten suodattimien kanssa:"
 
 msgid "Separate contextual filter values with a \"/\". For example, %example."
 msgstr ""
+"Erottele sisältöriippuvaisen suodattimen arvot merkillä \"/\". Esimerkiksi "
+"%example."
 
 msgid ":"
-msgstr ""
+msgstr ":"
 
 msgid "Apply and continue"
-msgstr ""
+msgstr "Ota käyttöön ja jatka"
 
 msgid "@current of @total"
-msgstr ""
+msgstr "@current / @total"
 
 msgid "All displays (except overridden)"
-msgstr ""
+msgstr "Kaikki näkymät (paitsi ohitetut)"
 
 msgid "All displays"
-msgstr ""
+msgstr "Kaikki näkymät"
 
 msgid "This @display_type (override)"
-msgstr ""
+msgstr "Tämä @display_type (ohita)"
 
 msgid "Create new filter group"
-msgstr ""
+msgstr "Lisää uusi suodatinryhmä"
 
 msgid "No filters have been added."
-msgstr ""
+msgstr "Suodattimia ei ole lisättyinä."
 
 msgid "Drag to add filters."
-msgstr ""
+msgstr "Vedä lisätäksesi suodattimia."
 
 msgid "Add and configure @types"
-msgstr ""
+msgstr "Lisää ja muokkaa @types"
 
 msgid "Configure @type: @item"
-msgstr ""
+msgstr "Säädä @type: @item"
 
 msgid "Always show advanced display settings"
-msgstr ""
+msgstr "Näytä aina lisänäyttöasetukset"
 
 msgid "Label for \"Any\" value on non-required single-select exposed filters"
 msgstr ""
+"\"Mikä tahansa\" arvon etiketti ei-pakollisissa yhden valinnan käyttäjille "
+"näytetyissä suodattimissa"
 
 msgid "Live preview settings"
-msgstr ""
+msgstr "Reaaliaikaisen esikatselun asetukset"
 
 msgid "Automatically update preview on changes"
-msgstr ""
+msgstr "Automaatisesti päivitä esikatselu muutosten yhteydessä"
 
 msgid "Show information and statistics about the view during live preview"
 msgstr ""
+"Näytä näkymän tiedot ja statistiikkaa reaaliaikaisen esikatselun aikana"
 
 msgid "Above the preview"
-msgstr ""
+msgstr "Esikatselun yläpuolella"
 
 msgid "Below the preview"
-msgstr ""
+msgstr "Esikatselun alapuolella"
 
 msgid "Show the SQL query"
-msgstr ""
+msgstr "Näytä tietokantakysely"
 
 msgid "Show performance statistics"
-msgstr ""
+msgstr "Näytä suorituskykystatistiikat"
 
 msgid "Display"
 msgid_plural "Displays"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Näyttöruutu"
+msgstr[1] "Näyttöruudut"
 
 msgid "Unformatted list"
-msgstr ""
+msgstr "Muokkaamaton lista"
 
 msgid "Contextual filters"
-msgstr ""
+msgstr "Sisältöriippuvaiset suodattimet"
 
 msgid "contextual filters"
-msgstr ""
+msgstr "sisältöriippuvaiset suodattimet"
 
 msgid "Contextual filter"
-msgstr ""
+msgstr "Sisältöriippuvanen suodatin"
 
 msgid "contextual filter"
-msgstr ""
+msgstr "kontekstiriippuvainen suodatin"
 
 msgid "filter criteria"
-msgstr ""
+msgstr "suodatinkriteerit"
 
 msgid "Filter criterion"
-msgstr ""
+msgstr "Suodatinkriteeri"
 
 msgid "filter criterion"
-msgstr ""
+msgstr "suodatinkriteeri"
 
 msgid "no results behavior"
-msgstr ""
+msgstr "käyttäytyminen kun ei tuloksia"
 
 msgid "The node ID."
-msgstr ""
+msgstr "Solmun ID"
 
 msgid "The content title."
-msgstr ""
+msgstr "Sisällön otsikko."
 
 msgid "The date the content was posted."
-msgstr ""
+msgstr "Sisällön kirjoituspäivämäärä."
 
 msgid "Filters out unpublished content if the current user cannot view it."
 msgstr ""
+"Suodattaa julkaisemattoman sisällön pois tuloksista jos senhetkisellä "
+"käyttäjällä ei ole oikeuksia nähdä niitä."
 
 msgid "Whether or not the content is sticky."
-msgstr ""
+msgstr "Onko sisältö kiinteä listoissa vaiko ei."
 
 msgid ""
 "Whether or not the content is sticky. To list sticky content first, set this"
 " to descending."
 msgstr ""
+"Onko sisältö kiinteä listoilla vaiko ei, Listataksesi kiinteästi listoille "
+"kiinnitetyn sisällön ensimmäiseksi, laita tähän asetukseksi aleneva."
 
 msgid "Relate content to the user who created it."
-msgstr ""
+msgstr "Linkitä sisältö käyttäjään joka sen kirjoitti."
 
 msgid "User has a revision"
-msgstr ""
+msgstr "Käyttäjällä on versio"
 
 msgid "All nodes where a certain user has a revision"
-msgstr ""
+msgstr "Kaikki solmut joissa tietyllä käyttäjällä on versio."
 
 msgid "Content revision is a history of changes to content."
-msgstr ""
+msgstr "Sisällön versiot ovat historiatietoa sisältöön tehdyistä muutoksista."
 
 msgid "Relate a content revision to the user who created the revision."
-msgstr ""
+msgstr "Liitä sisältöversio sen kirjoittaneeseen käyttäjään."
 
 msgid "Get the actual content from a content revision."
-msgstr ""
+msgstr "Hae sisältö sisältöversiosta."
 
 msgid "Provide a simple link to delete the content revision."
-msgstr ""
+msgstr "Tarjoaa yksinkertaisen linkin sisältöversion poistamiseksi."
 
 msgid ""
 "Filter for content by view access. <strong>Not necessary if you are using "
 "node as your base table.</strong>"
 msgstr ""
+"Suodata sisältöä pääsyoikeuksien perusteella. <strong>Ei tarpeen mikäli "
+"käytät solmua perustaulunasi.</strong>"
 
 msgid "Show a marker if the content is new or updated."
-msgstr ""
+msgstr "Näytä merkki jos sisältö on uutta tai se on päivittynyt."
 
 msgid "Show only content that is new or updated."
-msgstr ""
+msgstr "Näytä vain uusi tai päivitetty sisältö."
 
 msgid "Display the content with standard node view."
-msgstr ""
+msgstr "Näytä sisältö normaalissa solmunäkymässä."
 
 msgid "Content ID from URL"
-msgstr ""
+msgstr "Sisällön ID URLista"
 
 msgid ""
 "Content that is associated with this file, usually because this file is in a"
 " field on the content."
 msgstr ""
+"Tiedostoon liittyvä sisältö, useimmiten koska tiedosto on sisältötyypin "
+"kentässä."
 
 msgid ""
 "Allows the \"depth\" for Taxonomy: Term ID (with depth) to be modified via "
 "an additional contextual filter value."
 msgstr ""
+"Sallii \"syvyyden\" Luokittelu: Termin ID (syvyydellä) muuttamisen "
+"ylimääräisellä sisältöriippuvaisella suodattimella."
 
 msgid "Content authored"
-msgstr ""
+msgstr "Sisältö kirjoitettu"
 
 msgid ""
 "Relate content to the user who created it. This relationship will create one"
 " record for each content item created by the user."
 msgstr ""
+"Liitä sisältö kirjoittajaansa. Tämä suhde luo yhden tuloksen jokaista "
+"käyttäjän luomaa sisältöä kohden."
 
 msgid ""
 "Allow a contextual filter value to be ignored. The query will not be altered"
 " by this contextual filter value. Can be used when contextual filter values "
 "come from the URL, and a part of the URL needs to be ignored."
 msgstr ""
+"Salli sisältöriippuvaisen suodattimen ohitus. Kyselyä ei muuteta tämän "
+"sisältöriippuvaisen suodattimen arvon mukaisesti. Voidaan käyttää kun "
+"sisältöriippuvaisen suodattimen arvot tulevat URLista ja osa URLista tulee "
+"ohittaa."
 
 msgid "View area"
-msgstr ""
+msgstr "Näyttöalue"
 
 msgid "Insert a view inside an area."
-msgstr ""
+msgstr "Syötä näkymä tälle alueelle."
 
 msgid "Enable to override this field's links."
-msgstr ""
+msgstr "Salli ylikirjoitus tämän kentän linkeille."
 
 msgid "Use field template"
-msgstr ""
+msgstr "Käytä kenttäpohjaa"
 
 msgid ""
 "Checking this option will cause the group Display Type and Separator values "
 "to be ignored."
 msgstr ""
+"Tämän vaihtoehdon valinnan seurauksena ryhmien Näyttöruudun Tyyppi sekä "
+"Erottaja arvot ohitetaan."
 
 msgid "Multiple field settings"
-msgstr ""
+msgstr "Usean kentän asetukset"
 
 msgid "Display all values in the same row"
-msgstr ""
+msgstr "Näytä arvot samalla rivillä"
 
 msgid "Display @count value(s)"
-msgstr ""
+msgstr "Näytä @count arvoa"
 
 msgid "Raw @column"
-msgstr ""
+msgstr "Raaka @column"
 
 msgid "Link this field to the original piece of content"
-msgstr ""
+msgstr "Linkitä kenttä alkuperäiseen sisältöönsä"
 
 msgid ""
 "Enable this option to output an absolute link. Required if you want to use "
 "the path as a link destination (as in \"output this field as a link\" "
 "above)."
 msgstr ""
+"Valitse tämä vaihtoehto tulostaaksesi absoluuttinen linkki. Tämä on "
+"pakollista jos haluat käyttää polkua linkin kohteena (ts. yläpuolella oleva "
+"\"tulosta kenttä linkkinä\")."
 
 msgid "Access operation to check"
-msgstr ""
+msgstr "Tarkistettava pääsymenetelmä"
 
 msgid ""
 "If selected, users can enter multiple values in the form of 1+2+3. Due to "
 "the number of JOINs it would require, AND will be treated as OR with this "
 "filter."
 msgstr ""
+"Mikäli valittuna, käyttäjät voivat syöttää useampia arvoja muodossa 1+2+3. "
+"Tarvittavien JOIN syntaksien määrästä johtuen, AND syntaksia kohdellaan OR "
+"syntaksina tämän suodattimen yhteydessä."
 
 msgid "Load default filter from term page"
-msgstr ""
+msgstr "Lataa oletussuodatin termin sivulta"
 
 msgid "Transform dashes in URL to spaces in term name filter values"
 msgstr ""
+"Muunna URLien väliviivat välilyönneiksi termien nimien suodatinarvoissa."
 
 msgid ""
 "Note: you do not have permission to modify this. If you change the default "
 "filter type, this setting will be lost and you will NOT be able to get it "
 "back."
 msgstr ""
+"Huomaa: sinulle ei ole oikeuksia muuttaa tätä. Jos muutat "
+"oletussuodatintyypin, asetus menetetään etkä saa sitä takaisin."
 
 msgid "Change the way content is formatted."
-msgstr ""
+msgstr "Muuta sisällön muotoilua."
 
 msgid "Change settings for this format"
-msgstr ""
+msgstr "Muuta muotoilun asetuksia"
 
 msgid "Change the way each row in the view is styled."
-msgstr ""
+msgstr "Muuta tapaa jolla kukin näkymän rivi esitetään."
 
 msgid "Hide attachments in summary"
-msgstr ""
+msgstr "Piilota liitetiedostot lyhennelmässä"
 
 msgid ""
 "Change whether or not to display attachments when displaying a contextual "
 "filter summary."
 msgstr ""
+"Valitse näytetäänkö liitteet vaiko ei näytettäessä sisältöriippuvaisen "
+"suodattimen tiivistelmää."
 
 msgid "Hide attachments when displaying a contextual filter summary"
 msgstr ""
+"Piilota liitteet näytettäessä sisältöriippuvaisen suodattimen tiivistelmää"
 
 msgid "Attachment position"
-msgstr ""
+msgstr "Liitetiedoston sijoittelu"
 
 msgid ""
 "Should this display inherit its contextual filter values from the parent "
 "display to which it is attached?"
 msgstr ""
+"Periikö näyttöruutu kontekstiriippuvaisten suodattimiensa arvot "
+"isäntäruudusta johon se on liitetty?"
 
 msgid ""
 "This view will be displayed by visiting this path on your site. It is "
@@ -12210,180 +13006,192 @@ msgid ""
 "\"path/%/%/rss.xml\", putting one % in the path for each contextual filter "
 "you have defined in the view."
 msgstr ""
+"Näkymä näytetään tietyssä polussa sivustollasi. On suositeltavaa että polku "
+"on muotoa \"polku/%/%/syote\" tai \"polku/%/%/rss,xml\" jossa kukin % vastaa"
+" yhtä näkymässäsi määriteltyä sisältöriippuvaista suodatinta."
 
 msgid ""
 "Display @display is set to use a menu but the menu link text is not set."
 msgstr ""
+"Näyttöruutu @display on asetettu käyttämään valikkoa mutta valikon linkin "
+"tekstiä ei ole asetettu."
 
 msgid ""
 "Display @display is set to use a parent menu but the parent menu link text "
 "is not set."
 msgstr ""
+"Näyttöruutu @display on asetettu käyttämään isäntävalikkoa mutta "
+"isäntävalikon linkin tekstiä ei ole asetettu."
 
 msgid "@count item, skip @skip"
 msgid_plural "Paged, @count items, skip @skip"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count tulos, ohita @skip"
+msgstr[1] "@count tulosta, ohita @skip"
 
 msgid "@count item"
 msgid_plural "Paged, @count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count tulos"
+msgstr[1] "Sivutettu, @count tulosta"
 
 msgid "Create a page"
-msgstr ""
+msgstr "Luo sivu"
 
 msgid "Create a menu link"
-msgstr ""
+msgstr "Luo valikkolinkki"
 
 msgid "Include an RSS feed"
-msgstr ""
+msgstr "Sisällytä RSS syöte"
 
 msgid "Feed path"
-msgstr ""
+msgstr "Syötteen polku"
 
 msgid "Feed row style"
-msgstr ""
+msgstr "Syötteen rivityyli"
 
 msgid "Create a block"
-msgstr ""
+msgstr "Luo lohko"
 
 msgid "of fields"
-msgstr ""
+msgstr "kentistä"
 
 msgid "of type"
-msgstr ""
+msgstr "tyyppiä"
 
 msgid "tagged with"
-msgstr ""
+msgstr "tagatty"
 
 msgid "teasers"
-msgstr ""
+msgstr "lyhennelmät"
 
 msgid "full posts"
-msgstr ""
+msgstr "kokonaiset artikkelit"
 
 msgid "titles"
-msgstr ""
+msgstr "otsikot"
 
 msgid "titles (linked)"
-msgstr ""
+msgstr "otsikot (linkitettyinä)"
 
 msgid "Sorts"
-msgstr ""
+msgstr "Lajittelut"
 
 msgid "Hide view"
-msgstr ""
+msgstr "Piilota näkymä"
 
 msgid "@group (historical data)"
-msgstr ""
+msgstr "@group (historiatieto)"
 
 msgid "Use path alias"
-msgstr ""
+msgstr "Käytä polkualiasta"
 
 msgid "Field mappings"
-msgstr ""
+msgstr "Kenttien mappaukset"
 
 msgid "Cooking time"
-msgstr ""
+msgstr "Valmistusaika"
 
 msgid "View any unpublished content"
-msgstr ""
+msgstr "Katsele mitä tahansa julkaisematonta sisältöä"
 
 msgid "Relative default value"
-msgstr ""
+msgstr "Suhteellinen oletuspäivämäärä"
 
 msgid "The comment UUID."
-msgstr ""
+msgstr "Kommentin UUID."
 
 msgid "The file UUID."
-msgstr ""
+msgstr "Tiedoston UUID."
 
 msgid "The term UUID."
-msgstr ""
+msgstr "Termin UUID."
 
 msgid "The user UUID."
-msgstr ""
+msgstr "Käyttäjän UUID."
 
 msgid "Field item"
-msgstr ""
+msgstr "Kenttäkohde"
 
 msgid "Edit shortcut set"
-msgstr ""
+msgstr "Muokkaa oikopolkuryhmää"
 
 msgid "Appearance settings"
-msgstr ""
+msgstr "Ulkoasu-asetukset"
 
 msgid "Delete translation"
-msgstr ""
+msgstr "Poista käännös"
 
 msgid "Unsorted"
-msgstr ""
+msgstr "Lajittelematon"
 
 msgid "Changes to the style have been saved."
-msgstr ""
+msgstr "Tyylin muutokset on tallennettu."
 
 msgid "Media query"
-msgstr ""
+msgstr "Mediakysely"
 
 msgid "Aggregation type"
-msgstr ""
+msgstr "Aggregointityyppi"
 
 msgid "Mapping type"
-msgstr ""
+msgstr "Mappauksen tyyppi"
 
 msgid "Create media"
-msgstr ""
+msgstr "Luo media"
 
 msgid "Use replacement tokens from the first row"
-msgstr ""
+msgstr "Käytä korvausarvoja ensimmäiseltä riviltä"
 
 msgid "Allow multiple filter values to work together"
-msgstr ""
+msgstr "Salli useampien kuin yhden suodattimen toimia yhdessä"
 
 msgid "Customize field HTML"
-msgstr ""
+msgstr "Kustomoi kentän HTML"
 
 msgid ""
 "You may use token substitutions from the rewriting section in this class."
-msgstr ""
+msgstr "Voit käyttää korvausmerkkejä uudelleenkirjoittaaksesi osia luokasta."
 
 msgid "Customize label HTML"
-msgstr ""
+msgstr "Kustomisoi etiketin HTML:ää"
 
 msgid "Customize field and label wrapper HTML"
-msgstr ""
+msgstr "Kustomisoi kenttää ja etikettiä ympäröivää HTML-elementtiä"
 
 msgid ""
 "Choose the HTML element to wrap around this field and label, e.g. H1, H2, "
 "etc. This may not be used if the field and label are not rendered together, "
 "such as with a table."
 msgstr ""
+"Valitse tämän kentän ja sen etiketin ympärille asetettava HTML-elementti, "
+"ts. H1, H2, jne. Tätä ei voi käyttää jos etikettiä ja itse kenttää ei "
+"renderöidä yhdessä, esimerkiksi taulukoissa."
 
 msgid "Remove whitespace"
-msgstr ""
+msgstr "Poista välilyönti"
 
 msgid "Hide rewriting if empty"
-msgstr ""
+msgstr "Piilota uudelleenkirjoitus mikäli tyhjä"
 
 msgid "Do not display rewritten content if this field is empty."
-msgstr ""
+msgstr "Älä näytä uudelleenkirjoitettua sisältöä jos kenttä on tyhjä."
 
 msgid "Thousands marker"
-msgstr ""
+msgstr "Tuhansien merkki"
 
 msgid "Expose this filter to visitors, to allow them to change it"
 msgstr ""
+"Näytä suodatin kävijöille, tämä mahdollistaa suodattimen arvon muuttamisen"
 
 msgid "Subquery namespace"
-msgstr ""
+msgstr "Alikyselyn nimitila"
 
 msgid ""
 "Advanced. Enter a namespace for the subquery used by this relationship."
 msgstr ""
+"Asiantuntijoille. Syötä tämän suhteen käyttmän alikyselyn nimiavaruus."
 
 msgid "Representative view"
-msgstr ""
+msgstr "Edustava näkymä"
 
 msgid ""
 "Advanced. Use another view to generate the relationship subquery. This "
@@ -12391,407 +13199,459 @@ msgid ""
 " the sort options above are ignored. Your view must have the ID of its base "
 "as its only field, and should have some kind of sorting."
 msgstr ""
+"Edistynyt. Käytä toista näkymää suhdealikyselyn luomisessa. Tämä "
+"mahdollistaa suodatuksen ja lajittelun useamman kuin yhden arvon "
+"perusteella. Jos valitset näkymän, ylläolevat lajitteluvaihtoehdot "
+"ohitetaan. Näkymälläsi on oltava perustansa ID ainoana kenttänään ja sen "
+"lajittelun tulee olla samankaltainen."
 
 msgid ""
 "Will re-generate the subquery for this relationship every time the view is "
 "run, instead of only when these options are saved. Use for testing if you "
 "are making changes elsewhere. WARNING: seriously impairs performance."
 msgstr ""
+"Luo uudelleen alikyselyn tälle liitokselle joka kerta kun näkymä ajetaan sen"
+" sijaan että alikysely luotaisiin vain näitä valintoja tallennettaessa. "
+"Käytä testaukseen jos olet tekemässä muutoksia muualle. VAROITUS: vaikuttaa "
+"suorituskykyyn."
 
 msgid "Expose this sort to visitors, to allow them to change it"
-msgstr ""
+msgstr "Paljasta lajittelu käyttäjille mahdollistaaksesi sen muuttamisen"
 
 msgid "This display is disabled."
-msgstr ""
+msgstr "Näyttöruutu on pois käytöstä."
 
 msgid ""
 "Error: Display @display refers to a plugin named '@plugin', but that plugin "
 "is not available."
 msgstr ""
+"Virhe: Näyttöruutu @display viittaa pluginniin nimeltä '@plugin' mutta "
+"kyseinen plugin ei ole käytettävissä."
 
 msgid "Aggregation settings"
-msgstr ""
+msgstr "Aggregointiasetukset"
 
 msgid "Display extenders"
-msgstr ""
+msgstr "Näytä laajennukset"
 
 msgid "Select extensions of the views interface."
-msgstr ""
+msgstr "Valitse näkymien käyttöliittymän laajennukset."
 
 msgid ""
 "You have configured display %display with a path which is an path alias as "
 "well. This might lead to unwanted effects so better use an internal path."
 msgstr ""
+"Olet määritellyt näyttöruudulle %display polun, joka on myös osoitealias. "
+"Tämä voi johtaa ei-toivottuihin tuloksiin joten on parempi käyttää sisäistä "
+"polkua."
 
 msgid "Configure aggregation settings for @type %item"
-msgstr ""
+msgstr "Säädä aggregointiasetuksia @type %item"
 
 msgid "Select the aggregation function to use on this field."
-msgstr ""
+msgstr "Valitse kentässä käytettävä aggregointitoiminto."
 
 msgid "Empty display extender"
-msgstr ""
+msgstr "Tyhjennä näyttöruudun laajennin"
 
 msgid "Raw value from URL"
-msgstr ""
+msgstr "Raaka-arvo URLista"
 
 msgid "Apply (all displays)"
-msgstr ""
+msgstr "Käytä (kaikki sivut)"
 
 msgid "Apply (this display)"
-msgstr ""
+msgstr "Käytä (tämä sivu)"
 
 msgid "The date of the most recent new content on the feed."
-msgstr ""
+msgstr "Syötteen viimeisimmän sisällön julkaisupäivämäärä."
 
 msgid "This is an alias of @group: @field."
-msgstr ""
+msgstr "Tämä on alias ryhmän @group kentälle @field."
 
 msgid "@label:delta"
-msgstr ""
+msgstr "@label:delta"
 
 msgid "Delta - Appears in: @bundles."
-msgstr ""
+msgstr "Delta - Esiintyy: @bundles."
 
 msgid "User who uploaded"
-msgstr ""
+msgstr "Käyttäjä joka latasi"
 
 msgid "Taxonomy term chosen from autocomplete or select widget."
 msgstr ""
+"Valintalistasta tai automaattisesta täydennyksestä valittu luokittelutermi."
 
 msgid "Representative node"
-msgstr ""
+msgstr "Esittävä solmu"
 
 msgid ""
 "Obtains a single representative node for each term, according to a chosen "
 "sort criterion."
 msgstr ""
+"Saa yhden esittävän solmun kullekin hakutermille valitusta "
+"lajittelukriteeristä riippuen."
 
 msgid "Content with term"
-msgstr ""
+msgstr "SIsältöä termillä"
 
 msgid "Relate all content tagged with a term."
-msgstr ""
+msgstr "Liitä kaikki termillä tagitettu sisältö."
 
 msgid "Has taxonomy term ID"
-msgstr ""
+msgstr "On luokittelutermin ID"
 
 msgid "Display content if it has the selected taxonomy terms."
-msgstr ""
+msgstr "Näytä sisältö jos siihen liittyy valitut luokittelutermit."
 
 msgid "Has taxonomy term"
-msgstr ""
+msgstr "On luokittelutermi"
 
 msgid "Taxonomy terms on node"
-msgstr ""
+msgstr "Solmun luokittelutermit"
 
 msgid "All taxonomy terms"
-msgstr ""
+msgstr "Kaikki luokittelutermit"
 
 msgid ""
 "Display content if it has the selected taxonomy terms, or children of the "
 "selected terms. Due to additional complexity, this has fewer options than "
 "the versions without depth."
 msgstr ""
+"Näytä sisältöä jos sillä on valitut luokittelutermit tai valittujen termien "
+"alitermit. Monimutkaisuudesta johtuen tällä on vähemmän vaihtoehtoja kuin "
+"versioilla joilla ei ole syvyyttä."
 
 msgid "Has taxonomy term ID (with depth)"
-msgstr ""
+msgstr "On taxonomy ID (syvyydellä)"
 
 msgid "Has taxonomy terms (with depth)"
-msgstr ""
+msgstr "On luokittelutermejä (syvyydellä)"
 
 msgid "Has taxonomy term ID depth modifier"
-msgstr ""
+msgstr "On luokittelun ID:n syvyystunnistin"
 
 msgid "@entity using @field"
-msgstr ""
+msgstr "entiteetti @entity käyttäen kenttää @field"
 
 msgid "Taxonomy term ID from URL"
-msgstr ""
+msgstr "Luokittelutermin ID sivun URLista"
 
 msgid ""
 "Obtains a single representative node for each user, according to a chosen "
 "sort criterion."
 msgstr ""
+"Saa yhden kuvaavan solmun kullekin käyttäjälle valitusta "
+"lajittelukriteeristä riippuen."
 
 msgid ""
 "Display an icon representing the file type, instead of the MIME text (such "
 "as \"image/jpeg\")"
 msgstr ""
+"Näytä kuvake esittämässä tiedoston tyyppiä MIME tekstin sijaan (kuten "
+"image/jpeg)"
 
 msgid ""
 "Load default filter from node page, that's good for related taxonomy blocks"
 msgstr ""
+"Lataa oletussuodatin solmun sivulta, hyödyllistä esimerkiksi sanastoihin "
+"liittyvissä lohkoissa"
 
 msgid "Path component"
-msgstr ""
+msgstr "Polkukomponentti"
 
 msgid ""
 "The numbering starts from 1, e.g. on the page admin/structure/types, the 3rd"
 " path component is \"types\"."
 msgstr ""
+"Numerointi alkaa arvosta 1, esimerkiksi sivulla admin/structure/types kolmas"
+" komponentti on \"types\"."
 
 msgid "Use aggregation"
-msgstr ""
+msgstr "Käytä aggregointia"
 
 msgid "Display title may not be empty."
-msgstr ""
+msgstr "Näyttöruudun otsikko ei voi olla tyhjä."
 
 msgid "When the filter value is <em>NOT</em> available"
-msgstr ""
+msgstr "Kun suodattimen arvo <em>EI</em> ole saatavilla"
 
 msgid "When the filter value <em>IS</em> available or a default is provided"
 msgstr ""
+"Kun suodattimen arvo <em>ON</em> saatavilla tai oletusarvo on annettuna"
 
 msgid ""
 "This display does not have a source for contextual filters, so no contextual"
 " filter value will be available unless you select 'Provide default'."
 msgstr ""
+"Näyttöruudulla ei ole sisältöriippuvaisten suodattimien lähdettä joten "
+"sisältöriippuvaisia suodattimia ei ole tarjolla paitsi jos valitset \"anna "
+"oletusarvo\"."
 
 msgid "Query Comment"
-msgstr ""
+msgstr "Kyselyn kommentti"
 
 msgid ""
 "If set, this comment will be embedded in the query and passed to the SQL "
 "server. This can be helpful for logging or debugging."
 msgstr ""
+"Mikäli valittuna, kommentti lähetetään tietokantapalvelimelle osana kyselyä."
+" Tämä voi olla hyödyllistä debuggauksen ja logituksen yhteydessä."
 
 msgid "Count DISTINCT"
-msgstr ""
+msgstr "Laske DISTINCT"
 
 msgid "Provide default field wrapper elements"
-msgstr ""
+msgstr "Tarjoa oletuskentät ympäröivälle elementille"
 
 msgid ""
 "Inline fields will be displayed next to each other rather than one after "
 "another. Note that some fields will ignore this if they are block elements, "
 "particularly body fields and other formatted HTML."
 msgstr ""
+"Sisennetyt kentät näytetään toistensa perään sen sijaan että ne "
+"esitettäisiin peräkkäin. Huomaa että jotkut kentät ohittavat tämän "
+"asetuksen, esimerkiksi runkokentät ja muu muotoiltu HTML."
 
 msgid "Show the empty text in the table"
-msgstr ""
+msgstr "Näytä tyhjä teksti taulussa"
 
 msgid "The block could not be saved."
-msgstr ""
+msgstr "Lohkon tallentaminen epäonnistui."
 
 msgid "Datetime"
-msgstr ""
+msgstr "Datetime"
 
 msgid "Language (fr, en, ...)"
-msgstr ""
+msgstr "Kieli (fr, en, ...)"
 
 msgid "Link attributes"
-msgstr ""
+msgstr "Linkin ominaisuudet"
 
 msgid "Max age"
-msgstr ""
+msgstr "Maksimi-ikä"
 
 msgid "Last Cron Run"
-msgstr ""
+msgstr "Viimeisin Cron-ajo"
 
 msgid "The user ID."
-msgstr ""
+msgstr "Käyttäjän ID."
 
 msgid "Latest revision"
-msgstr ""
+msgstr "Uusin versio"
 
 msgid "Responsive image"
-msgstr ""
+msgstr "Responsiivinen kuva"
 
 msgid "The field that is going to be used as the RSS item title for each row."
-msgstr ""
+msgstr "Kenttä jota käytetään RSS elementin otsikkona kullekin riville."
 
 msgid ""
 "The field that is going to be used as the RSS item link for each row. This "
 "must be a drupal relative path."
 msgstr ""
+"Kenttä jota käytetään RSS elementtien linkkinä kullekin riville. Tämän on "
+"oltava suhteellinen polku Drupalin asennukseen nähden."
 
 msgid ""
 "The field that is going to be used as the RSS item description for each row."
-msgstr ""
+msgstr "Kenttä jota käytetään RSS elementtien otsikkona kullekin riville."
 
 msgid "Creator field"
-msgstr ""
+msgstr "Luojan kenttä"
 
 msgid ""
 "The field that is going to be used as the RSS item creator for each row."
-msgstr ""
+msgstr "Kenttä jota käytetään RSS:ssä luojan tietona kullakin rivillä."
 
 msgid "Publication date field"
-msgstr ""
+msgstr "Julkaisupäivämäärä-kenttä"
 
 msgid ""
 "Row style plugin requires specifying which views fields to use for RSS item."
 msgstr ""
+"Rivityylin pluginni vaatii että määrittelet, mitä kenttiä RSS:ssä käytetään."
 
 msgid "Unique watchdog event ID."
-msgstr ""
+msgstr "Yksilöllinen watchdog-tapahtuman ID."
 
 msgid ""
 "The severity level of the event; ranges from 0 (Emergency) to 7 (Debug)."
-msgstr ""
+msgstr "Tapahtuman vakavuusaste; skaala 0 (vaaratilanne) - 7 (debuggaa)."
 
 msgid "Logo image"
-msgstr ""
+msgstr "Logokuva"
 
 msgid "Curaçao"
-msgstr ""
+msgstr "Curaçao"
 
 msgid "Réunion"
-msgstr ""
+msgstr "Réunion"
 
 msgid "Sint Maarten"
-msgstr ""
+msgstr "Sint Maarten"
 
 msgid "Manage view modes"
-msgstr ""
+msgstr "Hallitse näyttötapoja"
 
 msgid "JavaScript settings"
-msgstr ""
+msgstr "JavaScript-asetukset"
 
 msgid "Entity Reference"
-msgstr ""
+msgstr "Entiteettiviittaus"
 
 msgid "An autocomplete text field."
-msgstr ""
+msgstr "Autocomplete tekstikenttä."
 
 msgid "Display the label of the referenced entities."
-msgstr ""
+msgstr "Näytä viitattujen entiteettien etiketit."
 
 msgid "Rendered entity"
-msgstr ""
+msgstr "Renderöity entiteetti"
 
 msgid "Display the referenced entities rendered by entity_view()."
-msgstr ""
+msgstr "Näytä entity_view():n renderöimät viitatut entiteetit."
 
 msgid "Link label to the referenced entity"
-msgstr ""
+msgstr "Linkitä etiketti viitattuun entiteettiin"
 
 msgid "Link to the referenced entity"
-msgstr ""
+msgstr "Linkitä viitattuun entiteettiin"
 
 msgid "Rendered as @mode"
-msgstr ""
+msgstr "Renderöity muodossa @mode"
 
 msgid "Language types"
-msgstr ""
+msgstr "Kielityypit"
 
 msgid "Add view mode"
-msgstr ""
+msgstr "Lisää esitystapa"
 
 msgid "@group: @field"
-msgstr ""
+msgstr "@group: @field"
 
 msgid "@group (historical data): @field"
-msgstr ""
+msgstr "@group (historiatieto): @field"
 
 msgid "Edit view mode"
-msgstr ""
+msgstr "Muokkaa esitystapaa"
 
 msgid "Default date"
-msgstr ""
+msgstr "Oletuspäivämäärä"
 
 msgid "Default end date"
-msgstr ""
+msgstr "Oletus-päättymispäivämäärä"
 
 msgid "Time increments"
-msgstr ""
+msgstr "Aikamäärän kasvu"
 
 msgid "10 minute"
-msgstr ""
+msgstr "10 minuuttia"
 
 msgid "30 minute"
-msgstr ""
+msgstr "30 minuuttia"
 
 msgid "Text of the auto-reply message."
-msgstr ""
+msgstr "Automaattisen vastauksen teksti."
 
 msgid "Entity reference"
-msgstr ""
+msgstr "Entiteettiviittaus"
 
 msgid "@name field is required."
-msgstr ""
+msgstr "@name kenttä on pakollinen."
 
 msgid "Fields pending deletion"
-msgstr ""
+msgstr "Jotkin kentät odottavat poistamista"
 
 msgid "No translatable fields"
-msgstr ""
+msgstr "Ei käännöskelpoisia kenttiä"
 
 msgid "Translations of %label"
-msgstr ""
+msgstr "Käännökset %label"
 
 msgid "This translation is published"
-msgstr ""
+msgstr "Käännös on julkaistu"
 
 msgid "Are you sure you want to delete the @language translation of %label?"
 msgstr ""
+"Oletko varma että haluat poistaa @language käännöksen kokonaisuudelle "
+"%label?"
 
 msgid "Shown"
-msgstr ""
+msgstr "Näytetty"
 
 msgid "Translate any entity"
-msgstr ""
+msgstr "Käännä entiteetti"
 
 msgid "Hide empty columns"
-msgstr ""
+msgstr "Piilota tyhjät sarakkeet"
 
 msgid ""
 "The node ID of the node a user created or commented on. You must use an "
 "argument or filter on UID or you will get misleading results using this "
 "field."
 msgstr ""
+"Käyttäjän luoman tai kommentoiman solmun ID. Sinun on käytettävä argumenttia"
+" tai suodatettava UID:n perusteella tai voit saada harhaanjohtavia tuloksia "
+"tähän kenttään."
 
 msgid ""
 "The user ID of a user who touched the node (either created or commented on "
 "it)."
 msgstr ""
+"Solmuun koskeneen käyttäjän ID (joko kirjoittajan tai kommentoijan ID)."
 
 msgid ""
 "The date the node was last updated or commented on. You must use an argument"
 " or filter on UID or you will get misleading results using this field."
 msgstr ""
+"Päivämäärä jolloin solmua viimeksi päivitettiin tai kommentoitiin. Sinun on "
+"käytettävä argumenttia tai suodatettava UID:n perusteella tai voit saada "
+"harhaanjohtavia tuloksia tähän kenttään."
 
 msgid "Entity types"
-msgstr ""
+msgstr "Entiteettityypit"
 
 msgid "Change handler"
-msgstr ""
+msgstr "Vaihda käsittelijää"
 
 msgid "Autocomplete (Tags style)"
-msgstr ""
+msgstr "Automaattinen täydennys (Tagien tavalla)"
 
 msgid "Mail system"
-msgstr ""
+msgstr "Sähköpostijärjestelmä"
 
 msgid "Hide empty column"
-msgstr ""
+msgstr "Piilota tyhjä sarake"
 
 msgid "Restrict images to this site"
-msgstr ""
+msgstr "Rajoita kuvat tälle sivustolle"
 
 msgid ""
 "Disallows usage of &lt;img&gt; tag sources that are not hosted on this site "
 "by replacing them with a placeholder image."
 msgstr ""
+"Estää muualla kuin tällä sivustolla sijaitsevien kuvien käyttämisen "
+"&lt;img&gt;-tageissa vaihtamalla tilalle korvauskuvan."
 
 msgid "Maximum dimensions"
-msgstr ""
+msgstr "Suurimmat sallitut mittasuhteet"
 
 msgid "Fallback image style"
-msgstr ""
+msgstr "Varmistus-kuvatyyli"
 
 msgid "Wide"
-msgstr ""
+msgstr "Leveä"
 
 msgid "The operator is invalid on filter: @filter."
-msgstr ""
+msgstr "Operaattori on epäkelpo suodattimelle: @filter."
 
 msgid "No valid values found on filter: @filter."
-msgstr ""
+msgstr "Suodattimelle ei löytynyt arvoja: @filter."
 
 msgid "The value @value is not an array for @operator on filter: @filter"
 msgstr ""
+"Arvo @value ei ole array operaattorille @operator suodattimessa: @filter"
 
 msgid ""
 "If not checked, fields that are not configured to customize their HTML "
@@ -12800,177 +13660,202 @@ msgid ""
 "view provides by default, at the cost of making it more difficult to apply "
 "CSS."
 msgstr ""
+"Mikäli ei valittuna, kentät jotka eivät kustomoi HTML-elementtejään eivät "
+"saa ympäröivää elementtiä kenttänsä, etikettinsä ja kenttä + etiketti "
+"-yhdistelmän ympärille. Voit käyttää tätä vähentämään näkymien tulostaman "
+"HTML-koodin määrää mutta se voi osaltaan vaikeuttaa CSS:n käyttämistä."
 
 msgid "@label (@column)"
-msgstr ""
+msgstr "@label (@column)"
 
 msgid "banned IP addresses"
-msgstr ""
+msgstr "Estetyt IP-osoitteet"
 
 msgid "The IP address %ip has been banned."
-msgstr ""
+msgstr "IP-osoite %ip on nyt estetty."
 
 msgid "CKEditor settings"
-msgstr ""
+msgstr "CKEditorin asetukset"
 
 msgid "The field name."
-msgstr ""
+msgstr "Kentän nimi."
 
 msgid "Validate options"
-msgstr ""
+msgstr "Validoi vaihtoehdot"
 
 msgid "Whether the user is active or blocked."
-msgstr ""
+msgstr "Kun käyttäjä on aktiivinen tai estetty."
 
 msgid "Views query"
-msgstr ""
+msgstr "Näkymäkysely"
 
 msgid ""
 "The throbber display does not show the status of uploads but takes up less "
 "space. The progress bar is helpful for monitoring progress on large uploads."
 msgstr ""
+"Throbber-näkymä ei näytä tiedostojen latauksen tilaa mutta vie vähemmän "
+"tilaa ruudulla. Latauspalkki on hyödyllinen seurattaessa suurien "
+"tiedostolatauksien etenemistä."
 
 msgid "Leave this blank to delete both the existing username and password."
 msgstr ""
+"Jätä tyhjäksi poistaaksesi olemassaolevan käyttäjätunnuksen ja salasanan."
 
 msgid "To change the password, enter the new password here."
-msgstr ""
+msgstr "Muuttaaksesi salasanan syötä uusi salasana tähän."
 
 msgid ""
 "HTTP authentication credentials must include a username in addition to a "
 "password."
 msgstr ""
+"HTTP tunnistetietojen täytyy sisältää salasanan lisäksi myös käyttäjätunnus."
 
 msgid ""
 "Cron takes care of running periodic tasks like checking for updates and "
 "indexing content for search."
 msgstr ""
+"Cron huolehtii ajastetuista toiminnoista kuten päivitysten tarkistuksesta ja"
+" sisällön indeksoinnista hakua varten."
 
 msgid "User name and password"
-msgstr ""
+msgstr "Käyttäjänimi ja salasana"
 
 msgid "User module account form elements."
-msgstr ""
+msgstr "User moduulin lomakkeen elementit."
 
 msgid "Manage form display"
-msgstr ""
+msgstr "Hallitse lomakkeen esitystapaa"
 
 msgid ""
 "A Drupal path or external URL the more link will point to. Note that this "
 "will override the link display setting above."
 msgstr ""
+"Drupal-polku tai ulkoinen URL johon linkki osoittaa. Huomaa että tämä "
+"ylikirjoittaa yllämääritellyt linkin tulostusasetukset."
 
 msgid "<em>Alt</em> field required"
-msgstr ""
+msgstr "<em>Alt</em> kenttä pakollinen"
 
 msgid "<em>Title</em> field required"
-msgstr ""
+msgstr "<em>Otsikko</em> kenttä pakollinen"
 
 msgid "Link to entity"
-msgstr ""
+msgstr "Linkitä entiteettiin"
 
 msgid "Bypass access checks"
-msgstr ""
+msgstr "Ohita oikeuksien tarkistus"
 
 msgid "Media type"
-msgstr ""
+msgstr "Median tyyppi"
 
 msgid "@view : @display"
-msgstr ""
+msgstr "@view : @display"
 
 msgid "View: @view - Display: @display"
-msgstr ""
+msgstr "Näkymä: @view - Ruutu: @display"
 
 msgid "Transform the case"
-msgstr ""
+msgstr "Muunna kirjainkokoa"
 
 msgid ""
 "If \"Custom\", see <a href=\"http://us.php.net/manual/en/function.date.php\""
 " target=\"_blank\">the PHP docs</a> for date formats. Otherwise, enter the "
 "number of different time units to display, which defaults to 2."
 msgstr ""
+"Mikäli \"Kustomoitu\", katso tietoa päivämäärämuodoista <a "
+"href=\"http://us.php.net/manual/en/function.date.php\" target=\"_blank\">PHP"
+" dokumentaatiosta</a>. Muussa tapauksessa syötä näytettävien "
+"päivämääräyksiköiden määrä, oletusarvo on 2."
 
 msgid "Representative sort criteria"
-msgstr ""
+msgstr "Alustava lajittelukriteeri"
 
 msgid ""
 "The sort criteria is applied to the data brought in by the relationship to "
 "determine how a representative item is obtained for each row. For example, "
 "to show the most recent node for each user, pick 'Content: Updated date'."
 msgstr ""
+"Suhteen tuomaan tietoon käytettävät lajittelukriteerit, tätä käytetään "
+"määrittelemään tapaa jolla kutakin riviä kuvaava elementti haetaan. "
+"Esimerkiksi näyttääksesi uusimman solmun kullekin käyttäjälle, valitse "
+"'Sisältö: Päivityspäivämäärä'."
 
 msgid "The ordering to use for the sort criteria selected above."
-msgstr ""
+msgstr "Yllävalitun lajittelukriteerin yhteydessä käytettävä järjestelytapa."
 
 msgid "Revert to default"
-msgstr ""
+msgstr "Palauta oletusasetuksiin"
 
 msgid "No fields have been used in views yet."
-msgstr ""
+msgstr "Näkymissä ei ole vielä kenttiä käytössä."
 
 msgid "Provide a simple link to approve the comment."
-msgstr ""
+msgstr "Tarjoaa linkin kommentin hyväksymiseen."
 
 msgid "Author uid"
-msgstr ""
+msgstr "Kirjoittajan käyttäjä ID (uid)"
 
 msgid "Relate each @entity with a @field set to the file."
-msgstr ""
+msgstr "Liitä jokainen @entity kenttään @field asetettuun tiedostoon."
 
 msgid "Relate each @entity with a @field set to the image."
-msgstr ""
+msgstr "Liitä jokainen @entity kenttään @field asetettuun kuvaan."
 
 msgid "The tid of a taxonomy term."
-msgstr ""
+msgstr "Luokittelutermin ID (tid)."
 
 msgid "The user permissions."
-msgstr ""
+msgstr "Käyttöoikeudet."
 
 msgid "First and last only"
-msgstr ""
+msgstr "Vain ensimmäinen ja viimeinen"
 
 msgid "Multiple-value handling"
-msgstr ""
+msgstr "Moniarvoisuuden hallinta"
 
 msgid "Filter to items that share all terms"
-msgstr ""
+msgstr "Suodata tuloksiin jotka jakavat kaikki arvot"
 
 msgid "Filter to items that share any term"
-msgstr ""
+msgstr "Suodata tuloksiin, jotka jakavat minkä tahansa arvoista"
 
 msgid "Use a pager"
-msgstr ""
+msgstr "Käytä sivutusta"
 
 msgid "Logo path"
-msgstr ""
+msgstr "Logon polku"
 
 msgid ""
 "@module (<span class=\"admin-missing\">incompatible with</span> this version"
 " of Drupal core)"
 msgstr ""
+"@module (<span class=\"admin-missing\">ei yhteensopiva</span> tämän Drupal-"
+"ytimen version kanssa)."
 
 msgid "Responsive"
-msgstr ""
+msgstr "Responsiivinen"
 
 msgid "Tokens related to views."
-msgstr ""
+msgstr "Näkymiin liittyvät tokenit."
 
 msgid "The description of the view."
-msgstr ""
+msgstr "Näkymän kuvaus."
 
 msgid "The title of current display of the view."
-msgstr ""
+msgstr "Näkymän tämänhetkisen näyttöruudun otsikko."
 
 msgid "The URL of the view."
-msgstr ""
+msgstr "Näkymän URL."
 
 msgid "-Select-"
-msgstr ""
+msgstr "-Valitse-"
 
 msgid ""
 "Text to place as \"title\" text which most browsers display as a tooltip "
 "when hovering over the link."
 msgstr ""
+"Teksti joka korvaa \"otsikkotekstin\", näytetään suurimmassa osassa "
+"selaimista tooltippinä kun hiirtä viedään linkin päälle."
 
 msgid ""
 "Enable to hide this field if it is empty. Note that the field label or "
@@ -12978,914 +13863,1044 @@ msgid ""
 "row style settings for empty fields. To hide rewritten content, check the "
 "\"Hide rewriting if empty\" checkbox."
 msgstr ""
+"Valitse piilottaaksesi tämän kentän sen ollessa tyhjä. Huomaa että "
+"uudelleenkirjoitetun kentän etiketti saatetaan tästä huolimatta tulostaa. "
+"Piilottaaksesi etiketit, tarkista rivityylin asetukset tyhjille kentille. "
+"Piilottaaksesi uudelleenkirjoitetun sisällön valitse \"Piilota "
+"uudelleenkirjoitus mikäli tyhjä\" valintaruutu."
 
 msgid "Apostrophe"
-msgstr ""
+msgstr "Heittomerkki"
 
 msgid "Date in the form of CCYYMMDD."
-msgstr ""
+msgstr "Päivämäärä muodossa CCYYMMDD."
 
 msgid "Date in the form of YYYYMM."
-msgstr ""
+msgstr "Päivämäärä muodossa YYYYMM."
 
 msgid "Date in the form of YYYY."
-msgstr ""
+msgstr "Päivämäärä muodossa YYYY."
 
 msgid "Date in the form of MM (01 - 12)."
-msgstr ""
+msgstr "Päivämäärä muodossa MM (01 - 12)."
 
 msgid "Date value"
-msgstr ""
+msgstr "Päivämääräarvo"
 
 msgid "Full HTML"
-msgstr ""
+msgstr "Full HTML"
 
 msgid "View modes"
-msgstr ""
+msgstr "Näyttötavat"
 
 msgid "Date in the form of DD (01 - 31)."
-msgstr ""
+msgstr "Päivämäärä muodossa DD (01 - 31)."
 
 msgid "Date in the form of WW (01 - 53)."
-msgstr ""
+msgstr "Päivämäärä muodossa WW (01 - 53)."
 
 msgid ""
 "If you need more fields than the uid add the comment: author relationship"
 msgstr ""
+"Jos tarvitset enemmän kenttiä kuin vain uid, voit lisätä kommentin: "
+"kirjoittajariippuvuus"
 
 msgid "Last comment uid"
-msgstr ""
+msgstr "Viimeisimmän kommentin uid"
 
 msgid ""
 "The user authoring the content. If you need more fields than the uid add the"
 " content: author relationship"
 msgstr ""
+"Sisältöä muokkaava käyttäjä. Jos tarvitset enemmän kenttiä kuin vain uid, "
+"voit lisätä seuraavan sisällön: kirjoittajariippuvuus."
 
 msgid "Convert spaces in term names to hyphens"
-msgstr ""
+msgstr "Muuta välilyönnit termien nimissä tavuviivoiksi"
 
 msgid "Use rendered output to group rows"
-msgstr ""
+msgstr "Käytä renderöityä tulostetta rivien ryhmittelyssä."
 
 msgid ""
 "If enabled the rendered output of the grouping field is used to group the "
 "rows."
 msgstr ""
+"Mikäli käytössä, ryhmittelykentän renderöityä tulostetta käytetään rivien "
+"ryhmittelyyn."
 
 msgid "Block count"
-msgstr ""
+msgstr "Lohkojen lukumäärä"
 
 msgid "Limit to vocabulary"
-msgstr ""
+msgstr "Rajoita sanastoon"
 
 msgid ""
 "You may use HTML code in this field. The following tokens are supported:"
 msgstr ""
+"Voit käyttää HTML-koodia tässä kentässä. Seuraavat tokenit ovat tuettuja:"
 
 msgid "Result summary"
-msgstr ""
+msgstr "Tulosten yhteenveto"
 
 msgid "Shows result summary, for example the items per page."
-msgstr ""
+msgstr "Näytä tulosten yhteenveto, esimerkiksi tuloksia per sivu."
 
 msgid "Use site default RSS settings"
-msgstr ""
+msgstr "Käytä RSS:n oletusasetuksia"
 
 msgid "Display list value as human readable"
-msgstr ""
+msgstr "Näytä arvo ihmisluettavassa muodossa"
 
 msgid "Displays the link in contextual links"
-msgstr ""
+msgstr "Näyttää linkin kontekstiriippuvaisten linkkien joukossa"
 
 msgid "Grouping field Nr.@number"
-msgstr ""
+msgstr "Ryhmittelykentän numero. @number"
 
 msgid "Response status code"
-msgstr ""
+msgstr "Vastauksen tilakoodi"
 
 msgid "Callback function"
-msgstr ""
+msgstr "Paluufunktio"
 
 msgid ""
 "Your search used too many AND/OR expressions. Only the first @count terms "
 "were included in this search."
 msgstr ""
+"Hakusi käytti liian montaa JA/TAI-lausetta. Vain ensimmäiset @count "
+"hakusanaa sisällytettiin hakuun."
 
 msgid "Other…"
-msgstr ""
+msgstr "Muu..."
 
 msgid "The selected selection handler is broken."
-msgstr ""
+msgstr "Valittu valinnan käsittelijä on rikki."
 
 msgid "Performance settings"
-msgstr ""
+msgstr "Suorituskykyasetukset"
 
 msgid "Display field as machine name."
-msgstr ""
+msgstr "Näytä kenttä koneluettavana nimenä."
 
 msgid "Provide a display which can be embedded using the views api."
-msgstr ""
+msgstr "Tarjoa näyttöruutu joka voidaan sisällyttää käyttäen Views APIa."
 
 msgid "Only has the 'authenticated user' role"
-msgstr ""
+msgstr "On ainoastaan rooli \"kirjautunut käyttäjä\""
 
 msgid "Has roles in addition to 'authenticated user'"
-msgstr ""
+msgstr "On muitakin rooleja \"kirjautunut käyttäjä\" roolin lisäksi"
 
 msgid "Remove tags from rendered output"
-msgstr ""
+msgstr "Poista tagit renderöidystä tulosteesta"
 
 msgid "Fields to be included as contextual links."
-msgstr ""
+msgstr "Kontekstiriippuvaisina linkkeinä sisällytettävät kentät."
 
 msgid "Include destination"
-msgstr ""
+msgstr "Sisällytä kohde"
 
 msgid ""
 "Include a \"destination\" parameter in the link to return the user to the "
 "original view upon completing the contextual action."
 msgstr ""
+"Sisällytä \"kohde\" parametri linkkiin palauttaaksesi käyttäjä alkuperäiseen"
+" näkymään hänen päätettyään kontekstiriippuvaisen toimenpiteen."
 
 msgid "Contextual Links"
-msgstr ""
+msgstr "Kontekstiriippuvaiset linkit"
 
 msgid "Display fields in a contextual links menu."
-msgstr ""
+msgstr "Näytä kenttiä kontekstiriippuvaisten linkkien valikossa."
 
 msgid "Upload directory"
-msgstr ""
+msgstr "Tallennushakemisto"
 
 msgid "The file %file could not be saved because the upload did not complete."
 msgstr ""
+"Tiedoston %file tallentaminen ei onnistunut koska latausta ei suoritettu "
+"loppuun."
 
 msgid "Authentication provider"
-msgstr ""
+msgstr "Autentikoinnin tarjoaja"
 
 msgid "Allowed values function"
-msgstr ""
+msgstr "Sallittujen arvojen funktio"
 
 msgid "Select media"
-msgstr ""
+msgstr "Valitse tiedosto"
 
 msgid "Third party settings"
-msgstr ""
+msgstr "Kolmannen osapuolen asetukset"
 
 msgid "Date/time format"
-msgstr ""
+msgstr "Aikamuoto"
 
 msgid "Enable translation"
-msgstr ""
+msgstr "Ota käyttöön käännökset"
 
 msgid "Drupal Version"
-msgstr ""
+msgstr "Drupal-versio"
 
 msgid "This field supports tokens."
-msgstr ""
+msgstr "Kenttä tukee korvauskuvioita."
 
 msgid "Twig"
-msgstr ""
+msgstr "Twig"
 
 msgid "Search score"
-msgstr ""
+msgstr "Hae tulosta"
 
 msgid "Add transition"
-msgstr ""
+msgstr "Lisää siirtymä"
 
 msgid "There was a problem creating field %label: @message"
-msgstr ""
+msgstr "Virhe luodessa kenttää %label: @message"
 
 msgid "No content selected."
-msgstr ""
+msgstr "Sisältöä ei ole valittu."
 
 msgid ""
 "A list field (@field_name) with existing data cannot have its keys changed."
 msgstr ""
+"Avainten muuttaminen listakentälle (@field_name) joka sisältää tallennettua "
+"tietoa ei ole mahdollista."
 
 msgid ""
 "A unique machine-readable name containing letters, numbers, and underscores."
 msgstr ""
+"Yksilöllinen koneluettava nimi sisältäen kirjaimia, numeroita ja alaviivoja."
 
 msgid ""
 "If no image is uploaded, this image will be shown on display and will "
 "override the field's default image."
 msgstr ""
+"Jos kuvaa ei ole ladattuna, tämä kuva näytetään ja se ohittaa kentän "
+"oletuskuvan."
 
 msgid "The menu name. Primary key."
-msgstr ""
+msgstr "Valikon nimi. Pääavain."
 
 msgid "The human-readable name of the menu."
-msgstr ""
+msgstr "Valikon selkokielinen nimi."
 
 msgid "A description of the menu"
-msgstr ""
+msgstr "Valikon kuvaus"
 
 msgid ""
 "The menu name. All links with the same menu name (such as 'navigation') are "
 "part of the same menu."
 msgstr ""
+"Valikon nimi. Kaikki linkit, joilla on sama nimi (esim. 'navigointi') "
+"kuuluvat samaan menuun."
 
 msgid "The menu link ID (mlid) is the integer primary key."
-msgstr ""
+msgstr "Menu link ID (mlid) on kokonaisluku-pääavain."
 
 msgid "The name of the module that generated this link."
-msgstr ""
+msgstr "Moduulin nimi joka loi tämän linkin."
 
 msgid "Bulk operation"
-msgstr ""
+msgstr "Massatoiminto"
 
 msgid "View used to select the entities"
-msgstr ""
+msgstr "Näkymä jota käytetään entiteettien valitsemiseen"
 
 msgid ""
 "Choose the view and display that select the entities that can be "
 "referenced.<br />Only views with a display of type \"Entity Reference\" are "
 "eligible."
 msgstr ""
+"Valitse näkymä ja näyttöruutu jota käytetään entiteettien valitsemisessa.<br"
+" />Vain näkymät jotka sisältävät \"Entiteettiviittaus\" kentän ovat "
+"käyttökelpoisia."
 
 msgid "Views: Filter by an entity reference view"
-msgstr ""
+msgstr "Näkymät: Suodata entiteettiviittauksen perusteella"
 
 msgid "Entity Reference Source"
-msgstr ""
+msgstr "Entiteettiviittauksen lähde"
 
 msgid "Entity Reference list"
-msgstr ""
+msgstr "Entiteettiviittauslista"
 
 msgid ""
 "Display \"@display\" needs a selected search fields to work properly. See "
 "the settings for the Entity Reference list format."
 msgstr ""
+"Näkymä \"@display\" vaatii hakukenttiä toimiakseen kunnolla. Tarkista "
+"Entiteettiviittausten listamuodon asetukset."
 
 msgid ""
 "Display \"@display\" uses field %field as search field, but the field is no "
 "longer present. See the settings for the Entity Reference list format."
 msgstr ""
+"Näkymä \"@display\" käyttää kenttää %field hakukenttänä mutta kenttää ei ole"
+" enää olemassa. Tarkista Entiteettiviittauksen listamuodon asetukset."
 
 msgid ""
 "<strong>Note:</strong> In 'Entity Reference' displays, all fields will be "
 "displayed inline unless an explicit selection of inline fields is made here."
 msgstr ""
+"<strong>Huomaa:</strong> 'Entiteettiviittaus'-näkymissä kaikki kentät "
+"näytetään sisennettyinä paitsi jos nimeomaan valitset jonkin muun "
+"esitystavan."
 
 msgid ""
 "Select the field(s) that will be searched when using the autocomplete "
 "widget."
 msgstr ""
+"Valitse kentät joista haetaan käytettäessä automaattisesti täydentyvää "
+"kenttää."
 
 msgid "Public files directory"
-msgstr ""
+msgstr "Julkisten tiedostojen polku"
 
 msgid "Temporary files directory"
-msgstr ""
+msgstr "Tilapäistiedostojen polku"
 
 msgid "Private files directory"
-msgstr ""
+msgstr "Yksityisten tiedostojen polku"
 
 msgid "Comment Statistics"
-msgstr ""
+msgstr "Kommentin statistiikat"
 
 msgid "You have unsaved changes"
-msgstr ""
+msgstr "Sinulla on tallentamattomia muutoksia"
 
 msgid "Loading…"
-msgstr ""
+msgstr "Lataa..."
 
 msgid "Use site name"
-msgstr ""
+msgstr "Käytä sivuston nimeä"
 
 msgid "Use site slogan"
-msgstr ""
+msgstr "Käytän sivuston slogania"
 
 msgid "File status"
-msgstr ""
+msgstr "Tiedoston tilanne"
 
 msgid "Reduce"
-msgstr ""
+msgstr "Vähennä"
 
 msgid "Easy"
-msgstr ""
+msgstr "Helppo"
 
 msgid "Breakpoint"
-msgstr ""
+msgstr "Keskeytyskohta"
 
 msgid "Needs to be updated"
-msgstr ""
+msgstr "Tarvitsee päivittää"
 
 msgid "Does not need to be updated"
-msgstr ""
+msgstr "Ei tarvitse päivittää"
 
 msgid "Edit comment @subject"
-msgstr ""
+msgstr "Muokkaa kommenttia @subject"
 
 msgid ""
 "Only this translation is published. You must publish at least one more "
 "translation to unpublish this one."
 msgstr ""
+"Vain tämä käännös on julkaistu. Sinun on julkaistava ainakin yksi muu "
+"käännös ennenkuin voit perua tämän käännöksen julkaisun."
 
 msgid "Time interval"
-msgstr ""
+msgstr "Aikaväli"
 
 msgid "Used in views"
-msgstr ""
+msgstr "Käytetään näkymissä"
 
 msgid "Display \"Access Denied\""
-msgstr ""
+msgstr "Näytä \"Pääsy kielletty\""
 
 msgid "Timezone to be used for date output."
-msgstr ""
+msgstr "Päivämäärän näytössä käytettävä aikavyöhyke."
 
 msgid "- Default site/user timezone -"
-msgstr ""
+msgstr "- Käyttäjän/sivuston oletusaikavyöhyke -"
 
 msgid ""
 "Grouped filters allow a choice between predefined operator|value pairs."
 msgstr ""
+"Ryhmitellyt suodattimet mahdollistavat valinnan esimääriteltyjen "
+"operaattori|arvo parien välillä."
 
 msgid "Filter type to expose"
-msgstr ""
+msgstr "Näytettävä suodattimen tyyppi"
 
 msgid "Single filter"
-msgstr ""
+msgstr "Yksittäinen suodatin"
 
 msgid "Grouped filters"
-msgstr ""
+msgstr "Ryhmitellyt suodattimet"
 
 msgid "Language type"
-msgstr ""
+msgstr "Kielityyppi"
 
 msgid "No book content available."
-msgstr ""
+msgstr "Kirjasisältöä ei ole tarjolla."
 
 msgid "Default translation"
-msgstr ""
+msgstr "Oletuskäännös"
 
 msgid "Views plugins"
-msgstr ""
+msgstr "Näkymien laajennukset"
 
 msgid "Translation for @language"
-msgstr ""
+msgstr "Käännös kielelle @language"
 
 msgid "Last page"
-msgstr ""
+msgstr "Viimeinen sivu"
 
 msgid "Export options"
-msgstr ""
+msgstr "Vientiasetukset"
 
 msgid "Hide description"
-msgstr ""
+msgstr "Piilota kuvaus"
 
 msgid ""
 "Remember exposed selection only for the selected user role(s). If you select"
 " no roles, the exposed data will never be stored."
 msgstr ""
+"Muista suodattimen valinta vain valituille käyttäjärooleille. Jos et valitse"
+" rooleja, suodattimen arvoja ei tallenneta koskaan."
 
 msgid ""
 "Select which kind of widget will be used to render the group of filters"
 msgstr ""
+"Valitse, minkälaista widgettiä käytetään renderöitäessä suodatinryhmiä."
 
 msgid "grouped"
-msgstr ""
+msgstr "ryhmitetty"
 
 msgid "Choose fields to combine for filtering"
-msgstr ""
+msgstr "Valitse suodatusta varten yhdistettävät kentät"
 
 msgid "This filter doesn't work for very special field handlers."
-msgstr ""
+msgstr "Suodatin ei toimi hyvin erikoislaatuisten kenttien kanssa."
 
 msgid "You have to add some fields to be able to use this filter."
 msgstr ""
+"Sinun on lisättävä kenttiä jotka kykenevät käyttämään tätä suodatinta."
 
 msgid "@entity types"
-msgstr ""
+msgstr "@entity tyypit"
 
 msgid "There is no lock on view %name to break."
-msgstr ""
+msgstr "Näkymässä %name ei ole rikottavaa lukitusta."
 
 msgid "&lt;Any&gt;"
-msgstr ""
+msgstr "&lt;Mikä tahansa&gt;"
 
 msgid "There are no enabled views."
-msgstr ""
+msgstr "Yhtään näkymää ei ole käytössä."
 
 msgid "Display fields as RSS items."
-msgstr ""
+msgstr "Näytä kentät RSS syötteinä."
 
 msgid "- No value -"
-msgstr ""
+msgstr "- Ei arvoa -"
 
 msgid "Provide a simple link to the revision."
-msgstr ""
+msgstr "Tarjoa yksinkertainen linkki sisällön versioon."
 
 msgid "The ID of the entity that is related to the file."
-msgstr ""
+msgstr "Tiedostoon liittyvän entiteetin ID."
 
 msgid "The raw numeric user ID."
-msgstr ""
+msgstr "Käyttäjä ID raakamuodossa."
 
 msgid "Unfiltered text"
-msgstr ""
+msgstr "Suodattamaton teksti"
 
 msgid ""
 "Add unrestricted, custom text or markup. This is similar to the custom text "
 "field."
 msgstr ""
+"Lisää rajoittamatonta, kustomoitua tekstiä tai markuppia. Tämä vastaa "
+"kustomoitua tekstikenttää."
 
 msgid "Combine fields filter"
-msgstr ""
+msgstr "Yhdistä kenttien suodattimet"
 
 msgid "Column used for click sorting"
-msgstr ""
+msgstr "Klikkausjärjestelyssä käytettävä sarake"
 
 msgid "Use path alias instead of internal path."
-msgstr ""
+msgstr "Käytä polkualiasta sisäisen polun sijaan."
 
 msgid "Length of time in seconds raw query results should be cached."
-msgstr ""
+msgstr "Sekunteina aika jona raakakyselyiden tulokset tulee välimuistittaa."
 
 msgid "Length of time in seconds rendered HTML output should be cached."
-msgstr ""
+msgstr "Sekunteina aika jona tuotettu HTML tuloste tulee välimuistittaa."
 
 msgid "Custom time values must be numeric."
-msgstr ""
+msgstr "Kustomoitujen aika-arvojen on oltava numeerisia."
 
 msgid "Change whether or not to display contextual links for this view."
 msgstr ""
+"Valitse, näytetäänkö vai piilotetaanko kontekstiriippuvaiset suodattimet "
+"tässä näkymässä."
 
 msgid "Display 'more' link only if there is more content"
-msgstr ""
+msgstr "Näytä 'lisää' linkki vain jos lisää sisältöä on olemassa"
 
 msgid ""
 "Exposed filters in block displays require \"Use AJAX\" to be set to work "
 "correctly."
 msgstr ""
+"Käyttäjälle näytetyt suodattimet lohkonäkymissä vaativat \"Käytä AJAXia\" "
+"asetuksen päälläoloa toimiakseen oikein."
 
 msgid "Number of pager links visible"
-msgstr ""
+msgstr "Näytettävien sivutuslinkkien lukumäärä"
 
 msgid "Specify the number of links to pages to display in the pager."
-msgstr ""
+msgstr "Määrittele, montako linkkiä sivuille näytetään sivutuksessa."
 
 msgid "Query Tags"
-msgstr ""
+msgstr "Kyselytagit"
 
 msgid ""
 "If set, these tags will be appended to the query and can be used to identify"
 " the query in a module. This can be helpful for altering queries."
 msgstr ""
+"Mikäli asetettuna, nämä tagit lisätään kyselyyn ja niitä voidaan käyttää "
+"kyselyn tunnistamiseen moduulissa. Tämä on hyödyllistä muokattaessa "
+"kyselyitä."
 
 msgid ""
 "The query tags may only contain lower-case alphabetical characters and "
 "underscores."
 msgstr ""
+"Kyselytagit voivat sisältää vain pieniä aakkosnumeerisia kirjaimia sekä "
+"alaviivoja."
 
 msgid ""
 "The field that is going to be used as the RSS item pubDate for each row. It "
 "needs to be in RFC 2822 format."
 msgstr ""
+"Kenttä jota käytetään julkaisupäivämääränä RSS syötteissä. Päivämäärän on "
+"oltava RFC 2822 muodossa."
 
 msgid "GUID settings"
-msgstr ""
+msgstr "GUID asetukset"
 
 msgid "GUID field"
-msgstr ""
+msgstr "GUID kenttä"
 
 msgid "The globally unique identifier of the RSS item."
-msgstr ""
+msgstr "Maailmanlaajuisesti uniikki RSS elementin tunniste."
 
 msgid "GUID is permalink"
-msgstr ""
+msgstr "GUID on ikilinkki"
 
 msgid "The RSS item GUID is a permalink."
-msgstr ""
+msgstr "RSS-elementin GUID on ikilinkki"
 
 msgid "Add views row classes"
-msgstr ""
+msgstr "Lisää luokkia kyselyriveihin"
 
 msgid "Force using fields"
-msgstr ""
+msgstr "Pakota käyttämään kenttiä"
 
 msgid ""
 "If neither the row nor the style plugin supports fields, this field allows "
 "to enable them, so you can for example use groupby."
 msgstr ""
+"Jos rivi- ja tyyliplugini eivät kumpikaan tue kenttiä, voit tätä käyttämällä"
+" ottaa ne silti käyttöön, jolloin voit esimerkiksi hyödyntää groupby:ta."
 
 msgid "File storage"
-msgstr ""
+msgstr "Tiedostojen tallennus"
 
 msgid ""
 "A flexible, recolorable theme with many regions and a responsive, mobile-"
 "first layout."
 msgstr ""
+"Joustava, uudelleenväritettävä teema, jossa on paljon sisältöalueita ja "
+"mobiilioptimoitu ulkoasu."
 
 msgid "Enter 0 for no limit."
-msgstr ""
+msgstr "Syötä 0 jos et halua rajaa."
 
 msgid "Entity label"
-msgstr ""
+msgstr "Entiteetin etiketti"
 
 msgid "The @type %title has been deleted."
-msgstr ""
+msgstr "@type %title on poistettu."
 
 msgid "The URL %url is not valid."
-msgstr ""
+msgstr "URL %url ei ole kelvollinen."
 
 msgid "All messages, with backtrace information"
-msgstr ""
+msgstr "Kaikki viestit sisältäen jäljitystiedot"
 
 msgid "The views entity selection mode requires a view."
-msgstr ""
+msgstr "Näkymäperusteinen valintatapa vaatii näkymän."
 
 msgid "The connection protocol %backend does not exist."
-msgstr ""
+msgstr "Yhteysprotokollaa %backend ei ole olemassa."
 
 msgid "Unknown (@langcode)"
-msgstr ""
+msgstr "Tuntematon (@langcode)"
 
 msgid ""
 "The file %file could not be saved because it exceeds %maxsize, the maximum "
 "allowed size for uploads."
 msgstr ""
+"Tiedoston %file tallentaminen ei onnistunut koska sen koko ylittää suurimman"
+" sallitun koon %maxsize."
 
 msgid ""
 "The file could not be uploaded because the destination %destination is "
 "invalid."
 msgstr ""
+"Tiedoston lataaminen ei onnistunut koska kohde %destination ei ole "
+"kelvollinen."
 
 msgid "The file %path was not deleted because it does not exist."
-msgstr ""
+msgstr "Tiedostoa %file ei poistettu koska sitä ei ole olemassa."
 
 msgid "%name field is not in the right format."
-msgstr ""
+msgstr "%name kenttä ei ole oikeassa muodossa."
 
 msgid "%name is not a valid number."
-msgstr ""
+msgstr "%name ei ole kelvollinen numero."
 
 msgid "%name must be a valid color."
-msgstr ""
+msgstr "%name on oltava validi väri."
 
 msgid "Theme hook %hook not found."
-msgstr ""
+msgstr "Teemahookkia %hook ei löytynyt."
 
 msgid "…"
-msgstr ""
+msgstr "..."
 
 msgid "Table @name already exists."
-msgstr ""
+msgstr "Taulu @name on jo olemassa."
 
 msgid "Cannot rename @table to @table_new: table @table doesn't exist."
 msgstr ""
+"Taulun @table uudelleennimeäminen @table_new ei onnistunut: taulua @table ei"
+" ole olemassa."
 
 msgid "Cannot rename @table to @table_new: table @table_new already exists."
 msgstr ""
+"Taulun @table uudelleennimeäminen @table_new ei onnistunut: taulu @table_new"
+" on jo olemassa."
 
 msgid "Cannot add field @table.@field: table doesn't exist."
-msgstr ""
+msgstr "Kentän @table.@field ei onnistunut: taulua ei ole olemassa."
 
 msgid "Cannot add field @table.@field: field already exists."
-msgstr ""
+msgstr "Kentän @table.@field ei onnistunut: kenttä on jo olemassa."
 
 msgid "Cannot set default value of field @table.@field: field doesn't exist."
 msgstr ""
+"Oletusarvon asettaminen kentälle @table.@field ei onnistunut: kenttää ei ole"
+" olemassa."
 
 msgid ""
 "Cannot remove default value of field @table.@field: field doesn't exist."
 msgstr ""
+"Kentän @table.@field oletusarvon poistaminen ei onnistunut: kenttää ei ole "
+"olemassa."
 
 msgid "Cannot add primary key to table @table: table doesn't exist."
 msgstr ""
+"Pääavaimen lisääminen tauluun @table ei onnistunut: taulua ei ole olemassa."
 
 msgid "Cannot add primary key to table @table: primary key already exists."
 msgstr ""
+"Pääavaimen lisääminen tauluun @table ei onnistunut: pääavain on jo olemassa."
 
 msgid "Cannot add unique key @name to table @table: table doesn't exist."
 msgstr ""
+"Yksilöllisen avaimen @name lisääminen tauluun @table ei onnistunut: taulua "
+"ei ole olemassa."
 
 msgid ""
 "Cannot add unique key @name to table @table: unique key already exists."
 msgstr ""
+"Yksilöllisen avaimen @name lisääminen tauluun @table ei onnistunut: "
+"yksilöllinen avain on jo olemassa."
 
 msgid "Cannot add index @name to table @table: table doesn't exist."
 msgstr ""
+"Indeksin @name lisääminen tauluun @table ei onnistunut: taulua ei ole "
+"olemassa."
 
 msgid "Cannot add index @name to table @table: index already exists."
 msgstr ""
+"Indeksin @name lisääminen tauluun @table ei onnistunut: indeksi on jo "
+"olemassa."
 
 msgid ""
 "Cannot change the definition of field @table.@name: field doesn't exist."
 msgstr ""
+"Kentän @table.@name määrityksen muuttaminen ei onnistunut: kenttää ei ole "
+"olemassa."
 
 msgid ""
 "Cannot rename field @table.@name to @name_new: target field already exists."
 msgstr ""
+"Kentän @table.@name uudelleennimeäminen @name_new ei onnistunut: kohdekenttä"
+" on jo olemassa."
 
 msgid "Boolean value"
-msgstr ""
+msgstr "Boolean arvo"
 
 msgid "The referenced entity"
-msgstr ""
+msgstr "Viitattu entiteetti"
 
 msgid "Integer value"
-msgstr ""
+msgstr "Muuttuja-arvo"
 
 msgid "Language object"
-msgstr ""
+msgstr "Kieliobjekti"
 
 msgid "Text value"
-msgstr ""
+msgstr "Tekstin arvo"
 
 msgid ""
 "A unique label for this advanced action. This label will be displayed in the"
 " interface of modules that integrate with actions."
 msgstr ""
+"Yksilöllinen etiketti tälle edistyneelle toiminnolle. Etiketti näytetään "
+"sellaisten moduulien käyttöliittymissä jotka hyödyntävät toimintoja."
 
 msgid "Aggregator refresh"
-msgstr ""
+msgstr "Aggregaattorin päivitys"
 
 msgid "The feed from %site seems to be broken because of error \"%error\"."
 msgstr ""
+"Syöte kohteesta %title vaikuttaisi olevan rikki johtuen virheestä "
+"\"%error\"."
 
 msgid "This IP address is already banned."
-msgstr ""
+msgstr "IP-osoitteen pääsy on jo estetty."
 
 msgid "You may not ban your own IP address."
-msgstr ""
+msgstr "Et voi estää oman IP-osoitteesi pääsyä."
 
 msgid "Banning IP addresses"
-msgstr ""
+msgstr "IP-osoitteiden pääsyn esto"
 
 msgid ""
 "IP addresses listed here are banned from your site. Banned addresses are "
 "completely forbidden from accessing the site and instead see a brief message"
 " explaining the situation."
 msgstr ""
+"Tässä listatut IP-osoitteet ovat estettyjä sivustollasi. Estettyjen IP-"
+"osoitteiden pääsy on kokonaan estetty sivustolle ja sivuston sijaan "
+"näytetään lyhyt viesti selittäen tilannetta."
 
 msgid "Ban IP addresses"
-msgstr ""
+msgstr "Estä IP-osoitteiden pääsy"
 
 msgid "IP address bans"
-msgstr ""
+msgstr "IP-osoitteiden pääsyn estot"
 
 msgid "Perform tasks on specific events triggered within the system."
-msgstr ""
+msgstr "Suorita asioita tiettyjen järjestelmän tapahtumien yhteydessä."
 
 msgid "List additional actions"
-msgstr ""
+msgstr "Listaa lisätoiminnot"
 
 msgid "Enables banning of IP addresses."
-msgstr ""
+msgstr "Ottaa käyttöön IP-osoitteiden estot."
 
 msgid "You must enter a valid hexadecimal color value for %name."
 msgstr ""
+"Sinun on syötettävä kelvollinen heksadesimaalinen väriarvo värille %name."
 
 msgid "Database Logging"
-msgstr ""
+msgstr "Tietokantaloggaus"
 
 msgid "Trim link text length"
-msgstr ""
+msgstr "Lyhennä linkkitekstin pituutta"
 
 msgid "Leave blank to allow unlimited link text lengths."
-msgstr ""
+msgstr "Jätä tyhjäksi salliaksesi kaikenpituiset linkkitekstit."
 
 msgid "URL only"
-msgstr ""
+msgstr "Vain URL"
 
 msgid "Show URL as plain text"
-msgstr ""
+msgstr "Näytä URL pelkkänä tekstinä"
 
 msgid "Add rel=\"nofollow\" to links"
-msgstr ""
+msgstr "Lisää rel=\"nofollow\" linkkeihin"
 
 msgid "Link text trimmed to @limit characters"
-msgstr ""
+msgstr "Linkin teksti lyhennettynä @limit merkkiin"
 
 msgid "Link text not trimmed"
-msgstr ""
+msgstr "Linkin teksti lyhentämättä"
 
 msgid "Show URL only as plain-text"
-msgstr ""
+msgstr "Näytä URL vain puhdastekstinä"
 
 msgid "Show URL only"
-msgstr ""
+msgstr "Näytä vain URL"
 
 msgid "Add rel=\"@rel\""
-msgstr ""
+msgstr "Lisää rel=\"@rel\""
 
 msgid "Thin space"
-msgstr ""
+msgstr "Ohut väli"
 
 msgid "Processed text"
-msgstr ""
+msgstr "Läpikäyty teksti"
 
 msgid "Re-use existing field: you need to provide a label."
 msgstr ""
+"Uudelleenkäytä olemassaolevaa kenttää: sinun on annettava kentän etiketti."
 
 msgid ""
 "The specified file %file could not be copied because the destination is "
 "invalid. More information is available in the system log."
 msgstr ""
+"Tiedoston %file kopioiminen ei ole mahdollista koska kohde on epäkelpo. "
+"Lisätietoa virhetilanteesta saat järjestelmälogista."
 
 msgid ""
 "The specified file %file could not be moved because the destination is "
 "invalid. More information is available in the system log."
 msgstr ""
+"Tiedoston %file siirtäminen ei ole mahdollista koska kohde on epäkelpo. "
+"Lisätietoa virhetilanteesta saat järjestelmälogista."
 
 msgid ""
 "The data could not be saved because the destination is invalid. More "
 "information is available in the system log."
 msgstr ""
+"Tiedon tallentaminen ei ole mahdollista koska kohde on epäkelpo. Lisätietoa "
+"virhetilanteesta saat järjestelmälogista."
 
 msgid ""
 "File %file (%realpath) could not be copied because the destination "
 "%destination is invalid. This is often caused by improper use of file_copy()"
 " or a missing stream wrapper."
 msgstr ""
+"Tiedoston %file (%realpath) kopioiminen ei ole mahdollista koska kohde "
+"%destination on epäkelpo. Tämä johtuu usein virheellisestä file_copy() "
+"funktion käytöstä tai puuttuvasta virran wrapperista."
 
 msgid ""
 "File %file could not be copied because the destination %destination is "
 "invalid. This is often caused by improper use of file_copy() or a missing "
 "stream wrapper."
 msgstr ""
+"Tiedoston %file kopioiminen ei ole mahdollista koska kohde %destination on "
+"epäkelpo. Tämä johtuu usein virheellisestä file_copy() funktion käytöstä tai"
+" puuttuvasta virran wrapperista."
 
 msgid ""
 "File %file (%realpath) could not be moved because the destination "
 "%destination is invalid. This may be caused by improper use of file_move() "
 "or a missing stream wrapper."
 msgstr ""
+"Tiedoston %file (%realpath) siirtäminen ei ole mahdollista koska kohde "
+"%destination on epäkelpo. Tämä johtuu usein virheellisestä file_copy() "
+"funktion käytöstä tai puuttuvasta virran wrapperista."
 
 msgid ""
 "File %file could not be moved because the destination %destination is "
 "invalid. This may be caused by improper use of file_move() or a missing "
 "stream wrapper."
 msgstr ""
+"Tiedoston %file siirtäminen ei ole mahdollista koska kohde %destination on "
+"epäkelpo. Tämä johtuu usein virheellisestä file_copy() funktion käytöstä tai"
+" puuttuvasta virran wrapperista."
 
 msgid ""
 "Did not delete temporary file \"%path\" during garbage collection because it"
 " is in use by the following modules: %modules."
 msgstr ""
+"Tilapäistiedostoa \"%path\" ei poistettu jätteenkeruun yhteydessä koska se "
+"on seuraavien moduulien käytössä: %modules."
 
 msgid "Are you sure you want to delete the forum %label?"
-msgstr ""
+msgstr "Oletko varma että haluat poistaa foorumin %label?"
 
 msgid "Edit style %name"
-msgstr ""
+msgstr "Muokkaa tyyliä %name"
 
 msgid "Error generating image, missing source file."
-msgstr ""
+msgstr "Virhe luotaessa kuvaa, puuttuva lähdetiedosto."
 
 msgid "Set @title as default"
-msgstr ""
+msgstr "Aseta @title oletukseksi"
 
 msgid "Custom language..."
-msgstr ""
+msgstr "Kustomoitu kieli..."
 
 msgid ""
 "Fill in the language details and save the language with <em>Add custom "
 "language</em>."
 msgstr ""
+"Syötä kielen tiedot ja tallenna se klikkaamalla <em>Lisdää uusi kieli</em> "
+"painiketta."
 
 msgid "The language %language (%langcode) already exists."
-msgstr ""
+msgstr "Kieli %language (%langcode) on jo olemassa."
 
 msgid "Use the <em>Add language</em> button to save a predefined language."
 msgstr ""
+"Käytä <em>Lisää kieli</a> painiketta tallentaaksesi esimääritellyn kielen."
 
 msgid "The language %language has been created and can now be used."
-msgstr ""
+msgstr "Kieli %language on luotu ja on nyt käytettävissä."
 
 msgid "The %language (%langcode) language has been removed."
-msgstr ""
+msgstr "Kieli %language (%langcode) on poistettu."
 
 msgid "Path prefix configuration"
-msgstr ""
+msgstr "Polun etuliitteen asetukset"
 
 msgid "Domain configuration"
-msgstr ""
+msgstr "Verkkotunnuksen asetukset"
 
 msgid "%language (%langcode) path prefix (Default language)"
-msgstr ""
+msgstr "%language (%langcode) polun etuliite (Oletuskieli)"
 
 msgid "%language (%langcode) path prefix"
-msgstr ""
+msgstr "%language (%langcode) polun etuliite"
 
 msgid "%language (%langcode) domain"
-msgstr ""
+msgstr "%language (%langcode) verkkotunnus"
 
 msgid "The prefix may not contain a slash."
-msgstr ""
+msgstr "Etuliite ei voi sisältää kautta-merkkiä."
 
 msgid "The prefix for %language, %value, is not unique."
-msgstr ""
+msgstr "Etuliite kielelle %language, %value, ei ole yksilöllinen."
 
 msgid "The domain for %language, %value, is not unique."
-msgstr ""
+msgstr "Verkkotunnus kielelle %language, %value ei ole yksilöllinen."
 
 msgid "Existing languages"
-msgstr ""
+msgstr "Olemassaolevat kielet"
 
 msgid "Add a new mapping"
-msgstr ""
+msgstr "Lisää uusi kartoitus"
 
 msgid "Browser language code"
-msgstr ""
+msgstr "Selaimen kielikoodi"
 
 msgid "Browser language codes must be unique."
-msgstr ""
+msgstr "Selainten kielikoodien on oltava yksilöllisiä."
 
 msgid ""
 "Browser language codes can only contain lowercase letters and a hyphen(-)."
 msgstr ""
+"Selainten kielikoodit voivat sisältää ainoastaan pieniä kirjaimia ja "
+"väliviivoja (-)."
 
 msgid "Are you sure you want to delete %browser_langcode?"
 msgstr ""
+"Oletko varma että haluat poistaa selaimen kielikoodin %browser_langcode?"
 
 msgid ""
 "Add a language to be supported by your site. If your desired language is not"
 " available, pick <em>Custom language...</em> at the end and provide a "
 "language code and other details manually."
 msgstr ""
+"Lisää sivustosi tukema kieli. Jos haluamaasi kieltä ei ole listattuna, "
+"valitse <em>Kustomoitu kieli...</em> lopussa ja syötä sille kielikoodi sekä "
+"muut tiedot manuaalisesti."
 
 msgid "- @name -"
-msgstr ""
+msgstr "- @name -"
 
 msgid "Language from the URL (Path prefix or domain)."
-msgstr ""
+msgstr "Kieli URLista (polun etuliite tai verkkotunnus)."
 
 msgid "Language from a request/session parameter."
-msgstr ""
+msgstr "Kieli sessio- tai kutsuparametristä."
 
 msgid "Language from the browser's language settings."
-msgstr ""
+msgstr "Kieli selaimen kieliasetuksista."
 
 msgid "Account administration pages"
-msgstr ""
+msgstr "Tilin hallintasivut"
 
 msgid "Account administration pages language setting."
-msgstr ""
+msgstr "Tilin hallintasivujen kieliasetus"
 
 msgid "The %language (%langcode) language has been created."
-msgstr ""
+msgstr "Kieli %language (%langcode) luotu."
 
 msgid "The %language (%langcode) language has been updated."
-msgstr ""
+msgstr "Kieli %language (%langcode) päivitetty."
 
 msgid "Browser language detection configuration"
-msgstr ""
+msgstr "Selaimen kielentunnistuksen asetukset"
 
 msgid "A Gettext Portable Object file."
-msgstr ""
+msgstr "Gettext Portable Object tiedosto"
 
 msgid "Treat imported strings as custom translations"
-msgstr ""
+msgstr "Kohtele tuotuja merkkijonoja kustomoituina käännöksinä"
 
 msgid "Overwrite non-customized translations"
-msgstr ""
+msgstr "Ylikirjoita ei-kustomoidut käännökset"
 
 msgid "Overwrite existing customized translations"
-msgstr ""
+msgstr "Ylikirjoita olemassaolevat kustomoidut käännökset"
 
 msgid "No language available. The export will only contain source strings."
-msgstr ""
+msgstr "Kieltä ei ole saatavilla. Viedään ainoastaan lähdemerkkijonot."
 
 msgid "@count disallowed HTML string(s) in files: @files."
-msgstr ""
+msgstr "@count kiellettyä HTML merkkijonoa tiedostoissa: @files."
 
 msgid "In Context"
-msgstr ""
+msgstr "kontekstissa"
 
 msgid "First plural form"
 msgid_plural "@count. plural form"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ensimmäinen monikkomuoto"
+msgstr[1] "@count monikkomuoto"
 
 msgid "Interface translation"
-msgstr ""
+msgstr "Käyttöliittymän kääntäminen"
 
 msgid "@translated/@total (@ratio%)"
-msgstr ""
+msgstr "@translated/@total (@ratio%)"
 
 msgid "not applicable"
-msgstr ""
+msgstr "ei sovellettavissa"
 
 msgid "Enable interface translation to English"
-msgstr ""
+msgstr "Ottaa käyttöön käyttöliittymän kääntämisen englannin kielelle"
 
 msgid "Interface translations directory"
-msgstr ""
+msgstr "Käyttöliittymäkäännösten kansio"
 
 msgid ""
 "Removed JavaScript translation file for the language %language because no "
 "translations currently exist for that language."
 msgstr ""
+"Poistettiin JavaScript käännöstiedosto kielelle %language koska sille ei "
+"tällä hetkellä ole olemassa käännöksiä."
 
 msgid ""
 "Import of string \"%string\" was skipped because of disallowed or malformed "
 "HTML."
 msgstr ""
+"Merkkijonon \"%string\" tuonti ohitettiin johtuen puuttuvasta tai "
+"väärinmuotoillusta HTML:stä."
 
 msgid "logged in users only"
-msgstr ""
+msgstr "vain sisäänkirjautuneet käyttäjät"
 
 msgid "Author's preferred language"
-msgstr ""
+msgstr "Kirjoittajan oletuskieli"
 
 msgid ""
 "%type is used by 1 piece of content on your site. You can not remove this "
@@ -13894,66 +14909,80 @@ msgid_plural ""
 "%type is used by @count pieces of content on your site. You may not remove "
 "%type until you have removed all of the %type content."
 msgstr[0] ""
+"Sisältötyyppi %type on 1 sisältökohteen käytössä sivustollasi. Et voi "
+"poistaa sisältötyyppiä ennenkuin olet poistanut kaiken sisältötyypin %type "
+"sisällön."
 msgstr[1] ""
+"Sisältötyyppi %type on @count sisältökohteen käytössä sivustollasi. Et voi "
+"poistaa sisältötyyppiä ennenkuin olet poistanut kaiken sisältötyypin %type "
+"sisällön."
 
 msgid "The language code of the language the node is written in."
-msgstr ""
+msgstr "Kielikoodi kielelle jolla solmu on kirjoitettu."
 
 msgid ""
 "Query tagged for node access but there is no node table, specify the "
 "base_table using meta data."
 msgstr ""
+"Kysely liittyy solmun pääsysääntöihin mutta solmutaulua ei löydy, määrittele"
+" base_table metatiedon avulla."
 
 msgid "Briefly describe the changes you have made."
-msgstr ""
+msgstr "Kuvaa lyhyesti tekemäsi muutokset."
 
 msgid "@name format: @date"
-msgstr ""
+msgstr "@name muoto: @date"
 
 msgid "Non-customized translation"
-msgstr ""
+msgstr "Kustomoimaton käännös"
 
 msgid "Customized translation"
-msgstr ""
+msgstr "Kustomoitu käännös"
 
 msgid "Translation type"
-msgstr ""
+msgstr "Käännöksen tyyppi"
 
 msgid "Include non-customized translations"
-msgstr ""
+msgstr "Sisällytä ei-kustomoidut käännökset"
 
 msgid "Include customized translations"
-msgstr ""
+msgstr "Sisällytä kustomoidut käännökset"
 
 msgid "Include untranslated text"
-msgstr ""
+msgstr "Sisällytä kääntämättömät tekstit"
 
 msgid "The strings have been saved."
-msgstr ""
+msgstr "Merkkijonot tallennettu."
 
 msgid ""
 "A path alias set for a specific language will always be used when displaying"
 " this page in that language, and takes precedence over path aliases set as "
 "<em>- None -</em>."
 msgstr ""
+"Tietylle kielelle asetettua polkualiasta käytetään aina kun näytetään sivua "
+"kyseisellä kielellä. Se ohittaa asetuksen jos polkualiakset on asetettu "
+"<em>- Ei mikään - </em>."
 
 msgid "Use the default shortcut icon supplied by the theme"
-msgstr ""
+msgstr "Käytä teeman tarjoamaa oletus-oikopolkukuvaketta"
 
 msgid ""
 "Examples: <code>@implicit-public-file</code> (for a file in the public "
 "filesystem), <code>@explicit-file</code>, or <code>@local-file</code>."
 msgstr ""
+"Esimerkkejä: <code>@implicit-public-file</code> (tiedostolle julkisessa "
+"tiedostojärjestelmässä), <code>@explicit-file</code>, tai <code>@local-"
+"file</code>."
 
 msgid "Message to display when in maintenance mode"
-msgstr ""
+msgstr "Ylläpitotilassa näytettävä teksti"
 
 msgid "This theme requires the base theme @base_theme to operate correctly."
-msgstr ""
+msgstr "Tämä teema vaatii perusteeman @base_theme toimiakseen oikein."
 
 msgid ""
 "This theme requires the theme engine @theme_engine to operate correctly."
-msgstr ""
+msgstr "Tämä teema vaatii teemamoottorin @theme_engine toimiakseen oikein."
 
 msgid ""
 "Use maintenance mode when making major updates, particularly if the updates "
@@ -13961,50 +14990,58 @@ msgid ""
 "importing or exporting content, modifying a theme, modifying content types, "
 "and making backups."
 msgstr ""
+"Käytä ylläpitotilaa tehdessäsi suuria muutoksia sivustollesi, esimerkiksi "
+"kun moduulien päivitys voi haitata sivuston käyttöä. Esimerkkeinä moduulien "
+"päivitykset, teeman muutokset, sisältötyyppien muutokset ja "
+"varmuuskopiointi."
 
 msgid "A language object."
-msgstr ""
+msgstr "Kieliobjekti."
 
 msgid "All kind of entities, e.g. nodes, comments or users."
-msgstr ""
+msgstr "Kaikenlaiset entiteetit, ts. nodet, kommentit tai käyttäjät."
 
 msgid "An entity field containing a boolean value."
-msgstr ""
+msgstr "Entiteettikenttä sisältäen totuusarvon."
 
 msgid "An entity field referencing a language."
-msgstr ""
+msgstr "Entiteettikenttä joka viittaa kieleen."
 
 msgid "An entity field containing an entity reference."
-msgstr ""
+msgstr "Entiteettikenttä sisältäen entiteettiviittauksen."
 
 msgid ""
 "The directory %file is not protected from modifications and poses a security"
 " risk. You must change the directory's permissions to be non-writable."
 msgstr ""
+"Kansiota %file ei ole suojattu muutoksilta mikä aiheuttaa tietoturvariskin. "
+"Sinun on muutettava kansion asetuksia ja estettävä kirjoittaminen siihen."
 
 msgid "Configuration directories"
-msgstr ""
+msgstr "Asetuskansiot"
 
 msgid "Apply pending updates"
-msgstr ""
+msgstr "Suorita odottavat päivitykset"
 
 msgid ""
 "Translation is not supported if language is always one of: @locked_languages"
 msgstr ""
+"Käännökset eivät ole tuettuja jos kieli on aina yksi seuraavisrta: "
+"@locked_languages"
 
 msgid "HTTP request to @url failed with error: @error."
-msgstr ""
+msgstr "HTTP kutsu URLiin @url epäonnistui virheellä: @error."
 
 msgid "Update Manager"
-msgstr ""
+msgstr "Update Manager"
 
 msgid ""
 "The name for this role. Example: \"Moderator\", \"Editorial board\", \"Site "
 "architect\"."
-msgstr ""
+msgstr "Roolin nimi. Esimerkki: \"Moderaattori\", \"Muokkaaja\", \"Sivuston arkkitehti\"."
 
 msgid "User module 'member for' view element."
-msgstr ""
+msgstr "User moduulin 'käyttäjä jo' näyttöelementti."
 
 msgid ""
 "This is also assumed to be the primary language of this account's profile "
@@ -14012,133 +15049,154 @@ msgid ""
 msgstr "Tämän oletetaan olevan myös käyttäjätietojen ensisijainen kieli."
 
 msgid "Administration pages language"
-msgstr ""
+msgstr "Ylläpitosivujen kieli"
 
 msgid ""
 "Build a custom site without pre-configured functionality. Suitable for "
 "advanced users."
 msgstr ""
+"Rakenna kustomoitu sivusto ilman etukäteen asetettuja asetuksia. Sopiva "
+"edistyneille käyttäjille."
 
 msgid "Header background top"
-msgstr ""
+msgstr "Ylätunnisteen taustan yläosa"
 
 msgid "Header background bottom"
-msgstr ""
+msgstr "Ylätunnisteen taustan alaosa"
 
 msgid "Site's default language (@lang_name)"
-msgstr ""
+msgstr "Sivuston oletuskieli (@lang_name)"
 
 msgid "Installation profile"
-msgstr ""
+msgstr "Asennusprofiili"
 
 msgid "Selected language"
-msgstr ""
+msgstr "Valittu kieli"
 
 msgid "Expose sort order"
-msgstr ""
+msgstr "Näytä lajittelujärjestys"
 
 msgid "Use a custom %field_name"
-msgstr ""
+msgstr "Käytä kustomoitua %field_name"
 
 msgid "Validation settings"
-msgstr ""
+msgstr "Validointiasetukset"
 
 msgid "Language Code"
-msgstr ""
+msgstr "Kielikoodi"
 
 msgid "@dir can not be opened"
-msgstr ""
+msgstr "@dir ei voida avata"
 
 msgid ""
 "Breakpoints can be organized into groups. Modules and themes should use "
 "groups to separate out breakpoints that are meant to be used for different "
 "purposes, such as breakpoints for layouts or breakpoints for image sizing."
 msgstr ""
+"Keskeytyskohdat voidaan lajitella ryhmiin. Moduulien ja teemojen tulee "
+"käyttää näitä ryhmiä erottelemaan eri käyttötapauksia varten tehtyjä "
+"keskeytyskohtia kuten teeman keskeytyskohdat tai kuvien koon muuttamisen "
+"keskeytyskohdat."
 
 msgid "Parent permalink"
-msgstr ""
+msgstr "Isännän ikilinkki"
 
 msgid "Save and manage fields"
-msgstr ""
+msgstr "Tallenna ja ylläpidä kenttiä"
 
 msgid "Image removed."
-msgstr ""
+msgstr "Kuva poistettu."
 
 msgid ""
 "This image has been removed. For security reasons, only images from the "
 "local domain are allowed."
 msgstr ""
+"Kuva on poistettu. Tietoturvasyistä ainoastaan lokaalitiedostot ovat "
+"sallittuja."
 
 msgid "Only images hosted on this site may be used in &lt;img&gt; tags."
 msgstr ""
+"Vain paikallistiedostot ovat mahdollisia käytettäessä &lt;img&gt; tageja."
 
 msgid ""
 "An error occurred trying to check available interface translation updates."
 msgstr ""
+"Virhe tarkistettaessa saatavilla olevia käyttöliittymän käännöspäivityksiä."
 
 msgid "Checked available interface translation updates for one project."
 msgid_plural ""
 "Checked available interface translation updates for @count projects."
 msgstr[0] ""
+"Tarkistettiin yhden projektin saatavilla olevat käyttöliittymäkäännökset."
 msgstr[1] ""
+"Tarkistettiin @count projektin saatavilla olevat käyttöliittymäkäännökset."
 
 msgid ""
 "Optionally, specify a relative URL to display as the front page. Leave blank"
 " to display the default front page."
 msgstr ""
+"Vaihtoehtoisesti tarjoa suhteellinen URL näytettäväksi sivuston etusivuna. "
+"Jätä tyhjäksi käyttääksesi oletus-etusivua."
 
 msgid "Vocabulary language"
-msgstr ""
+msgstr "Sanaston kieli"
 
 msgid "The role machine-name of the role."
-msgstr ""
+msgstr "Roolin koneluettava nimi."
 
 msgid "The base table used for this view."
-msgstr ""
+msgstr "Näkymässä käytettävä perustaulukko"
 
 msgid "The base field used for this view."
-msgstr ""
+msgstr "Näkymässä käytettävä peruskenttä."
 
 msgid ""
 "The total amount of results returned from the view. The current display will"
 " be used."
-msgstr ""
+msgstr "Näkymän tulosten kokonaismäärä. Käytetään tämänhetkistä näyttöruutua."
 
 msgid "The number of items per page."
-msgstr ""
+msgstr "Tulosta per sivu."
 
 msgid "The current page of results the view is on."
-msgstr ""
+msgstr "Senhetkinen näkymän tulossivu jolla näkymä sillä hetkellä on."
 
 msgid "The total page count."
-msgstr ""
+msgstr "Sivujen kokonaismäärä."
 
 msgid ""
 "Override the default view title for this view. This is useful to display an "
 "alternative title when a view is empty."
 msgstr ""
+"Ylikirjoita tämän näkymän oletus-näkymäotsikko. Tämä on hyödyllistä "
+"näytettäessä vaihtoehtoinen otsikko näkymän ollessa tyhjä."
 
 msgid "Overridden title"
-msgstr ""
+msgstr "Ohitettu otsikko"
 
 msgid "Tracker - User"
-msgstr ""
+msgstr "Seuraaja - Käyttäjä"
 
 msgid ""
 "Whether or not the node is published. You must use an argument or filter on "
 "UID or you will get misleading results using this field."
 msgstr ""
+"Onko solmu julkaistu vaiko ei. Sinun on käytettävä argumenttia tai "
+"suodatettava UID:n perusteella tai voit saada harhaanjohtavia tuloksia tähän"
+" kenttään."
 
 msgid "The translation authoring username %name does not exist."
-msgstr ""
+msgstr "Käännöksen kirjoituspäivämäärän käyttäjänimeä %name ei ole olemassa."
 
 msgid "You have to specify a valid translation authoring date."
-msgstr ""
+msgstr "Sinun on syötettävä kelvollinen käännöksen kirjoituspäivämäärä."
 
 msgid ""
 "Database %database not found. The server reports the following message when "
 "attempting to create the database: %error."
 msgstr ""
+"Tietokantaa %database ei löytynyt. Palvelin ilmoittaa seuraavat virheet "
+"tietokantaa luotaessa: %error."
 
 msgid ""
 "Failed to connect to your database server. The server reports the following "
@@ -14148,80 +15206,87 @@ msgid ""
 "name?</li><li>Have you entered the correct username and "
 "password?</li><li>Have you entered the correct database hostname?</li></ul>"
 msgstr ""
+"Yhdistäminen tietokantapalvelimellesi epäonnistui. Palvelin palautti "
+"seuraavan viestin: %error.<ul><li>Onko tietokantapalvelin "
+"toiminnassa?</li><li>Onko tietokanta olemassa ja oletko syöttänyt oikean "
+"tietokannan nimen?</li><li>Oletko syöttänyt oikean käyttäjätunnuksen ja "
+"salasanan?</li><li>Oletko syöttänyt oikean tietokannan osoitteen?</li></ul>"
 
 msgid "Install another module"
-msgstr ""
+msgstr "Asenna toinen moduuli"
 
 msgid "Are you sure you want to unblock %ip?"
-msgstr ""
+msgstr "Oletko varma että haluat jälleen sallia IP-osoitteen %ip pääsyn?"
 
 msgid "Import all"
-msgstr ""
+msgstr "Tuo kaikki"
 
 msgid "Another request may be synchronizing configuration already."
-msgstr ""
+msgstr "Toinen kutsu saattaa olla jo synkronoimassa asetuksia."
 
 msgid "The configuration was imported successfully."
-msgstr ""
+msgstr "Asetustiedosto onnistuneesti tuotu."
 
 msgid "@count new"
 msgid_plural "@count new"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count uusi"
+msgstr[1] "@count uutta"
 
 msgid "@count changed"
 msgid_plural "@count changed"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count muuttunut"
+msgstr[1] "@count muuttunutta"
 
 msgid "@count removed"
 msgid_plural "@count removed"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count poistettu"
+msgstr[1] "@count poistettua"
 
 msgid "Synchronize configuration"
-msgstr ""
+msgstr "Synkronoi asetukset"
 
 msgid "Flag other translations as outdated"
-msgstr ""
+msgstr "Merkitse muut käännökset vanhentuneiksi"
 
 msgid "Do not flag other translations as outdated"
-msgstr ""
+msgstr "Älä merkitse muita käännöksiä vanhentuneiksi"
 
 msgid "Example: 'Hero image' or 'Author image'."
-msgstr ""
+msgstr "Esimerkki: 'Sankarikuva' tai 'Kirjoittajan kuva'."
 
 msgid "Breakpoint group"
-msgstr ""
+msgstr "Keskeytyskohtaryhmä"
 
 msgid "Select an image style for this breakpoint."
-msgstr ""
+msgstr "Valitse tähän keskeytyskohtaryhmään liittyvä kuvatyyli."
 
 msgid "Base field"
-msgstr ""
+msgstr "Peruskenttä"
 
 msgid "Manage customized lists of content."
-msgstr ""
+msgstr "Hallinnoi räätälöityjä listauksia sisällöstä."
 
 msgid "Add and enable modules to extend site functionality."
-msgstr ""
+msgstr "Lisää ja ota käyttöön moduuleita laajentaaksesi sivustosi toimintoja."
 
 msgid "User account actions"
-msgstr ""
+msgstr "Käyttäjätilin toiminnot"
 
 msgid "View profile"
-msgstr ""
+msgstr "Näytä profiili"
 
 msgid ""
 "Provides an image formatter and breakpoint mappings to output responsive "
 "images using the HTML5 picture tag."
 msgstr ""
+"Tarjoaa kuvaformaatin ja leikkauskohdan mappaukset responsiivisten kuvien "
+"tulostamiseksi käyttäen HTML5 kuva-tagia."
 
 msgid "Administrative interface for Views."
-msgstr ""
+msgstr "Ylläpitoliittymä Viewsille"
 
 msgid "Access @method on %label resource"
-msgstr ""
+msgstr "Pääsy resurssin %label metodiin @method"
 
 msgid ""
 "By default SimpleTest will clear the results after they have been viewed on "
@@ -14232,18 +15297,26 @@ msgid ""
 "the results the first time. Additionally, some modules may provide more "
 "analysis or features that require this setting to be disabled."
 msgstr ""
+"SimpleTest oletuksena poistaa tulokset kunhan ne on katsottu läpi "
+"tulossivulla mutta joissakin tilanteissa voi olla hyödyllistä jättää ne "
+"tietokantaan. Tuloksia voi tuolloin tarkastella osoitteessa "
+"<em>admin/config/development/testing/results/[test_id]</em>. Testin ID "
+"löytyy tietokannasta, simpletest tietokannasta tai siitä pidetään kirjaa kun"
+" tuloksia tarkastellaan ensimmäistä kertaa. Lisäksi jotkut moduulit "
+"saattavat tarjota lisää analyysiä tai ominaisuuksia jotka tarvitsevat tämän "
+"asetuksen poiskytkemistä."
 
 msgid "Displayed as %date_format"
-msgstr ""
+msgstr "Näytetään muodossa %date_format"
 
 msgid "Enabling translation"
-msgstr ""
+msgstr "Käännösten käyttöönotto"
 
 msgid "Create %language translation of %title"
-msgstr ""
+msgstr "Luo %language käännös kohteelle %title"
 
 msgid "Source language: @language"
-msgstr ""
+msgstr "Lähdekieli: @language"
 
 msgid ""
 "If you made a significant change, which means the other translations should "
@@ -14251,74 +15324,80 @@ msgid ""
 "will not change any other property of them, like whether they are published "
 "or not."
 msgstr ""
+"Jos teit merkittävän muutoksen (ts. tässä yhteydessä tulisi päivittää myös "
+"muut käännökset), voit merkitä kaikki tämän sisällön käännökset "
+"vanhentuneiksi. Tämä ei muuta niiden mitään muuta ominaisuutta kuten "
+"julkaisun tilaa."
 
 msgid ""
 "When this option is checked, this translation needs to be updated. Uncheck "
 "when the translation is up to date again."
 msgstr ""
+"Kun tämä vaihtoehto on valittuna, tämä käännös vaatii päivitystä. Poista "
+"valinta, kun käännös taas on ajan tasalla."
 
 msgid "Source language set to: %language"
-msgstr ""
+msgstr "Asetettava lähdekieli: %language"
 
 msgid "This will delete all the translations of %label."
-msgstr ""
+msgstr "Tämä poistaa kaikki %label käännökset."
 
 msgid "No path is set"
-msgstr ""
+msgstr "Polkua ei ole asetettu"
 
 msgid "@type: @field"
-msgstr ""
+msgstr "@type: @field"
 
 msgid "View differences"
-msgstr ""
+msgstr "Näytä ero"
 
 msgid "Menu language"
-msgstr ""
+msgstr "Valikon kieli"
 
 msgid "Block types"
-msgstr ""
+msgstr "Lohkojen tyypit"
 
 msgid "@field_name"
-msgstr ""
+msgstr "@field_name"
 
 msgid "Access in-place editing"
-msgstr ""
+msgstr "Pääsy in-place muokkaukseen"
 
 msgid "Updated the %field-name field through in-place editing."
-msgstr ""
+msgstr "Päivitettiin kenttä %field-name in-place muokkauksen kautta."
 
 msgid "No item selected."
-msgstr ""
+msgstr "Ei valittua kohdetta."
 
 msgid "Modified timestamp"
-msgstr ""
+msgstr "Muokattu-aikaleima"
 
 msgid "Are you sure you want to delete the @entity-type %label?"
-msgstr ""
+msgstr "Haluatko varmasti poistaa @entity-type: %label?"
 
 msgid "The @entity-type %label has been deleted."
-msgstr ""
+msgstr "@entity-type %label on poistettu."
 
 msgid "Edit %label"
-msgstr ""
+msgstr "Muokkaa %label"
 
 msgid "Add @bundle"
-msgstr ""
+msgstr "Lisää @bundle"
 
 msgid "Reference type"
-msgstr ""
+msgstr "Viittaustyyppi"
 
 msgid "Delete state"
-msgstr ""
+msgstr "Poista tila"
 
 msgid "South Sudan"
-msgstr ""
+msgstr "Etelä-Sudan"
 
 msgid "Custom output for TRUE"
-msgstr ""
+msgstr "Muokattu tuloste arvolle TRUE"
 
 msgid "Custom output for FALSE"
-msgstr ""
+msgstr "Kustomoitu tuloste arvolle FALSE"
 
 msgid ""
 "Thank you for applying for an account. Your account is currently pending "
@@ -14333,225 +15412,232 @@ msgid ""
 "An unrecoverable error has occurred. You can find the error message below. "
 "It is advised to copy it to the clipboard for reference."
 msgstr ""
+"Ohittamaton virhe. Löydät virheviestin alta. On suositeltavaa että kopioit "
+"sen leikepöydälle talteen myöhempää tarkastelua varten."
 
 msgid "Place block"
-msgstr ""
+msgstr "Sijoita lohko"
 
 msgid "Port number"
-msgstr ""
+msgstr "Portin numero"
 
 msgid "Revision timestamp"
-msgstr ""
+msgstr "Version aikaleima"
 
 msgid "Administer account settings"
-msgstr ""
+msgstr "Ylläpidä tilin asetuksia"
 
 msgid "Entity language"
-msgstr ""
+msgstr "Kokonaisuuden kieli"
 
 msgid "Hide empty"
-msgstr ""
+msgstr "Piiloita tyhjät"
 
 msgid "Quick Edit"
-msgstr ""
+msgstr "Nopea muokkaus"
 
 msgid "Revision Log message"
-msgstr ""
+msgstr "Sisältöversion logiviesti"
 
 msgid "The translation set id for this node"
-msgstr ""
+msgstr "Tämän solmun käännössarja"
 
 msgid "Registered timestamp"
-msgstr ""
+msgstr "Rekisteröitymisen aikaleima"
 
 msgid "Signature format"
-msgstr ""
+msgstr "Allekirjoituksen muoto"
 
 msgid "Init"
-msgstr ""
+msgstr "Oletussähköposti"
 
 msgid "Update form"
-msgstr ""
+msgstr "Päivitä lomake"
 
 msgid "HTTP Basic Authentication"
-msgstr ""
+msgstr "HTTP autentikointi"
 
 msgid "Storage settings"
-msgstr ""
+msgstr "Tallennusasetukset"
 
 msgid "File added"
-msgstr ""
+msgstr "Tiedosto lisätty"
 
 msgid "File removed"
-msgstr ""
+msgstr "Tiedosto poistettu"
 
 msgid "Translate configuration"
-msgstr ""
+msgstr "Käännä asetukset"
 
 msgid "Translations directory"
-msgstr ""
+msgstr "Käännöskansio"
 
 msgid "The translations directory does not exist."
-msgstr ""
+msgstr "Käännöskansiota ei ole olemassa."
 
 msgid "The translations directory is not readable."
-msgstr ""
+msgstr "Käännöskansio ei ole lukukelvollinen."
 
 msgid "The translations directory is not writable."
-msgstr ""
+msgstr "Käännöskansio ei ole kirjoituskelpoinen."
 
 msgid "The translations directory is writable."
-msgstr ""
+msgstr "Käännöskansio on lukukelpoinen."
 
 msgid "The translation server is offline."
-msgstr ""
+msgstr "Käännöspalvelin ei ole linjoilla."
 
 msgid "The translation server is online."
-msgstr ""
+msgstr "Käännöspalvelin on linjoilla."
 
 msgid "The %language translation is not available."
-msgstr ""
+msgstr "Kielen %language käännöstä ei ole saatavilla."
 
 msgid "The %language translation is available."
-msgstr ""
+msgstr "Kielen %language käännös on saatavilla."
 
 msgid "The %language translation could not be downloaded."
-msgstr ""
+msgstr "Käännöstä kielelle %klanguage ei voitu ladata."
 
 msgid "Not blank"
-msgstr ""
+msgstr "Ei tyhjä"
 
 msgid "You have unsaved changes."
-msgstr ""
+msgstr "Sinulla on tallentamattomia muutoksia."
 
 msgid "Allows users to apply an action to one or more items."
-msgstr ""
+msgstr "Salli käyttäjän suorittaa toiminto yhdelle tai useammalle kohteelle."
 
 msgid ""
 "A unique name for this action. It must only contain lowercase letters, "
 "numbers and underscores."
 msgstr ""
+"Toiminnon yksilöllinen nimi. Se voi sisältää ainoastaan pieniä kirjaimia, "
+"numeroita ja alaviivoja."
 
 msgid "All actions, except selected"
-msgstr ""
+msgstr "Kaikki paitsi valitut toiminnot"
 
 msgid "Only selected actions"
-msgstr ""
+msgstr "Vain valitut toiminnot"
 
 msgid "Selected actions"
-msgstr ""
+msgstr "Valitut toiminnot"
 
 msgid "%action was applied to @count item."
 msgid_plural "%action was applied to @count items."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%action suoritettiin @count kohteelle."
+msgstr[1] "%action suoritettiin @count kohteelle."
 
 msgid "The feed language code."
-msgstr ""
+msgstr "Syötteen kielikoodi."
 
 msgid "Time when this feed was queued for refresh, 0 if not queued."
 msgstr ""
+"Ajankohta jolloin syöte jonoutettiin päivitettäväksi, 0 jos ei jonoutettu."
 
 msgid "The link of the feed."
-msgstr ""
+msgstr "Linkki syötteeseen."
 
 msgid "Calculated hash of the feed data, used for validating cache."
-msgstr ""
+msgstr "Syötteen tiedon laskettu hash, käytetään välimuistin validointiin."
 
 msgid "Etag"
-msgstr ""
+msgstr "Etag"
 
 msgid "The ID of the aggregator feed."
-msgstr ""
+msgstr "Aggregointisyötteen ID."
 
 msgid "The title of the feed item."
-msgstr ""
+msgstr "Syötekohteen otsikko."
 
 msgid "The feed item language code."
-msgstr ""
+msgstr "Syötekohteen kielikoodi."
 
 msgid "The link of the feed item."
-msgstr ""
+msgstr "Linkki syötekohteeseen."
 
 msgid "The author of the feed item."
-msgstr ""
+msgstr "Syötekohteen kirjoittaja."
 
 msgid "The body of the feed item."
-msgstr ""
+msgstr "Syötekohteen runko."
 
 msgid "Posted date of the feed item, as a Unix timestamp."
-msgstr ""
+msgstr "Syötekohteen lähetysajankohta Unix aikaleimana."
 
 msgid "Failed to download OPML file due to \"%error\"."
-msgstr ""
+msgstr "OPML tiedoston lataaminen ei onnistunut johtuen virheestä \"%error\"."
 
 msgid "Edit custom block %label"
-msgstr ""
+msgstr "Muokkaa kustomoitua lohkoa %label"
 
 msgid "Custom block types"
-msgstr ""
+msgstr "Kustomoidut lohkotyypit"
 
 msgid "Add custom block type"
-msgstr ""
+msgstr "Lisää  kustomoitu lohkotyyppi"
 
 msgid "@type %info has been created."
-msgstr ""
+msgstr "@type %info luotu."
 
 msgid "@type %info has been updated."
-msgstr ""
+msgstr "@type %info päivitetty."
 
 msgid "@type: added %info."
-msgstr ""
+msgstr "@type: lisätty %info."
 
 msgid "@type: updated %info."
-msgstr ""
+msgstr "@type: päivitetty %info."
 
 msgid "The custom block ID."
-msgstr ""
+msgstr "Kustomoidun lohkon ID."
 
 msgid "The custom block UUID."
-msgstr ""
+msgstr "Kustomoidun lohkon UUID."
 
 msgid "The comment language code."
-msgstr ""
+msgstr "Kommentin kielikoodi."
 
 msgid "The block type."
-msgstr ""
+msgstr "Lohkon tyyppi."
 
 msgid ""
 "Provide a label for this block type to help identify it in the "
 "administration pages."
 msgstr ""
+"Tarjoa etiketti tälle lohkotyypille helpottamaan sen tunnistamista "
+"ylläpitosivuilla."
 
 msgid "Enter a description for this block type."
-msgstr ""
+msgstr "Syötä kuvaus tälle lohkotyypille."
 
 msgid "Create a new revision by default for this block type."
-msgstr ""
+msgstr "Luo automaattisesti uusi versio tälle lohkotyypille."
 
 msgid "Custom block type %label has been updated."
-msgstr ""
+msgstr "Kustomoitu lohkotyyppi %label päivitetty."
 
 msgid "Delete forum"
-msgstr ""
+msgstr "Poista foorumi"
 
 msgid "User-defined shortcuts"
-msgstr ""
+msgstr "Käyttäjän määrittelemät oikopolut"
 
 msgid "Vertical orientation"
-msgstr ""
+msgstr "Pystysuuntainen"
 
 msgid "Tray orientation changed to @orientation."
-msgstr ""
+msgstr "Korin asennoksi muutettu @orientation."
 
 msgid "opened"
-msgstr ""
+msgstr "avattu"
 
 msgid "Custom block type %label has been added."
-msgstr ""
+msgstr "Kustomoitu lohkotyyppi %label lisätty."
 
 msgid "Add %type custom block"
-msgstr ""
+msgstr "Lisää kustomoitu lohko tyyppiä %type"
 
 msgid ""
 "%label is used by 1 custom block on your site. You can not remove this block"
@@ -14560,333 +15646,377 @@ msgid_plural ""
 "%label is used by @count custom blocks on your site. You may not remove "
 "%label until you have removed all of the %label custom blocks."
 msgstr[0] ""
+"Lohkotyyppi %label on yhden kustomoidun lohkon käytössä sivustollasi. Et voi"
+" poistaa tätä lohkotyyppiä ennenkuin olet poistanut kaikki tyypin %label "
+"lohkot."
 msgstr[1] ""
+"Lohkotyyppi %label on @count kustomoidun lohkon käytössä sivustollasi. Et "
+"voi poistaa tätä lohkotyyppiä ennenkuin olet poistanut kaikki tyypin %label "
+"lohkot."
 
 msgid "Output the block in this view mode."
-msgstr ""
+msgstr "Tulosta lohko näyttötilassaan."
 
 msgid "Select the region where this block should be displayed."
-msgstr ""
+msgstr "Valitse sisältöalue jossa lohko esitetään."
 
 msgid "- Create a new book -"
-msgstr ""
+msgstr "- Luo uusi kirja -"
 
 msgid "Edit order and titles"
-msgstr ""
+msgstr "Muokkaa järjestystä ja otsikoita"
 
 msgid "Toolbar configuration"
-msgstr ""
+msgstr "Työkalupalkin asetukset"
 
 msgid "Available buttons"
-msgstr ""
+msgstr "Käytettävissä olevat painikkeet"
 
 msgid "Active toolbar"
-msgstr ""
+msgstr "Aktiivinen työkalupalkki"
 
 msgid "No styles configured"
-msgstr ""
+msgstr "Ei asetettuja tyylejä"
 
 msgid "@count styles configured"
-msgstr ""
+msgstr "@count asetettua tyyliä"
 
 msgid "Button separator"
-msgstr ""
+msgstr "Painikkeen erottaja"
 
 msgid "The provided list of styles is syntactically incorrect."
-msgstr ""
+msgstr "Antamasi tyylien listan syntaksi on väärin."
 
 msgid "You must configure the selected text editor."
-msgstr ""
+msgstr "Sinun on säädettävä tekstityökalun asetukset."
 
 msgid "Approved status"
-msgstr ""
+msgstr "Hyväksynnän tila"
 
 msgid "Approved comment status"
-msgstr ""
+msgstr "Hyväksytyn kommentin tila"
 
 msgid "Link to approve comment"
-msgstr ""
+msgstr "Linkki kommentin hyväksymiseen"
 
 msgid "Link to reply-to comment"
-msgstr ""
+msgstr "Linkki kommentiin vastaamiseen"
 
 msgid "The parent comment ID if this is a reply to a comment."
-msgstr ""
+msgstr "Isäntäkommentin ID mikäli kommentti on vastaus aiempaan kommenttiin."
 
 msgid "The user ID of the comment author."
-msgstr ""
+msgstr "Kommentin kirjoittajan käyttäjä ID."
 
 msgid "The comment author's home page address."
-msgstr ""
+msgstr "Kommentin kirjoittajan kotisivun osoite."
 
 msgid "The comment author's hostname."
-msgstr ""
+msgstr "Kommentin kirjoittajan konenimi."
 
 msgid "The time that the comment was created."
-msgstr ""
+msgstr "Kommentin luontiajankohta."
 
 msgid "The time that the comment was last edited."
-msgstr ""
+msgstr "Ajankohta jolloin kommenttia viimeksi muokattiin."
 
 msgid "Thread place"
-msgstr ""
+msgstr "Sijainti viestiketjussa"
 
 msgid ""
 "The alphadecimal representation of the comment's place in a thread, "
 "consisting of a base 36 string prefixed by an integer indicating its length."
 msgstr ""
+"Kommentin sijainnin aakkosdesimaalinen kuvaus viestiketjussa, sisältäen 36 "
+"merkkisen merkkijonon jossa etuliitteenä muuttuja joka kuvaa sen pituutta."
 
 msgid "View changes of @config_file"
-msgstr ""
+msgstr "Näytä muutokset asetustiedostossa @config_file"
 
 msgid "Send copy to sender"
-msgstr ""
+msgstr "Lähetä kopio lähettäjälle"
 
 msgid "Contact module form element."
-msgstr ""
+msgstr "Contact moduulin lomake-elementti."
 
 msgid "Selected user"
-msgstr ""
+msgstr "Valittu käyttäjä"
 
 msgid "The name of the person that is sending the contact message."
-msgstr ""
+msgstr "Yhteydenottoviestin lähettäjän nimi."
 
 msgid "Whether to send a copy of the message to the sender."
-msgstr ""
+msgstr "Lähetetäänkö kopio viestistä lähettäjälle."
 
 msgid "The ID of the recipient user for personal contact messages."
-msgstr ""
+msgstr "Vastaanottajakäyttäjän ID yksityisille yhteydenottoviesteille."
 
 msgid "@action @title configuration options"
-msgstr ""
+msgstr "@action @title asetusvaihtoehdot"
 
 msgid "Tabbing is no longer constrained by the Contextual module."
-msgstr ""
+msgstr "Välilehdet eivät enää ole Contextual moduulin ylläpidossa."
 
 msgid ""
 "Tabbing is constrained to a set of @contextualsCount and the edit mode "
 "toggle."
 msgstr ""
+"Välilehdet rajoittuvat sarjaan @contextualsCount ja muokkausmuodon vaihtoon."
 
 msgid "Press the esc key to exit."
-msgstr ""
+msgstr "Paina esc poistuaksesi."
 
 msgid "@count contextual link"
 msgid_plural "@count contextual links"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count sisällöllinen linkki"
+msgstr[1] "@count sisällöllistä linkkiä"
 
 msgid "No contextual ids specified."
-msgstr ""
+msgstr "Konteksti-ID:tä ei oltu määritetty."
 
 msgid "Create and store date values."
-msgstr ""
+msgstr "Luo ja tallenna päivämäätäarvoja."
 
 msgid "Choose the type of date to create."
-msgstr ""
+msgstr "Valitse luotavan päivämäärän tyyppi."
 
 msgid "Date only"
-msgstr ""
+msgstr "Vain päivämäärä"
 
 msgid "Set a default value for this date."
-msgstr ""
+msgstr "Aseta oletus tälle päivämäärälle."
 
 msgid ""
 "The %field date is required. Please enter a date in the format %format."
 msgstr ""
+"Päivämääräkenttä %field on pakollinen. Ole hyvä ja syötä päivämäärä muodossa"
+" %format."
 
 msgid "The %field date is invalid. Please enter a date in the format %format."
 msgstr ""
+"Arvo päivämääräkentässä %field ei ole kelvollinen. Ole hyvä ja syötä "
+"päivämäärä muodossa %format."
 
 msgid "AM/PM"
-msgstr ""
+msgstr "AM/PM"
 
 msgid "The %field date is required."
-msgstr ""
+msgstr "Päivämääräkenttä %field on pakollinen."
 
 msgid "The %field date is invalid."
-msgstr ""
+msgstr "Päivämääräkenttä %field on epäkelpo."
 
 msgid "Format: %format. Leave blank to use the time of form submission."
 msgstr ""
+"Muoto %format. Jätä tyhjäksi käyttääksesi lomakkeen lähetysajankohtaa."
 
 msgid ""
 "Choose a format for displaying the date. Be sure to set a format appropriate"
 " for the field, i.e. omitting time for a field that only has a date."
 msgstr ""
+"Valitse päivämäärän esitysmuoto. Varmista että asetat oikean muodon "
+"kentälle, esimerkiksi älä syötä kellonaikaa kentälle joka sallii ainoastaan "
+"päivämäärän."
 
 msgid "Format: @display"
-msgstr ""
+msgstr "Muoto: @display"
 
 msgid "Date part order"
-msgstr ""
+msgstr "Päivämäärän osien järjestys"
 
 msgid "Month/Day/Year"
-msgstr ""
+msgstr "Kuukausi/Päivä/Vuosi"
 
 msgid "Day/Month/Year"
-msgstr ""
+msgstr "Päivä/Kuukausi/Vuosi"
 
 msgid "Year/Month/Day"
-msgstr ""
+msgstr "Vuosi/Kuukausi/Päivä"
 
 msgid "Time type"
-msgstr ""
+msgstr "Ajan tyyppi"
 
 msgid "24 hour time"
-msgstr ""
+msgstr "24 tunnin aika"
 
 msgid "12 hour time"
-msgstr ""
+msgstr "12 tunnin aika"
 
 msgid "Text editor"
-msgstr ""
+msgstr "Tekstityökalu"
 
 msgid ""
 "This option is disabled because no modules that provide a text editor are "
 "currently enabled."
 msgstr ""
+"Tämä vaihtoehto ei ole käytettävissä koska yksikään käytössäolevista "
+"moduuleista ei tarjoa tekstityökalua."
 
 msgid ""
 "Text that will be shown inside the field until a value is entered. This hint"
 " is usually a sample value or a brief description of the expected format."
 msgstr ""
+"Teksti joka näytetään kentän sisällä kunnes arvo on syötetty. Tämä vihje on "
+"usein esimerkkiarvo tai lyhyt kuvaus oletetusta muodosta."
 
 msgid "Type of item to reference"
-msgstr ""
+msgstr "Viitattavan kohteen tyyppi"
 
 msgid "Reference method"
-msgstr ""
+msgstr "Viittaustapa"
 
 msgid "@entity_type selection"
-msgstr ""
+msgstr "@entity_type valinta"
 
 msgid "There are no entities matching \"%value\"."
-msgstr ""
+msgstr "Arvoa \"%value\" vastaavia entiteettejä ei löytynyt."
 
 msgid ""
 "Many entities are called %value. Specify the one you want by appending the "
 "id in parentheses, like \"@value (@id)\"."
 msgstr ""
+"Useita entiteettejä on nimellä %value. Määrittele haluamasi lisäämällä id "
+"nimen loppuun, esimerkiksi \"@value (@id)\"."
 
 msgid ""
 "Multiple entities match this reference; \"%multiple\". Specify the one you "
 "want by appending the id in parentheses, like \"@value (@id)\"."
 msgstr ""
+"Useat entiteetit vastaavat tätä viittausta; \"%multiple\". Määrittele "
+"haluamasi lisäämällä id nimen loppuun, esimerkiksi \"@value (@id)\"."
 
 msgid ""
 "Select the method used to collect autocomplete suggestions. Note that "
 "<em>Contains</em> can cause performance issues on sites with thousands of "
 "entities."
 msgstr ""
+"Valitse automaattiseen täydennykseen käytettävää automaattisen täydennyksen "
+"tapaa. Huomaa että <em>Sisältää</em> voi aiheuttaa suorituskykyongelmia jos "
+"sivustollasi on tuhansia entiteettejä."
 
 msgid ""
 "If checked, field api classes will be added by field templates. This is not "
 "recommended unless your CSS depends upon these classes. If not checked, "
 "template will not be used."
 msgstr ""
+"Mikäli valittuna, field api luokat lisätään kenttien mallinteisiin. Tämä ei "
+"ole suositeltavaa paitsi jos CSS tiedostosi on riippuvainen näistä luokista."
+" Mikäli ei valittuna, mallinteita ei käytetä."
 
 msgid "%entity_label: Administer fields"
-msgstr ""
+msgstr "%entity_label: Ylläpidä kenttiä"
 
 msgid "%entity_label: Administer display"
-msgstr ""
+msgstr "%entity_label: Ylläpidä näyttöasetuksia"
 
 msgid "Allowed number of values"
-msgstr ""
+msgstr "Sallittujen arvojen lukumäärä"
 
 msgid "Number of values is required."
-msgstr ""
+msgstr "Arvojen lukumäärä on pakollinen."
 
 msgid ""
 "Field %field can only hold @max values but there were @count uploaded. The "
 "following files have been omitted as a result: %list."
 msgstr ""
+"Kenttä %field voi sisältää enintään @max arvoa mutta siihen ladattiin @count"
+" arvoa. Tämän seurauksena seuraavat tiedostot jätettiin pois: %list."
 
 msgid "Unlimited number of files can be uploaded to this field."
-msgstr ""
+msgstr "Kenttään on mahdollista ladata rajoittamaton määrä tiedostoja."
 
 msgid "The file ID."
-msgstr ""
+msgstr "Tiedoston ID."
 
 msgid "The file language code."
-msgstr ""
+msgstr "Tiedoston kielikoodi."
 
 msgid "The user ID of the file."
-msgstr ""
+msgstr "Tiedoston luojan käyttäjä ID."
 
 msgid "Name of the file with no path components."
-msgstr ""
+msgstr "Tiedoston nimi ilman polkukomponentteja."
 
 msgid "The URI to access the file (either local or remote)."
 msgstr ""
+"Tiedoston verkko-osoite (joko paikallinen polku tai ulkoinen verkko-osoite)."
 
 msgid "The time that the node was created."
-msgstr ""
+msgstr "Solmun luontiajankohta."
 
 msgid "Detect if tar is part of the extension"
-msgstr ""
+msgstr "Tunnista, onko tar osa tiedostopäätettä"
 
 msgid "This format is shown when no other formats are available"
-msgstr ""
+msgstr "Tätä muotoilua käytetään jos muita muotoiluja ei ole saatavilla"
 
 msgid ""
 "Based on the text editor configuration, these tags have automatically been "
 "added: <strong>@tag-list</strong>."
 msgstr ""
+"Tekstityökalun asetuksien perusteella nämä tagit lisättiin automaattisesti: "
+"<strong>@tag-list</strong>."
 
 msgid "Forum content"
-msgstr ""
+msgstr "Foorum-sisältö"
 
 msgid "The content ID of the forum index entry."
-msgstr ""
+msgstr "Foorumin indeksointikohteen sisältö ID."
 
 msgid "1 new post<span class=\"visually-hidden\"> in forum %title</span>"
 msgid_plural ""
 "@count new posts<span class=\"visually-hidden\"> in forum %title</span>"
 msgstr[0] ""
+"1 uusi kirjoitus <span class=\"visually-hidden\">foorumissa %title</span>"
 msgstr[1] ""
+"@count uutta kirjoitusta <span class=\"visually-hidden\">foorumissa "
+"%title</span>"
 
 msgid "The user ID of the author of the current revision."
-msgstr ""
+msgstr "Tämänhetkisen version kirjoittajan ID."
 
 msgid "Displaying link text"
-msgstr ""
+msgstr "Linkkitekstin esittäminen"
 
 msgid "1 new post<span class=\"visually-hidden\"> in topic %title</span>"
 msgid_plural ""
 "@count new posts<span class=\"visually-hidden\"> in topic %title</span>"
 msgstr[0] ""
+"1 uusi kirjoitus <span class=\"visually-hidden\">aiheessa %title</span>"
 msgstr[1] ""
+"@count uutta kirjoitusta <span class=\"visually-hidden\">aiheessa "
+"%title</span>"
 
 msgid "The forum %label and all sub-forums have been deleted."
-msgstr ""
+msgstr "Forum %label ja sen alifoorumit poistettiin."
 
 msgid "forum: deleted %label and all its sub-forums."
-msgstr ""
+msgstr "foorum: poistettiin %label ja sen alifoorumit"
 
 msgid ""
 "Source image at %source_image_path not found while trying to generate "
 "derivative image at %derivative_path."
 msgstr ""
+"Lähdekuvaa %source_image_path ei löytynyt yritettäessä luoda johdannaiskuvaa"
+" polussa %derivative_path."
 
 msgid "Alternative image text, for the image's 'alt' attribute."
-msgstr ""
+msgstr "Vaihtoehtoinen kuvateksti kuvan 'alt' määrelle."
 
 msgid "Image title text, for the image's 'title' attribute."
-msgstr ""
+msgstr "Kuvan otsikkoteksti kuvan 'title' määrelle."
 
 msgid "The width of the image in pixels."
-msgstr ""
+msgstr "Kuvan leveys pikseleinä."
 
 msgid "The height of the image in pixels."
-msgstr ""
+msgstr "Kuvan korkeus pikseleinä."
 
 msgid "Custom language settings"
-msgstr ""
+msgstr "Kustomoidun kielen asetukset"
 
 msgid "Settings successfully updated."
-msgstr ""
+msgstr "Asetukset onnistuneesti päivitetty."
 
 msgid ""
 "Change language settings for <em>content types</em>, <em>taxonomy "
@@ -14894,73 +16024,86 @@ msgid ""
 " your site. By default, language settings hide the language selector and the"
 " language is the site's default language."
 msgstr ""
+"Muuta kieliasetuksia <em>sisältötyypeille</em>, <em>sanastoille</em> tai "
+"muille tuetuille elementeille sivustollasi. Oletuksena kieliasetukset "
+"piilottavat kielenvalitsimen ja kieli on sivuston oletuskieli."
 
 msgid "Show language selector on create and edit pages"
-msgstr ""
+msgstr "Näytä kielenvalitsin luonti- ja muokkaussivuilla"
 
 msgid ""
 "Select languages to enforce. If none are selected, all languages will be "
 "allowed."
 msgstr ""
+"Valitse pakotettava kieli. Mikäli mitään ei ole valittuna, kaikki kielet "
+"ovat sallittuja."
 
 msgid "The language is not @languages."
-msgstr ""
+msgstr "Kieli ei ole yksi kielistä @languages."
 
 msgid "The language is @languages."
-msgstr ""
+msgstr "Kieli on yksi kielistä @languages."
 
 msgid ""
 "Stores a URL string, optional varchar link text, and optional blob of "
 "attributes to assemble a link."
 msgstr ""
+"Tallentaa merkkijonon, vaihtoehtoisen varchar linkkitekstin ja "
+"vaihtoehtoiset blob muuttujat linkin luomista varten."
 
 msgid "Allow link text"
-msgstr ""
+msgstr "Salli linkkiteksti"
 
 msgid "Placeholder for URL"
-msgstr ""
+msgstr "Paikkamerkki URLille"
 
 msgid "Placeholder for link text"
-msgstr ""
+msgstr "Paikkamerkki linkkitekstille"
 
 msgid "Nothing to check."
-msgstr ""
+msgstr "Ei tarkistettavaa."
 
 msgid "Importing translation for %project."
-msgstr ""
+msgstr "Tuodaan käännöstä projektille %project."
 
 msgid "Translation file not found: @uri."
-msgstr ""
+msgstr "Käännöstiedostoa ei löytynyt: @uri."
 
 msgid "Unable to download translation file @uri."
-msgstr ""
+msgstr "Käännöstiedoston @uri lataaminen epäonnistui."
 
 msgid "One translation files could not be checked. See the log for details."
 msgid_plural ""
 "@count translation files could not be checked. See the log for details."
 msgstr[0] ""
+"Yhden käännöstiedoston tarkistaminen ei onnistunut. Tarkista tiedot logista."
 msgstr[1] ""
+"@count käännöstiedoston tarkistaminen ei onnistunut. Tarkista tiedot "
+"logista."
 
 msgid "Updating configuration translations"
-msgstr ""
+msgstr "Päivitetään asetusten käännöksiä"
 
 msgid "Error updating configuration translations"
-msgstr ""
+msgstr "Virhe päivitettäessä asetusten käännöksiä"
 
 msgid "No configuration objects have been updated."
-msgstr ""
+msgstr "Asetusobjekteja ei päivitetty."
 
 msgid "Unable to import translations file: @file"
-msgstr ""
+msgstr "Käännöstiedoston tuonti epäonnistui: @file"
 
 msgid ""
 "Translations imported: %number added, %update updated, %delete removed."
 msgstr ""
+"Käännökset tuotu: %number lisätty, %update päivitetty, %delete poistettu."
 
 msgid ""
 "The configuration was successfully updated. %number configuration objects "
 "updated."
 msgstr ""
+"Asetustiedostot onnistuneesti päivitetty. %number asetusobjektia "
+"päivitettiin."
 
 msgid ""
 "One translation string was skipped because of disallowed or malformed HTML. "
@@ -14969,245 +16112,264 @@ msgid_plural ""
 "@count translation strings were skipped because of disallowed or malformed "
 "HTML. See the log for details."
 msgstr[0] ""
+"Yksi käännösmerkkijono ohitettiin kielletystä tai huonosti muotoillusta "
+"HTML:stä johtuen. Katso lisätietoja logeista."
 msgstr[1] ""
+"@count käännösmerkkijonoa ohitettiin kielletystä tai huonosti muotoillusta "
+"HTML:stä johtuen. Katso lisätietoja logeista."
 
 msgid "Checking translations"
-msgstr ""
+msgstr "Käännöksien tarkistaminen"
 
 msgid "Error checking translation updates."
-msgstr ""
+msgstr "Käännösten päivityksien tarkistaminen epäonnistui."
 
 msgid "Updating translations"
-msgstr ""
+msgstr "Käännöksien päivittäminen"
 
 msgid "Error importing translation files"
-msgstr ""
+msgstr "Käännöstiedostojen tuonnissa tapahtui virhe."
 
 msgid "Updating translations."
-msgstr ""
+msgstr "Päivitetään käännöksiä."
 
 msgid "All translations up to date."
-msgstr ""
+msgstr "Kaikki käännökset ovat ajantasalla."
 
 msgid "Select a language to update."
-msgstr ""
+msgstr "Valitse päivitettävä kieli."
 
 msgid "File not found at %remote_path nor at %local_path"
 msgstr ""
+"Tiedostoa ei löytynyt ulkoisesta polusta %remote_path tai paikallispolusta "
+"%local_path"
 
 msgid "File not found at %local_path"
-msgstr ""
+msgstr "Tiedostoa ei löytynyt paikallispolusta %local_path"
 
 msgid "Translation file location could not be determined."
-msgstr ""
+msgstr "Käännöstiedoston sijainnin määrittely ei onnistunut."
 
 msgid "Missing translations for:"
-msgstr ""
+msgstr "Puuttuvat käännökset:"
 
 msgid "Missing translations for one project"
 msgid_plural "Missing translations for @count projects"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Yhdelle projektille ei löytynyt käännöstä."
+msgstr[1] "@count projektille ei löytynyt käännöstä."
 
 msgid ""
 "A local file system path where interface translation files will be stored."
-msgstr ""
+msgstr "Paikallinen tiedostopolku johon käännöstiedostot tallennetaan."
 
 msgid "Updates available"
-msgstr ""
+msgstr "Päivityksiä saatavilla"
 
 msgid "Missing translations"
-msgstr ""
+msgstr "Puuttuvat käännökset"
 
 msgid "Translation source"
-msgstr ""
+msgstr "Käännösten lähde"
 
 msgid "Drupal translation server and local files"
-msgstr ""
+msgstr "Drupalin käännöspalvelin ja paikallistiedostot"
 
 msgid "Local files only"
-msgstr ""
+msgstr "Vain paikalliset tiedostot"
 
 msgid "The source of translation files for automatic interface translation."
-msgstr ""
+msgstr "Lähdetiedostot automaattiselle käyttöliittymän kääntämiselle."
 
 msgid "Don't overwrite existing translations."
-msgstr ""
+msgstr "Älä ylikirjoita olemassaolevia käännöksiä."
 
 msgid ""
 "Only overwrite imported translations, customized translations are kept."
 msgstr ""
+"Ylikirjoita ainoastaan tuodut käännökset, kustomoidut käännökset "
+"säilytetään."
 
 msgid "Overwrite existing translations."
-msgstr ""
+msgstr "Ylikirjoita olemassaolevat käännökset."
 
 msgid ""
 "How to treat existing translations when automatically updating the interface"
 " translations."
 msgstr ""
+"Kuinka olemassaolevia käännöksiä kohdellaan automaattisesti päivitettäessä "
+"käyttöliittymäkäännöksiä."
 
 msgid "Edit menu %label"
-msgstr ""
+msgstr "Muokkaa valikkoa %label"
 
 msgid "Add menu link"
-msgstr ""
+msgstr "Lisää valikkolinkki"
 
 msgid "Administrative summary"
-msgstr ""
+msgstr "Ylläpidollinen tiivistelmä"
 
 msgid "Menu %label has been updated."
-msgstr ""
+msgstr "Valikko %label päivitetty."
 
 msgid "Menu %label has been added."
-msgstr ""
+msgstr "Valikko %label lisätty."
 
 msgid "The menu link has been saved."
-msgstr ""
+msgstr "Valikkolinkki on tallennettu."
 
 msgid "Published status or admin user"
-msgstr ""
+msgstr "Julkaisutila tai ylläpitokäyttäjä."
 
 msgid "Promoted to front page status"
-msgstr ""
+msgstr "Etusivulle noston tila"
 
 msgid "Node operations bulk form"
-msgstr ""
+msgstr "Solmujen bulkkitoimintojen lomake"
 
 msgid "Add a form element that lets you run operations on multiple nodes."
 msgstr ""
+"Lisää lomake-elementti joka mahdollistaa toimintojen suorittamisen "
+"useammalle solmulle kerrallaan."
 
 msgid "Empty Node Frontpage behavior"
-msgstr ""
+msgstr "Etusivun toiminnallisuus ilman sisältöä"
 
 msgid "Provides a link to the node add overview page."
-msgstr ""
+msgstr "Tarjoaa linkin nodejen lisäyksen yhteenvetosivulle."
 
 msgid "Link to revision"
-msgstr ""
+msgstr "Linkki versioon"
 
 msgid "Link to revert revision"
-msgstr ""
+msgstr "Linkki version palauttamiseen"
 
 msgid "Link to delete revision"
-msgstr ""
+msgstr "Linkki version poistamiseen"
 
 msgid "Access the Content overview page"
-msgstr ""
+msgstr "Pääsy sisällön kokonaiskatsaussivulle"
 
 msgid "View all revisions"
-msgstr ""
+msgstr "Näytä kaikki versiot"
 
 msgid "Revert all revisions"
-msgstr ""
+msgstr "Palauta kaikki versiot"
 
 msgid "%type_name: View revisions"
-msgstr ""
+msgstr "%type_name: Näytä versiot"
 
 msgid "%type_name: Revert revisions"
-msgstr ""
+msgstr "%type_name: Palauta versiot"
 
 msgid "%type_name: Delete revisions"
-msgstr ""
+msgstr "%type_name: Poista versiot"
 
 msgid "Promotion options"
-msgstr ""
+msgstr "Nostovaihtoehdot"
 
 msgid "Read more<span class=\"visually-hidden\"> about @title</span>"
-msgstr ""
+msgstr "Lue lisää <span class=\"visually-hidden\">@title</span>"
 
 msgid "The node revision ID."
-msgstr ""
+msgstr "Solmun version ID."
 
 msgid "The time that the node was last edited."
-msgstr ""
+msgstr "Ajankohta jolloin solmua viimeksi muokattiin."
 
 msgid "The time that the current revision was created."
-msgstr ""
+msgstr "Ajankohta jolloin nykyistä versiota muokattiin."
 
 msgid "Checked translation for %project."
-msgstr ""
+msgstr "Tarkistettiin käännös projektille %project."
 
 msgid "Downloaded translation for %project."
-msgstr ""
+msgstr "Ladattiin käännös projektille %project."
 
 msgid "Imported translation for %project."
-msgstr ""
+msgstr "Tuotiin käännös projektille %project."
 
 msgid "Importing translation file: %filename (@percent%)."
-msgstr ""
+msgstr "Tuodaan käännöstiedostoa: %filename (@percent%)."
 
 msgid "Translations imported."
-msgstr ""
+msgstr "Käännökset tuotu."
 
 msgid ""
 "The configuration was successfully updated. There are %number configuration "
 "objects updated."
 msgstr ""
+"Asetukset onnistuneesti päivitetty. %number asetusobjektia päivitettiin."
 
 msgid "Source string (@language)"
-msgstr ""
+msgstr "Lähdemerkkijono (@language)"
 
 msgid "Built-in English"
-msgstr ""
+msgstr "Sisäänrakennettu englanti"
 
 msgid "Translated string (@language)"
-msgstr ""
+msgstr "Tallennettu merkkijono (@language)"
 
 msgid "The node bundle is @bundles or @last"
-msgstr ""
+msgstr "Solmun nippu on joko @bundles tai @last"
 
 msgid "The node bundle is @bundle"
-msgstr ""
+msgstr "Solmun nippu on @bundle"
 
 msgid "Float value"
-msgstr ""
+msgstr "Liukulukuarvo"
 
 msgid "An entity field containing a path alias and related data."
-msgstr ""
+msgstr "Entiteettikenttä sisältäen polkualiaksen ja siihen liittyvää tietoa."
 
 msgid "Path id"
-msgstr ""
+msgstr "Polun id"
 
 msgid "Log entry with ID @id was not found"
-msgstr ""
+msgstr "Logimerkintää ID:llä @id ei löytynyt"
 
 msgid "Created entity %type with ID %id."
-msgstr ""
+msgstr "Luo entiteetti %type jonka ID on %id."
 
 msgid "Updated entity %type with ID %id."
-msgstr ""
+msgstr "Päivitä entiteetti %type jonka ID on %id."
 
 msgid "Deleted entity %type with ID %id."
-msgstr ""
+msgstr "Poista entiteetti %type jonka ID on %id."
 
 msgid "Raw output"
-msgstr ""
+msgstr "Raakatuloste"
 
 msgid "You have no fields. Add some to your view."
-msgstr ""
+msgstr "Sinulla ei ole kenttiä. Lisää joitakin näkymääsi."
 
 msgid ""
 "The machine-readable name must contain only letters, numbers, dashes and "
 "underscores."
 msgstr ""
+"Koneluettava nimi voi sisältää ainoastaan kirjaimia, numeroita, väliviivoja "
+"ja alaviivoja."
 
 msgid "Accepted request formats"
-msgstr ""
+msgstr "Hyväksyt kutsumuodot"
 
 msgid ""
 "Request formats that will be allowed in responses. If none are selected all "
 "formats will be allowed."
 msgstr ""
+"Kutsumuodot jotka ovat sallittuja vastauksissa. Jos yhtäkään ei ole "
+"valittuna, kaikki muodot ovat sallittuja."
 
 msgid "The new set label is required."
-msgstr ""
+msgstr "Uuden ryhmän nimi on pakollinen."
 
 msgid "Enter test name…"
-msgstr ""
+msgstr "Syötä testin nimi..."
 
 msgid ""
 "Enter at least 3 characters of the test name or description to filter by."
 msgstr ""
+"Syötä vähintään kolme kirjainta testin nimestä tai kuvauksesta suodatusta "
+"varten."
 
 msgid ""
 "On UNIX, Linux, and Mac OS X, you will find the configuration in the file "
@@ -15219,106 +16381,122 @@ msgid ""
 "or <em>rsyslog.conf</em>, see the <em>syslog.conf</em> or "
 "<em>rsyslog.conf</em> manual page on your command line."
 msgstr ""
+"UNIX, Linux, ja Mac OS X ympäristöissä tiedosto <em>/etc/syslog.conf</em> "
+"määrittelee rutiiniasetukset. Viestit voidaan merkitä koodeilla "
+"<code>LOG_LOCAL0</code> - <code>LOG_LOCAL7</code>. Lisätietoa Syslogin "
+"toiminnasta, turvatasoista ja <em>syslog.confin</em> tai "
+"<em>rsyslog.confin</em> asetuksista saat niiden ohjesivulta (man page) "
+"komentokehotteessasi."
 
 msgid "Any data"
-msgstr ""
+msgstr "Mikä tahansa tieto"
 
 msgid "An entity field containing a UUID."
-msgstr ""
+msgstr "Entiteettikenttä sisältäen UUID:n."
 
 msgid "@zone"
-msgstr ""
+msgstr "@zone"
 
 msgid "Failed to fetch file due to error \"%error\""
-msgstr ""
+msgstr "Tiedoston haku epäonnistui \"%error\" virheestä johtuen."
 
 msgid ""
 "The update.php script is accessible to everyone without authentication "
 "check, which is a security risk. You must change the @settings_name value in"
 " your settings.php back to FALSE."
 msgstr ""
+"Update.php -skripti on kaikkien käytettävissä, eikä kirjautumista vaadita. "
+"Tämä on turvariski. Aseta arvo $update_free_access tiedostossa settings.php "
+"takaisin muotoon FALSE."
 
 msgid "Name of the date format"
-msgstr ""
+msgstr "Päivämäärämuodon nimi"
 
 msgid "@toolkit settings"
-msgstr ""
+msgstr "@toolkit asetukset"
 
 msgid "Update this item"
-msgstr ""
+msgstr "Päivitä termi"
 
 msgid "This value should not be null."
-msgstr ""
+msgstr "Arvon on oltava erisuuri kuin null."
 
 msgid "This value should be %limit or more."
-msgstr ""
+msgstr "Arvon on oltava %limit tai enemmän."
 
 msgid "The term ID."
-msgstr ""
+msgstr "Termin ID."
 
 msgid "The term language code."
-msgstr ""
+msgstr "Termin kielikoodi."
 
 msgid "Term Parents"
-msgstr ""
+msgstr "Termin isännät"
 
 msgid "The parents of this term."
-msgstr ""
+msgstr "Tämän termin isännät."
 
 msgid "Create referenced entities if they don't already exist"
-msgstr ""
+msgstr "Luo viitatut entiteetit jos niitä ei ole jo olemassa"
 
 msgid "Telephone number"
-msgstr ""
+msgstr "Puhelinnumero"
 
 msgid "This field stores a telephone number in the database."
-msgstr ""
+msgstr "Tämä kenttä tallentaa puhelinnumeron tietokantaan."
 
 msgid "Link using text: @title"
-msgstr ""
+msgstr "Linkki käyttäen tekstiä: @title"
 
 msgid "Link using provided telephone number."
-msgstr ""
+msgstr "Linkki käyttäen tarjottua puhelinnumeroa."
 
 msgid "Translatable elements"
-msgstr ""
+msgstr "Käännettävät elementit"
 
 msgid ""
 "At least one field needs to be translatable to enable %bundle for "
 "translation."
 msgstr ""
+"Vähintään yhden kentistä on oltava käännettävissä jotta voit ottaa käyttöön "
+"%bundle käännöksiä varten."
 
 msgid "<strong>@language_name (Original language)</strong>"
-msgstr ""
+msgstr "<strong>@language_name (Alkuperäinen kieli)</strong>"
 
 msgid "Administer translation settings"
-msgstr ""
+msgstr "Ylläpidä käännösasetuksia"
 
 msgid "Create translations"
-msgstr ""
+msgstr "Luo käännöksiä"
 
 msgid "Delete translations"
-msgstr ""
+msgstr "Poista käännökset"
 
 msgid "Translate %bundle_label @entity_label"
-msgstr ""
+msgstr "Käännä %bundle_label @entity_label"
 
 msgid "Translate @entity_label"
-msgstr ""
+msgstr "Käännä @entity_label"
 
 msgid ""
 "\"Show language selector\" is not compatible with translating content that "
 "has default language: %choice. Either do not hide the language selector or "
 "pick a specific language."
 msgstr ""
+"\"Näytä kielenvalitsin\" ei ole yhteensopiva sellaisen sisällön kanssa jolla"
+" on oletuskieli: %choice. Joko piilota kielenvalitsin tai valitse jokin "
+"tietty kieli."
 
 msgid ""
 "An unpublished translation will not be visible without translation "
 "permissions."
 msgstr ""
+"Julkaisemattomat käännökset ovat näkymättömiä kaikille paitsi niille joilla "
+"on oikeus kääntää sisältöä."
 
 msgid "%archive_file does not contain any .info.yml files."
-msgstr ""
+msgstr "%archive_file ei sisällä yhtäkään .info.yml tiedostoa."
 
 msgid ""
 "<p>This is a one-time login for %user_name.</p><p>Click on this button to "
@@ -15329,196 +16507,216 @@ msgstr ""
 "salasanasi.</p>"
 
 msgid "Provides access to the user data service."
-msgstr ""
+msgstr "Tarjoaa pääsyn käyttäjädatapalveluihin."
 
 msgid "Add a form element that lets you run operations on multiple users."
 msgstr ""
+"Lisää lomake-elementti joka sallii sinun suorittaa toimintoja usealle "
+"käyttäjälle kerrallaan."
 
 msgid "User module form element."
-msgstr ""
+msgstr "User moduulin lomakkeen elementti."
 
 msgid "System module form element."
-msgstr ""
+msgstr "System moduulin lomakkeen elementti."
 
 msgid "Login attempt failed from %ip."
-msgstr ""
+msgstr "Kirjautuminen epäonnistui IP-osoitteesta %ip."
 
 msgid "Cancel user"
-msgstr ""
+msgstr "Peru käyttäjätili"
 
 msgid "Enable password strength indicator"
-msgstr ""
+msgstr "Ota käyttöön salasanan turvallisuuden esitystyökalu"
 
 msgid "Admin (user awaiting approval)"
-msgstr ""
+msgstr "Ylläpitäjä (käyttäjä odottaa hyväksyntää)"
 
 msgid "Role %label has been updated."
-msgstr ""
+msgstr "Rooli %label on päivitetty."
 
 msgid "Role %label has been added."
-msgstr ""
+msgstr "Rooli %label on lisätty."
 
 msgid "The user language code."
-msgstr ""
+msgstr "Käyttäjän kielikoodi."
 
 msgid "The time that the user last accessed the site."
-msgstr ""
+msgstr "Ajankohta jolloin käyttäjä viimeksi kävi sivustolla."
 
 msgid "The time that the user last logged in."
-msgstr ""
+msgstr "Ajankohta jolloin käyttäjä viimeksi kirjautui sisään."
 
 msgid "The email address used for initial account creation."
-msgstr ""
+msgstr "Sähköpostiosoite jota käytetään käyttäjätiliä luotaessa."
 
 msgid "The roles the user has."
-msgstr ""
+msgstr "Käyttäjän roolit."
 
 msgid "Update the user %name"
-msgstr ""
+msgstr "Päivitä käyttäjä %name"
 
 msgid "The module which sets this user data."
-msgstr ""
+msgstr "Moduuli joka asettaa tämän käyttäjän tiedot."
 
 msgid "The name of the data key."
-msgstr ""
+msgstr "Tietoavaimen nimi."
 
 msgid "The label of the view."
-msgstr ""
+msgstr "Näkymän etiketti"
 
 msgid "The machine-readable ID of the view."
-msgstr ""
+msgstr "Näkymän koneluettava ID."
 
 msgid "Dropbutton"
-msgstr ""
+msgstr "Dropbutton"
 
 msgid "Display fields in a dropbutton."
-msgstr ""
+msgstr "Näyttöö kentät Dropbuttoneissa."
 
 msgid "Rendered entity - @label"
-msgstr ""
+msgstr "Tulostettu entiteetti - @label"
 
 msgid "Displays a rendered @label entity in an area."
-msgstr ""
+msgstr "Näyttää tulostetun @label entiteetin jollakin alueella."
 
 msgid "Display the @label"
-msgstr ""
+msgstr "Näytä @label"
 
 msgid "Available global token replacements"
-msgstr ""
+msgstr "Käytettävissä olevat sivuston laajuiset tokenit."
 
 msgid ""
 "Override the title of this view when it is empty. The available global "
 "tokens below can be used here."
 msgstr ""
+"Ohita tämän näkymän otsikko sen ollessa tyhjä. Voit käyttää seuraavia "
+"sivuston laajuisia tokeneja."
 
 msgid "Administrative comment"
-msgstr ""
+msgstr "Ylläpidollinen kommentti"
 
 msgid "Machine name of the display"
-msgstr ""
+msgstr "Näyttöruudun koneluettava nimi"
 
 msgid ""
 "This description will only be seen within the administrative interface and "
 "can be used to document this display."
 msgstr ""
+"Kuvaus näytetään ainoastaan ylläpitoliittymässä ja sitä voidaan käyttää "
+"näkymän dokumentoinnissa."
 
 msgid "CSS class name(s)"
-msgstr ""
+msgstr "CSS luokkien nimi / nimet"
 
 msgid "Show contextual links on this view."
-msgstr ""
+msgstr "Näytä sisältöön liittyvät linkit tässä näkymässä."
 
 msgid "Show contextual links"
-msgstr ""
+msgstr "Näytä sisältöön liittyvät linkit"
 
 msgid ""
 "In the menu, the heavier links will sink and the lighter links will be "
 "positioned nearer the top."
 msgstr ""
+"Valikossa raskaammat linkit vajoavat ja kevyemmät linkit näytetään lähempänä"
+" valikkojen juurta."
 
 msgid ""
 "If the parent menu item is a tab, enter the weight of the tab. Heavier tabs "
 "will sink and the lighter tabs will be positioned nearer to the first menu "
 "item."
 msgstr ""
+"Mikäli isäntä-valikkokohde on välilehti, syötä välilehden painokerroin. "
+"Raskaammat välilehdet vajoavat alaspäin ja kevyemmät näytetään lähempänä "
+"valikon juurta."
 
 msgid "Allow people to choose the sort order"
-msgstr ""
+msgstr "Salli käyttäjien valita lajittelujärjestys"
 
 msgid ""
 "If sort order is not exposed, the sort criteria settings for each sort will "
 "determine its order."
 msgstr ""
+"Mikäli lajittelua ei näytetä käyttäjälle, lajittelukriteerien asetukset "
+"kullekin lajittelulle määrittelevät sen järjestyksen."
 
 msgid "Label for ascending sort"
-msgstr ""
+msgstr "Etiketti nousevalle järjestelylle"
 
 msgid "Label for descending sort"
-msgstr ""
+msgstr "Etiketti laskevalle järjestelylle"
 
 msgid "Toolbar items"
-msgstr ""
+msgstr "Työkalupalkin elementit"
 
 msgid "Edit user account"
-msgstr ""
+msgstr "Muokkaa käyttäjätiliä"
 
 msgid "End tour"
-msgstr ""
+msgstr "Lopeta kierros"
 
 msgid "Override the output of this field with custom text"
-msgstr ""
+msgstr "Ohita kentän tuloste kustomoidulla tekstillä"
 
 msgid "Output this field as a custom link"
-msgstr ""
+msgstr "Tulosta kenttä kustomoituna linkkinä"
 
 msgid "Trim this field to a maximum number of characters"
-msgstr ""
+msgstr "Leikkaa kentän pituus enimmäismäärään merkkejä"
 
 msgid "More link label"
-msgstr ""
+msgstr "Lisää-linkin etiketti"
 
 msgid "You may use the \"Replacement patterns\" above."
-msgstr ""
+msgstr "Voit käyttää allaolevia \"korvauskuvioita\""
 
 msgid ""
 "An HTML corrector will be run to ensure HTML tags are properly closed after "
 "trimming."
 msgstr ""
+"HTML tarkistin suoritetaan varmistamaan että HTML tagit on oikein suljettu "
+"lyhentämisen jälkeen."
 
 msgid "Fields to be included as links."
-msgstr ""
+msgstr "Kentät jotka sisällytetään linkkeinä."
 
 msgid ""
 "Include a \"destination\" parameter in the link to return the user to the "
 "original view upon completing the link action."
 msgstr ""
+"Sisällytä \"kohde\" parametri linkkiin palauttamaan käyttäjän alkuperäiseen "
+"näkymään linkin toiminnon suorittamisen jälkeen."
 
 msgid "First page link text"
-msgstr ""
+msgstr "Ensimmäisen sivun linkin teksti"
 
 msgid "Last page link text"
-msgstr ""
+msgstr "Viimeisen sivun linkin teksti"
 
 msgid "Offset (number of items to skip)"
-msgstr ""
+msgstr "Ohitettavien tulosten lukumäärä"
 
 msgid ""
 "For example, set this to 3 and the first 3 items will not be displayed."
 msgstr ""
+"Esimerkiksi jos asetat arvoksi 3, ensimmäistä kolmea tulosta ei näytetä."
 
 msgid "Pager link labels"
-msgstr ""
+msgstr "Sivutuksen linkkien etiketit"
 
 msgid "Previous page link text"
-msgstr ""
+msgstr "Edellisen sivun linkin teksti"
 
 msgid "Next page link text"
-msgstr ""
+msgstr "Seuraavan sivun linkin teksti"
 
 msgid ""
 "Insert a list of integer numeric values separated by commas: e.g: 10, 20, "
 "50, 100"
 msgstr ""
+"Syötä lista numeerisia arvoja pilkuin eroteltuina, esimerkiksi: 10, 20, 50, "
+"100"
 
 msgid ""
 "WARNING: Disabling SQL rewriting means that node access security is "
@@ -15526,375 +16724,393 @@ msgid ""
 " your view is misconfigured. Use this option only if you understand and "
 "accept this security risk."
 msgstr ""
+"VAROITUS: SQL-uudelleenkirjoituksen käytöstä poistaminen tarkoittaa, että "
+"nodejen käyttöoikeustietoja ei käytetä. Tämä saattaa mahdollistaa, että "
+"käyttäjät näkevät sisältöä, jota heidän ei tulisi nähdä, mikäli näkymäsi on "
+"väärin konfiguroitu. Käytä tätä vaihtoehtoa ainoastaan jos ymmärrät ja olet "
+"valmis hyväksymään tämän tietoturvariskin."
 
 msgid "No view mode selected"
-msgstr ""
+msgstr "Näyttötapaa ei ole valittuna"
 
 msgid "Caption for the table"
-msgstr ""
+msgstr "Kuvateksti taulukolle"
 
 msgid "Table details"
-msgstr ""
+msgstr "Taulukon tiedot"
 
 msgid "Summary title"
-msgstr ""
+msgstr "Tiivistelmän otsikko"
 
 msgid "Table description"
-msgstr ""
+msgstr "Taulukon kuvaus"
 
 msgid "Provide additional details about the table to increase accessibility."
 msgstr ""
+"Syötä lisätietoja taulukkoon liittyen parantaaksesi sen saavutettavuutta."
 
 msgid "Enable @display_title"
-msgstr ""
+msgstr "Ota käyttöön @display_title"
 
 msgid "Delete @display_title"
-msgstr ""
+msgstr "Poista @display_title"
 
 msgid "Undo delete of @display_title"
-msgstr ""
+msgstr "Peru @display_title poistaminen"
 
 msgid "Disable @display_title"
-msgstr ""
+msgstr "Poista käytöstä @display_title"
 
 msgid "Edit view name/description"
-msgstr ""
+msgstr "Muokkaa näkymän nimeä/kuvausta"
 
 msgid "Analyze view"
-msgstr ""
+msgstr "Analysoi näkymää"
 
 msgid "Reorder displays"
-msgstr ""
+msgstr "Uudelleenjärjestele näyttöruudut"
 
 msgid "Revert view"
-msgstr ""
+msgstr "Palauta näkymä"
 
 msgid "Add <span class=\"visually-hidden\">@type</span>"
-msgstr ""
+msgstr "Lisää <span class=\"visually-hidden\">@type</span>"
 
 msgid "And/Or Rearrange <span class=\"visually-hidden\">filter criteria</span>"
 msgstr ""
+"Ja/Tai Uudelleenjärjestele <span class=\"visually-"
+"hidden\">suodatuskriteerit</span>"
 
 msgid "Rearrange <span class=\"visually-hidden\">@type</span>"
-msgstr ""
+msgstr "Uudelleenjärjestele <span class=\"visually-hidden\">@type</span>"
 
 msgid "This display has one or more validation errors."
-msgstr ""
+msgstr "Näkymässä on yksi tai useampi validointivirhe."
 
 msgid "There are no disabled views."
-msgstr ""
+msgstr "Käytöstä poistettujanäkymiä ei löytynyt."
 
 msgid "[@time ms] @query"
-msgstr ""
+msgstr "[@time ms] @query"
 
 msgid "Do you want to break the lock on view %name?"
-msgstr ""
+msgstr "Haluatko murtaa lukituksen näkymältä %name?"
 
 msgid "View language"
-msgstr ""
+msgstr "Näytä kieli"
 
 msgid "Language of labels and other textual elements in this view."
-msgstr ""
+msgstr "Kielten etiketit ja muut tekstilliset elementit tässä näkymässä."
 
 msgid "No displays available."
-msgstr ""
+msgstr "Näyttöruutuja ei ole saatavilla."
 
 msgid "Last saved"
-msgstr ""
+msgstr "Viimeksi tallennettu"
 
 msgid "Not saved yet"
-msgstr ""
+msgstr "Ei vielä tallennettu"
 
 msgid "Hard"
-msgstr ""
+msgstr "Vaikea"
 
 msgid "Book Page"
-msgstr ""
+msgstr "Kirjan sivu"
 
 msgid "Aggregator feed item"
-msgstr ""
+msgstr "Aggregointisyöte"
 
 msgid "Default parser for RSS, Atom and RDF feeds."
-msgstr ""
+msgstr "Oletusjäsennin RSS-, Atom- ja RDF-syötteille."
 
 msgid "Custom Block"
-msgstr ""
+msgstr "Kustomoitu lohko"
 
 msgid "CKEditor core"
-msgstr ""
+msgstr "CKEditor ydin"
 
 msgid "Styles dropdown"
-msgstr ""
+msgstr "Tyylien alasvetovalikko"
 
 msgid "Comment selection"
-msgstr ""
+msgstr "Kommentin valitsin"
 
 msgid "My Editor"
-msgstr ""
+msgstr "Tekstityökaluni"
 
 msgid "Entity display"
-msgstr ""
+msgstr "Entiteettinäkymä"
 
 msgid "Display the ID of the referenced entities."
-msgstr ""
+msgstr "Näytä viitattujen entiteettien ID't."
 
 msgid "Selects referenceable entities for an entity reference field."
-msgstr ""
+msgstr "Valitse viittauskelpoiset entiteetit entiteettiviittauskentälle."
 
 msgid "Entity Reference inline fields"
-msgstr ""
+msgstr "Entiteettiviittauksen inline-kentät"
 
 msgid "Returns results as a PHP array of labels and rendered rows."
-msgstr ""
+msgstr "Palauttaa tulokset PHP joukkona etikettejä ja suoritettuja rivejä."
 
 msgid "File selection"
-msgstr ""
+msgstr "Tiedoston valinta"
 
 msgid "Separate link text and URL"
-msgstr ""
+msgstr "Erillinen linkin teksti ja osoite"
 
 msgid "Node Bundle"
-msgstr ""
+msgstr "Solmunippu"
 
 msgid "Node selection"
-msgstr ""
+msgstr "Solmun valinta"
 
 msgid "Watchdog database log"
-msgstr ""
+msgstr "Watchdog tietokantalogi"
 
 msgid "REST export"
-msgstr ""
+msgstr "REST vienti"
 
 msgid "Create a REST export resource."
-msgstr ""
+msgstr "Luo REST vientiresurssi."
 
 msgid "Use entities as row data."
-msgstr ""
+msgstr "Käytä entiteettejä rivitietona."
 
 msgid "Use fields as row data."
-msgstr ""
+msgstr "Käytä kenttiä rivitietona."
 
 msgid "Serializer"
-msgstr ""
+msgstr "Sarjoittaja"
 
 msgid "Serializes views row data using the Serializer component."
-msgstr ""
+msgstr "Sarjoittaa näkymien rivitiedon käyttäen Sarjoittaja komponenttia."
 
 msgid "Tar"
-msgstr ""
+msgstr "Tar"
 
 msgid "Handles .tar files."
-msgstr ""
+msgstr "Käsittelee .tar tiedostoja."
 
 msgid "Handles zip files."
-msgstr ""
+msgstr "Käsittelee zip tiedostoja."
 
 msgid "Taxonomy Term selection"
-msgstr ""
+msgstr "Luokittelutermin valinta"
 
 msgid "Display reference to taxonomy term in RSS."
-msgstr ""
+msgstr "Näytä viittaus luokittelutermiin RSS-syötteessä."
 
 msgid "Telephone link"
-msgstr ""
+msgstr "Puhelinnumerolinkki"
 
 msgid "User selection"
-msgstr ""
+msgstr "Käyttäjän valinta"
 
 msgid "Views Exposed Filter Block"
-msgstr ""
+msgstr "Näkymien käyttäjille näytettyjen suodattimien lohko"
 
 msgid " - Basic validation - "
-msgstr ""
+msgstr " - Perusvalidointi - "
 
 msgid "A simple pager containing previous and next links."
-msgstr ""
+msgstr "Yksinkertainen sivutus sisältäen \"edellinen\" ja \"seuraava\" linkit."
 
 msgid "Display all items that this view might find."
-msgstr ""
+msgstr "Näytä kaikki tulokset jotka tämä näkymä löytää."
 
 msgid "Displays rows as HTML list."
-msgstr ""
+msgstr "Näyttää rivit HTML listana."
 
 msgid "Language detection and selection"
-msgstr ""
+msgstr "Kielen tunnistaminen ja valitseminen"
 
 msgid "Toolkit"
-msgstr ""
+msgstr "Työkalupakki"
 
 msgid "Configuration Translation"
-msgstr ""
+msgstr "Asetusten käännökset"
 
 msgid "- empty image -"
-msgstr ""
+msgstr "- tyhjä kuva -"
 
 msgid "Field formatters"
-msgstr ""
+msgstr "Kentän muokkaajat"
 
 msgid ""
 "If enabled, access permissions for rendering the entity are not checked."
 msgstr ""
+"Jos tämä on valittuna, käyttöoikeuksia ei tarkisteta entiteettiä "
+"renderöitäessä."
 
 msgid "The directory %translations_directory exists."
-msgstr ""
+msgstr "Hakemisto %translations_directory on olemassa."
 
 msgid "MySQL, MariaDB, Percona Server, or equivalent"
-msgstr ""
+msgstr "MySQL, MariaDB, Percona Server tai vastaava"
 
 msgid "The referenced language"
-msgstr ""
+msgstr "Viitattu kieli"
 
 msgid "Language reference"
-msgstr ""
+msgstr "Kieliviittaus"
 
 msgid "URI value"
-msgstr ""
+msgstr "Osoitearvo"
 
 msgid "An entity field containing a URI."
-msgstr ""
+msgstr "Entiteettikenttä sisältäen osoitteen."
 
 msgid "Caribbean Netherlands"
-msgstr ""
+msgstr "Alankomaiden Karibia"
 
 msgid "Cocos [Keeling] Islands"
-msgstr ""
+msgstr "Kookossaaret [Keelingsaaret]"
 
 msgid "Congo - Kinshasa"
-msgstr ""
+msgstr "Kongo - Kinshasa"
 
 msgid "Congo - Brazzaville"
-msgstr ""
+msgstr "Kongo - Brazzaville"
 
 msgid "Côte d’Ivoire"
-msgstr ""
+msgstr "Norsunluurannikko"
 
 msgid "Clipperton Island"
-msgstr ""
+msgstr "Clipperton saari"
 
 msgid "Ceuta and Melilla"
-msgstr ""
+msgstr "Ceuta ja Melilla"
 
 msgid "Hong Kong SAR China"
-msgstr ""
+msgstr "Hong Kongin erikoishallintoalue, Kiina"
 
 msgid "Canary Islands"
-msgstr ""
+msgstr "Kanarian saaret"
 
 msgid "Myanmar [Burma]"
-msgstr ""
+msgstr "Myanmar [Burma]"
 
 msgid "Macau SAR China"
-msgstr ""
+msgstr "Macaon erikoishallintoalue, Kiina"
 
 msgid "Palestinian Territories"
-msgstr ""
+msgstr "Palestiinalaisalueet"
 
 msgid "Outlying Oceania"
-msgstr ""
+msgstr "Oseania"
 
 msgid "São Tomé and Príncipe"
-msgstr ""
+msgstr "São Tomé ja Príncipe"
 
 msgid "U.S. Outlying Islands"
-msgstr ""
+msgstr "Yhdysvaltain pienet erillissaaret"
 
 msgid "Time span in seconds"
-msgstr ""
+msgstr "Aikakesto sekunteina"
 
 msgid "Using simple actions"
-msgstr ""
+msgstr "Käytä yksinkertaisia toimintoja"
 
 msgid "Shortcut set"
-msgstr ""
+msgstr "Oikopolku asetettu"
 
 msgid "Entity form display"
-msgstr ""
+msgstr "Entiteettilomakkeen näkymä"
 
 msgid "WYSIWYG editing for rich text fields using CKEditor."
-msgstr ""
+msgstr "Tarjoaa WYSIWYG-muokkausmahdollisuuden valittuihin tekstikenttiin."
 
 msgid "Creating and configuring advanced actions"
-msgstr ""
+msgstr "Edistyneiden toimintojen luonti ja asetusten säätäminen"
 
 msgid ""
 "A unique name for this block instance. Must be alpha-numeric and underscore "
 "separated."
 msgstr ""
+"Lohkoinstanssin yksilöllinen nimi. Oltava aakkosnumeerinen ja alaviivoin "
+"eroteltu."
 
 msgid "Filter by block name"
-msgstr ""
+msgstr "Suodata lohkon nimellä"
 
 msgid "Allow settings in the block configuration"
-msgstr ""
+msgstr "Salli asetukset lohkon asetussivulla"
 
 msgid "Items per block"
-msgstr ""
+msgstr "Elementtiä per lohko"
 
 msgid "@count (default setting)"
-msgstr ""
+msgstr "@count (oletusasetus)"
 
 msgid "Enabling CKEditor for individual text formats"
-msgstr ""
+msgstr "CKEditorin käyttöönotto eri tekstimuodoille"
 
 msgid "Configuring the toolbar"
-msgstr ""
+msgstr "Säädä työkalupalkin asetuksia"
 
 msgid "Formatting content"
-msgstr ""
+msgstr "Sisällön muotoilu"
 
 msgid "Toggling between formatted text and HTML source"
-msgstr ""
+msgstr "Selaa muotoillun tekstin ja HTML lähdekoodin välillä"
 
 msgid "Uploads disabled"
-msgstr ""
+msgstr "Lataukset poissa käytöstä"
 
 msgid "Uploads enabled, max size: @size @dimensions"
-msgstr ""
+msgstr "Lataukset käytössä, enimmäiskoko: @size @dimensions"
 
 msgid "Edit Image"
-msgstr ""
+msgstr "Muokkaa kuvaa"
 
 msgid "Drupal link"
-msgstr ""
+msgstr "Drupal linkki"
 
 msgid "CKEditor plugin settings"
-msgstr ""
+msgstr "CKEditorin lisäosa-asetukset"
 
 msgid ""
 "Could not extract the contents of the tar file. The error message is "
 "<em>@message</em>"
 msgstr ""
+"Tar-tiedoston sisällön purkaminen ei onnistunut. Virheviesti "
+"<em>@message</em>"
 
 msgid "Discard changes?"
-msgstr ""
+msgstr "Hylkää muutokset?"
 
 msgid "Enable image uploads"
-msgstr ""
+msgstr "Salli kuvien lataaminen"
 
 msgid "Storage: @name"
-msgstr ""
+msgstr "Tallennus: @name"
 
 msgid ""
 "A directory relative to Drupal's files directory where uploaded images will "
 "be stored."
 msgstr ""
+"Hakemisto suhteessa Drupalin tiedostot-hakemistoon, johon lähetetyt kuvat "
+"tallennetaan."
 
 msgid ""
 "If this is left empty, then the file size will be limited by the PHP maximum"
 " upload size of @size."
 msgstr ""
+"Jos tämä kohta jätetään tyhjäksi, tiedostojen suurin sallittu koko on PHP:n "
+"suurin sallittu lähetyskoko @size."
 
 msgid "Images larger than these dimensions will be scaled down."
-msgstr ""
+msgstr "Tätä suuremmat kuvat skaalataan pienemmiksi."
 
 msgid "Installing text editors"
-msgstr ""
+msgstr "Tekstityökalujen asentaminen"
 
 msgid "Enabling a text editor for a text format"
-msgstr ""
+msgstr "Tekstityökalun käyttöönotto tekstimuodolle"
 
 msgid "Configuring a text editor"
-msgstr ""
+msgstr "Tekstityökalun asetusten määrittely"
 
 msgid ""
 "Once a text editor is associated with a text format, you can configure it by"
@@ -15904,69 +17120,77 @@ msgid ""
 "and they often insert HTML tags into the field source. For details, see the "
 "help page of the specific text editor."
 msgstr ""
+"Kun tekstieditori on yhdistetty tekstimuotoon, voit mukauttaa sitä "
+"klikkaamalla <em>Määrittele</em>-linkkiä tämän muodon kohdalla. Valitusta "
+"tekstieditorista riippuen voit esimerkiksi muokata työkalupalkin "
+"painikkeita. Yleensä painikkeilla helpotetaan tekstin muotoilua tai "
+"muokkaamista, ja usein ne lisäävät HTML-tageja kentän lähdekoodiin. "
+"Lisätietoja saat valitun tekstieditorin ohjesivulta."
 
 msgid "Using different text editors and formats"
-msgstr ""
+msgstr "Käytä eri tekstityökaluja ja syöttömuotoja"
 
 msgid "Placeholder: @placeholder"
-msgstr ""
+msgstr "Kirjanmerkki: @placeholder"
 
 msgid "No placeholder"
-msgstr ""
+msgstr "Ei paikkamerkkiä"
 
 msgid "Add, edit, and delete custom display modes."
-msgstr ""
+msgstr "Lisää, muokkaa ja poista kustomoituja esitystapoja."
 
 msgid "Add form mode"
-msgstr ""
+msgstr "Lisää lomakemuoto"
 
 msgid "Edit form mode"
-msgstr ""
+msgstr "Muokkaa lomakemuotoa"
 
 msgid "Choose view mode entity type"
-msgstr ""
+msgstr "Valitse näkymämuotoinen entiteettityyppi"
 
 msgid "Choose form mode entity type"
-msgstr ""
+msgstr "Valitse lomakemuotoinen entiteettityyppi"
 
 msgid "Saved the %label @entity-type."
-msgstr ""
+msgstr "Tallennettiin %label @entity-type."
 
 msgid "Autocomplete matching: @match_operator"
-msgstr ""
+msgstr "Automaattinen täydennys @match_operator avulla"
 
 msgid "The referenced entity (%type: %id) does not exist."
-msgstr ""
+msgstr "Viitattua entiteettiä (%type: %id) ei löydy."
 
 msgctxt "Sort order"
 msgid "Order"
 msgstr ""
+"Järjestys\r\n"
+"kontekstissa: Lajittelujärjestys"
 
 msgid "%entity_label: Administer form display"
-msgstr ""
+msgstr "%entity_label: Ylläpidä lomakenäkymää"
 
 msgid "Plugin for @title"
-msgstr ""
+msgstr "Lisäosa @title'lle"
 
 msgid "@type (module: @module)"
-msgstr ""
+msgstr "@type (moduuli: @module)"
 
 msgid "Widget settings:"
-msgstr ""
+msgstr "Widgetin asetukset:"
 
 msgid "The label of the entity that is related to the file."
-msgstr ""
+msgstr "Tiedostoon liittyvän entiteetin etiketti."
 
 msgid "Access the Files overview page"
-msgstr ""
+msgstr "Pääsy tiedostojen kokonaisuuskatsaussivulle."
 
 msgid "Progress indicator: @progress_indicator"
-msgstr ""
+msgstr "Etenemispalkki: @progress_indicator"
 
 msgid ""
 "The %filter filter is missing, and will be removed once this format is "
 "saved."
-msgstr ""
+msgstr "Suodatin %filter puuttuu, ja poistetaan kun tämä muoto tallennetaan."
 
 msgid ""
 "Lines and paragraphs are automatically recognized. The &lt;br /&gt; line "
@@ -15974,42 +17198,51 @@ msgid ""
 "automatically. If paragraphs are not recognized simply add a couple of blank"
 " lines."
 msgstr ""
+"Rivit ja kappaleet tunnistetaan automaattisesti. Tagit &lt;br /&gt; "
+"(rivinvaihto), &lt;p&gt; (kappale) ja &lt;/p&gt; (kappaleen lopetus) "
+"lisätään automaattisesti. Jos kappaleet eivät tunnistu, lisää pari tyhjää "
+"riviä."
 
 msgid "Missing filter. All text is removed"
-msgstr ""
+msgstr "Suodatin puuttuu. Kaikki teksti poistetaan"
 
 msgid "Missing filter plugin: %filter."
-msgstr ""
+msgstr "Suodattimen lisäosa puuttuu: %filter."
 
 msgid "Provides a fallback for missing filters. Do not use."
-msgstr ""
+msgstr "Tarjoaa oletuksen puuttuville suodattimille. Älä käytä."
 
 msgid "Updated @type %term."
-msgstr ""
+msgstr "Päivitettiin @type %form."
 
 msgid "Add image style"
-msgstr ""
+msgstr "Lisää kuvatyyli"
 
 msgid "Preview image style: @style"
-msgstr ""
+msgstr "Esikatsele kuvatyyliä: @style"
 
 msgid ""
 "Deleting a language will remove all interface translations associated with "
 "it, and content in this language will be set to be language neutral. This "
 "action cannot be undone."
 msgstr ""
+"Jos poistat kielen, kaikki siihen liittyvät käyttöliittymän käännökset "
+"poistetaan ja poistettavalla kielellä kirjoitettu sisältö merkitään "
+"kielineutraaliksi. Toimintoa ei voi perua."
 
 msgid "No placeholders"
-msgstr ""
+msgstr "Ei paikkamerkkejä"
 
 msgid "Title placeholder: @placeholder_title"
-msgstr ""
+msgstr "Otsikon paikkamerkki: @placeholder_title"
 
 msgid "URL placeholder: @placeholder_url"
-msgstr ""
+msgstr "Verkko-osoitteen paikkamerkki: @placeholder_url"
 
 msgid "Note that importing large .po files may take several minutes."
 msgstr ""
+"Huomaa että suurien .po tiedostojen tuominen saattaa viedä useita "
+"minuutteja."
 
 msgid ""
 "Content items can be edited using different form modes. Here, you can define"
@@ -16017,25 +17250,32 @@ msgid ""
 " mode, and define how the field form widgets are displayed in each form "
 "mode."
 msgstr ""
+"Sisällön muokkauslomakkeilla voi olla useita esitystapoja. Tällä sivulla "
+"määritellään mitkä kentät näytetään, mitkä piilotetaan ja kuinka kenttien "
+"widgetit näytetään sisältötyypin %type muokkauslomakkeen eri esitystavoissa."
 
 msgid "Edit %label content type"
-msgstr ""
+msgstr "Muokkaa sisältötyyppiä %label"
 
 msgid ""
 "The content has either been modified by another user, or you have already "
 "submitted modifications. As a result, your changes cannot be saved."
 msgstr ""
+"Sisältö on joko toisen käyttäjän muokkaamaa tai olet jo lähettänyt "
+"muutoksesi. Tämän vuoksi muutoksiasi ei voida tallentaa."
 
 msgid "Use field label: @display_label"
-msgstr ""
+msgstr "Käyttäjän kentän etiketti: @display_label"
 
 msgid "Provides a row plugin to display search results."
-msgstr ""
+msgstr "Tarjoaa rivi-lisäosan käytettäväksi näytettäessä hakutuloksia."
 
 msgid ""
 "More information about setting up scheduled tasks can be found by <a "
 "href=\"@url\">reading the cron tutorial on drupal.org</a>."
 msgstr ""
+"Lisätietoja ajastettujen toimintojen asettamisesta saat <a href=\"@url"
+"\">cron-ohjeiden sivulta drupal.orgista</a>."
 
 msgid ""
 "A local file system path where public files will be stored. This directory "
@@ -16043,64 +17283,76 @@ msgid ""
 " Drupal installation directory and be accessible over the web. This must be "
 "changed in settings.php"
 msgstr ""
+"Lokaalin tiedostojärjestelmän polku johon tiedostot tallennetaan. Kansion on"
+" oltava olemassa ja Drupalin on pystyttävä kirjoittamaan siihen. Kansion on "
+"oltava suhteessa Drupalin asennuskansioon ja saatavilla verkon yli. Tämä "
+"asetus on muutettava settings.php tiedostossa."
 
 msgid "%name: the telephone number may not be longer than @max characters."
-msgstr ""
+msgstr "%name: puhelinnumero ei voi olla kuin enintään @max merkkiä pitkä."
 
 msgid "%name: the text may not be longer than @max characters."
-msgstr ""
+msgstr "%name: teksti voi olla enintään @max merkkiä pitkä."
 
 msgid "Summary rows"
-msgstr ""
+msgstr "Yhteenvetorivit"
 
 msgid ""
 "This form lets administrators add and edit fields for storing user data."
 msgstr ""
+"Tämä lomake sallii ylläpitäjien lisätä ja muokata käyttäjien tietojen "
+"tallentamiseen käytettäviä kenttiä."
 
 msgid ""
 "This form lets administrators configure how form fields should be displayed "
 "when editing a user profile."
 msgstr ""
+"Tämä lomake sallii ylläpitäjien muokata tapaa jolla kentät esitetään "
+"käyttäjän profiilia muokattaessa."
 
 msgid ""
 "Alter the HTTP response status code used by this view, mostly helpful for "
 "empty results."
 msgstr ""
+"Muuta tämän näkymän HTTP paluukoodia, hyödyllisin tyhjien tulosten ollessa "
+"kyseessä."
 
 msgid "HTTP status code"
-msgstr ""
+msgstr "HTTP tilakoodi"
 
 msgid "Always display the more link"
-msgstr ""
+msgstr "Aina näytä \"lisää\"-linkki"
 
 msgid ""
 "Check this to display the more link even if there are no more items to "
 "display."
 msgstr ""
+"Valitse tämä näyttääksesi \"lisää\"-linkki vaikka lisätuloksia ei olisikaan."
 
 msgid "Make entity label a link to entity page."
-msgstr ""
+msgstr "Tee entiteetin etiketistä linkki entiteetin sivulle."
 
 msgid "Configure language support for content."
-msgstr ""
+msgstr "Säädä sisällön kieliasetuksia."
 
 msgid "Managing and displaying link fields"
-msgstr ""
+msgstr "Linkkikenttien esittäminen ja hallinta"
 
 msgid "Adding link text"
-msgstr ""
+msgstr "Linkkitekstin lisääminen"
 
 msgid "Display modes"
-msgstr ""
+msgstr "Esitystavat"
 
 msgid "Manage custom view modes."
-msgstr ""
+msgstr "Hallitse kustomoituja näyttötapoja."
 
 msgid "Configure what displays are available for your content and forms."
 msgstr ""
+"Säädä, mitkä esitystavat ovat käytettävissä sisällössäsi ja lomakkeissasi."
 
 msgid "Allows the creation of custom blocks through the user interface."
-msgstr ""
+msgstr "Mahdollistaa lohkojen luomisen käyttöliittymän kautta."
 
 msgid ""
 "You must add some additional fields to this display before using this field."
@@ -16108,36 +17360,44 @@ msgid ""
 "Note that due to rendering order, you cannot use fields that come after this"
 " field; if you need a field not listed here, rearrange your fields."
 msgstr ""
+"Käyttääksesi tätä kenttää sinun on lisättävä tähän näkymään joitakin muita "
+"kenttiä. Halutessasi voit merkitä lisättävät kentät <em>Piilota "
+"näkymästä</em>. Huomaa, että renderöintijärjestyksestä johtuen et voi "
+"käyttää kenttiä jotka ovat järjestyksessä tämän kentän jälkeen; jos "
+"tarvitset kenttää, jota ei ole listattu tähän, järjestä kentät uudelleen."
 
 msgid "Automatic width"
-msgstr ""
+msgstr "Automaattinen leveys"
 
 msgid "Default column classes"
-msgstr ""
+msgstr "Sarakkeen oletusluokat"
 
 msgid "Custom column class"
-msgstr ""
+msgstr "Kustomoitu sarakeluokka"
 
 msgid "Additional classes to provide on each column. Separated by a space."
-msgstr ""
+msgstr "Kullekin sarakkeelle asetettavat lisäluokat välilyönnein eroteltuina."
 
 msgid "Default row classes"
-msgstr ""
+msgstr "Oletus-riviluokat"
 
 msgid ""
 "Adds the default views row classes like views-row, row-1 and clearfix to the"
 " output. You can use this to quickly reduce the amount of markup the view "
 "provides by default, at the cost of making it more difficult to apply CSS."
 msgstr ""
+"Lisää näkymien tulosteeseen oletus-riviluokat kuten views-row, row-1 ja "
+"clearfix. Voit käyttää tätä vähentääksesi nopeasti näkymän oletuksena "
+"tarjoaman markupin määrää. Tämä saattaa hankaloittaa CSS:n toteuttamista."
 
 msgid "Custom row class"
-msgstr ""
+msgstr "Kustomoitu riviluokka"
 
 msgid "Additional classes to provide on each row. Separated by a space."
-msgstr ""
+msgstr "Kullekin riville asetettavat lisäluokat välilyönnein eroteltuina."
 
 msgid "Default wizard"
-msgstr ""
+msgstr "Oletus asetustyökalu"
 
 msgid ""
 "All Views-generated queries will include the name of the views and display "
@@ -16145,701 +17405,740 @@ msgid ""
 "makes identifying Views queries in database server logs simpler, but should "
 "only be used when troubleshooting."
 msgstr ""
+"Kaikki näkymien luomat kyselyt tulevat sisältämään näkymän nimen ja "
+"näyttöruudun nimen muodossa 'view-name:display-name' tunnisteena SELECT "
+"lausekkeen perässä. Tämä helpottaa Views kyselyiden tunnistamista "
+"tietokantalogeistasi mutta sen käyttö on suositeltavaa ainoastaan "
+"ongelmatilanteissa."
 
 msgid "Selected:"
-msgstr ""
+msgstr "Valittu:"
 
 msgctxt "Validation"
 msgid "Allowed values"
-msgstr ""
+msgstr "Sallitut arvot kontekstissa: Validointi"
 
 msgid "You must select at least %limit choice."
 msgid_plural "You must select at least %limit choices."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Sinun on valittava vähintään %limit vaihtoehto."
+msgstr[1] "Sinun on valittava vähintään %limit vaihtoehtoa."
 
 msgid "You must select at most %limit choice."
 msgid_plural "You must select at most %limit choices."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Sinun on valittava enintään %limit vaihtoehto."
+msgstr[1] "Sinun on valittava enintään %limit vaihtoehtoa."
 
 msgctxt "Validation"
 msgid "Bundle"
-msgstr ""
+msgstr "Paketti"
 
 msgid "The entity must be of bundle %bundle."
-msgstr ""
+msgstr "Entiteetin tulee kuulua pakettiin %bundle."
 
 msgctxt "Validation"
 msgid "Complex data"
-msgstr ""
+msgstr "Kompleksista dataa kontekstissa: Validointi"
 
 msgctxt "Validation"
 msgid "Count"
-msgstr ""
+msgstr "Lukumäärä kontekstissa: Validointi"
 
 msgid "This collection should contain %limit element or more."
 msgid_plural "This collection should contain %limit elements or more."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Kokoelman tulee sisältää vähintään %limit elementti tai enemmän."
+msgstr[1] "Kokoelman tulee sisältää vähintään %limit elementtiä tai enemmän."
 
 msgid "This collection should contain %limit element or less."
 msgid_plural "This collection should contain %limit elements or less."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Kokoelman tulee sisältää vähintään %limit elementti tai vähemmän."
+msgstr[1] "Kokoelman tulee sisältää vähintään %limit elementtiä tai vähemmän."
 
 msgid "This collection should contain exactly %limit element."
 msgid_plural "This collection should contain exactly %limit elements."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Kokoelman tulee sisältää %limit elementti."
+msgstr[1] "Kokoelman tulee sisältää %limit elementtiä."
 
 msgctxt "Validation"
 msgid "Entity type"
-msgstr ""
+msgstr "Entiteetin tyyppi kontekstissa: Validointi"
 
 msgid "The entity must be of type %type."
-msgstr ""
+msgstr "Entiteetin on oltava tyyppiä %type."
 
 msgctxt "Validation"
 msgid "Length"
-msgstr ""
+msgstr "Pituus kontekstissa: Validointi"
 
 msgid "This value is too long. It should have %limit character or less."
 msgid_plural ""
 "This value is too long. It should have %limit characters or less."
 msgstr[0] ""
+"Arvo on liian pitkä. Sen tulee olla pituudeltaan %limit merkkiä tai "
+"vähemmän."
 msgstr[1] ""
+"Arvo on liian pitkä. Sen tulee olla pituudeltaan %limit merkkiä tai "
+"vähemmän."
 
 msgid "This value is too short. It should have %limit character or more."
 msgid_plural ""
 "This value is too short. It should have %limit characters or more."
 msgstr[0] ""
+"Arvo on liian lyhyt. Sen tulee olla pituudeltaan %limit merkkiä tai enemmän."
 msgstr[1] ""
+"Arvo on liian lyhyt. Sen tulee olla pituudeltaan %limit merkkiä tai enemmän."
 
 msgid "This value should have exactly %limit character."
 msgid_plural "This value should have exactly %limit characters."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Arvossa tulee olla tarkalleen %limit merkki."
+msgstr[1] "Arvossa tulee olla tarkalleen %limit merkkiä."
 
 msgctxt "Validation"
 msgid "Primitive type"
-msgstr ""
+msgstr "Alkeellinen tyyppi kontekstissa: Validointi"
 
 msgid "This value should be of the correct primitive type."
-msgstr ""
+msgstr "Arvon tulee olla oikeanlaista alkeellista tyyppiä."
 
 msgctxt "Validation"
 msgid "Range"
-msgstr ""
+msgstr "Vaihteluväli kontekstissa: Validointi"
 
 msgid "This value should be %limit or less."
-msgstr ""
+msgstr "Arvon tulee olla %limit tai vähemmän."
 
 msgctxt "Validation"
 msgid "Entity Reference valid reference"
-msgstr ""
+msgstr "Entiteettiviittauksen validointiviittaus kontekstissa: Viittaus"
 
 msgctxt "Validation"
 msgid "User name"
-msgstr ""
+msgstr "Käyttäjänimi kontekstissa: Validointi"
 
 msgctxt "Validation"
 msgid "User name unique"
-msgstr ""
+msgstr "Käyttäjänimi yksilöllinen kontekstissa: Validointi"
 
 msgid "%name must be higher than or equal to %min."
-msgstr ""
+msgstr "%name on suurempi tai yhtäsuuri kuin %min."
 
 msgid "%name must be lower than or equal to %max."
-msgstr ""
+msgstr "%name on pienempi tai yhtäsuuri kuin %max."
 
 msgctxt "Validation"
 msgid "Entity changed"
-msgstr ""
+msgstr "Entiteetti vaihdettu kontekstissa: Validointi"
 
 msgid "Select the feed that should be displayed"
-msgstr ""
+msgstr "Valitse näytettävä syöte"
 
 msgid "Creating and managing custom block types"
-msgstr ""
+msgstr "Kustomoitujen lohkotyyppien luonti ja hallinta"
 
 msgid "The custom block language code."
-msgstr ""
+msgstr "Kustomoidun lohkon kielikoodi."
 
 msgid "The time that the custom block was last edited."
-msgstr ""
+msgstr "Ajankohta jolloin kustomoitua lohkoa viimeksi muokattiin."
 
 msgid "Block category"
-msgstr ""
+msgstr "Lohkon kategoria"
 
 msgid "Hide block if the view output is empty"
-msgstr ""
+msgstr "Piilota lohko mikäli näkymän tulos on tyhjä"
 
 msgid "Block empty settings"
-msgstr ""
+msgstr "Tyhjän lohkon asetukset"
 
 msgid "Hide block if no result/empty text"
-msgstr ""
+msgstr "Piilota lohko, mikäli tuloksena on tyhjä tai tyhjää kuvaava teksti."
 
 msgid ""
 "Hide the block if there is no result and no empty text and no header/footer "
 "which is shown on empty result"
 msgstr ""
+"Piilota lohko mikäli se on tyhjä eikä sille ole määritelty tekstiä tai "
+"ylä/alatunnistetta sen ollessa tyhjä."
 
 msgid "Enter caption here"
-msgstr ""
+msgstr "Syötä kuvateksti tähän"
 
 msgid "Drupal image caption widget"
-msgstr ""
+msgstr "Drupal kuvatekstin widgetti"
 
 msgid "The number of comments posted on an entity."
-msgstr ""
+msgstr "Entiteettiin lähetettyjen kommenttien kokonaismäärä."
 
 msgid ""
 "The number of comments posted on an entity since the reader last viewed it."
 msgstr ""
+"Tähän entiteettiin sen jälkeen postitettujen kommenttien määrä kun käyttäjä "
+"sen viimeksi luki."
 
 msgid "The entity the comment was posted to."
-msgstr ""
+msgstr "Entiteetti johon kommentti lähetettiin."
 
 msgid "The @entity_type to which the comment is a reply to."
-msgstr ""
+msgstr "@entity_type johon kommentti on vastaus."
 
 msgid "The number of comments an entity has."
-msgstr ""
+msgstr "Montako kommenttia entiteetillä on."
 
 msgid "Display the last comment of an entity"
-msgstr ""
+msgstr "Näytä entiteetin viimeinen kommentti"
 
 msgid "The last comment of an entity."
-msgstr ""
+msgstr "Entiteetin viimeinen kommentti."
 
 msgid "The entity type to which the comment is a reply to."
-msgstr ""
+msgstr "Entiteettityyppi johon kommentti on vastaus."
 
 msgid ""
 "Display nodes only if a user posted the @entity_type or commented on the "
 "@entity_type."
 msgstr ""
+"Näytä solmut vain jos käyttäjä lähetti entiteettityyppin @entity_type tai "
+"kommentoi entiteettityyppiin @entity_type."
 
 msgid "Comments of the @entity_type using field: @field_name"
 msgstr ""
+"Kommentit entiteetttityypille @entity_type käyttäen kenttää @field_name."
 
 msgid "Edit comment %title"
-msgstr ""
+msgstr "Muokkaa kommenttia %title"
 
 msgid "The ID of the entity of which this comment is a reply."
-msgstr ""
+msgstr "Sen entiteetin ID johon tämä kommentti on vastauksena."
 
 msgid "The entity type to which this comment is attached."
-msgstr ""
+msgstr "Entiteettityyppi johon tämä kommentti on liitetty."
 
 msgid "Comment field name"
-msgstr ""
+msgstr "Kommenttikentän nimi"
 
 msgid "The field name through which this comment was added."
-msgstr ""
+msgstr "Kenttä jonka kautta tämä kommentti lisättiin."
 
 msgid "The time that the last comment was created."
-msgstr ""
+msgstr "Ajankohta jolloin viimeinen kommentti luotiin."
 
 msgid "The name of the user posting the last comment."
-msgstr ""
+msgstr "Viimeisen kommentin lähettäjän nimi."
 
 msgid "The number of comments."
-msgstr ""
+msgstr "Kommenttien lukumäärä."
 
 msgid ""
 "This field manages configuration and presentation of comments on an entity."
 msgstr ""
+"Tämä kenttä hallinoi kommenttien esittämistä ja asetuksia entiteetin "
+"yhteydessä."
 
 msgid "Comment list"
-msgstr ""
+msgstr "Kommenttilista"
 
 msgid "Select source language"
-msgstr ""
+msgstr "Valitse lähdekieli"
 
 msgid "Computed date"
-msgstr ""
+msgstr "Laskettu päivämäärä"
 
 msgid "The computed DateTime object."
-msgstr ""
+msgstr "Laskettu DateTime objekti."
 
 msgid "Log entries"
-msgstr ""
+msgstr "Logimerkinnät"
 
 msgid "Contains a list of log entries."
-msgstr ""
+msgstr "Sisältää listan logimerkinnöistä."
 
 msgid "The user on which the log entry as written."
-msgstr ""
+msgstr "Käyttäjä jota koskien lokimerkintä kirjoitettiin."
 
 msgid "The actual message of the log entry."
-msgstr ""
+msgstr "Logiviesti."
 
 msgid "The variables of the log entry in a serialized format."
-msgstr ""
+msgstr "Logimerkinnän muuttujat sarjoitetussa muodossa."
 
 msgid "Operation links for the event."
-msgstr ""
+msgstr "Toimintolinkit tapahtumalle."
 
 msgid "URL of the previous page."
-msgstr ""
+msgstr "Edellisen sivun URL."
 
 msgid "Date when the event occurred."
-msgstr ""
+msgstr "Päivämäärä jolloin tapahtuma tapahtui."
 
 msgid "Replace variables"
-msgstr ""
+msgstr "Korvaa muuttujat"
 
 msgid "One file only."
 msgid_plural "Maximum @count files."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Vain yksi tiedosto."
+msgstr[1] "Enintään @count tiedostoa."
 
 msgid "Last comment ID"
-msgstr ""
+msgstr "Viimeisen kommentin ID"
 
 msgid "WID"
-msgstr ""
+msgstr "WID"
 
 msgid "Block layout"
-msgstr ""
+msgstr "Lohkojen sijoittelu"
 
 msgid "Content language and translation"
-msgstr ""
+msgstr "Sisällön kieli ja kääntäminen"
 
 msgid "Configure language and translation support for content."
-msgstr ""
+msgstr "Säädä kieltä ja käännösten tukea sisällölle."
 
 msgid "Adding attributes to links"
-msgstr ""
+msgstr "Attribuuttien lisääminen linkkeihin"
 
 msgid "Validating URLs"
-msgstr ""
+msgstr "URLien tarkistaminen"
 
 msgid "Number (decimal)"
-msgstr ""
+msgstr "Numero (desimaali)"
 
 msgid "Number (float)"
-msgstr ""
+msgstr "Numero (liukuluku)"
 
 msgid "Number (integer)"
-msgstr ""
+msgstr "Numero (luku)"
 
 msgid "Alias for @id"
-msgstr ""
+msgstr "Alias ID:lle @id"
 
 msgid "Raw output for @id"
-msgstr ""
+msgstr "Raakatulos ID:lle @id"
 
 msgid "The date the term was last updated."
-msgstr ""
+msgstr "Päivämäärä jolloin termi viimeksi päivitettiin."
 
 msgid "The time that the term was last edited."
-msgstr ""
+msgstr "Kellonaika jolloin termiä viimeksi päivitettiin."
 
 msgid "Managing and displaying telephone fields"
-msgstr ""
+msgstr "Puhelinkenttien näyttöasetukset ja ylläpito"
 
 msgid "Displaying telephone numbers as links"
-msgstr ""
+msgstr "Puhelinnumeroiden esittäminen linkkeinä"
 
 msgid "The user account %name cannot be canceled."
-msgstr ""
+msgstr "Käyttäjätilin %name peruminen ei ole mahdollista."
 
 msgid "Default actions"
-msgstr ""
+msgstr "Oletustoiminnot"
 
 msgid "Grouping @id"
-msgstr ""
+msgstr "Ryhmittelyn @id"
 
 msgid "Columns for @field"
-msgstr ""
+msgstr "Sarakkeet kentälle @field"
 
 msgid "Sortable for @field"
-msgstr ""
+msgstr "Lajiteltavissa kentälle @field"
 
 msgid "Default sort order for @field"
-msgstr ""
+msgstr "Oletus-lajittelujärjestys kentälle @field"
 
 msgid "Default sort for @field"
-msgstr ""
+msgstr "Oletuslajittelu kentälle @field"
 
 msgid "Alignment for @field"
-msgstr ""
+msgstr "Sisennytys kentälle @field"
 
 msgid "Separator for @field"
-msgstr ""
+msgstr "Erotin kentälle @field"
 
 msgid "Hide empty column for @field"
-msgstr ""
+msgstr "Piilota tyhjä sarake kentälle @field"
 
 msgid "Responsive setting for @field"
-msgstr ""
+msgstr "Responsiivisuusasetukset kentälle @field"
 
 msgid "No default sort"
-msgstr ""
+msgstr "Ei oletuslajittelua"
 
 msgid "Page display settings"
-msgstr ""
+msgstr "Sivun näyttöasetukset"
 
 msgid "Block display settings"
-msgstr ""
+msgstr "Lohkosivun näyttöasetukset"
 
 msgid "Always show the master (default) display"
-msgstr ""
+msgstr "Näytä aina pää- (oletus-) näyttöruutu"
 
 msgid "Allow embedded displays"
-msgstr ""
+msgstr "Salli sisällytetyt näkymät"
 
 msgid "Embedded displays can be used in code via views_embed_view()."
 msgstr ""
+"Sisällytettyjä näkymiä voidaan käyttää ohjelmallisesti funktion "
+"views_embed_view() avulla."
 
 msgid "Show SQL query"
-msgstr ""
+msgstr "Näytä SQL-kysely"
 
 msgid "Remove @title"
-msgstr ""
+msgstr "Poista @title"
 
 msgid "Weight for @id"
-msgstr ""
+msgstr "Paino id:lle @id"
 
 msgid "Group for @id"
-msgstr ""
+msgstr "Ryhmä id:lle @id"
 
 msgid "Remove @id"
-msgstr ""
+msgstr "Poista id @id"
 
 msgid "PHP date format"
-msgstr ""
+msgstr "PHP:n päivämäärämuoto"
 
 msgid "@group: @title"
-msgstr ""
+msgstr "@group: @title"
 
 msgid "Media types"
-msgstr ""
+msgstr "Mediatyypit"
 
 msgid "Not fully protected"
-msgstr ""
+msgstr "Suojauksessa on puutteita"
 
 msgid ""
 "Could not load the form for <q>@field-label</q>, either due to a website "
 "problem or a network connection problem.<br>Please try again."
 msgstr ""
+"Lomakkeen <q>@field-label</q> lataaminen ei onnistunut joko sivuston tai "
+"verkkoyhteyden ongelmasta johtuen.<br>Ole hyvä ja yritä uudestaan."
 
 msgid "Reset your password"
 msgstr "Salasanan palautus"
 
 msgid "Number of new comments"
-msgstr ""
+msgstr "Uusien kommenttien lukumäärä"
 
 msgid "Button divider"
-msgstr ""
+msgstr "Painikkeiden jakaja"
 
 msgid "CKEditor toolbar and button configuration."
-msgstr ""
+msgstr "CKEditorin työkalupalkki ja painikkeiden määritykset."
 
 msgid "Hide group names"
-msgstr ""
+msgstr "Piilota ryhmien nimet"
 
 msgid "Show group names"
-msgstr ""
+msgstr "Näytä ryhmien nimet"
 
 msgid "Press the down arrow key to create a new row."
-msgstr ""
+msgstr "Paina nuoli alas- näppäintä lisätäksesi uuden rivin."
 
 msgid "@name @type."
-msgstr ""
+msgstr "@name @type."
 
 msgid "Press the down arrow key to activate."
-msgstr ""
+msgstr "Paina nuoli alas -näppäintä aktivoidaksesi."
 
 msgid "This is the last group. Move the button forward to create a new group."
 msgstr ""
+"Tämä on viimeinen ryhmä. Paina eteenpäin-nappia luodaksesi uusi ryhmä."
 
 msgid "The \"@name\" button is currently enabled."
-msgstr ""
+msgstr "\"@name\" nappi on tällä hetkellä käytössä."
 
 msgid "Use the keyboard arrow keys to change the position of this button."
-msgstr ""
+msgstr "Käytä nuolinäppäimiä siirtääksesi painikkeen paikkaa"
 
 msgid "Press the up arrow key on the top row to disable the button."
 msgstr ""
+"Paina nuoli ylös -näppäintä rivin ylälaidassa poistaaksesi painike käytöstä."
 
 msgid "The \"@name\" button is currently disabled."
-msgstr ""
+msgstr "\"@name\" nappi on tällä hetkellä poissa käytöstä."
 
 msgid "Use the down arrow key to move this button into the active toolbar."
 msgstr ""
+"Paina nuoli alas -näppäintä siirtääksesi tämä nappi aktiiviseen "
+"työkalupalkkiin."
 
 msgid "This @name is currently enabled."
-msgstr ""
+msgstr "@name on tällä hetkellä käytössä."
 
 msgid "Use the keyboard arrow keys to change the position of this separator."
 msgstr ""
+"Käytä näppäimistön nuolinäppäimiä muuttaaksesi tämän erottimen sijaintia."
 
 msgid "Separators are used to visually split individual buttons."
-msgstr ""
+msgstr "Erottimia käytetään visuaalisesti jakamaan painikkeet ryhmiksi."
 
 msgid "This @name is currently disabled."
-msgstr ""
+msgstr "@name ei ole tällä hetkellä käytössä."
 
 msgid "Use the down arrow key to move this separator into the active toolbar."
 msgstr ""
+"Paina nuoli alas -näppäintä siirtääksesi erottimen aktiiviseen "
+"työkalupalkkiin."
 
 msgid "You may add multiple separators to each button group."
-msgstr ""
+msgstr "Voit lisätä useampia erottimia jokaiseen painikeryhmään."
 
 msgid "Please provide a name for the button group."
-msgstr ""
+msgstr "Anna painikeryhmälle nimi"
 
 msgid "Button group name"
-msgstr ""
+msgstr "Painikeryhmän nimi"
 
 msgid "Place a button to create a new button group."
-msgstr ""
+msgstr "Lisää painike luodaksesi painikeryhmä."
 
 msgid "Add a CKEditor button group to the end of this row."
-msgstr ""
+msgstr "Lisää CKEditor painikeryhmä tämän rivin loppuun."
 
 msgid "Simple configuration"
-msgstr ""
+msgstr "Yksinkertaiset asetukset"
 
 msgid "Configuration type"
-msgstr ""
+msgstr "Asetusten tyyppi"
 
 msgid "Here is your configuration:"
-msgstr ""
+msgstr "Tässä ovat asetuksesi:"
 
 msgid "Are you sure you want to update the %name @type?"
-msgstr ""
+msgstr "Oletko varma että haluat päivittää %name @type?"
 
 msgid "Enter block, theme or category"
-msgstr ""
+msgstr "Syötä lohko, teema tai kategoria"
 
 msgid "Enter a part of the block, theme or category to filter by."
-msgstr ""
+msgstr "Syötä osa lohkoa, teemaa ja kategoriaa suodattaaksesi."
 
 msgid "Translations for %label"
-msgstr ""
+msgstr "Käännökset etiketille %label"
 
 msgid "@language (original)"
-msgstr ""
+msgstr "@language (alkuperäinen)"
 
 msgid "Enter label"
-msgstr ""
+msgstr "Syötä etiketti"
 
 msgid "Enter a part of the label or description to filter by."
-msgstr ""
+msgstr "Syötä osa nimeä tai kuvausta suodattaaksesi."
 
 msgid "Enter field or @bundle"
-msgstr ""
+msgstr "Syötä kenttä tai @bundle"
 
 msgid "Successfully saved @language translation."
-msgstr ""
+msgstr "Onnistuneesti tallennettu @language käännös."
 
 msgid "Successfully updated @language translation."
-msgstr ""
+msgstr "Onnistuneesti pävitetty @language käännös."
 
 msgid "(Empty)"
-msgstr ""
+msgstr "(Tyhjä)"
 
 msgid "Feed channel"
-msgstr ""
+msgstr "Syötteen kanava"
 
 msgid "About text formats"
-msgstr ""
+msgstr "Tietoa tekstimuodoista"
 
 msgid "The image style %name has been flushed."
-msgstr ""
+msgstr "Kuvatyyli %name on poistettu."
 
 msgid "Image to be shown if no image is uploaded."
-msgstr ""
+msgstr "Kuva joka näytetään, jos muuta kuvaa ei lisätä."
 
 msgid "Action title"
-msgstr ""
+msgstr "Toiminnon otsikko"
 
 msgid "- Restricted access -"
-msgstr ""
+msgstr "- Rajoitettu pääsy -"
 
 msgid "Workflow type"
-msgstr ""
+msgstr "Työnkulun tyyppi"
 
 msgid "Display block title"
-msgstr ""
+msgstr "Näytä lohkon otsikko"
 
 msgid "List of items"
-msgstr ""
+msgstr "Kohdelista"
 
 msgid "The ID of the feed item."
-msgstr ""
+msgstr "Syötteen kohteen tunniste."
 
 msgid "Placing and moving blocks"
-msgstr ""
+msgstr "Lohkojen siirto ja asettelu"
 
 msgid "Demonstrating block regions for a theme"
-msgstr ""
+msgstr "Lohkoalueiden demonstraatio teemalle"
 
 msgid "Toggling between different themes"
-msgstr ""
+msgstr "Teemojen välillä vaihtaminen"
 
 msgid "Configuring block settings"
-msgstr ""
+msgstr "Lohkon asetusten määrittely"
 
 msgid ""
 "You can control the visibility of a block by restricting it to specific "
 "pages, content types, and/or roles by setting the appropriate options under "
 "<em>Visibility settings</em> of the block configuration."
 msgstr ""
+"Lohkon näkyvyyttä hallitaan määrittelysivulla kohdassa "
+"<em>Näkyvyysasetukset</em>. Lohkon näkyvyyttä voidaan rajoittaa vain "
+"erikseen määritellyille sivuille, sisältötyyppeihin tai rooleille."
 
 msgid "Adding custom blocks"
-msgstr ""
+msgstr "Kustomoitujen lohkojen lisääminen"
 
 msgid "Pager ID: @id"
-msgstr ""
+msgstr "Sivun ID: @id"
 
 msgid "The email of the person that is sending the contact message."
-msgstr ""
+msgstr "Yhteydenottolomakkeen lähettäjän sähköpostiosoite."
 
 msgid "Managing and displaying file fields"
-msgstr ""
+msgstr "Tiedostokenttien hallinnointi ja esittäminen"
 
 msgid "Allowing file extensions"
-msgstr ""
+msgstr "Tiedostopäätteiden salliminen"
 
 msgid "Restricting the maximum file size"
-msgstr ""
+msgstr "Tiedoston enimmäiskoon rajoittaminen"
 
 msgid "Displaying files and descriptions"
-msgstr ""
+msgstr "Tiedostojen ja niiden kuvausten esittäminen"
 
 msgid "The log entry explaining the changes in this revision."
-msgstr ""
+msgstr "Lokimerkintä, joka selittää tämän revision muutokset."
 
 msgid "At least one authentication provider must be defined for resource @id"
 msgstr ""
+"Vähintään yksi autentikoinnin tarjoaja on määriteltävä resurssille @id"
 
 msgid "Custom block ID"
-msgstr ""
+msgstr "Kustomoidun lohkon ID"
 
 msgid "File usage"
-msgstr ""
+msgstr "File usage"
 
 msgid "Configuration translation"
-msgstr ""
+msgstr "Asetusten kääntäminen"
 
 msgid "Translate the configuration."
-msgstr ""
+msgstr "Käännä asetukset."
 
 msgid "@label fields"
-msgstr ""
+msgstr "@label kentät"
 
 msgid "The uninstall process removes all data related to a module."
 msgstr ""
+"Poistoprosessi poistaa kaiken moduuliin liittyvän tiedon tietokannasta."
 
 msgid "At least one format must be defined for resource @id"
-msgstr ""
+msgstr "Vähintään yksi muoto on määritettävä resurssille @id"
 
 msgid "The ID of the shortcut."
-msgstr ""
+msgstr "Oikopolun ID."
 
 msgid "The UUID of the shortcut."
-msgstr ""
+msgstr "Oikopolun UUID."
 
 msgid "The bundle of the shortcut."
-msgstr ""
+msgstr "Oikopolun paketti."
 
 msgid "Route name"
-msgstr ""
+msgstr "Reitin nimi"
 
 msgid "The language code of the shortcut."
-msgstr ""
+msgstr "Oikopolun kielikoodi."
 
 msgid "Rebuild access"
-msgstr ""
+msgstr "Rakenna pääsyoikeudet uudelleen"
 
 msgid "Taxonomy term ID"
-msgstr ""
+msgstr "Luokittelutermin ID"
 
 msgid "Taxonomy term name"
-msgstr ""
+msgstr "Luokittelutermin nimi"
 
 msgid "The name of this user."
-msgstr ""
+msgstr "Käyttäjän nimi"
 
 msgid "The email of this user."
-msgstr ""
+msgstr "Käyttäjän sähköposti."
 
 msgid "The timezone of this user."
-msgstr ""
+msgstr "Käyttäjän aikavyöhyke."
 
 msgid "The time that the user was created."
-msgstr ""
+msgstr "Käyttäjän luonnin ajankohta."
 
 msgid "Adding functionality to administrative pages"
-msgstr ""
+msgstr "Lisää toiminnallisuutta hallintasivuille"
 
 msgid "Validate @label"
-msgstr ""
+msgstr "Validoi @label"
 
 msgid "Validate user has access to the %name"
-msgstr ""
+msgstr "Validoi käyttäjän pääsy %name"
 
 msgid "Multiple arguments"
-msgstr ""
+msgstr "Monta argumenttia"
 
 msgid "Single ID"
-msgstr ""
+msgstr "Yksittäinen ID"
 
 msgid "One or more IDs separated by , or +"
-msgstr ""
+msgstr "Yksi tai useampi ID, erotettuna , tai +"
 
 msgid "Tag based"
-msgstr ""
+msgstr "Tageihin perustuva"
 
 msgid ""
 "Tag based caching of data. Caches will persist until any related cache tags "
 "are invalidated."
 msgstr ""
+"Tageihin perustuva sisällön välimuistitus. Välimuistit säilyvät kunnes mikä "
+"tahansa liittyvistä tageista on poistunut."
 
 msgid "Name and description"
-msgstr ""
+msgstr "Nimi ja kuvaus"
 
 msgid "Administrative tags"
-msgstr ""
+msgstr "Ylläpidolliset tagit"
 
 msgid "Enter a comma-separated list of words to describe your view."
-msgstr ""
+msgstr "Lisää pilkuin eloteltu lista avainsanoja kuvaamaan näkymääsi."
 
 msgid "The aggregator feed UUID."
-msgstr ""
+msgstr "Aggregaattori-syötteen UUID."
 
 msgid "simple configuration"
-msgstr ""
+msgstr "yksinkertaiset asetukset"
 
 msgid "The date the file created."
-msgstr ""
+msgstr "Päivämäärä jolloin tiedosto luotiin."
 
 msgid "The timestamp that the file was created."
-msgstr ""
+msgstr "Tiedoston luonnin aikaleima"
 
 msgid "The timestamp that the file was last changed."
-msgstr ""
+msgstr "Tiedoston edellisen muutoksen aikaleima"
 
 msgid "Language based on a selected language."
-msgstr ""
+msgstr "Kielivalinta valitun kielen perusteella."
 
 msgid ""
 "Menu links with lower weights are displayed before links with higher "
 "weights."
 msgstr ""
+"Pienemmällä painolla olevat valikkokohdat näytetään ennen suurempipainoisia."
 
 msgid "The name of the user role."
-msgstr ""
+msgstr "Käyttäjäroolin nimi."
 
 msgid "Influence"
-msgstr ""
+msgstr "Vaikutus"
 
 msgid ""
 "Influence is a numeric multiplier used in ordering search results. A higher "
@@ -16847,81 +18146,92 @@ msgid ""
 "zero means the factor is ignored. Changing these numbers does not require "
 "the search index to be rebuilt. Changes take effect immediately."
 msgstr ""
+"Vaikutus on numeerinen kerroin, jota käytetään hakutulosten järjestämiseen. "
+"Korkeampi numero tarkoittaa, että vastaavalla tekijällä on korkeampi "
+"vaikutus hakutuloksissa; nolla tarkoittaa, että tekijää ei oteta huomioon. "
+"Näiden numeroiden muuttaminen ei vaadi hakuindeksin uudelleenrakentamista. "
+"Muutokset tulevat voimaan välittömästi."
 
 msgid "Search page type"
-msgstr ""
+msgstr "Sivun tyyppi"
 
 msgid "- Choose page type -"
-msgstr ""
+msgstr "- Valitse sivun tyyppi -"
 
 msgid "No search pages have been configured."
-msgstr ""
+msgstr "Hakusivuja ei ole konfiguroitu."
 
 msgid "You must select the new search page type."
-msgstr ""
+msgstr "Sinun on valittava uuden hakusivun tyyppi."
 
 msgid "Edit %label search page"
-msgstr ""
+msgstr "Muokkaa %label hakusivua"
 
 msgid "The %label search page has been enabled."
-msgstr ""
+msgstr "%label hakusivu on otettu käyttöön."
 
 msgid "The %label search page has been disabled."
-msgstr ""
+msgstr "%label hakusivu on poistettu käytöstä."
 
 msgid "The %label search page has been added."
-msgstr ""
+msgstr "%label hakusivu on lisätty."
 
 msgid "Save search page"
-msgstr ""
+msgstr "Tallenna hakusivu"
 
 msgid "The %label search page has been updated."
-msgstr ""
+msgstr "%label hakusivu on päivitetty."
 
 msgid "The label for this search page."
-msgstr ""
+msgstr "Tämän hakusivun etiketti."
 
 msgid "The search page path must be unique."
-msgstr ""
+msgstr "Hakusivun on oltava yksilöllinen."
 
 msgid "Managing and displaying text fields"
-msgstr ""
+msgstr "Tekstikenttien esittäminen ja ylläpito"
 
 msgid "Creating short text fields"
-msgstr ""
+msgstr "Lyhyiden tekstikenttien luominen"
 
 msgid "Creating long text fields"
-msgstr ""
+msgstr "Pitkien tekstikenttien luominen"
 
 msgid "Trimming the text length"
-msgstr ""
+msgstr "Tekstin pituuden lyhennys"
 
 msgid "Displaying summaries instead of trimmed text"
-msgstr ""
+msgstr "Tiivistelmien esittäminen lyhennetyn tekstin sijaan"
 
 msgid "Using text formats and editors"
-msgstr ""
+msgstr "Tekstityökalujen ja syöttömuotojen käyttäminen"
 
 msgctxt "Text alignment"
 msgid "Left"
 msgstr ""
+"Vasemmalla\r\n"
+"kontekstissa: Tekstin keskitys"
 
 msgctxt "Text alignment"
 msgid "Center"
 msgstr ""
+"Keskellä\r\n"
+"kontekstissa: Tekstin keskitys"
 
 msgctxt "Text alignment"
 msgid "Right"
 msgstr ""
+"Oikealla\r\n"
+"kontekstissa: Tekstin keskitys"
 
 msgid "%name: may not be longer than @max characters."
-msgstr ""
+msgstr "%name: ei voi olla pidempi kuin @max merkkiä."
 
 msgid "<abbr title=\"Outline Processor Markup Language\">OPML</abbr> integration"
-msgstr ""
+msgstr "<abbr title=\"Outline Processor Markup Language\">OPML</abbr>-integraatio"
 
 msgid "Resolution multiplier"
-msgstr ""
+msgstr "Resoluutiokerroin"
 
 msgid ""
 "Resolution multipliers are a measure of the viewport's device resolution, "
@@ -16931,42 +18241,57 @@ msgid ""
 "multipliers of 1, 1.5, and 2; when defining breakpoints, modules and themes "
 "can define which multipliers apply to each breakpoint."
 msgstr ""
+"Resoluutiokerroin ilmaisee laitteen tarkkuuden sen fyysisten pikseleiden "
+"koon ja <a "
+"href=\"http://en.wikipedia.org/wiki/Device_independent_pixel\">laiteriippumattoman"
+" pikselikoon</a> suhteena. Breakpoint-moduuli määrittelee kertoimet 1, 1.5 "
+"ja 2. Moduulit ja teemat voivat määritellä kullekin taittopisteelle "
+"käytettävät kertoimet."
 
 msgid "Defining breakpoints and breakpoint groups"
 msgstr ""
+"Responsiivisisten näkymien taittopisteiden ja niiden ryhmien määrittely"
 
 msgid ""
 "Modules and themes can use the API provided by the Breakpoint module to "
 "define breakpoints and breakpoint groups, and to assign resolution "
 "multipliers to breakpoints."
 msgstr ""
+"Breakpoint-moduulin rajapinnan avulla moduulit ja teemat voivat määritellä "
+"taittopisteitä ja taittopisteryhmiä, sekä määrittää resoluutiokertoimia "
+"taittopisteille."
 
 msgctxt "Validation"
 msgid "Comment author name"
-msgstr ""
+msgstr "Kommentin kirjoittajan nimi"
 
 msgid ""
 "Changing the text format to %text_format will permanently remove content "
 "that is not allowed in that text format.<br><br>Save your changes before "
 "switching the text format to avoid losing data."
 msgstr ""
+"Tekstimuodon vaihtaminen muotoon %text_format hävittää sellaisen sisällön, "
+"joka ei ole sallittua uudessa tekstimuodossa.<br><br>Tallenna muutokset "
+"ennen tekstimuodon vaihtamista välttääksesi tietojen katoamisen."
 
 msgid "Change text format?"
-msgstr ""
+msgstr "Haluatko vaihtaa tekstimuodon?"
 
 msgid "Managing and displaying entity reference fields"
-msgstr ""
+msgstr "Entiteettiviittauskenttien hallinta ja näyttäminen"
 
 msgid "Selecting reference type"
-msgstr ""
+msgstr "Viittauksen kohteen tyypin valinta"
 
 msgid ""
 "In the field settings you can select which entity type you want to create a "
 "reference to."
 msgstr ""
+"Kentän asetuksissa valitaan minkä tyyppiseen entiteettiin kentässä voidaan "
+"viitata."
 
 msgid "Filtering and sorting reference fields"
-msgstr ""
+msgstr "Suodatus ja lajittelu viittauskentissä"
 
 msgid ""
 "Depending on the chosen entity type, additional filtering and sorting "
@@ -16974,1022 +18299,1045 @@ msgid ""
 "the field settings. For example, the list of users can be filtered by role "
 "and sorted by name or ID."
 msgstr ""
+"Viittauksen kohteen tyypistä riippuen voidaan viitattavia entiteettejä "
+"suodattaa ja lajitella. Tämä voidaan määritellä kentän asetuksissa. "
+"Esimerkiksi käyttäjiä voidaan suodattaa roolin perustella ja lajitella nimen"
+" tai id:n perusteella."
 
 msgid "Displaying a reference"
-msgstr ""
+msgstr "Viittauksen näyttäminen"
 
 msgid "Managing text formats"
-msgstr ""
+msgstr "Tekstimuotojen hallinta"
 
 msgid "Assigning roles to text formats"
-msgstr ""
+msgstr "Roolien osoittaminen tekstiformaateille"
 
 msgid "Selecting filters"
-msgstr ""
+msgstr "Suodattimien valinta"
 
 msgid "The keywords to search for."
-msgstr ""
+msgstr "Hakusanat."
 
 msgid "Choosing list field type"
-msgstr ""
+msgstr "Listakentän tyypin valinta"
 
 msgid "Simpletest site directory"
-msgstr ""
+msgstr "Simpletest sivustokansio"
 
 msgid "The vocabulary to which the term is assigned."
-msgstr ""
+msgstr "Sanasto johon termi on lisättynä."
 
 msgid "Promo image"
-msgstr ""
+msgstr "Nostokuva"
 
 msgid "Missing profile parameter."
-msgstr ""
+msgstr "Puuttuva profiilin parametri."
 
 msgid "Timestamp value"
-msgstr ""
+msgstr "Aikaleiman arvo"
 
 msgid "An entity field containing a UNIX timestamp value."
-msgstr ""
+msgstr "Kokonaisuuskenttä sisältäen UNIX aikaleima-arvon."
 
 msgid "Default PHP mailer"
-msgstr ""
+msgstr "PHP:n oletussähköpostin lähettäjä"
 
 msgid "Sends the message as plain text, using PHP's native mail() function."
 msgstr ""
+"Lähettää sähköpostin pelkkänä tekstinä, käyttäen PHP:n natiivia "
+"mail()-funktiota."
 
 msgid "Mail collector"
-msgstr ""
+msgstr "Postien kerääjä"
 
 msgid ""
 "Does not send the message, but stores it in Drupal within the state system. "
 "Used for testing."
 msgstr ""
+"Ei lähetä viestiä, vaan tallentaa sen Drupalin tilajärjestelmään. Käytetään "
+"testaukseen."
 
 msgid "Synchronizing configuration"
-msgstr ""
+msgstr "Synkronoidaan asetuksia"
 
 msgid "Starting configuration synchronization."
-msgstr ""
+msgstr "Aloitetaan asetusten synkronointi"
 
 msgid "Configuration synchronization has encountered an error."
-msgstr ""
+msgstr "Asetusten synkronoinnissa tapahtui virhe."
 
 msgid "Nothing to export."
-msgstr ""
+msgstr "Ei mitään vietävää."
 
 msgid "Administer responsive images"
-msgstr ""
+msgstr "Ylläpidä responsiivisia kuvia"
 
 msgid "Return to site content"
-msgstr ""
+msgstr "Palaa sivuston sisältöön"
 
 msgid "Entity view display"
-msgstr ""
+msgstr "Kokonaisuuden näyttötila"
 
 msgid "Defines a field type for telephone numbers."
-msgstr ""
+msgstr "Määrittelee kenttätyypin puhelinnumeroille."
 
 msgid ""
 "Defined on the Appearance or Theme Settings page. You do not have the "
 "appropriate permissions to change the site logo."
 msgstr ""
+"Määritelty Ulkoasu- tai Teeman asetukset-sivulla. Sinulla ei ole tarvittavia"
+" oikeuksia muokkaaksesi sivuston logoa."
 
 msgid ""
 "Defined on the Site Information page. You do not have the appropriate "
 "permissions to change the site logo."
 msgstr ""
+"Määritelty Sivuston tiedot -sivulla. Sinulla ei ole sivuston logon "
+"vaihtamiseen tarvittavia oikeuksia."
 
 msgid "Toggle branding elements"
-msgstr ""
+msgstr "Muokkaa brändielementtejä"
 
 msgid ""
 "Choose which branding elements you want to show in this block instance."
-msgstr ""
+msgstr "Valitse mitkä brändielementit näytetään tässä lohkoinstanssissa."
 
 msgid "Rendering language"
-msgstr ""
+msgstr "Renderöintikieli"
 
 msgid ""
 "Form build-id mismatch detected while attempting to store a form in the "
 "cache."
 msgstr ""
+"Lomakkeen tunniste ei täsmännyt kun lomaketta yritettiin tallentaa "
+"välimuistiin."
 
 msgid "Deleted and replaced configuration \"@name\""
-msgstr ""
+msgstr "Poistettiin ja korvattiin asetukset \"@name\""
 
 msgid "Update target \"@name\" is missing."
-msgstr ""
+msgstr "Päivityksen kohde \"@name\" puuttuu."
 
 msgid "%name: The integer must be larger or equal to %min."
-msgstr ""
+msgstr "%name: kokonaisluvun pitää olla suurempi tai yhtä suuri kuin %min."
 
 msgid "Size of URI field"
-msgstr ""
+msgstr "Verkko-osoitekentän koko"
 
 msgid "URI field"
-msgstr ""
+msgstr "Verkko-osoitekenttä"
 
 msgid "Are you sure you want to delete all items from the feed %feed?"
-msgstr ""
+msgstr "Oletko varma, että haluat poistaa kaikki syötteen %feed kohteet?"
 
 msgid "The news items from %site have been deleted."
-msgstr ""
+msgstr "Uutiskohteet sivustolta %site ovat poistettu."
 
 msgid "A brief description of your block."
-msgstr ""
+msgstr "Lohkosi lyhyt kuvaus."
 
 msgid "Completed @current step of @total."
-msgstr ""
+msgstr "Suoritettu @current / @total."
 
 msgid "The configuration synchronization failed validation."
-msgstr ""
+msgstr "Asetusten synkronointi ei läpäissyt validointia."
 
 msgid "Allowed link type"
-msgstr ""
+msgstr "Sallittu linkkityyppi"
 
 msgid "Internal links only"
-msgstr ""
+msgstr "Vain sisäiset linkit"
 
 msgid "Both internal and external links"
-msgstr ""
+msgstr "Sekä sisäiset että ulkoiset linkit"
 
 msgid "Translating individual strings"
-msgstr ""
+msgstr "Yksittäisten merkkijonojen kääntäminen"
 
 msgid "Format ID."
-msgstr ""
+msgstr "Formaatin ID."
 
 msgid "(this translation)"
-msgstr ""
+msgstr "(tämä käännös)"
 
 msgid "(all translations)"
-msgstr ""
+msgstr "(kaikki käännökset)"
 
 msgid "Search is currently disabled"
-msgstr ""
+msgstr "Haku on tällä hetkellä pois käytöstä"
 
 msgid "No screenshot"
-msgstr ""
+msgstr "Ei kuvankaappausta"
 
 msgid "Configuration deletions"
-msgstr ""
+msgstr "Asetusten poistot"
 
 msgid "The listed configuration will be deleted."
-msgstr ""
+msgstr "Alla luetellut asetukset poistetaan."
 
 msgid "User's roles"
-msgstr ""
+msgstr "Käyttäjän roolit"
 
 msgid "One or more names separated by , or +"
-msgstr ""
+msgstr "Yksi tai useampia nimiä erotettuna , tai + -merkeillä"
 
 msgid "If none are selected, all are allowed."
-msgstr ""
+msgstr "Jos yksikään ei ole valittu, kaikki ovat sallittuja."
 
 msgid "Missing row plugin"
-msgstr ""
+msgstr "Puuttuva rivi-plugin"
 
 msgid "Tab options"
-msgstr ""
+msgstr "Tab vaihtoehdot"
 
 msgid "Enable menu link"
-msgstr ""
+msgstr "Ota valikkolinkki käyttöön"
 
 msgid "Allowed HTML"
-msgstr ""
+msgstr "Sallittu HTML"
 
 msgid "Providing module"
-msgstr ""
+msgstr "Moduuli tarjoaminen"
 
 msgid "@label entities"
-msgstr ""
+msgstr "@label entiteetit"
 
 msgid "Synchronizing configuration: @op @name in @collection."
-msgstr ""
+msgstr "Synkronoidaan asetukset: @op @name kokoelmassa @collection."
 
 msgctxt "Entity type group"
 msgid "Content"
-msgstr ""
+msgstr "Sisältö"
 
 msgctxt "Entity type group"
 msgid "Other"
-msgstr ""
+msgstr "Muu"
 
 msgctxt "Entity type group"
 msgid "Configuration"
-msgstr ""
+msgstr "Asetukset"
 
 msgid "Action ID"
-msgstr ""
+msgstr "Toiminnon ID"
 
 msgid "Action configuration"
-msgstr ""
+msgstr "Toiminnon asetukset"
 
 msgid "Action description"
-msgstr ""
+msgstr "Toiminnon kuvaus"
 
 msgid "The feed ID."
-msgstr ""
+msgstr "Syötteen ID."
 
 msgid "Refresh frequency in seconds."
-msgstr ""
+msgstr "Päivitysväli sekunneissa."
 
 msgid "Last-checked unix timestamp."
-msgstr ""
+msgstr "'Viimeksi tarkistettu' UNIX aikaleima."
 
 msgid "When the feed was last modified."
-msgstr ""
+msgstr "Milloin syöte on viimeksi päivitetty."
 
 msgid "The block numeric identifier."
-msgstr ""
+msgstr "Lohkon numeerinen tunniste."
 
 msgid "The module providing the block."
-msgstr ""
+msgstr "Lohkon tarjoava moduuli"
 
 msgid "The block's delta."
-msgstr ""
+msgstr "Lohkon delta."
 
 msgid "Pages list."
-msgstr ""
+msgstr "Sivulista."
 
 msgid "Cache rule."
-msgstr ""
+msgstr "Välimuistisääntö."
 
 msgid "Admin title of the block/box."
-msgstr ""
+msgstr "Lohkon/laatikon hallinnan otsikko."
 
 msgid "The comment title."
-msgstr ""
+msgstr "Kommentin otsikko."
 
 msgid "The {node}.type to which this comment is a reply."
-msgstr ""
+msgstr "[solmu].tyyppi johon tämä kommentti on vastaus."
 
 msgid "The node type"
-msgstr ""
+msgstr "Solmun tyyppi"
 
 msgid "Primary Key: Unique category ID."
-msgstr ""
+msgstr "Pääavain: Yksilöllisen kategorian ID."
 
 msgid "Category name."
-msgstr ""
+msgstr "Kategorian nimi."
 
 msgid "The category's weight."
-msgstr ""
+msgstr "Kategorian painokerroin."
 
 msgid "Type (text, integer, ....)"
-msgstr ""
+msgstr "Tyyppi (teksti, muuttuja, ...)"
 
 msgid "Global settings. Shared with every field instance."
 msgstr ""
+"Aivustonlaajuiset asetukset. Jaetaan kaikkien kenttäinstanssien kanssa."
 
 msgid "DB storage"
-msgstr ""
+msgstr "Tietokantatallennus"
 
 msgid "DB Columns"
-msgstr ""
+msgstr "Tietokannan sarakkeet"
 
 msgid "The machine name of field."
-msgstr ""
+msgstr "Kentän koneluettava nimi."
 
 msgid "Weight."
-msgstr ""
+msgstr "Paino."
 
 msgid "A name to show."
-msgstr ""
+msgstr "Näytettävä nimi."
 
 msgid "Widget type."
-msgstr ""
+msgstr "Asetustyökalun tyyppi."
 
 msgid "A description of field."
-msgstr ""
+msgstr "Kentän kuvaus."
 
 msgid "Module that implements widget."
-msgstr ""
+msgstr "Moduuli joka käyttää asetustyökalua."
 
 msgid "Status of widget"
-msgstr ""
+msgstr "Asetustyökalun tila"
 
 msgid "The module that provides the field."
-msgstr ""
+msgstr "Moduuli joka tarjoaa kentän."
 
 msgid "Content type where this field is used."
-msgstr ""
+msgstr "Sisältö jossa kenttää käytetään."
 
 msgid "The published status of a file."
-msgstr ""
+msgstr "Tiedoston julkaisun tila."
 
 msgid "The time that the file was added."
-msgstr ""
+msgstr "Ajankohta jolloin tiedosto lisättiin."
 
 msgid "The Drupal files path."
-msgstr ""
+msgstr "Drupal tiedostojen polku."
 
 msgid "TRUE if the files directory is public otherwise FALSE."
-msgstr ""
+msgstr "TRUE, jos files-hakemisto on julkinen, muutoin FALSE."
 
 msgid "Machine name of the node type."
-msgstr ""
+msgstr "SIsältötyypin koneluettava nimi."
 
 msgid "Human name of the node type."
-msgstr ""
+msgstr "Sisältötyypin ihmisluettava nimi."
 
 msgid "The module providing the node type."
-msgstr ""
+msgstr "Moduuli joka tarjoaa sisältötyypin."
 
 msgid "Description of the node type."
-msgstr ""
+msgstr "Sisältötyypin kuvaus."
 
 msgid "Help text for the node type."
-msgstr ""
+msgstr "Aputekstiä solmun tyypille."
 
 msgid "Title label."
-msgstr ""
+msgstr "Otsikon etiketti."
 
 msgid "Body label."
-msgstr ""
+msgstr "Rungon etiketti."
 
 msgid "Flag."
-msgstr ""
+msgstr "Lippu."
 
 msgid "The original type."
-msgstr ""
+msgstr "Alkuperäinen tyyppi."
 
 msgid "Primary Key: Unique profile field ID."
-msgstr ""
+msgstr "Pääavain: Yksilöllinen profiilikentän ID."
 
 msgid "Title of the field shown to the end user."
-msgstr ""
+msgstr "Kentän käyttäjälle näytettävä otsikko."
 
 msgid "Explanation of the field to end users."
-msgstr ""
+msgstr "Kentän selite loppukäyttäjälle."
 
 msgid "Type of form field."
-msgstr ""
+msgstr "Lomakekentän tyyppi."
 
 msgid "The numeric identifier of the path alias."
-msgstr ""
+msgstr "Polkualiaksen numeerinen tunniste."
 
 msgid "The name of the vocabulary."
-msgstr ""
+msgstr "Sanaston nimi."
 
 msgid "The description of the vocabulary."
-msgstr ""
+msgstr "Sanaston kuvaus."
 
 msgid "Menu selection requires the activation of Menu UI module."
-msgstr ""
+msgstr "Valikkovalinta vaatii Menu UI moduulin käyttöönoton."
 
 msgid ""
 "Numeric placeholders may not be used. Please use plain placeholders (%)."
 msgstr ""
+"Numeeristen kirjanmerkkien käyttö on kielletty. Käytä puhtaita "
+"kirjanmerkkejä (%)."
 
 msgid "Route Name"
-msgstr ""
+msgstr "Reitin nimi"
 
 msgid "Route Params"
-msgstr ""
+msgstr "Reitin parametrit"
 
 msgid "Param"
-msgstr ""
+msgstr "Parametri"
 
 msgid "Configuration dependencies"
-msgstr ""
+msgstr "Asetusriippuvuudet"
 
 msgid "Theme dependencies"
-msgstr ""
+msgstr "Teemariippuvuudet"
 
 msgid "Extension settings"
-msgstr ""
+msgstr "Laajennuksien asetukset"
 
 msgid "Action settings"
-msgstr ""
+msgstr "Toiminnon asetukset"
 
 msgid "Recursion limit for actions"
-msgstr ""
+msgstr "Rekursion rajoitus toimenpiteille"
 
 msgid "Redirect to URL configuration"
-msgstr ""
+msgstr "URL-ohjauksen asetukset"
 
 msgid "Display a message to the user configuration"
-msgstr ""
+msgstr "Käyttäjälle näytettävän viestin asetukset"
 
 msgid "Bulk form"
-msgstr ""
+msgstr "Bulkkilomake"
 
 msgid "Admin info"
-msgstr ""
+msgstr "Ylläpitotietoa"
 
 msgid "Block display options"
-msgstr ""
+msgstr "Lohkon näyttöasetukset"
 
 msgid "Book settings"
-msgstr ""
+msgstr "Kirjan asetukset"
 
 msgid "Button groups"
-msgstr ""
+msgstr "Painikeryhmät"
 
 msgid "Button group"
-msgstr ""
+msgstr "Painikeryhmä"
 
 msgid "List of styles"
-msgstr ""
+msgstr "Lista tyyleistä"
 
 msgid "Color theme settings"
-msgstr ""
+msgstr "Väriteeman asetukset"
 
 msgid "Palette settings"
-msgstr ""
+msgstr "Paletin asetukset"
 
 msgid "Last comment date"
-msgstr ""
+msgstr "Viimeisimmän kommentin päiväys"
 
 msgid "no caching"
-msgstr ""
+msgstr "ei välimuistitusta"
 
 msgid "Entity options"
-msgstr ""
+msgstr "Kokonaisuuksien asetukset"
 
 msgid "Translate @type_name"
-msgstr ""
+msgstr "Käännä @type_name"
 
 msgid "Personal contact form enabled by default"
-msgstr ""
+msgstr "Henkilökohtainen yhteydenottolomake on oletuksena käytössä"
 
 msgid "Content translation link"
-msgstr ""
+msgstr "Sisällön käännöksen linkki"
 
 msgid "Contextual link"
-msgstr ""
+msgstr "Kontekstiriippuvainen linkki"
 
 msgid "Delete form mode"
-msgstr ""
+msgstr "Poista lomakemuoto"
 
 msgid "Entity view mode settings"
-msgstr ""
+msgstr "Kokonaisuuden näyttötavan asetukset"
 
 msgid "Target entity type"
-msgstr ""
+msgstr "Kohde-entiteetin tyyppi"
 
 msgid "Entity form mode settings"
-msgstr ""
+msgstr "Entiteetin lomakemuodon asetukset"
 
 msgid "View or form mode machine name"
-msgstr ""
+msgstr "Näytötavan tai lomakkeen muodon koneluettava nimi"
 
 msgid "Field display setting"
-msgstr ""
+msgstr "Kentän näyttöasetukset"
 
 msgid "Text field display format settings"
-msgstr ""
+msgstr "Tekstikentän esitystavan asetukset"
 
 msgid "Sort settings"
-msgstr ""
+msgstr "Lajittele asetukset"
 
 msgid "Entity reference rendered entity display format settings"
 msgstr ""
+"Kokonaisuusviittauksen renderöidyn kokonaisuuden esitystavan asetukset"
 
 msgid "Entity reference entity ID display format settings"
-msgstr ""
+msgstr "Kokonaisuusviittauksen ID:n esitystavan asetukset"
 
 msgid "Entity reference label display format settings"
-msgstr ""
+msgstr "Kokonaisuusviittauksen etiketin esitystavan asetukset"
 
 msgid "Entity reference autocomplete (Tags style) display format settings"
 msgstr ""
+"Kokonaisuusviittauksen automaattisen täydennyksen (tagi-tyyli) esitystavan "
+"asetukset"
 
 msgid "Entity reference autocomplete display format settings"
 msgstr ""
+"Kokonaisuusviittauksen automaattisen täydennyksen esitystavan asetukset"
 
 msgid "Search field"
-msgstr ""
+msgstr "Hakukenttä"
 
 msgid "- Hidden - format settings"
-msgstr ""
+msgstr "Piilotettu - muotoiluasetukset"
 
 msgid "Integer settings"
-msgstr ""
+msgstr "Muuttujan asetukset"
 
 msgid "Decimal settings"
-msgstr ""
+msgstr "Desimaalin asetukset"
 
 msgid "Float settings"
-msgstr ""
+msgstr "Liukuluvun asetukset"
 
 msgid "Number decimal display format settings"
-msgstr ""
+msgstr "Desimaalinumeron esitystavan asetukset"
 
 msgid "Number unformatted display format settings"
-msgstr ""
+msgstr "Muotoilemattoman numeron esitystavan asetukset"
 
 msgid "Number default display format settings"
-msgstr ""
+msgstr "Numeron oletus-esitystavan asetukset"
 
 msgid "Reverse entity reference"
-msgstr ""
+msgstr "Käänteinen entiteettiviittaus"
 
 msgid "Field UI settings"
-msgstr ""
+msgstr "Kentän käyttöliittymäasetukset"
 
 msgid "Enable Description field"
-msgstr ""
+msgstr "Ota käyttöön Kuvaus-kenttä"
 
 msgid "HAL"
-msgstr ""
+msgstr "HAL"
 
 msgid "Delete language"
-msgstr ""
+msgstr "Poista kieli"
 
 msgid "All language types"
-msgstr ""
+msgstr "Kaikki kielityypit"
 
 msgid "Language detection methods"
-msgstr ""
+msgstr "Kielen tunnistustavat"
 
 msgid "Interface Translation"
-msgstr ""
+msgstr "Käyttöliittymän kääntäminen"
 
 msgid "Translate interface settings"
-msgstr ""
+msgstr "Käännä käyttöliittymän tekstejä"
 
 msgid "Cache strings"
-msgstr ""
+msgstr "Välimuistita merkkijonot"
 
 msgid "Overwrite non customized translations"
-msgstr ""
+msgstr "Ylikirjoita ei-muokatut käännökset"
 
 msgid "Menu UI"
-msgstr ""
+msgstr "Valikon käyttöliittymä"
 
 msgid "Per-content type menu settings"
-msgstr ""
+msgstr "Sisältötyyppikohtaiset valikkoasetukset"
 
 msgid "Menu machine name"
-msgstr ""
+msgstr "Valikon koneluettava nimi"
 
 msgid "Change the author of content configuration"
-msgstr ""
+msgstr "Muuta sisällön asetusten tekijä"
 
 msgid "Save content configuration"
-msgstr ""
+msgstr "Tallenna sisällön asetukset"
 
 msgid "Delete content configuration"
-msgstr ""
+msgstr "Poista sisällön asetukset"
 
 msgid "Node user ID"
-msgstr ""
+msgstr "Solmun käyttäjän ID"
 
 msgid "Node path"
-msgstr ""
+msgstr "Solmun polku"
 
 msgid "Link to a node revision"
-msgstr ""
+msgstr "Linkki solmun versioon"
 
 msgid "List (integer) settings"
-msgstr ""
+msgstr "Lista (muuttuja) asetukset"
 
 msgid "List (float) settings"
-msgstr ""
+msgstr "Lista (liuku) asetukset"
 
 msgid "List (text) settings"
-msgstr ""
+msgstr "Lista (teksti) asetukset"
 
 msgid "Options list default display settings"
-msgstr ""
+msgstr "Valintalistan näytön oletusasetukset"
 
 msgid "Key format settings"
-msgstr ""
+msgstr "Avaimen muodon asetukset"
 
 msgid "Single on/off checkbox format settings"
-msgstr ""
+msgstr "Yksinkertaisen on/off valintaruudun muodon asetukset"
 
 msgid "Select list format settings"
-msgstr ""
+msgstr "Valitun listamuodon asetukset"
 
 msgid "Responsive Image"
-msgstr ""
+msgstr "Responsiivinen kuva"
 
 msgid "RESTful Web Services"
-msgstr ""
+msgstr "RESTful Web Services"
 
 msgid "REST settings"
-msgstr ""
+msgstr "REST asetuksetr"
 
 msgid "GET method settings"
-msgstr ""
+msgstr "GET tavan asetukset"
 
 msgid "POST method settings"
-msgstr ""
+msgstr "POST tavan asetukset"
 
 msgid "PATCH method settings"
-msgstr ""
+msgstr "PATCH metodin asetukset"
 
 msgid "DELETE method settings"
-msgstr ""
+msgstr "DELETE metodin asetukset"
 
 msgid "Supported format"
-msgstr ""
+msgstr "Tuettu muoto"
 
 msgid "Supported authentication"
-msgstr ""
+msgstr "Tuettu autentikointi"
 
 msgid "REST display options"
-msgstr ""
+msgstr "REST näyttöasetukset"
 
 msgid "Field row"
-msgstr ""
+msgstr "Kenttärivi"
 
 msgid "Alias for ID"
-msgstr ""
+msgstr "Alias ID:lle"
 
 msgid "Raw output for ID"
-msgstr ""
+msgstr "Raakatuloste ID:lle"
 
 msgid "Serialized output format"
-msgstr ""
+msgstr "Serialisoitu tulosteen muoto"
 
 msgid "Configure search pages and search indexing options."
-msgstr ""
+msgstr "Säädä hakusivuja ja haun indeksointia."
 
 msgid "Add new search page"
-msgstr ""
+msgstr "Lisää uusi hakusivu"
 
 msgid "AND/OR combination limit"
-msgstr ""
+msgstr "AND/OR yhdistelmän raja"
 
 msgid "Default search page"
-msgstr ""
+msgstr "Oletus hakusivu"
 
 msgid "HTML tags weight"
-msgstr ""
+msgstr "HTML tagien painoarvo"
 
 msgid "Tag h1 weight"
-msgstr ""
+msgstr "Tagin h1 paino"
 
 msgid "Tag h2 weight"
-msgstr ""
+msgstr "Tagin h2 paino"
 
 msgid "Tag h3 weight"
-msgstr ""
+msgstr "Tagin h3 paino"
 
 msgid "Tag h4 weight"
-msgstr ""
+msgstr "Tagin h4 paino"
 
 msgid "Tag h5 weight"
-msgstr ""
+msgstr "Tagin h5 paino"
 
 msgid "Tag h6 weight"
-msgstr ""
+msgstr "Tagin h6 paino"
 
 msgid "Tag u weight"
-msgstr ""
+msgstr "Tagin u paino"
 
 msgid "Tag b weight"
-msgstr ""
+msgstr "Tagin b paino"
 
 msgid "Tag i weight"
-msgstr ""
+msgstr "Tagin i paino"
 
 msgid "Tag strong weight"
-msgstr ""
+msgstr "Tagin strong paino"
 
 msgid "Tag em weight"
-msgstr ""
+msgstr "Tagin em paino"
 
 msgid "Tag a weight"
-msgstr ""
+msgstr "Tagin a paino"
 
 msgid "Query key"
-msgstr ""
+msgstr "Kyselyavain"
 
 msgid "Source link"
-msgstr ""
+msgstr "Lähdelinkki"
 
 msgid "Serialization"
-msgstr ""
+msgstr "Sarjoitus"
 
 msgid "Shortcut settings"
-msgstr ""
+msgstr "Oikopolkujen asetukset"
 
 msgid "Statistics settings"
-msgstr ""
+msgstr "Statistiikan asetukset"
 
 msgid "Syslog settings"
-msgstr ""
+msgstr "Syslog asetukset"
 
 msgid "Set as default theme"
-msgstr ""
+msgstr "Valitse oletusteemaksi"
 
 msgid "Site UUID"
-msgstr ""
+msgstr "Sivuston UUID"
 
 msgid "Authorize settings"
-msgstr ""
+msgstr "Auktorisoinnin asetukset"
 
 msgid "Default file transfer protocol"
-msgstr ""
+msgstr "Tiedostonsiirron oletusprotokolla"
 
 msgid "Remind users at login if their time zone is not set"
 msgstr ""
+"Muistuta käyttäjää aikavyöhykeasetuksen puuttumisesta kirjautumisen "
+"yhteydessä"
 
 msgid "Logging settings"
-msgstr ""
+msgstr "Logituksen asetukset"
 
 msgid "CSS performance settings"
-msgstr ""
+msgstr "CSS suorituskykyasetukset"
 
 msgid "Compress CSS files"
-msgstr ""
+msgstr "Pakkaa CSS tiedostot"
 
 msgid "Fast 404 settings"
-msgstr ""
+msgstr "Fast 404 asetukset"
 
 msgid "Fast 404 enabled"
-msgstr ""
+msgstr "Fast 404 käytössä"
 
 msgid "Fast 404 page html"
-msgstr ""
+msgstr "Fast 404 sivun html"
 
 msgid "Theme global settings"
-msgstr ""
+msgstr "Teeman globaalit asetukset"
 
 msgid "Maintain index table"
-msgstr ""
+msgstr "Ylläpidä indeksitaulua"
 
 msgid "Override selector"
-msgstr ""
+msgstr "Ohita valitsin"
 
 msgid "Number of terms per page"
-msgstr ""
+msgstr "Termejä per sivu"
 
 msgid "Taxonomy format settings"
-msgstr ""
+msgstr "Sanaston muodon asetukset"
 
 msgid "Use taxonomy term path"
-msgstr ""
+msgstr "Käytä luokittelutermin polkua"
 
 msgid "Taxonomy depth modifier"
-msgstr ""
+msgstr "Sanaston syvyysmuunnin"
 
 msgid "Taxonomy language"
-msgstr ""
+msgstr "Sanaston kieli"
 
 msgid "Taxonomy term ID with depth"
-msgstr ""
+msgstr "Luokittelutermin ID syvyydellä"
 
 msgid "Telephone link format settings"
-msgstr ""
+msgstr "Puhelinnumero-linkin muotoilun asetukset"
 
 msgid "Telephone default format settings"
-msgstr ""
+msgstr "Puhelinnumeron muodon oletusasetukset"
 
 msgid "Default summary length"
-msgstr ""
+msgstr "Tiivistelmän oletuspituus"
 
 msgid "Text area (multiple rows) display format settings"
-msgstr ""
+msgstr "Tekstialueen (monirivisen) näyttömuotoiluasetukset"
 
 msgid "Number of summary rows"
-msgstr ""
+msgstr "Tiivistelmän rivien määrä"
 
 msgid "Route settings"
-msgstr ""
+msgstr "Reitin asetukset"
 
 msgid "Tracker settings"
-msgstr ""
+msgstr "Seurannan asetukset"
 
 msgid "Cron index limit"
-msgstr ""
+msgstr "Cron indeksin raja"
 
 msgid "User window"
-msgstr ""
+msgstr "Käyttäjän ikkuna"
 
 msgid "Default area"
-msgstr ""
+msgstr "Oletusalue"
 
 msgid "The shown text of the area"
-msgstr ""
+msgstr "Tekstialueessa näytettävä teksti"
 
 msgid "Provides guided tours."
-msgstr ""
+msgstr "Tarjoaa ohjattuja kierroksia."
 
 msgid "Translates the built-in user interface."
-msgstr ""
+msgstr "Kääntää sisäänrakennetun käyttöliittymän"
 
 msgctxt "With components"
 msgid "Extend"
-msgstr ""
+msgstr "Laajenna"
 
 msgid "Text custom"
-msgstr ""
+msgstr "Kustomoitu teksti"
 
 msgid "The shown text of the result summary area"
-msgstr ""
+msgstr "Tiivistelmäalueella näytettävä teksti"
 
 msgid "The title which will be overridden for the page"
-msgstr ""
+msgstr "Ylikirjoitetulla sivulla näytettävä otsikko"
 
 msgid "Node Creation Time"
-msgstr ""
+msgstr "Aolmun luontiajankohta"
 
 msgid "Node Update Time"
-msgstr ""
+msgstr "Solmun päivitysajankohta"
 
 msgid "Day Date"
-msgstr ""
+msgstr "Päivä päivämäärä"
 
 msgid "Formula"
-msgstr ""
+msgstr "Kaava"
 
 msgid "Place Holder"
-msgstr ""
+msgstr "Kirjanmerkki"
 
 msgid "Formula Used"
-msgstr ""
+msgstr "Käytetty kaava"
 
 msgid "Full Date"
-msgstr ""
+msgstr "Täysi päivämäärä"
 
 msgid "Group by Numeric"
-msgstr ""
+msgstr "Ryhmittele numeerisesti"
 
 msgid "Month Date"
-msgstr ""
+msgstr "Kuukausi Päivämäärä"
 
 msgid "Week Date"
-msgstr ""
+msgstr "Viikko Päivämäärä"
 
 msgid "Year Date"
-msgstr ""
+msgstr "Vuosi Päivämäärä"
 
 msgid "YearMonthDate"
-msgstr ""
+msgstr "VuosiKuukausiPäivä"
 
 msgid "Date Year month"
-msgstr ""
+msgstr "Päivämäärä Vuosi Kuukausi"
 
 msgid "Basic validation"
-msgstr ""
+msgstr "Perusvalidointi"
 
 msgid "Tag based caching"
-msgstr ""
+msgstr "Tageihin perustuva välimuistitus"
 
 msgid "Time based caching"
-msgstr ""
+msgstr "Aikaan perustuva välimuistitus"
 
 msgid "Exposed form type"
-msgstr ""
+msgstr "Näytettävän lomakkeen tyyppi"
 
 msgid "Row type"
-msgstr ""
+msgstr "Rivin tyyppi"
 
 msgid "Filter groups"
-msgstr ""
+msgstr "Suodatinryhmät"
 
 msgid "Display comment"
-msgstr ""
+msgstr "Näytä kommentti"
 
 msgid "Plugin ID"
-msgstr ""
+msgstr "Plugin ID"
 
 msgid "A unique ID per handler type"
-msgstr ""
+msgstr "Yksilöllinen ID per käsittelijän tyyppi"
 
 msgid "A sql aggregation type"
-msgstr ""
+msgstr "SQL aggregointityyppi"
 
 msgid "When the filter value is NOT available"
-msgstr ""
+msgstr "kun suodattimen arvo EI ole saatavilla"
 
 msgid "Default argument options"
-msgstr ""
+msgstr "Oletusargumentin optiot"
 
 msgid "Convert newlines to HTML <br> tags"
-msgstr ""
+msgstr "Muuta uudet rivit HTML >br> tageiksi"
 
 msgid "SQL pager"
-msgstr ""
+msgstr "SQL sivutus"
 
 msgid "Grouping field number %i"
-msgstr ""
+msgstr "Ryhmittelykentän numero %i"
 
 msgid "Group items"
-msgstr ""
+msgstr "Ryhmittele kohteet"
 
 msgid "Group item"
-msgstr ""
+msgstr "Ryhmittelykohde"
 
 msgid "Query comment"
-msgstr ""
+msgstr "Kyselyn kommentti"
 
 msgid "Default display options"
-msgstr ""
+msgstr "Näytön oletusasetukset"
 
 msgid "Page display options"
-msgstr ""
+msgstr "Näytön esitysasetukset"
 
 msgid "Attachment display options"
-msgstr ""
+msgstr "Liitetiedoston näyttöasetukset"
 
 msgid "Text on demand format"
-msgstr ""
+msgstr "Tekstiä pyynnöstä -muoto"
 
 msgid "Default field"
-msgstr ""
+msgstr "Oletuskenttä"
 
 msgid "Drop button"
-msgstr ""
+msgstr "Pudotusnappi"
 
 msgid "Default filter"
-msgstr ""
+msgstr "Oletussuodatin"
 
 msgid "Boolean string"
-msgstr ""
+msgstr "Boolean merkkijono"
 
 msgid "Group by numeric"
-msgstr ""
+msgstr "Ryhmittele metrisyyden mukaan"
 
 msgid "IN operator"
-msgstr ""
+msgstr "IN operaattori"
 
 msgid "Reduce duplicate"
-msgstr ""
+msgstr "Vähennä duplikaattien määrää"
 
 msgid "Default pager"
-msgstr ""
+msgstr "Oletus-sivutus"
 
 msgid "Groupwise max"
-msgstr ""
+msgstr "Ryhmäkohtainen maksimi"
 
 msgid "Generate subquery each time view is run"
-msgstr ""
+msgstr "Luo alikysely joka kerta kun näkymä suoritetaan"
 
 msgid "RSS field options"
-msgstr ""
+msgstr "RSS kenttien asetukset"
 
 msgid "Guid settings"
-msgstr ""
+msgstr "Guid asetukset"
 
 msgid "Display extender"
-msgstr ""
+msgstr "Näyttötilan laajentaja"
 
 msgid "Field rewrite elements"
-msgstr ""
+msgstr "Kentän uudelleenkirjoituksen elementit"
 
 msgid "Display plugin"
-msgstr ""
+msgstr "Näyttötila-plugin"
 
 msgid "Boolean sort"
-msgstr ""
+msgstr "Boolean lajittelu"
 
 msgid "Date sort"
-msgstr ""
+msgstr "Päivämäärälajittelu"
 
 msgid "Date sort expose settings"
-msgstr ""
+msgstr "Tiedon lajittelun näytettävät asetukset"
 
 msgid "Custom row classes"
-msgstr ""
+msgstr "Kustomoidut rivien luokat"
 
 msgid "Default views row classes"
-msgstr ""
+msgstr "Näkymän rivien oletusluokat"
 
 msgid "Custom column classes"
-msgstr ""
+msgstr "Sarakkeiden kustomoidut luokat"
 
 msgid "Columns name"
-msgstr ""
+msgstr "Sarakkeiden nimi"
 
 msgid "Columns info"
-msgstr ""
+msgstr "Sarakkeiden tiedot"
 
 msgid "Column info"
-msgstr ""
+msgstr "Sarakkeen tiedot"
 
 msgid "Preview view"
-msgstr ""
+msgstr "Esikatselunäkymä"
 
 msgid "Bartik settings"
-msgstr ""
+msgstr "Bartik asetukset"
 
 msgid "Seven settings"
-msgstr ""
+msgstr "Seven asetukset"
 
 msgid "Stark settings"
-msgstr ""
+msgstr "Stark asetukset"
 
 msgid "Visibility Conditions"
-msgstr ""
+msgstr "Näkyvyysriippuvuudet"
 
 msgid "Visibility Condition"
-msgstr ""
+msgstr "Näkyvyysriippuvuus"
 
 msgid "Context assignments"
-msgstr ""
+msgstr "Kontekstien käyttö"
 
 msgid "Display variant"
-msgstr ""
+msgstr "Näytä muunnos"
 
 msgid "Requirements review"
-msgstr ""
+msgstr "Vaatimuksien läpikäynti"
 
 msgid ""
 "Unable to send email. Contact the site administrator if the problem "
@@ -18000,253 +19348,266 @@ msgstr ""
 
 msgid "Error sending email (from %from to %to with reply-to %reply)."
 msgstr ""
+"Virhe sähköpostin lähetyksessä (lähettäjä %from vastaanottajalle %to "
+"vastausosoitteella %reply)."
 
 msgid "The label for this display variant."
-msgstr ""
+msgstr "Etiketti tälle näyttömuunnokselle."
 
 msgid "%name: the email address can not be longer than @max characters."
-msgstr ""
+msgstr "%name: sähköpostiosoite ei voi olla pidempi kuin @max merkkiä."
 
 msgid "An entity field containing an email value."
-msgstr ""
+msgstr "Kokonaisuus sisältäen sähköpostiarvon."
 
 msgid ""
 "Automated emails, such as registration information, will be sent from this "
 "address. Use an address ending in your site's domain to help prevent these "
 "emails from being flagged as spam."
 msgstr ""
+"Tästä osoitteesta lähetetään automaattiset viestit, esimerkiksi uuden "
+"käyttäjän tiedot. Käytä sivuston domainiin päättyvää osoitetta välttääksesi "
+"viestien roskapostiksi tulkitsemisen."
 
 msgid "Receive email notifications"
-msgstr ""
+msgstr "Vastaanota sähköposti-ilmoituksia"
 
 msgid "Send email configuration"
-msgstr ""
+msgstr "Sähköpostin lähetyksen asetukset"
 
 msgid "<em>Either</em> upload a file or enter a URL."
-msgstr ""
+msgstr "<em>Joko</em> lataa tiedosto tai syötä URL-osoite."
 
 msgid "Show for the listed pages"
-msgstr ""
+msgstr "Näytä listatuilla sivuilla"
 
 msgid "Hide for the listed pages"
-msgstr ""
+msgstr "Piilota listatuilta sivuilta"
 
 msgid "Duplicate @display_title"
-msgstr ""
+msgstr "Monista @display_title"
 
 msgid "Overriding default settings"
-msgstr ""
+msgstr "Oletusasetusten ohittaminen"
 
 msgid ""
 "This page provides a list of all comment types on the site and allows you to"
 " manage the fields, form and display settings for each."
 msgstr ""
+"Tämä sivu sisältää listan kaikista kommenttityypeistä sivustolla ja voit "
+"hallita jokaisen kenttiä, lomaketta ja näyttöasetuksia."
 
 msgid "Comment type %label has been updated."
-msgstr ""
+msgstr "Kommenttityyppi %label on päivitetty."
 
 msgid "Comment type %label has been added."
-msgstr ""
+msgstr "Kommenttityyppi %label on lisätty."
 
 msgid "The comment author's email address."
-msgstr ""
+msgstr "Kommentin kirjoittajan sähköpostiosoite."
 
 msgid "Comment Type"
-msgstr ""
+msgstr "Kommenttityyppi"
 
 msgid "The comment type."
-msgstr ""
+msgstr "Kommenttityyppi"
 
 msgid ""
 "Example: 'webmaster@example.com' or 'sales@example.com,support@example.com' "
 ". To specify multiple recipients, separate each email address with a comma."
 msgstr ""
+"Esimerkki: 'webmaster@example.com' tai "
+"'sales@example.com,support@example.com'. Määrittääksesi useamman "
+"vastaanottajan, erota sähköpostiosoitteet pilkulla."
 
 msgid "%recipient is an invalid email address."
-msgstr ""
+msgstr "%recipient ei ole kelvollinen sähköpostiosoite."
 
 msgctxt "Abbreviated month name"
 msgid "Jan"
-msgstr ""
+msgstr "Tam"
 
 msgctxt "Abbreviated month name"
 msgid "Feb"
-msgstr ""
+msgstr "Hel"
 
 msgctxt "Abbreviated month name"
 msgid "Mar"
-msgstr ""
+msgstr "Maa"
 
 msgctxt "Abbreviated month name"
 msgid "Apr"
-msgstr ""
+msgstr "Huh"
 
 msgctxt "Abbreviated month name"
 msgid "May"
-msgstr ""
+msgstr "Tou"
 
 msgctxt "Abbreviated month name"
 msgid "Jun"
-msgstr ""
+msgstr "Kes"
 
 msgctxt "Abbreviated month name"
 msgid "Jul"
-msgstr ""
+msgstr "Hei"
 
 msgctxt "Abbreviated month name"
 msgid "Aug"
-msgstr ""
+msgstr "Elo"
 
 msgctxt "Abbreviated month name"
 msgid "Sep"
-msgstr ""
+msgstr "Syy"
 
 msgctxt "Abbreviated month name"
 msgid "Oct"
-msgstr ""
+msgstr "Lok"
 
 msgctxt "Abbreviated month name"
 msgid "Nov"
-msgstr ""
+msgstr "Mar"
 
 msgctxt "Abbreviated month name"
 msgid "Dec"
-msgstr ""
+msgstr "Jou"
 
 msgctxt "Abbreviated weekday"
 msgid "Sun"
-msgstr ""
+msgstr "Sun"
 
 msgctxt "Abbreviated weekday"
 msgid "Mon"
-msgstr ""
+msgstr "Maa"
 
 msgctxt "Abbreviated weekday"
 msgid "Tue"
-msgstr ""
+msgstr "Tii"
 
 msgctxt "Abbreviated weekday"
 msgid "Wed"
-msgstr ""
+msgstr "Kes"
 
 msgctxt "Abbreviated weekday"
 msgid "Thu"
-msgstr ""
+msgstr "Tor"
 
 msgctxt "Abbreviated weekday"
 msgid "Fri"
-msgstr ""
+msgstr "Per"
 
 msgctxt "Abbreviated weekday"
 msgid "Sat"
-msgstr ""
+msgstr "Lau"
 
 msgctxt "Abbreviated weekday"
 msgid "Su"
-msgstr ""
+msgstr "Su"
 
 msgctxt "Abbreviated weekday"
 msgid "Mo"
-msgstr ""
+msgstr "Ma"
 
 msgctxt "Abbreviated weekday"
 msgid "Tu"
-msgstr ""
+msgstr "Ti"
 
 msgctxt "Abbreviated weekday"
 msgid "We"
-msgstr ""
+msgstr "Ke"
 
 msgctxt "Abbreviated weekday"
 msgid "Th"
-msgstr ""
+msgstr "To"
 
 msgctxt "Abbreviated weekday"
 msgid "Fr"
-msgstr ""
+msgstr "Pe"
 
 msgctxt "Abbreviated weekday"
 msgid "Sa"
-msgstr ""
+msgstr "La"
 
 msgctxt "Abbreviated 1 letter weekday Sunday"
 msgid "S"
-msgstr ""
+msgstr "S"
 
 msgctxt "Abbreviated 1 letter weekday Monday"
 msgid "M"
-msgstr ""
+msgstr "M"
 
 msgctxt "Abbreviated 1 letter weekday Tuesday"
 msgid "T"
-msgstr ""
+msgstr "T"
 
 msgctxt "Abbreviated 1 letter weekday Wednesday"
 msgid "W"
-msgstr ""
+msgstr "K"
 
 msgctxt "Abbreviated 1 letter weekday Thursday"
 msgid "T"
-msgstr ""
+msgstr "T"
 
 msgctxt "Abbreviated 1 letter weekday Friday"
 msgid "F"
-msgstr ""
+msgstr "P"
 
 msgctxt "Abbreviated 1 letter weekday Saturday"
 msgid "S"
-msgstr ""
+msgstr "L"
 
 msgid "Web page addresses and email addresses turn into links automatically."
-msgstr ""
+msgstr "Verkko- ja sähköpostiosoitteet muutetaan automaattisesti linkeiksi."
 
 msgid "Configuring content languages"
-msgstr ""
+msgstr "Sisältökielten asettaminen"
 
 msgid ""
 "<em>Selected language</em> allows you to specify the site's default language"
 " or a specific language as the fall-back language. This method should be "
 "listed last."
 msgstr ""
+"<em>Valittu kieli</em> antaa määritellä käytettäväksi sivuston oletuskielen "
+"tai jonkin muun valitun kielen, jos muita valintaperusteita ei ole "
+"käytettävissä. Tämä vaihtoehto on syytä asettaa viimeiseksi."
 
 msgid "Comma-separated list of recipient email addresses."
-msgstr ""
+msgstr "Pilkuin eroteltu lista vastaanottajien sähköpostiosoitteita."
 
 msgid "Syndicate block"
-msgstr ""
+msgstr "Syndikaattilohko"
 
 msgid "Use shortcuts"
-msgstr ""
+msgstr "Käytä oikopolkuja"
 
 msgid "Diff settings"
-msgstr ""
+msgstr "Diff asetukset"
 
 msgid "Branding block"
-msgstr ""
+msgstr "Brändilohko"
 
 msgid "Use site logo"
-msgstr ""
+msgstr "Käytä sivuston logoa"
 
 msgid "The current theme is not @theme"
-msgstr ""
+msgstr "Tämänhetkinen teema ei ole @theme"
 
 msgid "The current theme is @theme"
-msgstr ""
+msgstr "Tämänhetkinen teema on @theme"
 
 msgid "Request Path"
-msgstr ""
+msgstr "Kutsupolku"
 
 msgid "Username or email address"
 msgstr "Käyttäjätunnus tai sähköpostiosoite"
 
 msgid "Email addresses to notify when updates are available"
-msgstr ""
+msgstr "Sähköpostit joihin ilmoitetaan kun uusia päivityksiä on saatavilla"
 
 msgid "%email is not a valid email address."
-msgstr ""
+msgstr "%email ei ole oikea sähköpostiosoite."
 
 msgid "%emails are not valid email addresses."
-msgstr ""
+msgstr "%emails eivät ole oikeita sähköpostiosoitteita."
 
 msgid ""
 "A valid email address. All emails from the system will be sent to this "
@@ -18268,9 +19629,14 @@ msgid ""
 "setting disabled, users will be logged in immediately upon registering, and "
 "may select their own passwords during registration."
 msgstr ""
+"Uusilta käyttäjiltä vaaditaan sähköpostin vahvistus ennen kirjautumista "
+"sivustolle ja heille asetetaan järjestelmän generoima salasana. Tämän "
+"asetuksen päältä pois jättämällä käyttäjät ovat kirjautuneena sivustolle "
+"heti rekisteröitymisen yhteydessä ja voivat asettaa salasanansa "
+"rekisteröityessään."
 
 msgid "Notification email address"
-msgstr ""
+msgstr "Sähköpostiosoite järjestelmän ilmoituksiin"
 
 msgid ""
 "The email address to be used as the 'from' address for all account "
@@ -18279,806 +19645,858 @@ msgid ""
 "this address for any new registrations. Leave empty to use the default "
 "system email address <em>(%site-email).</em>"
 msgstr ""
+"Sähköpostiosoite, josta alla olevat käyttäjäilmoitukset lähetetään. Jos "
+"<em>'Vierailijat mutta ylläpitäjän hyväksyntä vaaditaan'</em> yläpuolelta on"
+" valittuna, ilmoitus hyväksyntää vaativista rekisteröitymisistä lähetetään "
+"tänne. Jätä tyhjäksi käyttääksesi järjestelmän oletussähköpostiosoitetta <em"
+">(%site-email).</em>"
 
 msgid "Further instructions have been sent to your email address."
 msgstr "Ohjeet salasanan palauttamiseen on lähetetty sähköpostiisi."
 
 msgid "When the user has the following roles"
-msgstr ""
+msgstr "Kun käyttäjällä on seuraavat roolit"
 
 msgid "The user is not a member of @roles"
-msgstr ""
+msgstr "Käyttäjä ei ole @roles-roolien jäsen"
 
 msgid "The user is a member of @roles"
-msgstr ""
+msgstr "Käyttäjä on @roles-roolien jäsen"
 
 msgid "Use Replica Server"
-msgstr ""
+msgstr "Käytä Replica Serveriä"
 
 msgid "Query parameter"
-msgstr ""
+msgstr "Kyselyn parametri"
 
 msgid "The query parameter to use."
-msgstr ""
+msgstr "Käytettävä kyselyn parametri."
 
 msgid "Fallback value"
-msgstr ""
+msgstr "Fallback arvo"
 
 msgid ""
 "The fallback value to use when the above query parameter is not present."
-msgstr ""
+msgstr "Käytettävä fallback arvo kun kyselyn parametri ei ole saatavilla."
 
 msgid ""
 "Conjunction to use when handling multiple values. E.g. "
 "\"?value[0]=a&value[1]=b\"."
 msgstr ""
+"Tapa jolla useampi arvo yhdistetään. Esimerkiksi \"?value[0]=a&value[1]=b\"."
 
 msgid "Use Secondary Server"
-msgstr ""
+msgstr "Käytä toissijaista palvelinta"
 
 msgid "Type attribute"
-msgstr ""
+msgstr "Tyyppi-attribuutti"
 
 msgid "The type of this row."
-msgstr ""
+msgstr "Tämän rivin tyyppi."
 
 msgid "Text attribute"
-msgstr ""
+msgstr "Teksti-attribuutti"
 
 msgid ""
 "The field that is going to be used as the OPML text attribute for each row."
-msgstr ""
+msgstr "Kenttä jota käytetään OPML teksti-attribuuttina kulleki riville."
 
 msgid "Created attribute"
-msgstr ""
+msgstr "Luotu-attribuutti"
 
 msgid ""
 "The field that is going to be used as the OPML created attribute for each "
 "row."
-msgstr ""
+msgstr "Kenttä jota käytetään OPML luotu-attribuuttina kulleki riville."
 
 msgid "Description attribute"
-msgstr ""
+msgstr "Kuvaus-attribuutti"
 
 msgid ""
 "The field that is going to be used as the OPML description attribute for "
 "each row."
-msgstr ""
+msgstr "Kenttä jota käytetään OPML kuvaus-attribuuttina kulleki riville."
 
 msgid "HTML URL attribute"
-msgstr ""
+msgstr "HTML URL attribuutti"
 
 msgid ""
 "The field that is going to be used as the OPML htmlUrl attribute for each "
 "row."
-msgstr ""
+msgstr "Kenttä jota käytetään OPML htmlUrl-attribuuttina kulleki riville."
 
 msgid "Language attribute"
-msgstr ""
+msgstr "Kieli-attribuutti"
 
 msgid ""
 "The field that is going to be used as the OPML language attribute for each "
 "row."
-msgstr ""
+msgstr "Kenttä jota käytetään OPML kieli-attribuuttina kulleki riville."
 
 msgid "XML URL attribute"
-msgstr ""
+msgstr "XML URL attribuutti"
 
 msgid "URL attribute"
-msgstr ""
+msgstr "URL attribuutti"
 
 msgid ""
 "Row style plugin requires specifying which views field to use for OPML text "
 "attribute."
 msgstr ""
+"Rivityylin plugin vaatii, mitä näkymäkenttää käytetään teksti-attribuuttina."
 
 msgid ""
 "Row style plugin requires specifying which views field to use for XML URL "
 "attribute."
 msgstr ""
+"Rivityylin plugin vaatii, mitä näkymäkenttää käytetään XML URL "
+"attribuuttina."
 
 msgid ""
 "Row style plugin requires specifying which views field to use for URL "
 "attribute."
 msgstr ""
+"Rivityyli-plugin vaatii, mitä näkymäkenttää käytetään URL attribuuttina."
 
 msgid "OPML fields"
-msgstr ""
+msgstr "OPML kentät"
 
 msgid "Display fields as OPML items."
-msgstr ""
+msgstr "Näytä kentät OPML kohteina."
 
 msgid "OPML Feed"
-msgstr ""
+msgstr "OPML syöte"
 
 msgid "Generates an OPML feed from a view."
-msgstr ""
+msgstr "Luo OPML syötteen näkymästä"
 
 msgid "Duplicate of @label"
-msgstr ""
+msgstr "Klooni @label"
 
 msgid "Site header"
-msgstr ""
+msgstr "Sivuston ylätunniste"
 
 msgid ""
 "The default administration theme for Drupal 8 was designed with clean lines,"
 " simple blocks, and sans-serif font to emphasize the tools and tasks at "
 "hand."
 msgstr ""
+"Drupal 8:n ylläpitokäyttöliittymän oletusteema on suunniteltu "
+"selkeälinjaiseksi korostamaan käytettävissä olevia työkaluja ja mahdollisia "
+"toimenpiteitä."
 
 msgid "\"On\" label"
-msgstr ""
+msgstr "\"Päälle\" etiketti"
 
 msgid "\"Off\" label"
-msgstr ""
+msgstr "\"Pois päältä\" etiketti"
 
 msgid "Edit menu link %title"
-msgstr ""
+msgstr "Muokkaa valikkolinkkiä %title"
 
 msgid ""
 "This link is provided by the @name module. The title and path cannot be "
 "edited."
 msgstr ""
+"Tämän linkin tuottaa @name moduuli. Otsikkoa ja polkua ei voi muokata."
 
 msgid "Add comment type"
-msgstr ""
+msgstr "Lisää kommenttityyppi"
 
 msgid "Format type machine name"
-msgstr ""
+msgstr "Muotoile koneluettava nimi"
 
 msgid "Boolean settings"
-msgstr ""
+msgstr "Boolean asetukset"
 
 msgid "On label"
-msgstr ""
+msgstr "Päälle-etiketti"
 
 msgid "Off label"
-msgstr ""
+msgstr "Pois päältä-etiketti"
 
 msgid "The comment type"
-msgstr ""
+msgstr "Kommentin tyyppi"
 
 msgid "Comments without subject field"
-msgstr ""
+msgstr "Kommentit ilman otsikkokenttää"
 
 msgid "Allows commenting on content, comments without subject field"
-msgstr ""
+msgstr "Sallii sisällön kommentoinnin ilman otsikkokenttää"
 
 msgid "The comment type label"
-msgstr ""
+msgstr "Kommenttityypin etiketti"
 
 msgid "The comment type description"
-msgstr ""
+msgstr "Kommenttityypin kuvaus"
 
 msgid "The language of the content or translation."
-msgstr ""
+msgstr "Sisällön tai käännöksen kieli."
 
 msgid "The language the original content is in."
-msgstr ""
+msgstr "Sisällön alkuperäinen kieli."
 
 msgid "Allowed value with label"
-msgstr ""
+msgstr "Sallittu arvo etiketillä"
 
 msgid "Data type callback"
-msgstr ""
+msgstr "Tietotyypin paluukutsu"
 
 msgid "Callable"
-msgstr ""
+msgstr "Kutsuttavissa"
 
 msgid "Interaction type"
-msgstr ""
+msgstr "Keskustelun tyyppi"
 
 msgid "Enabling REST support for an entity type"
-msgstr ""
+msgstr "REST palvelun käyttöönotto kokonaisuustyypille"
 
 msgid "Configuring search pages"
-msgstr ""
+msgstr "Hakusivujen konfigurointi"
 
 msgid "Managing the search index"
-msgstr ""
+msgstr "Hakuindeksin ylläpito"
 
 msgid "Displaying the Search block"
-msgstr ""
+msgstr "Hakulohkon näyttäminen"
 
 msgid "Searching your site"
-msgstr ""
+msgstr "Sisällön haku sivustolta"
 
 msgid "Extending the Search module"
-msgstr ""
+msgstr "Hakumoduulin laajentaminen"
 
 msgid "Search index progress"
-msgstr ""
+msgstr "Haun indeksoinnin prosessi"
 
 msgid "@percent% (@remaining remaining)"
-msgstr ""
+msgstr "@percent% (@remaining jäljellä)"
 
 msgid "Indexing progress"
-msgstr ""
+msgstr "Indeksointiprosessi"
 
 msgid "Updating default configuration (@percent%)."
-msgstr ""
+msgstr "Päivitetään oletusasetuksia (@percent %)."
 
 msgid "Allows commenting on content"
-msgstr ""
+msgstr "Allows commenting on content"
 
 msgid "Manage form and displays settings of comments."
-msgstr ""
+msgstr "Hallinnoi lomaketta ja näyttää kommenttien asetukset."
 
 msgid "%num_indexed of %num_total indexed"
-msgstr ""
+msgstr "%num_indexed / %num_total indeksoitu"
 
 msgid "Does not use index"
-msgstr ""
+msgstr "Ei käytä indeksiä"
 
 msgid "Overall results:"
-msgstr ""
+msgstr "Tulosten kokonaiskuva:"
 
 msgid "Converts an image to grayscale."
-msgstr ""
+msgstr "Muuttaa kuvan harmaasävyiseksi."
 
 msgid "Activity Tracker"
-msgstr ""
+msgstr "Aktivisuuden seuranta"
 
 msgid "Add \"…\" at the end of trimmed text"
-msgstr ""
+msgstr "Lisää \"...\" trimmatun tekstin perään"
 
 msgid "First page"
-msgstr ""
+msgstr "Ensimmäinen sivu"
 
 msgid "Base field bundle override"
-msgstr ""
+msgstr "Paketin kenttäpohjien ohitus"
 
 msgid "Datetime timestamp display format settings"
-msgstr ""
+msgstr "Päivämäärän aikaleiman esitystavan asetukset"
 
 msgid "Boolean checkbox display format settings"
-msgstr ""
+msgstr "Boolean valintaruutu esitysmuodon valitsemiseksi"
 
 msgid "Installed themes"
-msgstr ""
+msgstr "Asennetut teemat"
 
 msgid "The %file does not exist."
-msgstr ""
+msgstr "Tiedostoa %file ei ole olemassa."
 
 msgid "The %file exists."
-msgstr ""
+msgstr "Tiedosto %file on olemassa."
 
 msgid "The %file is not readable."
-msgstr ""
+msgstr "Tiedosto %file ei ole luettavissa."
 
 msgid "The %file is not writable."
-msgstr ""
+msgstr "Tiedosto %file ei ole kirjoitettavissa."
 
 msgid "The @file is writable."
-msgstr ""
+msgstr "Tiedosto @file on kirjoitettavissa."
 
 msgid "The @file is owned by the web server."
-msgstr ""
+msgstr "Tiedosto @file on palvelimen omistuksessa."
 
 msgid "Negate the condition"
-msgstr ""
+msgstr "Käänteistä ehto"
 
 msgid "Datetime Timestamp"
-msgstr ""
+msgstr "Datetime aikaleima"
 
 msgid "%theme theme installed."
-msgstr ""
+msgstr "%theme teema asennettu."
 
 msgid "Display prefix and suffix"
-msgstr ""
+msgstr "Näytä etu- ja loppuliite"
 
 msgid "Text (plain)"
-msgstr ""
+msgstr "Teksti (pelkkä)"
 
 msgid "A field containing a plain string value."
-msgstr ""
+msgstr "Kenttä sisältäen puhtaan merkkijonoarvon."
 
 msgid "Text (plain, long)"
-msgstr ""
+msgstr "Teksti (pelkkä, pitkä)"
 
 msgid "A field containing a long string value."
-msgstr ""
+msgstr "Kenttä sisältäen pitkän merkkijonoarvon."
 
 msgid "You cannot use an external URL, please enter a relative path."
 msgstr ""
+"Et voi käyttää ulkoista URL-osoitetta, ole hyvä ja syötä relatiivinen polku."
 
 msgid ""
 "This path does not exist or you do not have permission to link to %path."
 msgstr ""
+"Tätä polkua ei ole olemassa tai sinulla ei ole oikeutta linkittää polkuun "
+"%path."
 
 msgid "Install newly added themes"
-msgstr ""
+msgstr "Asenna äskettäin lisätyt teemat"
 
 msgid ""
 "Blocks are placed and configured specifically for each theme. The Block "
 "layout page opens with the default theme, but you can toggle to other "
 "installed themes."
 msgstr ""
+"Lohkojen sijoittelu ja asetukset määritellään kullekin teemalle erikseen. "
+"Lohkojen sijoittelu -sivu aukeaa oletusteeman asetuksiin mutta muihin "
+"asennettuihin teemoihin on mahdollista vaihtaa."
 
 msgid "Enable the personal contact form by default for new users"
 msgstr ""
+"Kytke päälle käyttäjäkohtainen yhteydenottolomake uusille käyttäjille."
 
 msgid "Add contact form"
-msgstr ""
+msgstr "Lisää yhteydenottolomake"
 
 msgid "Default form identifier"
-msgstr ""
+msgstr "Lomakkeen oletustunniste"
 
 msgid ""
 "When listing forms, those with lighter (smaller) weights get listed before "
 "forms with heavier (larger) weights. Forms with equal weights are sorted "
 "alphabetically."
 msgstr ""
+"Kun lomakkeita listataan, ne joilla on kevyempi (pienempi) paino näytetään "
+"ennen lomakkeita joilla on painavampi (isompi) paino. Lomakkeet joilla on "
+"sama paino järjestetään aakkosjärjestyksessä."
 
 msgid "Make this the default form"
-msgstr ""
+msgstr "Valitse tämä oletuslomakkeeksi"
 
 msgid "Send yourself a copy"
 msgstr "Lähetä kopio itsellesi"
 
 msgid "Content translation field settings"
-msgstr ""
+msgstr "Sisällön käännöksen kenttien asetukset"
 
 msgid "Allowed types: @extensions."
 msgstr "Sallitut tiedostomuodot: @extensions."
 
 msgid "Back to content editing"
-msgstr ""
+msgstr "Takaisin sisällön muokkaukseen"
 
 msgid "Align images"
-msgstr ""
+msgstr "Tasaa kuvat"
 
 msgid ""
 "Uses a <code>data-align</code> attribute on <code>&lt;img&gt;</code> tags to"
 " align images."
 msgstr ""
+"Kuvien tasaamiseen käytetään <code>data-align</code>-attribuuttia "
+"<code>&lt;img&gt;</code>-tageissa."
 
 msgid "Caption images"
-msgstr ""
+msgstr "Lisää kuviin kuvateksti"
 
 msgid ""
 "Uses a <code>data-caption</code> attribute on <code>&lt;img&gt;</code> tags "
 "to caption images."
 msgstr ""
+"Kuvatekstit lisätään <code>data-caption</code>-attribuutilla "
+"<code>&lt;img&gt;</code>-tageihin."
 
 msgid "Display author and date information"
-msgstr ""
+msgstr "Näytä kirjoittaja- ja aikatiedot"
 
 msgid "Breakpoint ID"
-msgstr ""
+msgstr "Leikkauskohdan ID"
 
 msgid "Unable to delete the shortcut for %title."
-msgstr ""
+msgstr "Oikopolun poistaminen osoitteelle %title epäonnistui."
 
 msgid "Maximum number of levels"
-msgstr ""
+msgstr "Tasojen enimmäismäärä"
 
 msgid "All errors have been logged."
-msgstr ""
+msgstr "Kaikki virheet logitettu."
 
 msgid ""
 "You may need to check the <code>watchdog</code> database table manually."
 msgstr ""
+"Sinun voi olla tarpeen tarkistaa <code>watchdog</code> tietokantataulu "
+"manuaalisesti."
 
 msgid "Failed:"
-msgstr ""
+msgstr "Epäonnistui:"
 
 msgid "Update #@count"
-msgstr ""
+msgstr "Päivitä #@count"
 
 msgid "The following updates returned messages:"
-msgstr ""
+msgstr "Seuraavat päivitykset palauttivat viestit:"
 
 msgid "Review updates"
-msgstr ""
+msgstr "Tarkista päivitykset"
 
 msgid "Starting updates"
-msgstr ""
+msgstr "Aloitetaan päivityksiä"
 
 msgid "Installed theme"
 msgid_plural "Installed themes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Asennettu teema"
+msgstr[1] "Asennetut teemat"
 
 msgid "Uninstalled theme"
 msgid_plural "Uninstalled themes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Poistettu teema"
+msgstr[1] "Poistetut teemat"
 
 msgid "%theme is the default theme and cannot be uninstalled."
-msgstr ""
+msgstr "%theme on oletusteema eikä sitä voi poistaa käytöstä."
 
 msgid "The %theme theme has been uninstalled."
-msgstr ""
+msgstr "Teema %theme on poistettu käytöstä."
 
 msgid "The %theme theme has been installed."
-msgstr ""
+msgstr "Teema %theme on otettu käyttöön."
 
 msgid "Empty time zone"
-msgstr ""
+msgstr "Tyhjä aikavyöhyke"
 
 msgid "Users may set their own time zone at registration"
-msgstr ""
+msgstr "Käyttäjät voivat asettaa aikavyöhykkeen rekisteröitymisen yhteydessä"
 
 msgid "Menu levels"
-msgstr ""
+msgstr "Valikon tasot"
 
 msgid "Whether or not the content related to a term is sticky."
-msgstr ""
+msgstr "Onko vaiko eikö ole sisältöön liittyvä termi kiinteää."
 
 msgid "The date the content related to a term was posted."
-msgstr ""
+msgstr "Päivämäärä jolloin liittyvä sisältö lähetettiin."
 
 msgid "Text (formatted) settings"
-msgstr ""
+msgstr "Teksti (muokattu) asetukset"
 
 msgid "Text (formatted, long) settings"
-msgstr ""
+msgstr "Teksti (muokattu, pitkä) asetukset"
 
 msgid "Text (formatted, long, with summary) settings"
-msgstr ""
+msgstr "Teksti (muotoiltu, pitkä, tiivistelmällä) asetukset"
 
 msgid "Text (formatted)"
-msgstr ""
+msgstr "Teksti (muotoiltu)"
 
 msgid "This field stores a text with a text format."
-msgstr ""
+msgstr "Kenttä tallentaa tekstin muotoiltuna."
 
 msgid "This field stores a long text with a text format."
-msgstr ""
+msgstr "Kenttä tallentaa pitkän muotoillun tekstin."
 
 msgid "This field stores long text with a format and an optional summary."
-msgstr ""
+msgstr "Kenttä tallentaa tekstin ja muodon sekä vaihtoehtoisen tiivistelmän."
 
 msgid "Require email verification when a visitor creates an account"
 msgstr ""
+"Vaadi sähköpostivahvistusta kävijöiltä, jotka luovat uuden käyttäjätilin."
 
 msgid "@entity_type revision"
-msgstr ""
+msgstr "@entity_type versio"
 
 msgid "@entity_type revisions"
-msgstr ""
+msgstr "@entity_type versiot"
 
 msgid "Include reset button (resets all applied exposed filters)"
 msgstr ""
+"Näytä Reset-nappi (palauttaa oletusasetuksille kaikki näkyvät suodattimet)"
 
 msgid "REST export settings"
-msgstr ""
+msgstr "REST vientiasetukset"
 
 msgid "Provide a REST export"
-msgstr ""
+msgstr "Tarjoa REST vienti"
 
 msgid "REST export path"
-msgstr ""
+msgstr "REST vientipolku"
 
 msgid "Default value callback"
-msgstr ""
+msgstr "Oletusarvon paluukutsu"
 
 msgid "URI as link display format settings"
-msgstr ""
+msgstr "Verkko-osoite linkkinä esitystavan asetukset"
 
 msgid "Timestamp ago display format settings"
-msgstr ""
+msgstr "Aikamäärä (aikaa sitten) näyttömuoto"
 
 msgid "Link to URI"
-msgstr ""
+msgstr "Linkki verkko-osoitteeseen"
 
 msgid "The description of this feed"
-msgstr ""
+msgstr "Tämän syötteen kuvaus"
 
 msgid ""
 "The length of time between feed updates. Requires a correctly configured "
 "cron maintenance task."
-msgstr ""
+msgstr "Syötteiden päivitysväli. Cron-ajon asetusten on oltava kunnossa."
 
 msgid "Edit storage settings."
-msgstr ""
+msgstr "Muokkaa tallennusasetuksia."
 
 msgid ""
 "The minimum allowed image size expressed as WIDTH×HEIGHT (e.g. 640×480). "
 "Leave blank for no restriction. If a smaller image is uploaded, it will be "
 "rejected."
 msgstr ""
+"Kuvan minimikoko muodossa LEVEYSxKORKEUS (esim. 640x480). Jätä kenttä "
+"tyhjäksi, jos et halua rajoitusta. Pienempien kuvien lataukset hylätään."
 
 msgid "Improving table accessibility"
-msgstr ""
+msgstr "Taulujen saatavuuden parantaminen"
 
 msgid "OPML field options"
-msgstr ""
+msgstr "OPML kenttäasetukset"
 
 msgid "Testing multilingual"
-msgstr ""
+msgstr "Testataan monikielisyyttä"
 
 msgid "Minimal profile for running tests with a multilingual installer."
 msgstr ""
+"Minimaalinen profiili ajettaakseen testejä monikielisellä asennusohjelmalla."
 
 msgid ""
 "This block is broken or missing. You may be missing content or you might "
 "need to enable the original module."
 msgstr ""
+"Tämä lohko on rikkinäinen tai kadonnut. Sisältöä tai tarvittava moduli "
+"saattaa puuttua."
 
 msgid "Broken/Missing"
-msgstr ""
+msgstr "Rikkinäinen/Puuttuva"
 
 msgctxt "Validation"
 msgid "Email"
 msgstr ""
+"Sähköposti\r\n"
+"kontekstissa: Validointi"
 
 msgid "Comments are responses to content."
-msgstr ""
+msgstr "Kommentit ovat vastauksia sisältöön."
 
 msgid "Filename: %name"
-msgstr ""
+msgstr "Tiedoston nimi: %name"
 
 msgid "Recipient username"
-msgstr ""
+msgstr "Vastaanottajan käyttäjätunnus"
 
 msgid "Content language of view row"
-msgstr ""
+msgstr "Näkymärivin alkuperäinen kieli"
 
 msgid "Install and set as default"
-msgstr ""
+msgstr "Asenna ja määritä oletukseksi"
 
 msgid "Create and manage contact forms."
-msgstr ""
+msgstr "Luo ja hallinnoi yhteydenottolomakkeita."
 
 msgid "Site administration toolbar"
-msgstr ""
+msgstr "Sivuston ylläpitopalkki"
 
 msgid "Base field override"
-msgstr ""
+msgstr "Peruskentän ylikirjoitus"
 
 msgid "Text (formatted, long, with summary)"
-msgstr ""
+msgstr "Teksti (muotoiltu, tiivistelmällä)"
 
 msgid "Text (formatted, long)"
-msgstr ""
+msgstr "Teksti (muotoiltu, pitkä)"
 
 msgid ""
 "You can align images (<code>data-align=\"center\"</code>), but also videos, "
 "blockquotes, and so on."
 msgstr ""
+"Voit tasata kuvat (<code>data-align=\"center\"</code>), sekä lisäksi myös "
+"videot, <code>blockquote</code>-tagit yms."
 
 msgid "Making this field required is recommended."
-msgstr ""
+msgstr "Tämän kentän pakolliseksi asettaminen on suositeltavaa."
 
 msgid "Leave preview?"
-msgstr ""
+msgstr "Poistu esikatselusta?"
 
 msgid "Leave preview"
-msgstr ""
+msgstr "Poistu esikatselusta"
 
 msgid ""
 "Leaving the preview will cause unsaved changes to be lost. Are you sure you "
 "want to leave the preview?"
 msgstr ""
+"Esikatselusta poistuminen aiheuttaa että kaikki tallentamattomat muutokset "
+"menetetään. Oletko varma että haluat poistua esikatselusta?"
 
 msgid ""
 "The human-readable name of this content type. This text will be displayed as"
 " part of the list on the <em>Add content</em> page. This name must be "
 "unique."
 msgstr ""
+"Sisältötyypin selkokielinen nimi. Tätä käytetään sisältötyyppien "
+"listauksessa <em>Lisää sisältöä</em> -sivulla. Nimen on oltava uniikki."
 
 msgid "Search for @keywords"
-msgstr ""
+msgstr "Hae avainsanoja @keywords"
 
 msgid "Set a new image"
-msgstr ""
+msgstr "Aseta uusi kuva"
 
 msgid "The text with the text format applied."
-msgstr ""
+msgstr "Muotoiltu teksti."
 
 msgid "Processed summary"
-msgstr ""
+msgstr "Käsitelty tiivistelmä"
 
 msgid "The summary text with the text format applied."
-msgstr ""
+msgstr "Tiivistelmäteksti muotoiltuna."
 
 msgid "Trays"
-msgstr ""
+msgstr "Korit"
 
 msgid "Original language of the user information"
-msgstr ""
+msgstr "Käyttäjän tietojen alkuperäinen kieli"
 
 msgid "Preferred language of the user"
-msgstr ""
+msgstr "Käyttäjän ensisijainen kieli"
 
 msgid "Preferred admin language"
-msgstr ""
+msgstr "Pääkäyttäjän ensisijainen kieli"
 
 msgid "Preferred administrative language of the user"
-msgstr ""
+msgstr "Käyttäjän ensisijainen hallinnollinen kieli"
 
 msgid "Cache metadata"
-msgstr ""
+msgstr "Välimuistin metatieto"
 
 msgid "Cache contexts"
-msgstr ""
+msgstr "Välimuistin kontekstit"
 
 msgid "Path is empty."
-msgstr ""
+msgstr "Polku on tyhjä."
 
 msgid "No query allowed."
-msgstr ""
+msgstr "Kyselyitä ei ole sallittu."
 
 msgid ""
 "Invalid path. Valid characters are alphanumerics as well as \"-\", \".\", "
 "\"_\" and \"~\"."
 msgstr ""
+"Epäkelpo polku. Sallitut merkit ovat aakkosnumeeriset merkit sekä \"-\", "
+"\".\", \"_\" ja \"~\"."
 
 msgid "Classy"
-msgstr ""
+msgstr "Classy"
 
 msgid "Select a @context value:"
-msgstr ""
+msgstr "Valitse @context arvo:"
 
 msgid "Configuration entity dependencies"
-msgstr ""
+msgstr "Konfiguraatiokokonaisuuksien riippuvuudet"
 
 msgid "Content entity dependencies"
-msgstr ""
+msgstr "Sisältäentiteettien riippuvuudet"
 
 msgid "Enforced configuration dependencies"
-msgstr ""
+msgstr "Pakotetut konfiguraation riippuvuudet"
 
 msgid "String (long) settings"
-msgstr ""
+msgstr "Merkkijonon (pitkä) asetukset"
 
 msgid "URI settings"
-msgstr ""
+msgstr "URI asetukset"
 
 msgid "Created timestamp settings"
-msgstr ""
+msgstr "Luotiin päiovämäärän aikaleiman asetukset"
 
 msgid "Changed timestamp settings"
-msgstr ""
+msgstr "Päivitettiin päivämäärän aikaleiman asetukset"
 
 msgid "Page @items.current"
-msgstr ""
+msgstr "Sivu @items.current"
 
 msgid "The selected style or row format does not use fields."
-msgstr ""
+msgstr "Valittu tyyli tai rivin muoto ei käytä kenttiä."
 
 msgid "The selected display type does not use @type plugins"
-msgstr ""
+msgstr "Valittu näyttötyyppi ei käytä @type pluginneja"
 
 msgid "The entity type"
-msgstr ""
+msgstr "Kokonaisuuden tyyppi"
 
 msgid "Database storage size"
-msgstr ""
+msgstr "Tietokannan tallennustilan koko"
 
 msgid "Text with text format"
-msgstr ""
+msgstr "Teksti ja tekstin muotoilu"
 
 msgid "Field widgets"
-msgstr ""
+msgstr "Kentän kohteet"
 
 msgid "Field widget"
-msgstr ""
+msgstr "Kentän kohde"
 
 msgid "Widget type machine name"
-msgstr ""
+msgstr "Asetustyökalun koneluettava nimi"
 
 msgid "Textarea display format settings"
-msgstr ""
+msgstr "Tekstialueen esitystavan asetukset"
 
 msgid "Email field display format settings"
-msgstr ""
+msgstr "Sähköpostikentän esitystavan asetukset"
 
 msgid "Link to the entity"
-msgstr ""
+msgstr "Linkki entiteettiin"
 
 msgid "Synchronizing extensions: @op @name."
-msgstr ""
+msgstr "Synkronoi laajennukset: @op @name."
 
 msgid "Link to the @entity_label"
-msgstr ""
+msgstr "Linkki kokonaisuuteen @entity_label"
 
 msgid "Linked to the @entity_label"
-msgstr ""
+msgstr "Linkitetty kokonaisuuteen @entity_label"
 
 msgid "Simple page"
-msgstr ""
+msgstr "Yksinkertainen sivu"
 
 msgid "Jump to the first comment."
-msgstr ""
+msgstr "Siirry ensimmäiseen kommenttiin."
 
 msgid "Jump to the first new comment."
-msgstr ""
+msgstr "Siirry ensimmäiseen uuteen kommenttiin."
 
 msgid "Share your thoughts and opinions."
-msgstr ""
+msgstr "Jaa mielipiteesi ja ajatuksesi."
 
 msgid "Content translation content settings"
-msgstr ""
+msgstr "Sisällön käännöksen sisältöasetukset"
 
 msgid "Content translation enabled"
-msgstr ""
+msgstr "Sisällön käännös on käytössä"
 
 msgid "Group by column"
-msgstr ""
+msgstr "Järjestä palstan mukaan"
 
 msgid "Group by columns"
-msgstr ""
+msgstr "Järjestä palstojen mukaan"
 
 msgid "Re-use an existing field"
-msgstr ""
+msgstr "Uudelleenkäytä olemassa olevaa kenttää"
 
 msgid "You need to select a field type or an existing field."
-msgstr ""
+msgstr "Sinun tulee valita kentän tyyppi tai olemassa oleva kenttä."
 
 msgid "Log in to post new content in the forum."
-msgstr ""
+msgstr "Kirjaudu sisään lisätäksesi uutta sisältöä foorumille."
 
 msgid "Influence of '@title'"
-msgstr ""
+msgstr "'@title' vaikutus"
 
 msgid "Installing supporting modules"
-msgstr ""
+msgstr "Tukimoduulien asennus"
 
 msgid "The default search index will be rebuilt."
-msgstr ""
+msgstr "Oletus hakusivu uudelleenrakennetaan."
 
 msgid "All search indexes will be rebuilt."
-msgstr ""
+msgstr "Kaikki hakuindeksit uudelleenrakennetaan."
 
 msgid "Add shortcut link"
-msgstr ""
+msgstr "Lisää oikopolkulinkki"
 
 msgid "Popular content block settings"
-msgstr ""
+msgstr "Suositun sisällön lohkon asetukset"
 
 msgid "Publish status"
-msgstr ""
+msgstr "Julkaisutila"
 
 msgid "The corresponding entity field"
-msgstr ""
+msgstr "Vastaava kokonaisuuden kenttä"
 
 msgid "The plugin ID"
-msgstr ""
+msgstr "Plugin ID"
 
 msgid "Row options"
-msgstr ""
+msgstr "Rivin vaihtoehdot"
 
 msgid "Display extender settings"
-msgstr ""
+msgstr "Näytä laajentajan asetukset"
 
 msgid "View block"
-msgstr ""
+msgstr "Näytä lohko"
 
 msgid "Number integer display format settings"
-msgstr ""
+msgstr "Numeerisen kokonaisluvun esitystavan asetukset"
 
 msgid "Static menu link overrides"
-msgstr ""
+msgstr "Staattisten valikkolinkkien ylikirjoitukset"
 
 msgctxt "Plural"
 msgid "Disabled"
-msgstr ""
+msgstr "Ei käytössä"
 
 msgid ""
 "Alternative text is required.<br />(Only in rare cases should this be left "
 "empty. To create empty alternative text, enter <code>\"\"</code> — two "
 "double quotes without any content)."
 msgstr ""
+"Vaihtoehtoinen teksti on pakollinen.<br />(Tyhjäksi jättäminen on "
+"perusteltua vain harvoissa tapauksissa. Syöttääksesi tyhjän vaihtoehtoisen "
+"tekstin kirjoita <code>\"\"</code> — kaksi lainausmerkkiä ilman sisältöä.)"
 
 msgid ""
 "Images must be larger than <strong>@min</strong> pixels. Images larger than "
 "<strong>@max</strong> pixels will be resized."
 msgstr ""
+"Kuvien on oltava mitoiltaan suurempia kuin <strong>@min</strong> pikseliä. "
+"Jos kuva on suurempi kuin <strong>@max</strong> pikseliä, sitä pienennetään."
 
 msgid "Images must be larger than <strong>@min</strong> pixels."
-msgstr ""
+msgstr "Kuvien on oltava mitoiltaan vähintään <strong>@min</strong> pikseliä."
 
 msgid "Node authored by (uid)"
-msgstr ""
+msgstr "Solmun kirjoittaja (uid)"
 
 msgid "Revision authored by (uid)"
-msgstr ""
+msgstr "Solmun version kirjoittaja (uid)"
 
 msgid "The location this shortcut points to."
-msgstr ""
+msgstr "Sijainti johon oikopolku osoittaa."
 
 msgid ""
 "Unable to install @extension, %config_names already exists in active "
@@ -19087,303 +20505,320 @@ msgid_plural ""
 "Unable to install @extension, %config_names already exist in active "
 "configuration."
 msgstr[0] ""
+"Laajennuksen @extension asennus ei onnistunut, %config_names on jo olemassa "
+"aktiivisessa konfiguraatiossa."
 msgstr[1] ""
+"Laajennuksen @extension asennus ei onnistunut, %config_names on jo olemassa "
+"aktiivisessa konfiguraatiossa."
 
 msgid "narrow"
-msgstr ""
+msgstr "kapea"
 
 msgctxt "Plural"
 msgid "Enabled"
 msgstr ""
+"Käytössä\r\n"
+"kontekstissa: monikko"
 
 msgid "Active menu trail"
-msgstr ""
+msgstr "Aktiivisen valikon polku"
 
 msgid "Configuration updates"
-msgstr ""
+msgstr "Asetusten päivitykset"
 
 msgid "The listed configuration will be updated."
-msgstr ""
+msgstr "Alla luetellut asetukset päivitetään."
 
 msgid "An entity field containing a password value."
-msgstr ""
+msgstr "Kokonaisuuskenttä sisältäen salasana-arvon."
 
 msgid "Selected default language no longer exists."
-msgstr ""
+msgstr "Valittua oletuskieltä ei enää ole."
 
 msgid "The username of the content author."
-msgstr ""
+msgstr "Sisällön luojan käyttäjänimi."
 
 msgid "Defining responsive image styles"
-msgstr ""
+msgstr "Responsiivisten kuvatyylien määrittäminen"
 
 msgid "Using responsive image styles in Image fields"
-msgstr ""
+msgstr "Responsiivisten kuvien käyttö kuvakentissä"
 
 msgid "Responsive image styles"
-msgstr ""
+msgstr "Responsiivisten kuvien tyylit"
 
 msgid "Edit responsive image style"
-msgstr ""
+msgstr "Muokkaa responsiivisen kuvan tyyliä"
 
 msgid "Duplicate responsive image style"
-msgstr ""
+msgstr "Kopioi responsiivisen kuvan tyyli"
 
 msgid "Add responsive image style"
-msgstr ""
+msgstr "Lisää responsiivisen kuvan tyyli"
 
 msgid "Responsive image style"
-msgstr ""
+msgstr "Responsiivisen kuvan tyyli"
 
 msgid "Image style mappings"
-msgstr ""
+msgstr "Kuvatyylien mappaukset"
 
 msgid "Image style mapping"
-msgstr ""
+msgstr "Kuvatyylin mappaus"
 
 msgid "Responsive image mapping type"
-msgstr ""
+msgstr "Responsiivisten kuvien mappaus-tyyppi"
 
 msgid "Sizes attribute"
-msgstr ""
+msgstr "Kokoattribuutti"
 
 msgid "<em>Duplicate responsive image style</em> @label"
-msgstr ""
+msgstr "<em>Kopioi responsiivisen kuvan tyyli</em> @label"
 
 msgid "<em>Edit responsive image style</em> @label"
-msgstr ""
+msgstr "<em>Muokkaa responsiivisen kuvan tyyliä</em> @label"
 
 msgid "Responsive image style @label saved."
-msgstr ""
+msgstr "Responsiivisen kuvan tyyli @label tallennettu."
 
 msgid "Responsive image style: @responsive_image_style"
-msgstr ""
+msgstr "Responsiivisen kuvan tyyli: @responsive_image_style"
 
 msgid "Select a responsive image style."
-msgstr ""
+msgstr "Valitse responsiivisen kuvan tyyli."
 
 msgid "The target entity"
-msgstr ""
+msgstr "Kohdekokonaisuus"
 
 msgid ""
 "Change site name, email address, slogan, default front page, and error "
 "pages."
 msgstr ""
+"Vaihda sivuston nimeä, sähköpostiosoitetta, tunnuslausetta, etusivua ja "
+"virhesivuja."
 
 msgid "Content Language Settings"
-msgstr ""
+msgstr "Sisällön kielten asetukset"
 
 msgid "Original language of content in view row"
-msgstr ""
+msgstr "Näyttörivin sisällön alkuperäinen kieli"
 
 msgid "@entity_type_label ID"
-msgstr ""
+msgstr "@entity_type_label ID"
 
 msgid "Rendering Language"
-msgstr ""
+msgstr "Renderöintikieli"
 
 msgid ""
 "All content that supports translations will be displayed in the selected "
 "language."
-msgstr ""
+msgstr "Kaikki käännöksiä tukeva sisältö näytetään valitulla kielellä."
 
 msgid "The contextual filter values are provided by the URL."
-msgstr ""
+msgstr "Sisältöriippuvaiset suodattimet tarjotaan osana verkko-osoitetta."
 
 msgid "Entity reference field storage settings"
-msgstr ""
+msgstr "Entiteettiviittauskentän tallennusasetukset"
 
 msgid "Entity reference field settings"
-msgstr ""
+msgstr "Entiteettiviittauskentän asetukset"
 
 msgid "Entity reference selection plugin settings"
-msgstr ""
+msgstr "Entiteettiviittauksen valintaliitännäisen asetukset"
 
 msgid "Display in native language"
-msgstr ""
+msgstr "Näytä natiivikielisenä"
 
 msgid "HTTP cookies"
-msgstr ""
+msgstr "HTTP-evästeet"
 
 msgid "HTTP headers"
-msgstr ""
+msgstr "HTTP-otsakkeet"
 
 msgid "Is super user"
-msgstr ""
+msgstr "On superkäyttäjä"
 
 msgid "Displayed in native language"
-msgstr ""
+msgstr "Näytetty natiivikielisenä"
 
 msgid "Submitted by @username on @datetime"
-msgstr ""
+msgstr "Lähettänyt @username @datetime"
 
 msgid "Submitted by @author_name on @date"
-msgstr ""
+msgstr "Lähettänyt @author_name @date"
 
 msgid "User is admin"
-msgstr ""
+msgstr "Käyttäjä on ylläpitäjä"
 
 msgid "Account's permissions"
-msgstr ""
+msgstr "Käyttäjätilin oikeudet"
 
 msgid "Existing password"
-msgstr ""
+msgstr "Nykyinen salasana"
 
 msgid "Display the author name."
-msgstr ""
+msgstr "Näytä kirjoittajan nimi."
 
 msgid "Using the personal contact form"
-msgstr ""
+msgstr "Käytä henkilökohtaista yhteydenottolomaketta"
 
 msgid "Adding content to contact forms"
-msgstr ""
+msgstr "Sisällön lisääminen yhteydenottolomakkeisiin"
 
 msgid "Display an icon"
-msgstr ""
+msgstr "Näytä ikoni"
 
 msgid "Speeding up your site"
-msgstr ""
+msgstr "Sivuston nopeuttaminen"
 
 msgid "Site default language code"
-msgstr ""
+msgstr "Sivuston oletuskielikoodi"
 
 msgid "Page caching"
-msgstr ""
+msgstr "Sivun välimuistitus"
 
 msgid "Contains US ASCII characters only"
-msgstr ""
+msgstr "Sisältää ainoastaan US ASCII -merkkejä"
 
 msgid "Delete @language translation"
-msgstr ""
+msgstr "Poista kielen @language käännökset"
 
 msgid "The core.extension configuration does not exist."
-msgstr ""
+msgstr "Määritystä core.extension ei ole."
 
 msgid "Unable to install the %module module since it does not exist."
-msgstr ""
+msgstr "Moduulia %module ei voitu asentaa, koska sitä ei ole."
 
 msgid "Unable to install the %theme theme since it does not exist."
-msgstr ""
+msgstr "Teeman %theme asennus ei onnistu, koska sitä ei ole."
 
 msgid "Interface text"
-msgstr ""
+msgstr "Käyttöliittymän teksti"
 
 msgid ""
 "Order of language detection methods for interface text. If a translation of "
 "interface text is available in the detected language, it will be displayed."
 msgstr ""
+"Käyttöliittymän kielen tunnistamismenetelmien järjestys. Jos "
+"käyttöliittymätekstistä löytyy käännös tunnistetulla kielellä, sitä "
+"käytetään."
 
 msgid "Interface text language selected for page"
-msgstr ""
+msgstr "Sivulla käytössä oleva käyttöliittymän kieli."
 
 msgid ""
 "Customize %language_name language detection to differ from Interface text "
 "language detection settings"
-msgstr ""
+msgstr "Käytä eri asetuksia kielen %language_name tunnistamisessa."
 
 msgid "Entity link"
-msgstr ""
+msgstr "Linkki entiteettiin"
 
 msgid "Select pager"
-msgstr ""
+msgstr "Valitse sivutuksen tyyppi"
 
 msgid "Timestamp display format settings"
-msgstr ""
+msgstr "Aikaleiman esitysmuodon asetukset"
 
 msgid "Future format"
-msgstr ""
+msgstr "Tuleva muoto"
 
 msgid "Past format"
-msgstr ""
+msgstr "Mennyt muoto"
 
 msgid "@requirements_message (Currently using @item version @version)"
-msgstr ""
+msgstr "@requirements_message (Tällä hetkellä käytössä @item versio @version)"
 
 msgid "The MyISAM storage engine is not supported."
-msgstr ""
+msgstr "MyISAM-tallennusmoottoria ei tueta."
 
 msgid ""
 "Unable to uninstall the %profile profile since it is the install profile."
 msgstr ""
+"Profiilin %profile asennusta ei voitu poistaa, koska se on "
+"asennusprofiilina."
 
 msgid "The @module module is required"
-msgstr ""
+msgstr "Moduuli @module vaaditaan"
 
 msgid "- Default site/user time zone -"
-msgstr ""
+msgstr "- Sivuston tai käyttäjän oletusaikavyöhyke -"
 
 msgid "Date format: @date_format"
-msgstr ""
+msgstr "Päivämäärän muoto: @date_format"
 
 msgid "Custom date format: @custom_date_format"
-msgstr ""
+msgstr "Mukautettu päivämäärämuoto: @custom_date_format"
 
 msgid "Time zone: @timezone"
-msgstr ""
+msgstr "Aikavyöhyke: @timezone"
 
 msgid "Translate interface text"
-msgstr ""
+msgstr "Käännä käyttöliittymän tekstejä"
 
 msgid "Last run: %time ago."
-msgstr ""
+msgstr "Viimeksi ajettu: %time sitten."
 
 msgid "Plural variants"
-msgstr ""
+msgstr "Monikot"
 
 msgid "Place block <span class=\"visually-hidden\">in the %region region</span>"
-msgstr ""
+msgstr "Sijoita lohko <span class=\"visually-hidden\">alueeseen %region</span>"
 
 msgid "@date by @username"
-msgstr ""
+msgstr "@date kirjoittajalta @username"
 
 msgid "Apache version"
-msgstr ""
+msgstr "Apache-versio"
 
 msgid "%type: @message in %function (line %line of %file)."
-msgstr ""
+msgstr "%type: @message funktiossa %function (rivi %line tiedostossa %file)."
 
 msgid "Container cannot be saved to cache."
-msgstr ""
+msgstr "Säiliötä ei voida tallentaa välimuistiin."
 
 msgid ""
 "The database server version %version is less than the minimum required "
 "version %minimum_version."
 msgstr ""
+"Tietokantapalvelimen versio %version ei vastaa vaadittua minimiversiota "
+"%minimum_version."
 
 msgid "1 error has been found: "
 msgid_plural "@count errors have been found: "
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 error has been found: "
+msgstr[1] "@count errors have been found: "
 
 msgid "imminently"
-msgstr ""
+msgstr "välittömästi"
 
 msgid "The blocked IP address."
-msgstr ""
+msgstr "Estetty IP-osoite."
 
 msgid "The time that the comment was created, as a Unix timestamp."
-msgstr ""
+msgstr "Ajankohta, jolloin kommentti luotiin. Unix-aikakoodi."
 
 msgid "Location of the comment form."
-msgstr ""
+msgstr "Kommenttilomakkeen sijainti."
 
 msgid "Do not use this breakpoint."
-msgstr ""
+msgstr "Älä käytä tätä taittopistettä."
 
 msgid "Run database updates"
-msgstr ""
+msgstr "Suorita tietokantapäivitykset"
 
 msgid "The weight of the role."
-msgstr ""
+msgstr "Roolin paino."
 
 msgid ""
 "Security warning: Couldn't write .htaccess file. Please create a .htaccess "
 "file in your %directory directory which contains the following lines: "
 "<pre><code>@htaccess</code></pre>"
 msgstr ""
+"Turvallisuusvaroitus: .htaccess-tiedostoon kirjoittaminen ei onnistunut. Luo hakemistoon %directory .htaccess-tiedosto, jossa on seuraavat rivit:\r\n"
+"<pre><code>@htaccess</code></pre>"
 
 msgid "Please continue to <a href=\":error_url\">the error page</a>"
-msgstr ""
+msgstr "Jatka <a href=\":error_url\">virhesivulle</a>"
 
 msgid ""
 "The installer requires that you create a translations directory as part of "
@@ -19391,18 +20826,28 @@ msgid ""
 "More details about installing Drupal are available in <a "
 "href=\":install_txt\">INSTALL.txt</a>."
 msgstr ""
+"Asennusohjelma vaatii, että luot käännöshakemiston osana asennusta. Luo "
+"kansio %translations_directory . Lisätietoa Drupalin asennuksesta saat "
+"tiedostosta <a href=\":install_txt\">INSTALL.txt</a>."
 
 msgid ""
 "The installer requires read permissions to %translations_directory at all "
 "times. The <a href=\":handbook_url\">webhosting issues</a> documentation "
 "section offers help on this and other topics."
 msgstr ""
+"Asennusohjelma edellyttää lukuoikeuksia hakemistoon %translations_directory."
+" Ohjeiden osiossa <a href=\":handbook_url\">palvelinongelmia</a> on ohjeita "
+"tästä ja muista aiheista."
 
 msgid ""
 "The installer requires write permissions to %translations_directory during "
 "the installation process. The <a href=\":handbook_url\">webhosting "
 "issues</a> documentation section offers help on this and other topics."
 msgstr ""
+"Asennusohjelma vaatii asennuksen aikana lukuoikeudet hakemistoon "
+"%translations_directory. Ohjeiden osiossa <a "
+"href=\":handbook_url\">palvelinongelmia</a> on ohjeita tästä ja muista "
+"aiheista."
 
 msgid ""
 "The installer requires to contact the translation server to download a "
@@ -19410,85 +20855,97 @@ msgid ""
 "website can reach the translation server at <a "
 "href=\":server_url\">@server_url</a>."
 msgstr ""
+"Asennusohjelma vaatii yhteyden käännöspalvelimelle ladatakseen "
+"käännöstiedoston. Tarkista internet-yhteytesi ja varmista että sivustosi saa"
+" yhteyden käännöspalvelimeen osoitteessa <a "
+"href=\":server_url\">@server_url</a>."
 
 msgid ""
 "The %language translation file is not available at the translation server. "
 "<a href=\":url\">Choose a different language</a> or select English and "
 "translate your website later."
 msgstr ""
+"Käännöspalvelimella ei ole saatavilla käännöstiedostoa kielelle %language. "
+"<a href=\":url\">Valitse jokin muu kieli</a> tai valitse \"English\" "
+"kääntääksesi sivuston myöhemmin."
 
 msgid "contact form"
-msgstr ""
+msgstr "contact form"
 
 msgid "0 seconds"
-msgstr ""
+msgstr "0 sekuntia"
 
 msgid "Primary admin actions"
-msgstr ""
+msgstr "Primary admin actions"
 
 msgid "Basic block"
-msgstr ""
+msgstr "Basic block"
 
 msgid "Website feedback"
-msgstr ""
+msgstr "Website feedback"
 
 msgid ""
 "Enter a comma-separated list. For example: Amsterdam, Mexico City, "
 "\"Cleveland, Ohio\""
 msgstr ""
+"Enter a comma-separated list. For example: Amsterdam, Mexico City, "
+"\"Cleveland, Ohio\""
 
 msgid "Basic HTML"
-msgstr ""
+msgstr "Basic HTML"
 
 msgid "Restricted HTML"
-msgstr ""
+msgstr "Restricted HTML"
 
 msgid "Default long date"
-msgstr ""
+msgstr "Default long date"
 
 msgid "Default medium date"
-msgstr ""
+msgstr "Default medium date"
 
 msgctxt "PHP date format"
 msgid "D, m/d/Y - H:i"
-msgstr ""
+msgstr "D, m/d/Y - H:i"
 
 msgid "Default short date"
-msgstr ""
+msgstr "Default short date"
 
 msgctxt "PHP date format"
 msgid "m/d/Y - H:i"
-msgstr ""
+msgstr "m/d/Y - H:i"
 
 msgid "Block the selected user(s)"
-msgstr ""
+msgstr "Block the selected user(s)"
 
 msgid "Cancel the selected user account(s)"
-msgstr ""
+msgstr "Cancel the selected user account(s)"
 
 msgid "Unblock the selected user(s)"
-msgstr ""
+msgstr "Unblock the selected user(s)"
 
 msgid "Configuration synchronization"
-msgstr ""
+msgstr "Asetusten synkronointi"
 
 msgid "Import and export your configuration."
-msgstr ""
+msgstr "Tuo ja vie sivuston asetuksia."
 
 msgid "Entity/field definitions"
-msgstr ""
+msgstr "Entiteetti- ja kenttämäärittelyt"
 
 msgid "@local-task-title@active"
-msgstr ""
+msgstr "@local-task-title@active"
 
 msgid "Core (Experimental)"
-msgstr ""
+msgstr "Ydin (Kokeellinen)"
 
 msgid ""
 "The %language translation file could not be downloaded. <a "
 "href=\":url\">Choose a different language</a> or select English and "
 "translate your website later."
 msgstr ""
+"Käännöstiedoston lataaminen kielelle %language ei onnistunut. <a "
+"href=\":url\">Valitse jokin muu kieli</a> tai valitse \"English\" "
+"kääntääksesi sivuston myöhemmin."
 
 msgid ""
 "The @drupal installer requires that you create a %file as part of the "
@@ -19496,18 +20953,28 @@ msgid ""
 "about installing Drupal are available in <a "
 "href=\":install_txt\">INSTALL.txt</a>."
 msgstr ""
+"@drupal -asennusohjelma vaatii, että luot tiedoston %file osana "
+"asennusprosessia. Kopioi %default_file nimelle %file. Lisätietoja Drupalin "
+"asentamisesta löytyy tiedostosta <a href=\":install_txt\">INSTALL.txt</a>."
 
 msgid ""
 "@drupal requires read permissions to %file at all times. The <a "
 "href=\":handbook_url\">webhosting issues</a> documentation section offers "
 "help on this and other topics."
 msgstr ""
+"@drupal edellyttää, että pystyy lukemaan tiedostoa %file koko ajan. "
+"Dokumentaation osiossa <a href=\":handbook_url\">Webhosting issues</a> "
+"kerrotaan lisää tästä ja muista aiheista."
 
 msgid ""
 "The @drupal installer requires write permissions to %file during the "
 "installation process. The <a href=\":handbook_url\">webhosting issues</a> "
 "documentation section offers help on this and other topics."
 msgstr ""
+"@drupal edellyttää, että pystyy kirjoittamaan tiedostoon %file "
+"asennusprosessin aikana. Dokumentaation osiossa <a "
+"href=\":handbook_url\">Webhosting issues</a> kerrotaan lisää tästä ja muista"
+" aiheista."
 
 msgid ""
 "The @drupal installer failed to create a %file file with proper file "
@@ -19518,26 +20985,36 @@ msgid ""
 "href=\":handbook_url\">webhosting issues</a> documentation section offers "
 "help on this and other topics."
 msgstr ""
+"@drupal -asennusohjelma ei pystynyt luomaan tiedostoa %file oikeilla "
+"omistajuustiedoilla. Kirjaudu palvelimelle, poista nykyinen %file -tiedosto "
+"ja luo uusi kopioimalla %default_file nimelle %file. Lisätietoja Drupalin "
+"asentamisesta löytyy tiedostosta <a href=\":install_txt\">INSTALL.txt</a>. "
+"Dokumentaation osiossa <a href=\":handbook_url\">Webhosting issues</a> "
+"kerrotaan lisää tästä ja muista aiheista."
 
 msgid ""
 "Check the messages and <a href=\":retry\">retry</a>, or you may choose to <a"
 " href=\":cont\">continue anyway</a>."
 msgstr ""
+"Tarkista viestit ja <a href=\":retry\">yritä uudelleen</a>. Voit myös "
+"halutessasi <a href=\":cont\">jatkaa joka tapauksessa</a>."
 
 msgid "Check the messages and <a href=\":url\">try again</a>."
-msgstr ""
+msgstr "Tarkista viestit ja <a href=\":url\">yritä uudelleen</a>."
 
 msgid ""
 "The following modules are required but were not found. Move them into the "
 "appropriate modules subdirectory, such as <em>/modules</em>. Missing "
 "modules: @modules"
 msgstr ""
+"Seuraavat moduulit ovat pakollisia, mutta niitä ei löydy. Siirrä ne oikeaan "
+"modules-alihakemistoon kuten <em>/modules</em>. Puuttuvat moduulit: @modules"
 
 msgid "Updating @module"
-msgstr ""
+msgstr "Päivitetään @module"
 
 msgid "Post updating @module"
-msgstr ""
+msgstr "Suoritetaan päivityksen jälkeisiä toimenpiteitä: @module"
 
 msgid "Date (e.g. @format)"
 msgstr "Päivämäärä (esim. @format)"
@@ -19546,26 +21023,32 @@ msgid "Time (e.g. @format)"
 msgstr "Kellonaika (esim. @format)"
 
 msgid "@uri"
-msgstr ""
+msgstr "@uri"
 
 msgid "Operating in maintenance mode. <a href=\":url\">Go online.</a>"
 msgstr ""
+"Sivusto on huoltotilassa (ei näy julkisena internetissä). <a "
+"href=\":url\">Siirry normaalitilaan.</a>"
 
 msgid "Textfield size: @size"
-msgstr ""
+msgstr "Tekstikentän koko: @size"
 
 msgid "Number of rows: @rows"
-msgstr ""
+msgstr "Rivien määrä: @rows"
 
 msgid ""
 "WARNING: You are not using an encrypted connection, so your password will be"
 " sent in plain text. <a href=\":https-link\">Learn more</a>."
 msgstr ""
+"VAROITUS: Yhteytesi ei ole salattu, joten salasanasi lähetetään "
+"suojaamattomana tekstinä. <a href=\":https-link\">Lue lisää</a>."
 
 msgid ""
 "@name cannot be longer than %max characters but is currently %length "
 "characters long."
 msgstr ""
+"@name ei voi olla pidempi kuin %max merkkiä pitkä, mutta se on tällä "
+"hetkellä %length merkkiä pitkä."
 
 msgid ""
 "All necessary changes to %dir and %file have been made, so you should remove"
@@ -19573,59 +21056,76 @@ msgid ""
 "unsure how to do so, consult the <a href=\":handbook_url\">online "
 "handbook</a>."
 msgstr ""
+"Kaikki tarvittavat muutokset %dir -kansioon ja %file -tiedostoon ovat tehty,"
+" joten voit nyt poistaa näiltä kirjoitusoikeudet. Näin vältyt "
+"tietoturvariskeiltä. Jos olet epävarma kuinka se tehdään, katso lisätietoa "
+"<a href=\":handbook_url\">online-käsikirjasta</a>."
 
 msgid ""
 "A working <a href=\":cron\">cron maintenance task</a> is required to update "
 "feeds automatically."
 msgstr ""
+"Syötteiden automaattinen päivitys edellyttää toimivaa <a href=\":cron"
+"\">cron-ajoa</a>."
 
 msgid ""
 "The length of time between feed updates. Requires a correctly configured <a "
 "href=\":cron\">cron maintenance task</a>."
 msgstr ""
+"Syötteiden päivitysväli. Edellyttää toimivaa <a href=\":cron\">cron-"
+"ajoa</a>."
 
 msgid ""
 "Requires a correctly configured <a href=\":cron\">cron maintenance task</a>."
-msgstr ""
+msgstr "Edellyttää toimivaa <a href=\":cron\">cron-ajoa</a>."
 
 msgid ""
 "<a href=\":login\">Log in</a> or <a href=\":register\">register</a> to post "
 "comments"
 msgstr ""
+"<a href=\":login\">Kirjaudu</a> tai <a href=\":register\">rekisteröidy</a> "
+"kirjoittaaksesi kommentteja"
 
 msgid "<a href=\":login\">Log in</a> to post comments"
-msgstr ""
+msgstr "<a href=\":login\">Kirjaudu sisään</a> kirjoittaaksesi kommentteja"
 
 msgid "[@form] @subject"
-msgstr ""
+msgstr "[@form] @subject"
 
 msgid "Hello @recipient-name,"
-msgstr ""
+msgstr "Hei @recipient-name,"
 
 msgid "@name (not verified)"
-msgstr ""
+msgstr "@name (ei varmistettu)"
 
 msgid ""
 "Before you can translate content, there must be at least two languages added"
 " on the <a href=\":url\">languages administration</a> page."
 msgstr ""
+"Sisällön kääntämiseksi <a href=\":url\">kielten asetussivulla</a> on "
+"määriteltävä vähintään kaksi kieltä."
 
 msgid "Date part order: @order"
-msgstr ""
+msgstr "Päiväyksen osien järjestys: @order"
 
 msgid "Time type: @time_type"
-msgstr ""
+msgstr "Ajan tyyppi: @time_type"
 
 msgid ""
 "The Database Logging module logs system events in the Drupal database. For "
 "more information, see the <a href=\":dblog\">online documentation for the "
 "Database Logging module</a>."
 msgstr ""
+"Database Logging -moduuli kirjaa järjestelmän tapahtumia Drupalin "
+"tietokantaan. Lisää tietoa saat <a href=\":dblog\">Database Logging "
+"-moduulin dokumentaatiosta</a>."
 
 msgid ""
 "The maximum number of messages to keep in the database log. Requires a <a "
 "href=\":cron\">cron maintenance task</a>."
 msgstr ""
+"Tietokantalokissa säilytettävien viestien maksimimäärä. Edellyttää toimivaa "
+"<a href=\":cron\">cron-ajoa</a>."
 
 msgid ""
 "Pages which are suitable for caching are cached the first time they are "
@@ -19633,25 +21133,34 @@ msgid ""
 " content is handled automatically so that both cache correctness and hit "
 "ratio is maintained."
 msgstr ""
+"Välimuistitettavissa olevat sivut tallennetaan välimuistiin ensimmäisen "
+"latauspyynnön yhteydessä, ja seuraavien pyyntöjen kohdalla käytetään "
+"välimuistissa olevaa versiota. Dynaaminen sisältö välimuistitetaan siten, "
+"että sekä välimuistin paikkansapitävyys että välimuistin osuvuus "
+"säilytetään."
 
 msgid "@size limit."
 msgstr "Max. @size"
 
 msgid "Limit allowed HTML tags and correct faulty HTML"
-msgstr ""
+msgstr "Rajoita sallittuja HTML-tageja ja korjaa rikkinäinen HTML"
 
 msgid ""
 "Explanation of the language options is found on the <a "
 "href=\":languages_list_page\">languages list page</a>."
 msgstr ""
+"Kielivalintojen selitykset löytyvät <a href=\":languages_list_page\">kielten"
+" listaussivulta</a>."
 
 msgid "Site's default language (@language)"
-msgstr ""
+msgstr "Sivuston oletuskieli (@language)"
 
 msgid ""
 "Each menu has a corresponding block that is managed on the <a "
 "href=\":blocks\">Block layout page</a>."
 msgstr ""
+"Jokaisella valikolla on oma lohko jota hallitaan <a "
+"href=\":blocks\">lohkojen sijoittelu</a>-sivulla."
 
 msgid ""
 "When new content is created, the Node module records basic information about"
@@ -19662,19 +21171,29 @@ msgid ""
 "Default settings can be configured for each <a href=\":content-type\">type "
 "of content</a> on your site."
 msgstr ""
+"Uutta sisältöä luodessa Node-moduuli tallentaa sisällöstä perustietoja, "
+"kuten kirjoittajan, luontipäivämäärän ja <a href=\":content-"
+"type\">sisältötyypin</a>. Lisäksi moduuli huolehtii "
+"<em>julkaisuasetuksista</em>, jotka määrittelevät onko sisältö julkaistu, "
+"nostettu etusivulle tai kiinnitetty listojen alkuun. Oletukset voidaan "
+"asettaa jokaiselle <a href=\":content-type\">sisältötyypille</a> sivustolla."
 
 msgid "This text will be displayed on the <em>Add new content</em> page."
-msgstr ""
+msgstr "Tämä teksti näytetään <em>Lisää sisältöä</em>-sivulla."
 
 msgid ""
 "Set and configure the default theme for your website.  Alternative <a "
 "href=\":themes\">themes</a> are available."
 msgstr ""
+"Valitse ja muokkaa asetuksia sivuston vakioteemaan. Vaihtoehtoisia <a "
+"href=\":themes\">teemoja</a> on saatavilla."
 
 msgid ""
 "You can place blocks for each theme on the <a href=\":blocks\">block "
 "layout</a> page."
 msgstr ""
+"Voit asetella lohkoja jokaiseen teemaan <a href=\":blocks\">lohkojen "
+"sijoittelu</a>-sivulla."
 
 msgid ""
 "Regularly review available updates to maintain a secure and current site. "
@@ -19682,88 +21201,110 @@ msgid ""
 "is updated. Enable the <a href=\":update-manager\">Update Manager module</a>"
 " to update and install modules and themes."
 msgstr ""
+"Tarkastele säännöllisesti päivityksiä ylläpitääksesi turvallisen ja "
+"ajantasaisen sivuston. Aja aina <a href=\":update-php\">päivitys-skripti</a>"
+" joka kerta kun moduuli päivitetään. Ota käyttöön <a href=\":update-"
+"manager\">Update Manager-moduuli</a> päivittääksesi ja asentaaksesi moduulit"
+" ja teemat."
 
 msgid "Configure your <a href=\":user-edit\">account time zone setting</a>."
-msgstr ""
+msgstr "Määritä <a href=\":user-edit\">oma aikavyöhykkeesi</a>."
 
 msgid ""
 "One or more problems were detected with your Drupal installation. Check the "
 "<a href=\":status\">status report</a> for more information."
 msgstr ""
+"Löydettiin yksi tai useampia ongelmia Drupal-asennuksessasi. Tarkastele "
+"lisätietoja <a href=\":status\">tilanneraportista</a>."
 
 msgid "Uninstall @theme theme"
-msgstr ""
+msgstr "Poista teeman @theme asennus"
 
 msgid "Set @theme as default theme"
-msgstr ""
+msgstr "Valitse @theme oletusteemaksi"
 
 msgid "Install @theme theme"
-msgstr ""
+msgstr "Asenna teema @theme"
 
 msgid "Install @theme as default theme"
-msgstr ""
+msgstr "Ota @theme käyttöön oletusteemana"
 
 msgid ""
 "Defined on the <a href=\":appearance\">Appearance Settings</a> or <a "
 "href=\":theme\">Theme Settings</a> page."
 msgstr ""
+"Määritelty <a href=\":appearance\">Ulkoasu</a>- tai <a "
+"href=\":theme\">Teeman asetukset</a>-sivulla."
 
 msgid "Defined on the <a href=\":information\">Site Information</a> page."
-msgstr ""
+msgstr "Määritelty <a href=\":information\">Sivuston tiedot</a> -sivulla."
 
 msgid "Installation tasks"
-msgstr ""
+msgstr "Asennustehtävät"
 
 msgid "Uninstalled modules"
-msgstr ""
+msgstr "Poistetut moduulit"
 
 msgid "Uninstalled themes"
-msgstr ""
+msgstr "Poistetut teemat"
 
 msgid "Check for updates of uninstalled modules and themes"
-msgstr ""
+msgstr "Tarkista päivitykset poistetuille moduuleille ja teemoille"
 
 msgid "@label:@column"
-msgstr ""
+msgstr "@label:@column"
 
 msgid "@label (@name:delta)"
-msgstr ""
+msgstr "@label (@name:delta)"
 
 msgid "Add section"
-msgstr ""
+msgstr "Add section"
 
 msgid ""
 "There was a problem checking <a href=\":update-report\">available "
 "updates</a> for your modules or themes."
 msgstr ""
+"Moduulien ja teemojen <a href=\":update-report\">päivitysten</a> "
+"tarkistamisessa oli ongelma."
 
 msgid ""
 "Download additional <a href=\":modules\">contributed modules</a> to extend "
 "your site's functionality."
 msgstr ""
+"Lataa lisää <a href=\":modules\">moduuleja</a> lisätäksesi toimintoja "
+"sivustolle."
 
 msgid ""
 "For more information, see the <a href=\":views\">online documentation for "
 "the Views module</a>."
 msgstr ""
+"Lisätietoa saatavilla <a href=\":views\">Views-moduulin "
+"dokumentaatiossa</a>."
 
 msgid "You must select a language to continue the installation."
-msgstr ""
+msgstr "Valitse kieli jatkaaksesi asennusta."
 
 msgid ""
 "Several special characters are allowed, including space, period (.), hyphen "
 "(-), apostrophe ('), underscore (_), and the @ sign."
 msgstr ""
+"Monet erikoismerkit ovat sallittuja, kuten välilyönti, piste (.), "
+"yhdysmerkki (-), lainausmerkki ('), alaviiva (_) ja @-merkki."
 
 msgid ""
 "Block placement is specific to each theme on your site. Changes will not be "
 "saved until you click <em>Save blocks</em> at the bottom of the page."
 msgstr ""
+"Sivustosi jokaisella teemalla on omat lohkojen sijoittelut. Muutoksia ei "
+"tallenneta ennen kuin klikkaat <em>Tallenna lohkot</em> sivun alalaidassa."
 
 msgid ""
 "The Database Logging module logs system events in the Drupal database. "
 "Monitor your site or debug site problems on this page."
 msgstr ""
+"Database Logging -moduuli kirjaa järjestelmän tapahtumia Drupalin "
+"tietokantaan. Tällä sivulla voit valvoa sivuston tapahtumia ja selvittää "
+"ongelmia."
 
 msgid ""
 "There has been more than one failed login attempt for this account. It is "
@@ -19774,55 +21315,64 @@ msgid_plural ""
 "is temporarily blocked. Try again later or <a href=\":url\">request a new "
 "password</a>."
 msgstr[0] ""
+"Tälle käyttäjätilille on ollut useampi kuin yksi epäonnistunut "
+"sisäänkirjautuminen ja tilin käyttö on tilapäisesti estetty. Yritä myöhemmin"
+" uudelleen tai <a href=\":url\">pyydä uusi salasana</a>."
 msgstr[1] ""
+"Tälle käyttäjätilille on ollut useampia kuin @count epäonnistunut "
+"sisäänkirjautuminen ja tilin käyttö on tilapäisesti estetty. Yritä myöhemmin"
+" uudelleen tai <a href=\":url\">pyydä uusi salasana</a>."
 
 msgid "Delete %label"
-msgstr ""
+msgstr "Poista %label"
 
 msgid "Max 1300x1300"
-msgstr ""
+msgstr "Enintään 1300×1300"
 
 msgid "Max 2600x2600"
-msgstr ""
+msgstr "Enintään 2600×2600"
 
 msgid "Max 325x325"
-msgstr ""
+msgstr "Enintään 325×325"
 
 msgid "Max 650x650"
-msgstr ""
+msgstr "Enintään 600×600"
 
 msgid "Narrow"
-msgstr ""
+msgstr "Kapea"
 
 msgid "Config override test"
-msgstr ""
+msgstr "Konfiguraation yliajotesti"
 
 msgid "This entity (%type: %label) cannot be referenced."
-msgstr ""
+msgstr "Entiteettiin (%type: %label) ei voida viitata."
 
 msgid "Importing configuration"
-msgstr ""
+msgstr "Tuodaan asetuksia"
 
 msgid "Starting configuration import."
-msgstr ""
+msgstr "Aloitetaan asetusten tuonti."
 
 msgid "Configuration import has encountered an error."
-msgstr ""
+msgstr "Asetusten tuonnissa tapahtui virhe."
 
 msgid "Authored on @date"
-msgstr ""
+msgstr "Luotu @date"
 
 msgid "Add @entity-type"
-msgstr ""
+msgstr "Lisää @entity-type"
 
 msgid "Size of email field"
-msgstr ""
+msgstr "Sähköpostikentän koko"
 
 msgid ""
 "Operations on Unicode strings are emulated on a best-effort basis. Install "
 "the <a href=\"http://php.net/mbstring\">PHP mbstring extension</a> for "
 "improved Unicode support."
 msgstr ""
+"Unicode-merkkijonojen operaatiot emuloidaan best-effort-periaatteella. "
+"Paremman tuen Unicodelle saat asentamalla <a "
+"href=\"http://php.net/mbstring\">PHP:n mbstring-laajennuksen</a>."
 
 msgid ""
 "Multibyte string function overloading in PHP is active and must be disabled."
@@ -19830,6 +21380,10 @@ msgid ""
 "the <a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for "
 "more information."
 msgstr ""
+"PHP:ssa on päällä Multibyte string function overloading -asetus, ja se pitää"
+" kääntää pois päältä. Tarkista php.ini-tiedoston "
+"<em>mbstring.func_overload</em>-asetus. Lisätietoja saat <a "
+"href=\"http://php.net/mbstring\">PHP:n mbstring-dokumentaatiosta</a>."
 
 msgid ""
 "Multibyte string input conversion in PHP is active and must be disabled. "
@@ -19837,6 +21391,10 @@ msgid ""
 "refer to the <a href=\"http://php.net/mbstring\">PHP mbstring "
 "documentation</a> for more information."
 msgstr ""
+"PHP:ssa on päällä Multibyte string input conversion -asetus, ja se pitää "
+"kääntää pois päältä. Tarkista php.ini-tiedoston "
+"<em>mbstring.encoding_translation</em>-asetus. Lisätietoja saat <a "
+"href=\"http://php.net/mbstring\">PHP:n mbstring-dokumentaatiosta</a>."
 
 msgid ""
 "Multibyte string input conversion in PHP is active and must be disabled. "
@@ -19844,6 +21402,10 @@ msgid ""
 "<a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for more "
 "information."
 msgstr ""
+"PHP:ssa on päällä Multibyte string input conversion -asetus, ja se pitää "
+"kääntää pois päältä. Tarkista php.ini-tiedoston "
+"<em>mbstring.http_output</em>-asetus. Lisätietoja saat <a "
+"href=\"http://php.net/mbstring\">PHP:n mbstring-dokumentaatiosta</a>."
 
 msgid ""
 "Multibyte string output conversion in PHP is active and must be disabled. "
@@ -19851,176 +21413,200 @@ msgid ""
 " <a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for more"
 " information."
 msgstr ""
+"PHP:ssa on päällä Multibyte string output conversion -asetus, ja se pitää "
+"kääntää pois päältä. Tarkista php.ini-tiedoston "
+"<em>mbstring.http_output</em>-asetus. Lisätietoja saat <a "
+"href=\"http://php.net/mbstring\">PHP:n mbstring-dokumentaatiosta</a>."
 
 msgid "United Nations' official languages"
-msgstr ""
+msgstr "Yhdistyneiden kansakuntien viralliset kielet"
 
 msgid "All @count languages"
-msgstr ""
+msgstr "Kaikki @count kieltä"
 
 msgid "Completed step @current of @total."
-msgstr ""
+msgstr "Suoritettu vaihe @current / @total."
 
 msgid ""
 "Control which roles can \"View the administration theme\" on the <a "
 "href=\":permissions\">Permissions page</a>."
 msgstr ""
+"Ylläpitoteeman käyttöoikeudet voit määrittää \"Näytä ylläpitoteema\" "
+"-asetuksella <a href=\":permissions\">Käyttöoikeudet</a>-sivulla."
 
 msgid "Bundle assigned to the auto-created entities."
-msgstr ""
+msgstr "Automaattisesti luotujen entiteettien paketti."
 
 msgid "Revision create time"
-msgstr ""
+msgstr "Version luontiaika"
 
 msgid "Administrative task links"
-msgstr ""
+msgstr "Administrative task links"
 
 msgid "Site information links"
 msgstr "Sivuston informaatio linkit"
 
 msgid "Site section links"
-msgstr ""
+msgstr "Site section links"
 
 msgid "All content, by month."
-msgstr ""
+msgstr "All content, by month."
 
 msgid "All content promoted to the front page."
-msgstr ""
+msgstr "All content promoted to the front page."
 
 msgid "Name or email contains"
-msgstr ""
+msgstr "Name or email contains"
 
 msgid "A list of new users"
-msgstr ""
+msgstr "A list of new users"
 
 msgid "Who's online block"
-msgstr ""
+msgstr "Who's online block"
 
 msgid ""
 "Shows the user names of the most recently active users, and the total number"
 " of active users."
 msgstr ""
+"Shows the user names of the most recently active users, and the total number"
+" of active users."
 
 msgid "There are currently @total users online."
-msgstr ""
+msgstr "There are currently @total users online."
 
 msgid "There are currently 0 users online."
-msgstr ""
+msgstr "There are currently 0 users online."
 
 msgid "A list of users that are currently logged in."
-msgstr ""
+msgstr "A list of users that are currently logged in."
 
 msgid "View edit page"
-msgstr ""
+msgstr "View edit page"
 
 msgid "Manage view settings"
-msgstr ""
+msgstr "Manage view settings"
 
 msgid "View or edit the configuration."
-msgstr ""
+msgstr "View or edit the configuration."
 
 msgid "Displays in this view"
-msgstr ""
+msgstr "Displays in this view"
 
 msgid ""
 "A display is a way of outputting the results, e.g., as a page or a block. A "
 "view can contain multiple displays, which are listed here. The active "
 "display is highlighted."
 msgstr ""
+"A display is a way of outputting the results, e.g., as a page or a block. A "
+"view can contain multiple displays, which are listed here. The active "
+"display is highlighted."
 
 msgid "View administration"
-msgstr ""
+msgstr "View administration"
 
 msgid "Filter your view"
-msgstr ""
+msgstr "Filter your view"
 
 msgid "Filter actions"
-msgstr ""
+msgstr "Filter actions"
 
 msgid "Add, rearrange or remove filters."
-msgstr ""
+msgstr "Add, rearrange or remove filters."
 
 msgid ""
 "Control the order in which the results are output. Click on an active sort "
 "rule to configure it."
 msgstr ""
+"Control the order in which the results are output. Click on an active sort "
+"rule to configure it."
 
 msgid "Sort actions"
-msgstr ""
+msgstr "Sort actions"
 
 msgid "Add, rearrange or remove sorting rules."
-msgstr ""
+msgstr "Add, rearrange or remove sorting rules."
 
 msgid "Default revision"
-msgstr ""
+msgstr "Oletusversio"
 
 msgid "Basic site settings"
-msgstr ""
+msgstr "Sivuston perusasetukset"
 
 msgid ""
 "Create and manage fields, forms, and display settings for your content."
-msgstr ""
+msgstr "Luo ja hallinnoi kenttiä, lomakkeita ja sisällön näkymisen asetuksia."
 
 msgid "Manage menus and menu links."
-msgstr ""
+msgstr "Hallinnoi valikoita ja valikoiden linkkejä."
 
 msgid ""
 "Configure default user account settings, including fields, registration "
 "requirements, and email messages."
 msgstr ""
+"Säädä käyttäjätilien asetuksia, kuten kenttiä, rekisteröintivaatimuksia ja "
+"sähköpostiviestejä."
 
 msgid ""
 "Select and configure text editors, and how content is filtered when "
 "displayed."
 msgstr ""
+"Valitse ja säädä tekstieditoreita, ja kuinka sisältöä suodatetaan "
+"katseltaessa."
 
 msgid "Configure caching and bandwidth optimization."
-msgstr ""
+msgstr "Säädä välimuistia ja optimoi kaistan käyttöä."
 
 msgid "Configure the display of error messages and database logging."
-msgstr ""
+msgstr "Virheviestien ja tietokantalokituksen asetukset."
 
 msgid "Take the site offline for updates and other maintenance tasks."
 msgstr ""
+"Aseta sivusto huoltotilaan päivityksiä ja muita huoltotoimenpiteitä varten."
 
 msgid "Configure and use development tools."
-msgstr ""
+msgstr "Kehitystyökalujen asetukset ja käyttöönotto"
 
 msgid "Configure the location of uploaded files and how they are accessed."
-msgstr ""
+msgstr "Säädä ladattujen tiedostojen sijaintia ja niihin pääsyä."
 
 msgid "Add custom URLs to existing paths."
-msgstr ""
+msgstr "Lisää omia URL-osoitteita olemassa oleviin polkuihin."
 
 msgid "Configure site search, metadata, and search engine optimization."
-msgstr ""
+msgstr "Säädä sivuston hakua, metadataa ja hakukoneoptimointia."
 
 msgid "Configure the locale and timezone settings."
-msgstr ""
+msgstr "Säädä aluekohtaisia ja aikavyöhykkeiden asetuksia."
 
 msgid "Configure how dates and times are displayed."
-msgstr ""
+msgstr "Säädä miten päivämäärät ja kellonajat näkyvät."
 
 msgid "Configure languages for content, interface, and configuration."
-msgstr ""
+msgstr "Säädä kieliä sisältöä, käyttöliittymää ja asetuksia varten."
 
 msgid ""
 "Configure the import of translation files, and add or customize interface "
 "translations."
 msgstr ""
+"Säädä käännöstiedostojen tuontia, ja lisää tai muokkaa käyttöliittymän "
+"käännöksiä."
 
 msgid "Configure regional settings, localization, and translation."
-msgstr ""
+msgstr "Säädä aluekohtaisia asetuksia, lokalisointia ja käännöksiä."
 
 msgid ""
 "Configure the site description, the number of items per feed, and whether "
 "feeds should be titles/teasers/full-text."
 msgstr ""
+"Säädä sivuston kuvausta, syötteiden tulosten lukumäärää ja näkyykö "
+"syötteissä otsikot, lyhennelmät vai koko sisältö."
 
 msgid ""
 "The specified file %file could not be moved/copied because no file by that "
 "name exists. Please check that you supplied the correct filename."
 msgstr ""
+"Tiedostoa %file ei voitu siirtää tai kopioida, koska sen nimistä tiedostoa "
+"ei ole olemassa. Ole hyvä ja tarkista antamasi tiedostonimi."
 
 msgid ""
 "The specified file %file could not be moved/copied because the destination "
@@ -20028,40 +21614,58 @@ msgid ""
 "file or directory permissions. More information is available in the system "
 "log."
 msgstr ""
+"Tiedostoa %file ei voitu siirtää tai kopioida, koska kohdehakemistoa ei ole "
+"asetettu oikein. Tämä voi johtua virheestä tiedoston tai hakemisto "
+"käyttöoikeuksien määrittelyssä. Tarkempia tietoja löytyy järjestelmän "
+"lokista."
 
 msgid ""
 "The file %file could not be moved/copied because a file by that name already"
 " exists in the destination directory."
 msgstr ""
+"Tiedostoa %file ei voitu siirtää tai kopioida, koska kohdehakemistossa on jo"
+" samanniminen tiedosto."
 
 msgid ""
 "The specified file %file was not moved/copied because it would overwrite "
 "itself."
 msgstr ""
+"Tiedostoa %file ei voitu siirtää tai kopioida, koska se ylikirjoittaisi "
+"itsensä."
 
 msgid ""
 "File %file (%realpath) could not be moved/copied because it does not exist."
 msgstr ""
+"Tiedostoa %file (%realpath) ei voitu siirtää tai kopioida, koska sitä ei "
+"ole."
 
 msgid "File %file could not be moved/copied because it does not exist."
-msgstr ""
+msgstr "Tiedostoa %file ei voitu siirtää tai kopioida, koska sitä ei ole."
 
 msgid ""
 "File %file could not be moved/copied because the destination directory "
 "%destination is not configured correctly."
 msgstr ""
+"Tiedostoa %file ei voitu siirtää tai kopioida, koska kohdehakemistoa "
+"%destination ei ole määritelty oikein."
 
 msgid ""
 "File %file could not be moved/copied because a file by that name already "
 "exists in the destination directory (%destination)"
 msgstr ""
+"Tiedostoa %file ei voitu siirtää tai kopioida, koska samanniminen tiedosto "
+"on jo olemassa kohdehakemistossa (%destination)."
 
 msgid ""
 "File %file could not be moved/copied because it would overwrite itself."
 msgstr ""
+"Tiedostoa %file ei voitu siirtää tai kopioida, koska se ylikirjoittaisi "
+"itsensä."
 
 msgid "%type: @message in %function (line %line of %file) @backtrace_string."
 msgstr ""
+"%type: @message funktiossa %function (rivi %line tiedostossa %file) "
+"@backtrace_string."
 
 msgid ""
 "The directory %directory could not be created. To proceed with the "
@@ -20069,257 +21673,284 @@ msgid ""
 "the permissions to create it automatically. For more information, see the <a"
 " href=\":handbook_url\">online handbook</a>."
 msgstr ""
+"Hakemiston %directory luominen epäonnistui. Jotta pystyt jatkamaan "
+"asennusta, sinun on joko luotava hakemisto tai varmistettava, että "
+"asennusohjelmalla on oikeudet luoda se automaattisesti. Lisätietoa saat <a "
+"href=\":handbook_url\">käsikirjasta</a>."
 
 msgid "Starting execution of @module_cron()."
-msgstr ""
+msgstr "Aloitetaan @module_cron() -funktion suoritusta."
 
 msgid ""
 "Starting execution of @module_cron(), execution of @module_previous_cron() "
 "took @time."
 msgstr ""
+"Aloitetaan @module_cron() -funktion suoritusta, @module_previous_cron() "
+"-funktion suorittaminen vei @time."
 
 msgid "Execution of @module_previous_cron() took @time."
-msgstr ""
+msgstr "@module_previous_cron() -funktion suorittaminen vei @time."
 
 msgid ""
 "The message to display to the user after submission of this form. Leave "
 "blank for no message."
 msgstr ""
+"Viesti joka näytetään käyttäjälle lomakkeen lähetyksen jälkeen. Jätä "
+"tyhjäksi jos et halua viestiä."
 
 msgid ""
 "Path to redirect the user to after submission of this form. For example, "
 "type \"/about\" to redirect to that page. Use a relative path with a slash "
 "in front."
 msgstr ""
+"Polku johon käyttäjä uudelleenohjataan lomakkeen lähettämisen jälkeen. "
+"Esimerkiksi, kirjoita \"/yhteystiedot\" ohjaaksesi kyseiselle sivulle. Käytä"
+" relatiivista polkua jossa on kauttaviiva ensimmäisenä."
 
 msgid ""
 "Specify an alternative path by which this data can be accessed. For example,"
 " type \"/about\" when writing an about page."
 msgstr ""
+"Määrittele valinnainen polku mistä tämä sisältö on katseltavissa. "
+"Esimerkiksi kirjoita \"/yhteystiedot\" jos olet tekemässä yhteystiedot-"
+"sivua."
 
 msgid ""
 "Control default display settings for your site, across all themes. Use "
 "theme-specific settings to override these defaults."
 msgstr ""
+"Muokkaa sivuston oletusnäkymäasetuksia kaikissa teemoissa. Käytä "
+"teemakohtaisia asetuksia ohittaaksesi nämä vakioasetukset."
 
 msgid "Page element display"
-msgstr ""
+msgstr "Sivun elementtien näkyminen"
 
 msgid "Use the logo supplied by the theme"
-msgstr ""
+msgstr "Käytän teeman oletuslogoa"
 
 msgid ""
 "Your shortcut icon, or favicon, is displayed in the address bar and "
 "bookmarks of most browsers."
 msgstr ""
+"Pikakuvake (tai favicon) näytetään selaimen osoiterivillä ja "
+"kirjanmerkeissä."
 
 msgid "Use the favicon supplied by the theme"
-msgstr ""
+msgstr "Käytä teeman oletuspikakuvaketta"
 
 msgid "Upload favicon image"
-msgstr ""
+msgstr "Tallenna pikakuvake"
 
 msgid "Apply to selected items"
-msgstr ""
+msgstr "Käytä valittuihin tuloksiin"
 
 msgid "Recommendations to make your password stronger:"
 msgstr "Näin teet salasanastasi vahvemman:"
 
 msgid "Combine multiple fields together and search by them."
-msgstr ""
+msgstr "Yhdistä useita kenttiä ja hae niiden perusteella."
 
 msgid "Field %field set in %filter is not set in display %display."
 msgstr ""
+"Suodatin %filter käyttää kenttää %field, jota ei ole lisätty näkymän "
+"näyttöön %display."
 
 msgid "A label is required for the specified operator."
-msgstr ""
+msgstr "Määritetylle operaattorille tarvitaan tunniste."
 
 msgid "A label is required if the value for this item is defined."
-msgstr ""
+msgstr "Tunniste tarvitaan, jos tämän kohteen arvo on määritetty."
 
 msgid "A value is required if the label for this item is defined."
-msgstr ""
+msgstr "Arvoa tarvitaan, jos tämän kohteen tunniste on määritetty."
 
 msgid "Leave empty to show all pages."
-msgstr ""
+msgstr "Jätä määrittämättä kaikkien sivujen esittämiseksi."
 
 msgid "@label moderation state"
-msgstr ""
+msgstr "@label moderoinnin tila"
 
 msgid "Date range settings"
-msgstr ""
+msgstr "Päivämäärävälin asetukset"
 
 msgid "Default start date type"
-msgstr ""
+msgstr "Aloituspäivämäärän oletustyyppi"
 
 msgid "Default start date value"
-msgstr ""
+msgstr "Aloituspäivämäärän oletusarvo"
 
 msgid "Default end date type"
-msgstr ""
+msgstr "Lopetuspäivämäärän oletustyyppi"
 
 msgid "Default end date value"
-msgstr ""
+msgstr "Lopetuspäivämäärän oletusarvo"
 
 msgid "Date separator"
-msgstr ""
+msgstr "Päivämääräerotin"
 
 msgid "The string to separate the start and end dates"
-msgstr ""
+msgstr "Merkit joka erottavat aloitus- ja lopetuspäivämäärät"
 
 msgid ""
 "Specify pages by using their paths. Enter one path per line. The '*' "
 "character is a wildcard. An example path is %user-wildcard for every user "
 "page. %front is the front page."
 msgstr ""
+"Määritä sivut käyttämällä niiden polkuja. Syötä yksi polku per rivi. "
+"'*'-merkki on korvausmerkki. Esimerkkinä polku %user-wildcard on jokaisen "
+"käyttäjän oma sivu. %front on etusivu."
 
 msgid "Is front page"
-msgstr ""
+msgstr "On etusivu"
 
 msgid "Recipient email address"
-msgstr ""
+msgstr "Vastaanottajan sähköpostiosoite"
 
 msgid "Are you sure you want to remove the @entity-type %label?"
-msgstr ""
+msgstr "Haluatko varmasti poistaa @entity-type %label?"
 
 msgid "The @entity-type %label has been removed."
-msgstr ""
+msgstr "@entity-type %label on poistettu."
 
 msgid "General System Information"
-msgstr ""
+msgstr "Järjestelmän yleistiedot"
 
 msgid "Disclaimer block"
-msgstr ""
+msgstr "Vastuuvapauslausekelohko"
 
 msgid "A locally hosted audio file."
-msgstr ""
+msgstr "Paikallisesti palveltava äänitiedosto."
 
 msgid "A locally hosted video file."
-msgstr ""
+msgstr "Paikallisesti palveltava videotiedosto."
 
 msgid "Tell us what you think"
-msgstr ""
+msgstr "Kerro meille mitä mieltä olet"
 
 msgid "Banner block"
-msgstr ""
+msgstr "Bannerilohko"
 
 msgid "A disclaimer block contains disclaimer and copyright text."
 msgstr ""
+"Vastuuvapauslohko sisältää vastuuvapauslausekkeen ja tekijänoikeustekstin."
 
 msgid "Footer promo block"
-msgstr ""
+msgstr "Alatunnisteen nostolohko"
 
 msgid ""
 "A footer promo block contains a title, promo text, and a \"find out more\" "
 "link."
 msgstr ""
+"Alatunnisteen nostolohko sisältää otsikon, nostotekstin ja ”katso "
+"lisää”-linkin."
 
 msgid "Recipe Name"
-msgstr ""
+msgstr "Reseptin nimi"
 
 msgid "Content Link"
-msgstr ""
+msgstr "Sisältölinkki"
 
 msgid "Find out more link"
-msgstr ""
+msgstr "Lisätietolinkki"
 
 msgid "Promo text"
-msgstr ""
+msgstr "Nostoteksti"
 
 msgid "Promo title"
-msgstr ""
+msgstr "Nosto-otsikko"
 
 msgid ""
 "This image will be used on both the recipe page and wherever the recipe is "
 "promoted."
 msgstr ""
+"Tätä kuvaa käytetään sekä reseptisivulla että aina, kun resepti nostetaan."
 
 msgid "List the ingredients required for this recipe, one per item."
-msgstr ""
+msgstr "Listaa ainesosat, jotka tarvitaan tähän reseptiin, yksi per kohta."
 
 msgid "Recipe category"
-msgstr ""
+msgstr "Reseptiluokka"
 
 msgid "Recipe instruction"
-msgstr ""
+msgstr "Reseptiohje"
 
 msgid "Provide a short overview of this recipe."
-msgstr ""
+msgstr "Tarjoa lyhyt yleiskuvaus tästä reseptistä."
 
 msgid "Large 21:9 (1440x620)"
-msgstr ""
+msgstr "Suuri 21:9 (1440×620)"
 
 msgid "Large 21:9 2x (2880x1240)"
-msgstr ""
+msgstr "Suuri 21:9 2x (2880×1240)"
 
 msgid "Large 3:2 2x (1536x1024)"
-msgstr ""
+msgstr "Suuri 3:2 2× (1536×1024)"
 
 msgid "Large 3:2 (768x512)"
-msgstr ""
+msgstr "Suuri 3:2 (768×512)"
 
 msgid "Medium 21:9 (1024x440)"
-msgstr ""
+msgstr "Keskikokoinen 21:9 (1024×440)"
 
 msgid "Medium 3:2 2x (1200x800)"
-msgstr ""
+msgstr "Keskikokoinen 3:2 2× (1200×800)"
 
 msgid "Medium 3:2 (600x400)"
-msgstr ""
+msgstr "Keskikokoinen 3:2 (600×400)"
 
 msgid "Medium 8:7 (266x236)"
-msgstr ""
+msgstr "Keskikokoinen 8:7 (266×236)"
 
 msgid "Scale crop 7:3 large"
-msgstr ""
+msgstr "Skaalausrajaus 7:3 suuri"
 
 msgid "Small 21:9 (768x330)"
-msgstr ""
+msgstr "Pieni 21:9 (768×330)"
 
 msgid "Square Large"
-msgstr ""
+msgstr "Neliö suuri"
 
 msgid "Square Medium"
-msgstr ""
+msgstr "Neliö keskikokoinen"
 
 msgid "Square Small"
-msgstr ""
+msgstr "Neliö pieni"
 
 msgid "3:2 Image"
-msgstr ""
+msgstr "3:2 kuva"
 
 msgid "Configuration validation"
-msgstr ""
+msgstr "Asetusten validointi"
 
 msgid "Preset Name"
-msgstr ""
+msgstr "Preset Name"
 
 msgid "Audio"
-msgstr ""
+msgstr "Audio"
 
 msgid "Node type"
-msgstr ""
+msgstr "Node type"
 
 msgid "content types"
-msgstr ""
+msgstr "content types"
 
 msgid "Heading"
-msgstr ""
+msgstr "Heading"
 
 msgid "Andorra"
-msgstr ""
+msgstr "Andorra"
 
 msgid "Configure content formatting and authoring."
-msgstr ""
+msgstr "Säädä sisällön muotoilua ja syöttämistä."
 
 msgid "Configure the administrative user interface."
-msgstr ""
+msgstr "Säädä ylläpidon käyttöliittymää."
 
 msgid "Manage the content workflow."
-msgstr ""
+msgstr "Hallitsen sisällön työnkulkua."
 
 msgid "Get a status report about your site's operation."
-msgstr ""
+msgstr "Lue tilanneraportti sivustosi toiminnasta."
 
 msgid ""
 "Unrecognized username or password. <a href=\":password\">Forgot your "
@@ -20329,81 +21960,86 @@ msgstr ""
 "salasanasi?</a>"
 
 msgid "Video"
-msgstr ""
+msgstr "Video"
 
 msgid "Unauthorized"
-msgstr ""
+msgstr "Unauthorized"
 
 msgid "users"
-msgstr ""
+msgstr "users"
 
 msgid "RDF"
-msgstr ""
+msgstr "RDF"
 
 msgid "About"
-msgstr ""
+msgstr "Tietoja"
 
 msgid "Edit action"
-msgstr ""
+msgstr "Edit action"
 
 msgid "Any text to display before this link. You may include HTML."
-msgstr ""
+msgstr "Any text to display before this link. You may include HTML."
 
 msgid "Display score"
-msgstr ""
+msgstr "Display score"
 
 msgid "Save book pages"
-msgstr ""
+msgstr "Save book pages"
 
 msgid "Last checked: @time ago"
-msgstr ""
+msgstr "Last checked: @time ago"
 
 msgid "Provider name"
-msgstr ""
+msgstr "Provider name"
 
 msgid "Moderation state"
-msgstr ""
+msgstr "Moderation state"
 
 msgid "This identifier is used by another handler."
-msgstr ""
+msgstr "This identifier is used by another handler."
 
 msgid ""
 "An error occurred while processing %error_operation with arguments: "
 "@arguments"
 msgstr ""
+"An error occurred while processing %error_operation with arguments: "
+"@arguments"
 
 msgid "Formatter settings"
-msgstr ""
+msgstr "Formatter settings"
 
 msgid "Users cannot post comments."
-msgstr ""
+msgstr "Users cannot post comments."
 
 msgid "Displaying menus"
-msgstr ""
+msgstr "Displaying menus"
 
 msgid ""
 "%capital_name contains terms with multiple parents. Drag and drop of terms "
 "with multiple parents is not supported, but you can re-enable drag-and-drop "
 "support by editing each term to include only a single parent."
 msgstr ""
+"%capital_name contains terms with multiple parents. Drag and drop of terms "
+"with multiple parents is not supported, but you can re-enable drag-and-drop "
+"support by editing each term to include only a single parent."
 
 msgid "Inline Form Errors"
-msgstr ""
+msgstr "Inline Form Errors"
 
 msgid "Last access timestamp"
-msgstr ""
+msgstr "Last access timestamp"
 
 msgid "Severity level"
-msgstr ""
+msgstr "Severity level"
 
 msgid "Transitions"
-msgstr ""
+msgstr "Transitions"
 
 msgid "Vocabulary machine name"
-msgstr ""
+msgstr "Vocabulary machine name"
 
 msgid "Preset ID"
-msgstr ""
+msgstr "Preset ID"
 
 msgid ""
 "A unique machine-readable name for this content type. It must only contain "
@@ -20411,21 +22047,25 @@ msgid ""
 "constructing the URL of the %node-add page, in which underscores will be "
 "converted into hyphens."
 msgstr ""
+"A unique machine-readable name for this content type. It must only contain "
+"lowercase letters, numbers, and underscores. This name will be used for "
+"constructing the URL of the %node-add page, in which underscores will be "
+"converted into hyphens."
 
 msgid "The author's host name."
-msgstr ""
+msgstr "The author's host name."
 
 msgid "Default moderation state"
-msgstr ""
+msgstr "Default moderation state"
 
 msgid "Full data (serialized)"
-msgstr ""
+msgstr "Full data (serialized)"
 
 msgid "HTTP method"
-msgstr ""
+msgstr "HTTP method"
 
 msgid "User limit"
-msgstr ""
+msgstr "User limit"
 
 msgid ""
 "If checked, multiple values for this field will be shown in the same row. If"
@@ -20433,65 +22073,74 @@ msgid ""
 " by, please make sure to group by \"Entity ID\" for this setting to have any"
 " effect."
 msgstr ""
+"If checked, multiple values for this field will be shown in the same row. If"
+" not checked, each value in this field will create a new row. If using group"
+" by, please make sure to group by \"Entity ID\" for this setting to have any"
+" effect."
 
 msgid "Filter HTML"
-msgstr ""
+msgstr "Filter HTML"
 
 msgid "Configuration Manager"
-msgstr ""
+msgstr "Configuration Manager"
 
 msgid "Maximum attempts"
-msgstr ""
+msgstr "Maximum attempts"
 
 msgid "No blocked IP addresses available."
-msgstr ""
+msgstr "No blocked IP addresses available."
 
 msgid ""
 "The first mlid in the materialized path. If N = depth, then pN must equal "
 "the mlid. If depth > 1 then p(N-1) must equal the plid. All pX where X > "
 "depth must equal zero. The columns p1 .. p9 are also called the parents."
 msgstr ""
+"The first mlid in the materialized path. If N = depth, then pN must equal "
+"the mlid. If depth > 1 then p(N-1) must equal the plid. All pX where X > "
+"depth must equal zero. The columns p1 .. p9 are also called the parents."
 
 msgid "The third mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The third mlid in the materialized path. See p1."
 
 msgid "The fourth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The fourth mlid in the materialized path. See p1."
 
 msgid "The fifth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The fifth mlid in the materialized path. See p1."
 
 msgid "The sixth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The sixth mlid in the materialized path. See p1."
 
 msgid "The seventh mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The seventh mlid in the materialized path. See p1."
 
 msgid "The eighth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The eighth mlid in the materialized path. See p1."
 
 msgid "The ninth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "The ninth mlid in the materialized path. See p1."
 
 msgid ""
 "Flag that indicates that this link was generated during the update from "
 "Drupal 5."
 msgstr ""
+"Flag that indicates that this link was generated during the update from "
+"Drupal 5."
 
 msgid "Displaying @start - @end of @total"
-msgstr ""
+msgstr "Displaying @start - @end of @total"
 
 msgid "The revision ID."
-msgstr ""
+msgstr "The revision ID."
 
 msgid "All field aliases must be unique"
-msgstr ""
+msgstr "All field aliases must be unique"
 
 msgid "Editorial"
-msgstr ""
+msgstr "Editorial"
 
 msgid "Enter a part of the block name to filter by."
-msgstr ""
+msgstr "Enter a part of the block name to filter by."
 
 msgid ""
 "The width of each column will be calculated automatically based on the "
@@ -20499,106 +22148,129 @@ msgid ""
 "injects classes based on a grid system, disabling this option may prove "
 "beneficial."
 msgstr ""
+"The width of each column will be calculated automatically based on the "
+"number of columns provided. If additional classes are entered or a theme "
+"injects classes based on a grid system, disabling this option may prove "
+"beneficial."
 
 msgid ""
 "Add the default views column classes like views-col, col-1 and clearfix to "
 "the output. You can use this to quickly reduce the amount of markup the view"
 " provides by default, at the cost of making it more difficult to apply CSS."
 msgstr ""
+"Add the default views column classes like views-col, col-1 and clearfix to "
+"the output. You can use this to quickly reduce the amount of markup the view"
+" provides by default, at the cost of making it more difficult to apply CSS."
 
 msgid "The most recent of last comment posted or entity updated time."
-msgstr ""
+msgstr "The most recent of last comment posted or entity updated time."
 
 msgid "The User ID of the author of the last comment of an entity."
-msgstr ""
+msgstr "The User ID of the author of the last comment of an entity."
 
 msgid ""
 "The handler for this item is broken or missing. The following details are "
 "available:"
 msgstr ""
+"The handler for this item is broken or missing. The following details are "
+"available:"
 
 msgid "View basic information"
-msgstr ""
+msgstr "View basic information"
 
 msgid ""
 "@groupName button group in position @position of @positionCount in row @row "
 "of @rowCount."
 msgstr ""
+"@groupName button group in position @position of @positionCount in row @row "
+"of @rowCount."
 
 msgid ""
 "@name @type in position @position of @positionCount in @groupName button "
 "group in row @row of @rowCount."
 msgstr ""
+"@name @type in position @position of @positionCount in @groupName button "
+"group in row @row of @rowCount."
 
 msgid "Press the down arrow key to create a new button group in a new row."
-msgstr ""
+msgstr "Press the down arrow key to create a new button group in a new row."
 
 msgid "Editing the name of the new button group in a dialog."
-msgstr ""
+msgstr "Editing the name of the new button group in a dialog."
 
 msgid "Editing the name of the \"@groupName\" button group in a dialog."
-msgstr ""
+msgstr "Editing the name of the \"@groupName\" button group in a dialog."
 
 msgid ""
 "An entity with this machine name already exists but the import did not "
 "specify a UUID."
 msgstr ""
+"An entity with this machine name already exists but the import did not "
+"specify a UUID."
 
 msgid ""
 "An entity with this machine name already exists but the UUID does not match."
 msgstr ""
+"An entity with this machine name already exists but the UUID does not match."
 
 msgid ""
 "An entity with this UUID already exists but the machine name does not match."
 msgstr ""
+"An entity with this UUID already exists but the machine name does not match."
 
 msgid "Enter a part of the field or @bundle to filter by."
-msgstr ""
+msgstr "Enter a part of the field or @bundle to filter by."
 
 msgid "Add @language translation for %label"
-msgstr ""
+msgstr "Add @language translation for %label"
 
 msgid "@language translation of %label was deleted"
-msgstr ""
+msgstr "@language translation of %label was deleted"
 
 msgid "Edit @language translation for %label"
-msgstr ""
+msgstr "Edit @language translation for %label"
 
 msgid ""
 "Are you sure you want to apply the updated %name image effect to all images?"
 msgstr ""
+"Are you sure you want to apply the updated %name image effect to all images?"
 
 msgid ""
 "The rebuild_access setting is enabled in settings.php. It is recommended to "
 "have this setting disabled unless you are performing a rebuild."
 msgstr ""
+"The rebuild_access setting is enabled in settings.php. It is recommended to "
+"have this setting disabled unless you are performing a rebuild."
 
 msgid "Preferred admin language code"
-msgstr ""
+msgstr "Preferred admin language code"
 
 msgid ""
 "The user's preferred language code for receiving emails and viewing the "
 "site."
 msgstr ""
+"The user's preferred language code for receiving emails and viewing the "
+"site."
 
 msgid "Preferred language code"
-msgstr ""
+msgstr "Preferred language code"
 
 msgid "The user's preferred language code for viewing administration pages."
-msgstr ""
+msgstr "The user's preferred language code for viewing administration pages."
 
 msgid "The password of this user (hashed)."
-msgstr ""
+msgstr "The password of this user (hashed)."
 
 msgid "Initial email"
-msgstr ""
+msgstr "Initial email"
 
 msgid "User ID from route context"
-msgstr ""
+msgstr "User ID from route context"
 
 msgid ""
 "Changing the title here means it cannot be dynamically altered anymore."
 msgstr ""
+"Changing the title here means it cannot be dynamically altered anymore."
 
 msgid ""
 "This view will be displayed by visiting this path on your site. You may use "
@@ -20606,78 +22278,91 @@ msgid ""
 "filters: For example, \"node/%/feed\". If needed you can even specify named "
 "route parameters like taxonomy/term/%taxonomy_term"
 msgstr ""
+"This view will be displayed by visiting this path on your site. You may use "
+"\"%\" in your URL to represent values that will be used for contextual "
+"filters: For example, \"node/%/feed\". If needed you can even specify named "
+"route parameters like taxonomy/term/%taxonomy_term"
 
 msgid ""
 "Some of the pending updates cannot be applied because their dependencies "
 "were not met."
 msgstr ""
+"Some of the pending updates cannot be applied because their dependencies "
+"were not met."
 
 msgid "taxonomy term"
-msgstr ""
+msgstr "taxonomy term"
 
 msgid "Revision user"
-msgstr ""
+msgstr "Revision user"
 
 msgid "In-place content editing."
-msgstr ""
+msgstr "In-place content editing."
 
 msgid ""
 "An entity field containing a UNIX timestamp of when the entity has been last"
 " updated."
 msgstr ""
+"An entity field containing a UNIX timestamp of when the entity has been last"
+" updated."
 
 msgid ""
 "An entity field containing a UNIX timestamp of when the entity has been "
 "created."
 msgstr ""
+"An entity field containing a UNIX timestamp of when the entity has been "
+"created."
 
 msgid "An entity field for storing a serialized array of values."
-msgstr ""
+msgstr "An entity field for storing a serialized array of values."
 
 msgid "The config name @config_name is invalid."
-msgstr ""
+msgstr "The config name @config_name is invalid."
 
 msgid "The configuration was imported with errors."
-msgstr ""
+msgstr "The configuration was imported with errors."
 
 msgid "Deleted and replaced configuration entity \"@name\""
-msgstr ""
+msgstr "Deleted and replaced configuration entity \"@name\""
 
 msgid "HTML help"
-msgstr ""
+msgstr "HTML help"
 
 msgid "Title field required"
-msgstr ""
+msgstr "Title field required"
 
 msgid "Updates for: @module_list"
-msgstr ""
+msgstr "Updates for: @module_list"
 
 msgid ""
 "You have not created any content types yet. Go to the <a "
 "href=\"@create_content\">content type creation page</a> to add a new content"
 " type."
 msgstr ""
+"You have not created any content types yet. Go to the <a "
+"href=\"@create_content\">content type creation page</a> to add a new content"
+" type."
 
 msgid "Embed display options"
-msgstr ""
+msgstr "Embed display options"
 
 msgid "Boolean sort expose settings"
-msgstr ""
+msgstr "Boolean sort expose settings"
 
 msgid "Standard sort expose settings"
-msgstr ""
+msgstr "Standard sort expose settings"
 
 msgid "Random sort expose settings"
-msgstr ""
+msgstr "Random sort expose settings"
 
 msgid "Default views column classes"
-msgstr ""
+msgstr "Default views column classes"
 
 msgid "Book traversal links for"
-msgstr ""
+msgstr "Book traversal links for"
 
 msgid "Administer comment types and settings"
-msgstr ""
+msgstr "Administer comment types and settings"
 
 msgid ""
 "Allow other users to contact you via a personal contact form which keeps "
@@ -20691,19 +22376,22 @@ msgstr ""
 "ominaisuuden käytöstä. "
 
 msgid "%sender-name (@sender-from) sent %recipient-name an email."
-msgstr ""
+msgstr "%sender-name (@sender-from) sent %recipient-name an email."
 
 msgid "Email notification threshold"
-msgstr ""
+msgstr "Email notification threshold"
 
 msgid ""
 "Whenever your site checks for available updates and finds new releases, it "
 "can notify a list of users via email. Put each address on a separate line. "
 "If blank, no emails will be sent."
 msgstr ""
+"Whenever your site checks for available updates and finds new releases, it "
+"can notify a list of users via email. Put each address on a separate line. "
+"If blank, no emails will be sent."
 
 msgid "This account's preferred language for emails and site presentation."
-msgstr ""
+msgstr "This account's preferred language for emails and site presentation."
 
 msgid ""
 "Password reset instructions will be mailed to %email. You must log out to "
@@ -20713,13 +22401,13 @@ msgstr ""
 "ettet ole kirjautuneena palveluun avatessasi viestissä olevaa linkkiä."
 
 msgid "Duplicate view"
-msgstr ""
+msgstr "Duplicate view"
 
 msgid "@field_name: @label"
-msgstr ""
+msgstr "@field_name: @label"
 
 msgid "This link is provided by the Views module from view %label."
-msgstr ""
+msgstr "This link is provided by the Views module from view %label."
 
 msgid ""
 "\n"
@@ -20731,6 +22419,14 @@ msgid ""
 "          <li>… and you can apply this to other elements as well: <code>&lt;video src=\"\" data-align=\"center\" /&gt;</code></li>\n"
 "        </ul>"
 msgstr ""
+"\n"
+"        <p>You can align images, videos, blockquotes and so on to the left, right or center. Examples:</p>\n"
+"        <ul>\n"
+"          <li>Align an image to the left: <code>&lt;img src=\"\" data-align=\"left\" /&gt;</code></li>\n"
+"          <li>Align an image to the center: <code>&lt;img src=\"\" data-align=\"center\" /&gt;</code></li>\n"
+"          <li>Align an image to the right: <code>&lt;img src=\"\" data-align=\"right\" /&gt;</code></li>\n"
+"          <li>… and you can apply this to other elements as well: <code>&lt;video src=\"\" data-align=\"center\" /&gt;</code></li>\n"
+"        </ul>"
 
 msgid ""
 "\n"
@@ -20742,98 +22438,124 @@ msgid ""
 "            <li><code>&lt;code data-caption=\"Hello world in JavaScript.\"&gt;alert(\"Hello world!\");&lt;/code&gt;</code></li>\n"
 "        </ul>"
 msgstr ""
+"\n"
+"        <p>You can caption images, videos, blockquotes, and so on. Examples:</p>\n"
+"        <ul>\n"
+"            <li><code>&lt;img src=\"\" data-caption=\"This is a caption\" /&gt;</code></li>\n"
+"            <li><code>&lt;video src=\"\" data-caption=\"The Drupal Dance\" /&gt;</code></li>\n"
+"            <li><code>&lt;blockquote data-caption=\"Dries Buytaert\"&gt;Drupal is awesome!&lt;/blockquote&gt;</code></li>\n"
+"            <li><code>&lt;code data-caption=\"Hello world in JavaScript.\"&gt;alert(\"Hello world!\");&lt;/code&gt;</code></li>\n"
+"        </ul>"
 
 msgid "Drupal database update"
-msgstr ""
+msgstr "Drupal database update"
 
 msgid ""
 "Use this utility to update your database whenever a new release of Drupal or"
 " a module is installed."
 msgstr ""
+"Use this utility to update your database whenever a new release of Drupal or"
+" a module is installed."
 
 msgid ""
 "<strong>Back up your code</strong>. Hint: when backing up module code, do "
 "not leave that backup in the 'modules' or 'sites/*/modules' directories as "
 "this may confuse Drupal's auto-discovery mechanism."
 msgstr ""
+"<strong>Back up your code</strong>. Hint: when backing up module code, do "
+"not leave that backup in the 'modules' or 'sites/*/modules' directories as "
+"this may confuse Drupal's auto-discovery mechanism."
 
 msgid ""
 "<strong>Back up your database</strong>. This process will change your "
 "database values and in case of emergency you may need to revert to a backup."
 msgstr ""
+"<strong>Back up your database</strong>. This process will change your "
+"database values and in case of emergency you may need to revert to a backup."
 
 msgid ""
 "Install your new files in the appropriate location, as described in the "
 "handbook."
 msgstr ""
+"Install your new files in the appropriate location, as described in the "
+"handbook."
 
 msgid "When you have performed the steps above, you may proceed."
-msgstr ""
+msgstr "When you have performed the steps above, you may proceed."
 
 msgid "Formatted text default display format settings"
-msgstr ""
+msgstr "Formatted text default display format settings"
 
 msgid "Summary or trimmed formatted text display format settings"
-msgstr ""
+msgstr "Summary or trimmed formatted text display format settings"
 
 msgid "%field settings for %bundle"
-msgstr ""
+msgstr "%field settings for %bundle"
 
 msgctxt "Validation"
 msgid "Entity Reference reference access"
-msgstr ""
+msgstr "Entity Reference reference access"
 
 msgid "You do not have access to the referenced entity (%type: %id)."
-msgstr ""
+msgstr "You do not have access to the referenced entity (%type: %id)."
 
 msgid ""
 "You can caption images (<code>data-caption=\"Text\"</code>), but also "
 "videos, blockquotes, and so on."
 msgstr ""
+"You can caption images (<code>data-caption=\"Text\"</code>), but also "
+"videos, blockquotes, and so on."
 
 msgid ""
 "CTRL+Left click will prevent this dialog from showing and proceed to the "
 "clicked link."
 msgstr ""
+"CTRL+Left click will prevent this dialog from showing and proceed to the "
+"clicked link."
 
 msgid ""
 "If more than one application will be sharing this database, a unique table "
 "name prefix – such as %prefix – will prevent collisions."
 msgstr ""
+"If more than one application will be sharing this database, a unique table "
+"name prefix – such as %prefix – will prevent collisions."
 
 msgctxt "Validation"
 msgid "Regex"
-msgstr ""
+msgstr "Regex"
 
 msgid "The formatted text of the area"
-msgstr ""
+msgstr "The formatted text of the area"
 
 msgid ""
 "Entities exist of type %entity_type and %bundle_label %bundle. These "
 "entities need to be deleted before importing."
 msgstr ""
+"Entities exist of type %entity_type and %bundle_label %bundle. These "
+"entities need to be deleted before importing."
 
 msgid "The message language code."
-msgstr ""
+msgstr "The message language code."
 
 msgid ""
 "A boolean indicating whether the translation is visible to non-translators."
 msgstr ""
+"A boolean indicating whether the translation is visible to non-translators."
 
 msgid "Fields and field types"
-msgstr ""
+msgstr "Fields and field types"
 
 msgid "Enabling field types, widgets, and formatters"
-msgstr ""
+msgstr "Enabling field types, widgets, and formatters"
 
 msgid "Images larger than <strong>@max</strong> pixels will be resized."
-msgstr ""
+msgstr "Images larger than <strong>@max</strong> pixels will be resized."
 
 msgid "The reference view %view_name cannot be found."
-msgstr ""
+msgstr "The reference view %view_name cannot be found."
 
 msgid "An autocomplete text field with tagging support."
-msgstr ""
+msgstr "An autocomplete text field with tagging support."
 
 msgid ""
 "You can also configure a default image that will be used if no image is "
@@ -20841,145 +22563,177 @@ msgid ""
 " the field in the field storage settings when you create a field, and the "
 "setting can be overridden for each entity sub-type that uses the field."
 msgstr ""
+"You can also configure a default image that will be used if no image is "
+"uploaded in an image field. This default can be defined for all instances of"
+" the field in the field storage settings when you create a field, and the "
+"setting can be overridden for each entity sub-type that uses the field."
 
 msgid "@title [%language translation]"
-msgstr ""
+msgstr "@title [%language translation]"
 
 msgid "Provides links to perform entity operations."
-msgstr ""
+msgstr "Provides links to perform entity operations."
 
 msgid "@label (@id)"
-msgstr ""
+msgstr "@label (@id)"
 
 msgid "Query arguments"
-msgstr ""
+msgstr "Query arguments"
 
 msgid "Request format"
-msgstr ""
+msgstr "Request format"
 
 msgid "A flag indicating whether this is the default translation."
-msgstr ""
+msgstr "A flag indicating whether this is the default translation."
 
 msgid "Field settings (@on_label / @off_label)"
-msgstr ""
+msgstr "Field settings (@on_label / @off_label)"
 
 msgid "@on_label / @off_label"
-msgstr ""
+msgstr "@on_label / @off_label"
 
 msgid "By @author @time ago"
-msgstr ""
+msgstr "By @author @time ago"
 
 msgid ""
 "Search looks for exact, case-insensitive keywords; keywords shorter than a "
 "minimum length are ignored."
 msgstr ""
+"Search looks for exact, case-insensitive keywords; keywords shorter than a "
+"minimum length are ignored."
 
 msgid ""
 "Use upper-case OR to get more results. Example: cat OR dog (content contains"
 " either \"cat\" or \"dog\")."
 msgstr ""
+"Use upper-case OR to get more results. Example: cat OR dog (content contains"
+" either \"cat\" or \"dog\")."
 
 msgid "Fallback date format"
-msgstr ""
+msgstr "Fallback date format"
 
 msgid "Primary tabs display toggle"
-msgstr ""
+msgstr "Primary tabs display toggle"
 
 msgid "Hide lower priority columns"
-msgstr ""
+msgstr "Hide lower priority columns"
 
 msgid "Allows users to configure languages and apply them to content."
-msgstr ""
+msgstr "Allows users to configure languages and apply them to content."
 
 msgid ""
 "You can use upper-case AND to require all words, but this is the same as the"
 " default behavior. Example: cat AND dog (same as cat dog, content must "
 "contain both \"cat\" and \"dog\")."
 msgstr ""
+"You can use upper-case AND to require all words, but this is the same as the"
+" default behavior. Example: cat AND dog (same as cat dog, content must "
+"contain both \"cat\" and \"dog\")."
 
 msgid "Use quotes to search for a phrase. Example: \"the cat eats mice\"."
-msgstr ""
+msgstr "Use quotes to search for a phrase. Example: \"the cat eats mice\"."
 
 msgid ""
 "You can precede keywords by - to exclude them; you must still have at least "
 "one \"positive\" keyword. Example: cat -dog (content must contain cat and "
 "cannot contain dog)."
 msgstr ""
+"You can precede keywords by - to exclude them; you must still have at least "
+"one \"positive\" keyword. Example: cat -dog (content must contain cat and "
+"cannot contain dog)."
 
 msgid "No eligible views were found."
-msgstr ""
+msgstr "No eligible views were found."
 
 msgid "Testing config overrides"
-msgstr ""
+msgstr "Testing config overrides"
 
 msgid "Minimal profile for running tests with config overrides in a profile."
-msgstr ""
+msgstr "Minimal profile for running tests with config overrides in a profile."
 
 msgid "The hashed password"
-msgstr ""
+msgstr "The hashed password"
 
 msgid "@entity using @field_name"
-msgstr ""
+msgstr "@entity using @field_name"
 
 msgid ""
 "The <em>Autocomplete (Tags style)</em> widget displays a multi-text field in"
 " which users can type in a comma-separated list of entity labels."
 msgstr ""
+"The <em>Autocomplete (Tags style)</em> widget displays a multi-text field in"
+" which users can type in a comma-separated list of entity labels."
 
 msgid ""
 "Revisions allow you to track differences between multiple versions of your "
 "content, and revert to older versions."
 msgstr ""
+"Revisions allow you to track differences between multiple versions of your "
+"content, and revert to older versions."
 
 msgid "Testing multilingual with English"
-msgstr ""
+msgstr "Testing multilingual with English"
 
 msgid "Checkout complete! Thank you for your purchase."
-msgstr ""
+msgstr "Checkout complete! Thank you for your purchase."
 
 msgid "Resolving missing content"
-msgstr ""
+msgstr "Resolving missing content"
 
 msgid "The following @entity-type translations will be deleted:"
-msgstr ""
+msgstr "The following @entity-type translations will be deleted:"
 
 msgid "The @entity-type %label @language translation has been deleted."
-msgstr ""
+msgstr "The @entity-type %label @language translation has been deleted."
 
 msgid ""
 "Are you sure you want to delete the @language translation of the @entity-"
 "type %label?"
 msgstr ""
+"Are you sure you want to delete the @language translation of the @entity-"
+"type %label?"
 
 msgid ""
 "Unable to uninstall the %module module since the %dependent_module module is"
 " installed."
 msgstr ""
+"Unable to uninstall the %module module since the %dependent_module module is"
+" installed."
 
 msgid ""
 "Unable to install the %theme theme since it requires the %required_theme "
 "theme."
 msgstr ""
+"Unable to install the %theme theme since it requires the %required_theme "
+"theme."
 
 msgid ""
 "Unable to uninstall the %theme theme since the %dependent_theme theme is "
 "installed."
 msgstr ""
+"Unable to uninstall the %theme theme since the %dependent_theme theme is "
+"installed."
 
 msgid ""
 "Configuration %name depends on the %owner module that will not be installed "
 "after import."
 msgstr ""
+"Configuration %name depends on the %owner module that will not be installed "
+"after import."
 
 msgid ""
 "Configuration %name depends on the %owner theme that will not be installed "
 "after import."
 msgstr ""
+"Configuration %name depends on the %owner theme that will not be installed "
+"after import."
 
 msgid ""
 "Configuration %name depends on the %owner extension that will not be "
 "installed after import."
 msgstr ""
+"Configuration %name depends on the %owner extension that will not be "
+"installed after import."
 
 msgid ""
 "Unable to install the %module module since it requires the %required_module "
@@ -20988,7 +22742,11 @@ msgid_plural ""
 "Unable to install the %module module since it requires the %required_module "
 "modules."
 msgstr[0] ""
+"Unable to install the %module module since it requires the %required_module "
+"module."
 msgstr[1] ""
+"Unable to install the %module module since it requires the %required_module "
+"modules."
 
 msgid ""
 "Configuration %name depends on the %module module that will not be installed"
@@ -20997,7 +22755,11 @@ msgid_plural ""
 "Configuration %name depends on modules (%module) that will not be installed "
 "after import."
 msgstr[0] ""
+"Configuration %name depends on the %module module that will not be installed"
+" after import."
 msgstr[1] ""
+"Configuration %name depends on modules (%module) that will not be installed "
+"after import."
 
 msgid ""
 "Configuration %name depends on the %theme theme that will not be installed "
@@ -21006,7 +22768,11 @@ msgid_plural ""
 "Configuration %name depends on themes (%theme) that will not be installed "
 "after import."
 msgstr[0] ""
+"Configuration %name depends on the %theme theme that will not be installed "
+"after import."
 msgstr[1] ""
+"Configuration %name depends on themes (%theme) that will not be installed "
+"after import."
 
 msgid ""
 "Configuration %name depends on the %config configuration that will not exist"
@@ -21015,15 +22781,19 @@ msgid_plural ""
 "Configuration %name depends on configuration (%config) that will not exist "
 "after import."
 msgstr[0] ""
+"Configuration %name depends on the %config configuration that will not exist"
+" after import."
 msgstr[1] ""
+"Configuration %name depends on configuration (%config) that will not exist "
+"after import."
 
 msgctxt "Validation"
 msgid "NotNull"
-msgstr ""
+msgstr "NotNull"
 
 msgctxt "Validation"
 msgid "Null"
-msgstr ""
+msgstr "Null"
 
 msgid ""
 "For more detailed information, see the <a "
@@ -21031,61 +22801,67 @@ msgid ""
 "unsure what these terms mean you should probably contact your hosting "
 "provider."
 msgstr ""
+"For more detailed information, see the <a "
+"href=\"https://www.drupal.org/upgrade\">upgrading handbook</a>. If you are "
+"unsure what these terms mean you should probably contact your hosting "
+"provider."
 
 msgid "Entity delete link"
-msgstr ""
+msgstr "Entity delete link"
 
 msgid "Entity edit link"
-msgstr ""
+msgstr "Entity edit link"
 
 msgid "Link to @entity_type_label"
-msgstr ""
+msgstr "Link to @entity_type_label"
 
 msgid "Provide a view link to the @entity_type_label."
-msgstr ""
+msgstr "Provide a view link to the @entity_type_label."
 
 msgid "Link to edit @entity_type_label"
-msgstr ""
+msgstr "Link to edit @entity_type_label"
 
 msgid "Provide an edit link to the @entity_type_label."
-msgstr ""
+msgstr "Provide an edit link to the @entity_type_label."
 
 msgid "Link to delete @entity_type_label"
-msgstr ""
+msgstr "Link to delete @entity_type_label"
 
 msgid "Provide a delete link to the @entity_type_label."
-msgstr ""
+msgstr "Provide a delete link to the @entity_type_label."
 
 msgid "Cache tags"
-msgstr ""
+msgstr "Cache tags"
 
 msgid ""
 "Use <em>@interval</em> where you want the formatted interval text to appear."
 msgstr ""
+"Use <em>@interval</em> where you want the formatted interval text to appear."
 
 msgid "How many time interval units should be shown in the formatted output."
-msgstr ""
+msgstr "How many time interval units should be shown in the formatted output."
 
 msgid "Future date: %display"
-msgstr ""
+msgstr "Future date: %display"
 
 msgid "Past date: %display"
-msgstr ""
+msgstr "Past date: %display"
 
 msgid ""
 "Indicates if the last edit of a translation belongs to current revision."
 msgstr ""
+"Indicates if the last edit of a translation belongs to current revision."
 
 msgid "Testing config import"
-msgstr ""
+msgstr "Testing config import"
 
 msgid "Tests install profiles in the config importer."
-msgstr ""
+msgstr "Tests install profiles in the config importer."
 
 msgid "Module %name has been enabled."
 msgid_plural "@count modules have been enabled: %names."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Module %name has been enabled."
+msgstr[1] "@count modules have been enabled: %names."
 
 msgid ""
 "The MySQLnd driver version %version is less than the minimum required "
@@ -21093,6 +22869,10 @@ msgid ""
 "alternatively switch mysql drivers to libmysqlclient version "
 "%libmysqlclient_minimum_version or up."
 msgstr ""
+"The MySQLnd driver version %version is less than the minimum required "
+"version. Upgrade to MySQLnd version %mysqlnd_minimum_version or up, or "
+"alternatively switch mysql drivers to libmysqlclient version "
+"%libmysqlclient_minimum_version or up."
 
 msgid ""
 "The libmysqlclient driver version %version is less than the minimum required"
@@ -21100,96 +22880,108 @@ msgid ""
 "or up, or alternatively switch mysql drivers to MySQLnd version "
 "%mysqlnd_minimum_version or up."
 msgstr ""
+"The libmysqlclient driver version %version is less than the minimum required"
+" version. Upgrade to libmysqlclient version %libmysqlclient_minimum_version "
+"or up, or alternatively switch mysql drivers to MySQLnd version "
+"%mysqlnd_minimum_version or up."
 
 msgid ""
 "Drupal could not be correctly setup with the existing database due to the "
 "following error: @error."
 msgstr ""
+"Drupal could not be correctly setup with the existing database due to the "
+"following error: @error."
 
 msgid "A value must be selected for %part."
-msgstr ""
+msgstr "A value must be selected for %part."
 
 msgid "@title (value @number)"
-msgstr ""
+msgstr "@title (value @number)"
 
 msgid "Shown tabs"
-msgstr ""
+msgstr "Shown tabs"
 
 msgid "Select tabs being shown in the block"
-msgstr ""
+msgstr "Select tabs being shown in the block"
 
 msgid "Show primary tabs"
-msgstr ""
+msgstr "Show primary tabs"
 
 msgid "Show secondary tabs"
-msgstr ""
+msgstr "Show secondary tabs"
 
 msgid "@label (@type)"
-msgstr ""
+msgstr "@label (@type)"
 
 msgid "Comment_forum"
-msgstr ""
+msgstr "Comment_forum"
 
 msgid "Default comment field"
-msgstr ""
+msgstr "Default comment field"
 
 msgid "Overridden block the selected user(s)"
-msgstr ""
+msgstr "Overridden block the selected user(s)"
 
 msgid ""
 "Entity type mismatch on rename. @old_type not equal to @new_type for "
 "existing configuration @old_name and staged configuration @new_name."
 msgstr ""
+"Entity type mismatch on rename. @old_type not equal to @new_type for "
+"existing configuration @old_name and staged configuration @new_name."
 
 msgid ""
 "Rename operation for simple configuration. Existing configuration @old_name "
 "and staged configuration @new_name."
 msgstr ""
+"Rename operation for simple configuration. Existing configuration @old_name "
+"and staged configuration @new_name."
 
 msgid ""
 "Back up your database and site before you continue. <a "
 "href=\":backup_url\">Learn how</a>."
 msgstr ""
+"Back up your database and site before you continue. <a "
+"href=\":backup_url\">Learn how</a>."
 
 msgid "Revision translation affected"
-msgstr ""
+msgstr "Revision translation affected"
 
 msgid "Medium (220×220)"
-msgstr ""
+msgstr "Medium (220×220)"
 
 msgid "Thumbnail (100×100)"
-msgstr ""
+msgstr "Thumbnail (100×100)"
 
 msgid "HTML Date"
-msgstr ""
+msgstr "HTML Date"
 
 msgid "HTML Datetime"
-msgstr ""
+msgstr "HTML Datetime"
 
 msgid "HTML Month"
-msgstr ""
+msgstr "HTML Month"
 
 msgid "HTML Time"
-msgstr ""
+msgstr "HTML Time"
 
 msgid "HTML Year"
-msgstr ""
+msgstr "HTML Year"
 
 msgid "HTML Yearless date"
-msgstr ""
+msgstr "HTML Yearless date"
 
 msgctxt "PHP date format"
 msgid "l, F j, Y - H:i"
-msgstr ""
+msgstr "l, F j, Y - H:i"
 
 msgid "Inaccessible"
-msgstr ""
+msgstr "Inaccessible"
 
 msgid "Filter by name or description"
-msgstr ""
+msgstr "Filter by name or description"
 
 msgid "The response failed verification so will not be processed."
-msgstr ""
+msgstr "The response failed verification so will not be processed."
 
 msgid ""
 "Your MySQL server and PHP MySQL driver must support utf8mb4 character "
@@ -21198,27 +22990,41 @@ msgid ""
 "compiled in. See the <a href=\":documentation\" target=\"_blank\">MySQL "
 "documentation</a> for more information."
 msgstr ""
+"Your MySQL server and PHP MySQL driver must support utf8mb4 character "
+"encoding. Make sure to use a database system that supports this (such as "
+"MySQL/MariaDB/Percona 5.5.3 and up), and that the utf8mb4 character set is "
+"compiled in. See the <a href=\":documentation\" target=\"_blank\">MySQL "
+"documentation</a> for more information."
 
 msgid ""
 "The %driver database must use %encoding encoding to work with Drupal. "
 "Recreate the database with %encoding encoding. See <a "
 "href=\"INSTALL.pgsql.txt\">INSTALL.pgsql.txt</a> for more details."
 msgstr ""
+"The %driver database must use %encoding encoding to work with Drupal. "
+"Recreate the database with %encoding encoding. See <a "
+"href=\"INSTALL.pgsql.txt\">INSTALL.pgsql.txt</a> for more details."
 
 msgid ""
 "The %setting setting is currently set to '%current_value', but needs to be "
 "'%needed_value'. Change this by running the following query: "
 "<code>@query</code>"
 msgstr ""
+"The %setting setting is currently set to '%current_value', but needs to be "
+"'%needed_value'. Change this by running the following query: "
+"<code>@query</code>"
 
 msgid "URI field size: @size"
-msgstr ""
+msgstr "URI field size: @size"
 
 msgid ""
 "Failed to connect to the server. The server reports the following message: "
 "<p class=\"error\">@message</p> For more help installing or updating code on"
 " your server, see the <a href=\":handbook_url\">handbook</a>."
 msgstr ""
+"Failed to connect to the server. The server reports the following message: "
+"<p class=\"error\">@message</p> For more help installing or updating code on"
+" your server, see the <a href=\":handbook_url\">handbook</a>."
 
 msgid ""
 "<ul>\n"
@@ -21227,53 +23033,68 @@ msgid ""
 "<li>View your <a href=\":base-url\">existing site</a>.</li>\n"
 "</ul>"
 msgstr ""
+"<ul>\n"
+"<li>To start over, you must empty your existing database and copy <em>default.settings.php</em> over <em>settings.php</em>.</li>\n"
+"<li>To upgrade an existing installation, proceed to the <a href=\":update-url\">update script</a>.</li>\n"
+"<li>View your <a href=\":base-url\">existing site</a>.</li>\n"
+"</ul>"
 
 msgid "File Transfer failed, reason: @reason"
-msgstr ""
+msgstr "File Transfer failed, reason: @reason"
 
 msgctxt "Validation"
 msgid "Unique field constraint"
-msgstr ""
+msgstr "Unique field constraint"
 
 msgid "A @entity_type with @field_name %value already exists."
-msgstr ""
+msgstr "A @entity_type with @field_name %value already exists."
 
 msgid "In reply to @parent_title by @parent_username"
-msgstr ""
+msgstr "In reply to @parent_title by @parent_username"
 
 msgid "Name for @anonymous"
-msgstr ""
+msgstr "Name for @anonymous"
 
 msgid "@source_name to @target_name"
-msgstr ""
+msgstr "@source_name to @target_name"
 
 msgid "@label <span class=\"visually-hidden\">(@source_language)</span>"
-msgstr ""
+msgstr "@label <span class=\"visually-hidden\">(@source_language)</span>"
 
 msgid ""
 "@sender-name (@sender-url) sent a message using the contact form at @form-"
 "url."
 msgstr ""
+"@sender-name (@sender-url) sent a message using the contact form at @form-"
+"url."
 
 msgid "[@site-name] @subject"
-msgstr ""
+msgstr "[@site-name] @subject"
 
 msgid ""
 "@sender-name (@sender-url) has sent you a message via your contact form at "
 "@site-name."
 msgstr ""
+"@sender-name (@sender-url) has sent you a message via your contact form at "
+"@site-name."
 
 msgid ""
 "No eligible views were found. <a href=\":create\">Create a view</a> with an "
 "<em>Entity Reference</em> display, or add such a display to an <a "
 "href=\":existing\">existing view</a>."
 msgstr ""
+"No eligible views were found. <a href=\":create\">Create a view</a> with an "
+"<em>Entity Reference</em> display, or add such a display to an <a "
+"href=\":existing\">existing view</a>."
 
 msgid ""
 "For more information see W3C's <a href=\":html-specifications\">HTML "
 "Specifications</a> or use your favorite search engine to find other sites "
 "that explain HTML."
 msgstr ""
+"For more information see W3C's <a href=\":html-specifications\">HTML "
+"Specifications</a> or use your favorite search engine to find other sites "
+"that explain HTML."
 
 msgid ""
 "If you do encounter problems, try using HTML character entities. A common "
@@ -21281,9 +23102,13 @@ msgid ""
 "list of entities see HTML's <a href=\":html-entities\">entities</a> page. "
 "Some of the available characters include:"
 msgstr ""
+"If you do encounter problems, try using HTML character entities. A common "
+"example looks like &amp;amp; for an ampersand &amp; character. For a full "
+"list of entities see HTML's <a href=\":html-entities\">entities</a> page. "
+"Some of the available characters include:"
 
 msgid "image from @field_name"
-msgstr ""
+msgstr "image from @field_name"
 
 msgid ""
 "Define how to decide which language is used to display page elements "
@@ -21297,9 +23122,19 @@ msgid ""
 "page. The default language can be changed in the <a href=\":admin-change-"
 "language\">list of languages</a>."
 msgstr ""
+"Define how to decide which language is used to display page elements "
+"(primarily text provided by modules, such as field labels and help text). "
+"This decision is made by evaluating a series of detection methods for "
+"languages; the first detection method that gets a result will determine "
+"which language is used for that type of text. Be aware that some language "
+"detection methods are unreliable under certain conditions, such as browser "
+"detection when page-caching is enabled and a user is not currently logged "
+"in. Define the order of evaluation of language detection methods on this "
+"page. The default language can be changed in the <a href=\":admin-change-"
+"language\">list of languages</a>."
 
 msgid "@message (@percent%)."
-msgstr ""
+msgstr "@message (@percent%)."
 
 msgid ""
 "One translation string was skipped because of disallowed or malformed HTML. "
@@ -21308,7 +23143,11 @@ msgid_plural ""
 "@count translation strings were skipped because of disallowed or malformed "
 "HTML. <a href=\":url\">See the log</a> for details."
 msgstr[0] ""
+"One translation string was skipped because of disallowed or malformed HTML. "
+"<a href=\":url\">See the log</a> for details."
 msgstr[1] ""
+"@count translation strings were skipped because of disallowed or malformed "
+"HTML. <a href=\":url\">See the log</a> for details."
 
 msgid ""
 "The Node module gives users with the <em>Administer content types</em> "
@@ -21318,6 +23157,12 @@ msgid ""
 "href=\":field\">fields</a> and configure default settings that suit the "
 "differing needs of various site content."
 msgstr ""
+"The Node module gives users with the <em>Administer content types</em> "
+"permission the ability to <a href=\":content-new\">create new content "
+"types</a> in addition to the default ones already configured. Creating "
+"custom content types gives you the flexibility to add <a "
+"href=\":field\">fields</a> and configure default settings that suit the "
+"differing needs of various site content."
 
 msgid ""
 "If the site is experiencing problems with permissions to content, you may "
@@ -21328,25 +23173,36 @@ msgid ""
 "automatically use the new permissions. <a href=\":rebuild\">Rebuild "
 "permissions</a>"
 msgstr ""
+"If the site is experiencing problems with permissions to content, you may "
+"have to rebuild the permissions cache. Rebuilding will remove all privileges"
+" to content and replace them with permissions based on the current modules "
+"and settings. Rebuilding may take some time if there is a lot of content or "
+"complex permission settings. After rebuilding has completed, content will "
+"automatically use the new permissions. <a href=\":rebuild\">Rebuild "
+"permissions</a>"
 
 msgid "No content types available. <a href=\":link\">Add content type</a>."
-msgstr ""
+msgstr "No content types available. <a href=\":link\">Add content type</a>."
 
 msgid "… @excerpt … @excerpt …"
-msgstr ""
+msgstr "… @excerpt … @excerpt …"
 
 msgid ""
 "For more information, see the online handbook entry for <a href=\":memory-"
 "limit\">increasing the PHP memory limit</a>."
 msgstr ""
+"For more information, see the online handbook entry for <a href=\":memory-"
+"limit\">increasing the PHP memory limit</a>."
 
 msgid "Last run @time ago"
-msgstr ""
+msgstr "Last run @time ago"
 
 msgid ""
 "For more information, see the online handbook entry for <a href=\":cron-"
 "handbook\">configuring cron jobs</a>."
 msgstr ""
+"For more information, see the online handbook entry for <a href=\":cron-"
+"handbook\">configuring cron jobs</a>."
 
 msgid ""
 "Update notifications are not enabled. It is <strong>highly "
@@ -21355,6 +23211,11 @@ msgid ""
 "on new releases. For more information, <a href=\":update\">Update status "
 "handbook page</a>."
 msgstr ""
+"Update notifications are not enabled. It is <strong>highly "
+"recommended</strong> that you enable the Update Manager module from the <a "
+"href=\":module\">module administration page</a> in order to stay up-to-date "
+"on new releases. For more information, <a href=\":update\">Update status "
+"handbook page</a>."
 
 msgid ""
 "The trusted_host_patterns setting is not configured in settings.php. This "
@@ -21363,37 +23224,46 @@ msgid ""
 "href=\":url\">Protecting against HTTP HOST Header attacks</a> for more "
 "information."
 msgstr ""
+"The trusted_host_patterns setting is not configured in settings.php. This "
+"can lead to security vulnerabilities. It is <strong>highly "
+"recommended</strong> that you configure this. See <a "
+"href=\":url\">Protecting against HTTP HOST Header attacks</a> for more "
+"information."
 
 msgid "Put your site into <a href=\":url\">maintenance mode</a>."
-msgstr ""
+msgstr "Put your site into <a href=\":url\">maintenance mode</a>."
 
 msgid "All errors have been <a href=\":url\">logged</a>."
-msgstr ""
+msgstr "All errors have been <a href=\":url\">logged</a>."
 
 msgid "Screenshot for @theme theme"
-msgstr ""
+msgstr "Screenshot for @theme theme"
 
 msgid "Settings for @theme theme"
-msgstr ""
+msgstr "Settings for @theme theme"
 
 msgid "Powered by <a href=\":poweredby\">Drupal</a>"
-msgstr ""
+msgstr "Powered by <a href=\":poweredby\">Drupal</a>"
 
 msgid "Number of summary rows: @rows"
-msgstr ""
+msgstr "Number of summary rows: @rows"
 
 msgid "Boolean indicating whether the node is published."
-msgstr ""
+msgstr "Boolean indicating whether the node is published."
 
 msgid ""
 "Your site is currently configured to send these emails when any updates are "
 "available. To get notified only for security updates, @url."
 msgstr ""
+"Your site is currently configured to send these emails when any updates are "
+"available. To get notified only for security updates, @url."
 
 msgid ""
 "Your site is currently configured to send these emails only when security "
 "updates are available. To get notified for any available updates, @url."
 msgstr ""
+"Your site is currently configured to send these emails only when security "
+"updates are available. To get notified for any available updates, @url."
 
 msgid ""
 "You can choose to send email only if a security update is available, or to "
@@ -21403,21 +23273,27 @@ msgid ""
 "page, and will also display an error message on administration pages if "
 "there is a security update."
 msgstr ""
+"You can choose to send email only if a security update is available, or to "
+"be notified about all newer versions. If there are updates available of "
+"Drupal core or any of your installed modules and themes, your site will "
+"always print a message on the <a href=\":status_report\">status report</a> "
+"page, and will also display an error message on administration pages if "
+"there is a security update."
 
 msgid "PHP OPcode caching"
-msgstr ""
+msgstr "PHP OPcode caching"
 
 msgid "@tour_item of @total"
-msgstr ""
+msgstr "@tour_item of @total"
 
 msgid "Version: @module-version"
-msgstr ""
+msgstr "Version: @module-version"
 
 msgid "Requires: @module-list"
-msgstr ""
+msgstr "Requires: @module-list"
 
 msgid "Required by: @module-list"
-msgstr ""
+msgstr "Required by: @module-list"
 
 msgid ""
 "Required if you want to change the %mail or %pass below. <a "
@@ -21436,129 +23312,150 @@ msgid ""
 "This link is provided by the Views module. The path can be changed by "
 "editing the view <a href=\":url\">@label</a>"
 msgstr ""
+"This link is provided by the Views module. The path can be changed by "
+"editing the view <a href=\":url\">@label</a>"
 
 msgid "@type language selected for page"
-msgstr ""
+msgstr "@type language selected for page"
 
 msgid "Will not be accessible."
-msgstr ""
+msgstr "Will not be accessible."
 
 msgid "@code (@title)"
-msgstr ""
+msgstr "@code (@title)"
 
 msgid ""
 "The following tokens are available. You may use Twig syntax in this field."
 msgstr ""
+"The following tokens are available. You may use Twig syntax in this field."
 
 msgid ""
 "Override the view and other argument titles. You may use Twig syntax in this"
 " field as well as the \"arguments\" and \"raw_arguments\" arrays."
 msgstr ""
+"Override the view and other argument titles. You may use Twig syntax in this"
+" field as well as the \"arguments\" and \"raw_arguments\" arrays."
 
 msgid ""
 "Override the view and other argument titles. You may use Twig syntax in this"
 " field."
 msgstr ""
+"Override the view and other argument titles. You may use Twig syntax in this"
+" field."
 
 msgid "The following replacement tokens are available for this argument."
-msgstr ""
+msgstr "The following replacement tokens are available for this argument."
 
 msgid ""
 "The category this block will appear under on the <a href=\":href\">blocks "
 "placement page</a>."
 msgstr ""
+"The category this block will appear under on the <a href=\":href\">blocks "
+"placement page</a>."
 
 msgid ""
 "You may also adjust the @settings for the currently selected access "
 "restriction."
 msgstr ""
+"You may also adjust the @settings for the currently selected access "
+"restriction."
 
 msgid ""
 "You may also adjust the @settings for the currently selected cache "
 "mechanism."
 msgstr ""
+"You may also adjust the @settings for the currently selected cache "
+"mechanism."
 
 msgid "You may also adjust the @settings for the currently selected style."
-msgstr ""
+msgstr "You may also adjust the @settings for the currently selected style."
 
 msgid ""
 "You may also adjust the @settings for the currently selected row style."
 msgstr ""
+"You may also adjust the @settings for the currently selected row style."
 
 msgid "You may also adjust the @settings for the currently selected pager."
-msgstr ""
+msgstr "You may also adjust the @settings for the currently selected pager."
 
 msgid ""
 "Views can be exported and imported as configuration files by using the <a "
 "href=\":config\">Configuration Manager module</a>."
 msgstr ""
+"Views can be exported and imported as configuration files by using the <a "
+"href=\":config\">Configuration Manager module</a>."
 
 msgid "Advanced Views settings"
-msgstr ""
+msgstr "Advanced Views settings"
 
 msgid "View @display_title"
-msgstr ""
+msgstr "View @display_title"
 
 msgid "Duplicate as @type"
-msgstr ""
+msgstr "Duplicate as @type"
 
 msgid "Add @display"
-msgstr ""
+msgstr "Add @display"
 
 msgid "By breaking this lock, any unsaved changes made by @user will be lost."
 msgstr ""
+"By breaking this lock, any unsaved changes made by @user will be lost."
 
 msgid ""
 "@display '@id': Component '@name' was disabled because its settings depend "
 "on removed dependencies."
 msgstr ""
+"@display '@id': Component '@name' was disabled because its settings depend "
+"on removed dependencies."
 
 msgid "No widget available for: %type."
-msgstr ""
+msgstr "No widget available for: %type."
 
 msgid "Create tasks that the system can execute."
-msgstr ""
+msgstr "Create tasks that the system can execute."
 
 msgid "Selection handler for entity reference fields have been adjusted."
-msgstr ""
+msgstr "Selection handler for entity reference fields have been adjusted."
 
 msgid ""
 "Configure how content is filtered when displayed, including which HTML tags "
 "are rendered, and enable module-provided filters."
 msgstr ""
+"Configure how content is filtered when displayed, including which HTML tags "
+"are rendered, and enable module-provided filters."
 
 msgid "- None (original image) -"
-msgstr ""
+msgstr "- None (original image) -"
 
 msgid "Checking site status"
-msgstr ""
+msgstr "Checking site status"
 
 msgid "Cache maximum age"
-msgstr ""
+msgstr "Cache maximum age"
 
 msgid "Creating and managing views"
-msgstr ""
+msgstr "Creating and managing views"
 
 msgid "Enabling and disabling views"
-msgstr ""
+msgstr "Enabling and disabling views"
 
 msgid "Exporting and importing views"
-msgstr ""
+msgstr "Exporting and importing views"
 
 msgid "Stable"
-msgstr ""
+msgstr "Stable"
 
 msgid "Aggregator RSS feed"
-msgstr ""
+msgstr "Aggregator RSS feed"
 
 msgid "Aggregator sources"
-msgstr ""
+msgstr "Aggregator sources"
 
 msgid "@label (@name:@column)"
-msgstr ""
+msgstr "@label (@name:@column)"
 
 msgid "Account cancellation request for [user:display-name] at [site:name]"
-msgstr ""
+msgstr "Account cancellation request for [user:display-name] at [site:name]"
 
 msgid "Replacement login information for [user:display-name] at [site:name]"
 msgstr ""
@@ -21581,6 +23478,20 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"A site administrator at [site:name] has created an account for you. You may now log in by clicking this link or copying and pasting it into your browser:\n"
+"\n"
+"[user:one-time-login-url]\n"
+"\n"
+"This link can only be used once to log in and will lead you to a page where you can set your password.\n"
+"\n"
+"After setting your password, you will be able to log in at [site:login-url] in the future using:\n"
+"\n"
+"username: [user:name]\n"
+"password: Your password\n"
+"\n"
+"--  [site:name] team"
 
 msgid ""
 "[user:display-name],\n"
@@ -21629,6 +23540,9 @@ msgid ""
 "\n"
 "[user:edit-url]"
 msgstr ""
+"[user:display-name] has applied for an account.\n"
+"\n"
+"[user:edit-url]"
 
 msgid ""
 "[user:display-name],\n"
@@ -21648,6 +23562,22 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"Your account at [site:name] has been activated.\n"
+"\n"
+"You may now log in by clicking this link or copying and pasting it into your browser:\n"
+"\n"
+"[user:one-time-login-url]\n"
+"\n"
+"This link can only be used once to log in and will lead you to a page where you can set your password.\n"
+"\n"
+"After setting your password, you will be able to log in at [site:login-url] in the future using:\n"
+"\n"
+"username: [user:account-name]\n"
+"password: Your password\n"
+"\n"
+"--  [site:name] team"
 
 msgid "Account details for [user:display-name] at [site:name] (approved)"
 msgstr ""
@@ -21665,173 +23595,195 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"Your account on [site:name] has been canceled.\n"
+"\n"
+"--  [site:name] team"
 
 msgid "Account details for [user:display-name] at [site:name] (canceled)"
 msgstr ""
 "Käyttäjätilin tiedot [site:name]-käyttäjälle [user:display-name] (peruttu)"
 
 msgid "Find and manage custom blocks."
-msgstr ""
+msgstr "Find and manage custom blocks."
 
 msgid "Recent comments."
-msgstr ""
+msgstr "Recent comments."
 
 msgid "Find and manage files."
-msgstr ""
+msgstr "Find and manage files."
 
 msgid "Files overview"
-msgstr ""
+msgstr "Files overview"
 
 msgid "File usage information for {{ arguments.fid }}"
-msgstr ""
+msgstr "File usage information for {{ arguments.fid }}"
 
 msgid ""
 "<p>This page provides the ability to add common languages to your "
 "site.</p><p>If the desired language is not available, you can add a custom "
 "language.</p>"
 msgstr ""
+"<p>This page provides the ability to add common languages to your "
+"site.</p><p>If the desired language is not available, you can add a custom "
+"language.</p>"
 
 msgid "Editing languages"
-msgstr ""
+msgstr "Editing languages"
 
 msgid "Recent content."
 msgstr "Tuore sisältö."
 
 msgid "All content, by letter."
-msgstr ""
+msgstr "All content, by letter."
 
 msgid "Content belonging to a certain taxonomy term."
-msgstr ""
+msgstr "Content belonging to a certain taxonomy term."
 
 msgid "Shows a list of the newest user accounts on the site."
-msgstr ""
+msgstr "Shows a list of the newest user accounts on the site."
 
 msgid ""
 "The following reason prevents @module.module_name from being uninstalled:"
 msgid_plural ""
 "The following reasons prevent @module.module_name from being uninstalled:"
 msgstr[0] ""
+"The following reason prevents @module.module_name from being uninstalled:"
 msgstr[1] ""
+"The following reasons prevent @module.module_name from being uninstalled:"
 
 msgid "Fallback sort expose settings"
-msgstr ""
+msgstr "Fallback sort expose settings"
 
 msgid "width @data.width"
-msgstr ""
+msgstr "width @data.width"
 
 msgid "height @data.height"
-msgstr ""
+msgstr "height @data.height"
 
 msgid "This entity (%type: %id) cannot be referenced."
-msgstr ""
+msgstr "This entity (%type: %id) cannot be referenced."
 
 msgid "A default base theme using Drupal 8.0.0's core markup and CSS."
-msgstr ""
+msgstr "A default base theme using Drupal 8.0.0's core markup and CSS."
 
 msgid "Install configuration"
-msgstr ""
+msgstr "Install configuration"
 
 msgid "Show &mdash; @configuration.label"
-msgstr ""
+msgstr "Show &mdash; @configuration.label"
 
 msgid "Hide &mdash; @configuration.label"
-msgstr ""
+msgstr "Hide &mdash; @configuration.label"
 
 msgid "Session exists"
-msgstr ""
+msgstr "Session exists"
 
 msgid "Default configuration hash"
-msgstr ""
+msgstr "Default configuration hash"
 
 msgid ""
 "Field %field set in %filter is not usable for this filter type. Combined "
 "field filter only works for simple fields."
 msgstr ""
+"Field %field set in %filter is not usable for this filter type. Combined "
+"field filter only works for simple fields."
 
 msgid "Renders an entity in a view mode."
-msgstr ""
+msgstr "Renders an entity in a view mode."
 
 msgctxt "decimal places"
 msgid "Scale"
-msgstr ""
+msgstr "Scale"
 
 msgid "The new size setting for email widgets has been added."
-msgstr ""
+msgstr "The new size setting for email widgets has been added."
 
 msgid "Did not save to map table due to NULL value for key field @field"
-msgstr ""
+msgstr "Did not save to map table due to NULL value for key field @field"
 
 msgid "A boolean indicating whether the node is visible on the front page."
-msgstr ""
+msgstr "A boolean indicating whether the node is visible on the front page."
 
 msgid ""
 "A boolean indicating whether the node should sort to the top of content "
 "lists."
 msgstr ""
+"A boolean indicating whether the node should sort to the top of content "
+"lists."
 
 msgid "The %entity_type entity type needs to be installed."
-msgstr ""
+msgstr "The %entity_type entity type needs to be installed."
 
 msgid "The %entity_type entity type needs to be updated."
-msgstr ""
+msgstr "The %entity_type entity type needs to be updated."
 
 msgid "The %field_name field needs to be installed."
-msgstr ""
+msgstr "The %field_name field needs to be installed."
 
 msgid "The %field_name field needs to be updated."
-msgstr ""
+msgstr "The %field_name field needs to be updated."
 
 msgid "The %field_name field needs to be uninstalled."
-msgstr ""
+msgstr "The %field_name field needs to be uninstalled."
 
 msgid "Custom text: @true_label / @false_label"
-msgstr ""
+msgstr "Custom text: @true_label / @false_label"
 
 msgid "Display: @true_label / @false_label"
-msgstr ""
+msgstr "Display: @true_label / @false_label"
 
 msgid ""
 "See <a href=\"http://php.net/manual/function.date.php\" "
 "target=\"_blank\">the documentation for PHP date formats</a>."
 msgstr ""
+"See <a href=\"http://php.net/manual/function.date.php\" "
+"target=\"_blank\">the documentation for PHP date formats</a>."
 
 msgid "An icon that links to the feed URL"
-msgstr ""
+msgstr "An icon that links to the feed URL"
 
 msgid "Parent website of the feed."
-msgstr ""
+msgstr "Parent website of the feed."
 
 msgid "Parent website's description of the feed."
-msgstr ""
+msgstr "Parent website's description of the feed."
 
 msgid "Check my spelling as I type"
-msgstr ""
+msgstr "Check my spelling as I type"
 
 msgid "Language list ID"
-msgstr ""
+msgstr "Language list ID"
 
 msgid "Remove content from front page"
-msgstr ""
+msgstr "Remove content from front page"
 
 msgid "Continuing on"
-msgstr ""
+msgstr "Continuing on"
 
 msgid ""
 "The %field_type_label field type is used in the following field: @fields"
 msgid_plural ""
 "The %field_type_label field type is used in the following fields: @fields"
 msgstr[0] ""
+"The %field_type_label field type is used in the following field: @fields"
 msgstr[1] ""
+"The %field_type_label field type is used in the following fields: @fields"
 
 msgid ""
 "<p>This page provides the ability to edit a language on your site, including"
 " custom languages.</p>"
 msgstr ""
+"<p>This page provides the ability to edit a language on your site, including"
+" custom languages.</p>"
 
 msgid ""
 "<p>You cannot change the code of a language on the site, since it is used by"
 " the system to keep track of the language.</p>"
 msgstr ""
+"<p>You cannot change the code of a language on the site, since it is used by"
+" the system to keep track of the language.</p>"
 
 msgid ""
 "<p>The language name is used throughout the site for all users and is "
@@ -21839,32 +23791,44 @@ msgid ""
 "Interface Translation module, and names of both built-in and custom "
 "languages can be translated using the Configuration Translation module.</p>"
 msgstr ""
+"<p>The language name is used throughout the site for all users and is "
+"written in English. Names of built-in languages can be translated using the "
+"Interface Translation module, and names of both built-in and custom "
+"languages can be translated using the Configuration Translation module.</p>"
 
 msgid ""
 "<p>Choose if the language is a \"Left to right\" or \"Right to left\" "
 "language.</p><p>Note that not all themes support \"Right to left\" layouts, "
 "so test your theme if you are using \"Right to left\".</p>"
 msgstr ""
+"<p>Choose if the language is a \"Left to right\" or \"Right to left\" "
+"language.</p><p>Note that not all themes support \"Right to left\" layouts, "
+"so test your theme if you are using \"Right to left\".</p>"
 
 msgid ""
 "<p>The \"Languages\" page allows you to add, edit, delete, and reorder "
 "languages for the site.</p>"
 msgstr ""
+"<p>The \"Languages\" page allows you to add, edit, delete, and reorder "
+"languages for the site.</p>"
 
 msgid ""
 "<p>To add more languages to your site, click the \"Add language\" "
 "button.</p><p>Added languages will be displayed in the language list and can"
 " then be edited or deleted.</p>"
 msgstr ""
+"<p>To add more languages to your site, click the \"Add language\" "
+"button.</p><p>Added languages will be displayed in the language list and can"
+" then be edited or deleted.</p>"
 
 msgid "Reordering languages"
-msgstr ""
+msgstr "Reordering languages"
 
 msgid "Set a language as default"
-msgstr ""
+msgstr "Set a language as default"
 
 msgid "Modifying languages"
-msgstr ""
+msgstr "Modifying languages"
 
 msgid ""
 "<p>Operations are provided for editing and deleting your "
@@ -21874,61 +23838,80 @@ msgid ""
 "it, and content in this language will be set to be language neutral. Note "
 "that you cannot delete the default language of the site.</p>"
 msgstr ""
+"<p>Operations are provided for editing and deleting your "
+"languages.</p><p>You can edit the name and the direction of the "
+"language.</p><p>Deleted languages can be added back at a later time. "
+"Deleting a language will remove all interface translations associated with "
+"it, and content in this language will be set to be language neutral. Note "
+"that you cannot delete the default language of the site.</p>"
 
 msgid "Choose the language you want to translate."
-msgstr ""
+msgstr "Choose the language you want to translate."
 
 msgid ""
 "Enter the specific word or sentence you want to translate, you can also "
 "write just a part of a word."
 msgstr ""
+"Enter the specific word or sentence you want to translate, you can also "
+"write just a part of a word."
 
 msgid "Filter the search"
-msgstr ""
+msgstr "Filter the search"
 
 msgid ""
 "You can search for untranslated strings if you want to translate something "
 "that isn't translated yet. If you want to modify an existing translation, "
 "you might want to search only for translated strings."
 msgstr ""
+"You can search for untranslated strings if you want to translate something "
+"that isn't translated yet. If you want to modify an existing translation, "
+"you might want to search only for translated strings."
 
 msgid "Apply your search criteria"
-msgstr ""
+msgstr "Apply your search criteria"
 
 msgid "To apply your search criteria, click on the <em>Filter</em> button."
-msgstr ""
+msgstr "To apply your search criteria, click on the <em>Filter</em> button."
 
 msgid ""
 "You can write your own translation in the text fields of the right column. "
 "Try to figure out in which context the text will be used in order to "
 "translate it in the appropriate way."
 msgstr ""
+"You can write your own translation in the text fields of the right column. "
+"Try to figure out in which context the text will be used in order to "
+"translate it in the appropriate way."
 
 msgid "Validate the translation"
-msgstr ""
+msgstr "Validate the translation"
 
 msgid ""
 "When you have finished your translations, click on the <em>Save "
 "translations</em> button. You must save your translations, each time before "
 "changing the page or making a new search."
 msgstr ""
+"When you have finished your translations, click on the <em>Save "
+"translations</em> button. You must save your translations, each time before "
+"changing the page or making a new search."
 
 msgid "{{ arguments.created_year_month }}"
-msgstr ""
+msgstr "{{ arguments.created_year_month }}"
 
 msgid "Find and manage content"
-msgstr ""
+msgstr "Find and manage content"
 
 msgid "Welcome to [site:name]"
-msgstr ""
+msgstr "Welcome to [site:name]"
 
 msgid "{{ arguments.tid }}"
-msgstr ""
+msgstr "{{ arguments.tid }}"
 
 msgid ""
 "Perform administrative tasks, including adding a description and creating a "
 "clone. Click the drop-down button to view the available options."
 msgstr ""
+"Perform administrative tasks, including adding a description and creating a "
+"clone. Click the drop-down button to view the available options."
 
 msgid ""
 "Choose how to output results. E.g., choose <em>Content</em> to output each "
@@ -21937,20 +23920,30 @@ msgid ""
 "result. Additional formats can be added by installing modules to "
 "<em>extend</em> Drupal's base functionality."
 msgstr ""
+"Choose how to output results. E.g., choose <em>Content</em> to output each "
+"item completely, using your configured display settings. Or choose "
+"<em>Fields</em>, which allows you to output only specific fields for each "
+"result. Additional formats can be added by installing modules to "
+"<em>extend</em> Drupal's base functionality."
 
 msgid ""
 "If this view uses fields, they are listed here. You can click on a field to "
 "configure it."
 msgstr ""
+"If this view uses fields, they are listed here. You can click on a field to "
+"configure it."
 
 msgid ""
 "Add filters to limit the results in the output. E.g., to only show content "
 "that is <em>published</em>, you would add a filter for <em>Published</em> "
 "and select <em>Yes</em>."
 msgstr ""
+"Add filters to limit the results in the output. E.g., to only show content "
+"that is <em>published</em>, you would add a filter for <em>Published</em> "
+"and select <em>Yes</em>."
 
 msgid "Show a preview of the view output."
-msgstr ""
+msgstr "Show a preview of the view output."
 
 msgid ""
 "PHP OPcode caching can improve your site's performance considerably. It is "
@@ -21958,249 +23951,265 @@ msgid ""
 "href=\"http://php.net/manual/opcache.installation.php\" "
 "target=\"_blank\">OPcache</a> installed on your server."
 msgstr ""
+"PHP OPcode caching can improve your site's performance considerably. It is "
+"<strong>highly recommended</strong> to have <a "
+"href=\"http://php.net/manual/opcache.installation.php\" "
+"target=\"_blank\">OPcache</a> installed on your server."
 
 msgid "This identifier has illegal characters."
-msgstr ""
+msgstr "This identifier has illegal characters."
 
 msgid "Add a new @entity_type."
-msgstr ""
+msgstr "Add a new @entity_type."
 
 msgid "There is no @entity_type yet. @add_link"
-msgstr ""
+msgstr "There is no @entity_type yet. @add_link"
 
 msgid "Store new items in"
-msgstr ""
+msgstr "Store new items in"
 
 msgid "Delete @entity_type"
-msgstr ""
+msgstr "Delete @entity_type"
 
 msgctxt "Entity type label"
 msgid "@count @label"
 msgid_plural "@count @label entities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count @label"
+msgstr[1] "@count @label entities"
 
 msgid "Parent path"
-msgstr ""
+msgstr "Parent path"
 
 msgid "Selected combination of day and month is not valid."
-msgstr ""
+msgstr "Selected combination of day and month is not valid."
 
 msgid "Determines if a password needs hashing"
-msgstr ""
+msgstr "Determines if a password needs hashing"
 
 msgid ""
 "View display '@id': Comment field formatter '@name' was disabled because it "
 "is using the comment view display '@display' (@mode) that was just disabled."
 msgstr ""
+"View display '@id': Comment field formatter '@name' was disabled because it "
+"is using the comment view display '@display' (@mode) that was just disabled."
 
 msgid "No entity view display updated."
-msgstr ""
+msgstr "No entity view display updated."
 
 msgid "administration theme"
-msgstr ""
+msgstr "administration theme"
 
 msgid "All @entity_type_plural have been deleted."
-msgstr ""
+msgstr "All @entity_type_plural have been deleted."
 
 msgid "Content moderation state"
-msgstr ""
+msgstr "Content moderation state"
 
 msgid "content moderation state"
-msgstr ""
+msgstr "content moderation state"
 
 msgid "content moderation states"
-msgstr ""
+msgstr "content moderation states"
 
 msgid "Configure Content Moderation permissions"
-msgstr ""
+msgstr "Configure Content Moderation permissions"
 
 msgid "Testing missing dependencies"
-msgstr ""
+msgstr "Testing missing dependencies"
 
 msgid ""
 "Minimal profile for running a test when dependencies are listed but missing."
 msgstr ""
+"Minimal profile for running a test when dependencies are listed but missing."
 
 msgid "The field ID."
-msgstr ""
+msgstr "The field ID."
 
 msgid "Last upgrade: @date"
-msgstr ""
+msgstr "Last upgrade: @date"
 
 msgid "A boolean indicating the published state."
-msgstr ""
+msgstr "A boolean indicating the published state."
 
 msgid "Warnings found"
-msgstr ""
+msgstr "Warnings found"
 
 msgid "Errors found"
-msgstr ""
+msgstr "Errors found"
 
 msgid ""
 "An intentionally plain theme with no styling to demonstrate default Drupal’s"
 " HTML and CSS. Learn how to build a custom theme from Stark in the <a "
 "href=\"https://www.drupal.org/docs/8/theming\">Theming Guide</a>."
 msgstr ""
+"An intentionally plain theme with no styling to demonstrate default Drupal’s"
+" HTML and CSS. Learn how to build a custom theme from Stark in the <a "
+"href=\"https://www.drupal.org/docs/8/theming\">Theming Guide</a>."
 
 msgid "There are no @label yet."
-msgstr ""
+msgstr "There are no @label yet."
 
 msgid "The %field date is incomplete."
-msgstr ""
+msgstr "The %field date is incomplete."
 
 msgid "Remove the @label role from the selected user(s)"
-msgstr ""
+msgstr "Remove the @label role from the selected user(s)"
 
 msgid "!!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz"
-msgstr ""
+msgstr "!!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz"
 
 msgid "!!binary MQNAY291bnQ="
-msgstr ""
+msgstr "!!binary MQNAY291bnQ="
 
 msgid "Entity reference selection handler settings"
-msgstr ""
+msgstr "Entity reference selection handler settings"
 
 msgid "Default selection handler settings"
-msgstr ""
+msgstr "Default selection handler settings"
 
 msgid "File selection handler settings"
-msgstr ""
+msgstr "File selection handler settings"
 
 msgid "User selection handler settings"
-msgstr ""
+msgstr "User selection handler settings"
 
 msgid "Views selection handler settings"
-msgstr ""
+msgstr "Views selection handler settings"
 
 msgid "The \"%plugin_id\" was not found"
-msgstr ""
+msgstr "The \"%plugin_id\" was not found"
 
 msgid ""
 "You must have the pdo_sqlite PHP extension installed. See "
 "core/INSTALL.sqlite.txt for instructions."
 msgstr ""
+"You must have the pdo_sqlite PHP extension installed. See "
+"core/INSTALL.sqlite.txt for instructions."
 
 msgid "No installation found. Use the 'install' command."
-msgstr ""
+msgstr "No installation found. Use the 'install' command."
 
 msgid "Select and configure themes."
-msgstr ""
+msgstr "Select and configure themes."
 
 msgid "Breadcrumbs"
 msgstr "Murupolut"
 
 msgid "Powered by Drupal"
-msgstr ""
+msgstr "Powered by Drupal"
 
 msgid "Help"
-msgstr ""
+msgstr "Help"
 
 msgid "Primary tabs"
-msgstr ""
+msgstr "Primary tabs"
 
 msgid "Status messages"
-msgstr ""
+msgstr "Status messages"
 
 msgid "Block"
-msgstr ""
+msgstr "Block"
 
 msgid ""
 "Use <em>articles</em> for time-sensitive content like news, press releases "
 "or blog posts."
 msgstr ""
+"Use <em>articles</em> for time-sensitive content like news, press releases "
+"or blog posts."
 
 msgid "Tools"
 msgstr "Työkalut"
 
 msgid "Comments published"
-msgstr ""
+msgstr "Comments published"
 
 msgid "Main page content"
-msgstr ""
+msgstr "Main page content"
 
 msgid "Footer menu"
-msgstr ""
+msgstr "Footer menu"
 
 msgid "Tabs"
-msgstr ""
+msgstr "Tabs"
 
 msgid "Page title"
-msgstr ""
+msgstr "Page title"
 
 msgid "A basic block contains a title and a body."
-msgstr ""
+msgstr "A basic block contains a title and a body."
 
 msgid "Default comments"
-msgstr ""
+msgstr "Default comments"
 
 msgid "Promoted to front page"
-msgstr ""
+msgstr "Promoted to front page"
 
 msgid "Image"
 msgstr "Kuva"
 
 msgid "Basic page"
-msgstr ""
+msgstr "Basic page"
 
 msgid ""
 "Use <em>basic pages</em> for your static content, such as an 'About us' "
 "page."
 msgstr ""
+"Use <em>basic pages</em> for your static content, such as an 'About us' "
+"page, which doesn't fall under any other content type"
 
 msgid "Administrator"
-msgstr ""
+msgstr "Administrator"
 
 msgid "Authenticated user"
 msgstr "Tunnistautunut käyttäjä"
 
 msgid "Full comment"
-msgstr ""
+msgstr "Full comment"
 
 msgid "Save comment"
-msgstr ""
+msgstr "Save comment"
 
 msgid "Unpublish comment"
-msgstr ""
+msgstr "Unpublish comment"
 
 msgid "Personal contact form"
 msgstr "Yhteydenottolomake"
 
 msgid "Your message has been sent."
-msgstr ""
+msgstr "Your message has been sent."
 
 msgid "Large (480×480)"
-msgstr ""
+msgstr "Large (480×480)"
 
 msgid "English"
-msgstr ""
+msgstr "English"
 
 msgid "Not specified"
-msgstr ""
+msgstr "Not specified"
 
 msgid "Full content"
-msgstr ""
+msgstr "Full content"
 
 msgid "Search result highlighting input"
-msgstr ""
+msgstr "Search result highlighting input"
 
 msgid "Make content sticky"
-msgstr ""
+msgstr "Make content sticky"
 
 msgid "Site branding"
-msgstr ""
+msgstr "Site branding"
 
 msgid "Comments unapproved"
-msgstr ""
+msgstr "Comments unapproved"
 
 msgid "The unapproved comments listing."
-msgstr ""
+msgstr "The unapproved comments listing."
 
 msgid "User account menu"
 msgstr "Käyttäjätilin valikko"
 
 msgid "{{ message }}"
-msgstr ""
+msgstr "{{ message }}"
 
 msgid ""
 "<p>Now that you have an overview of the \"Edit language\" feature, you can "
@@ -22208,6 +24217,10 @@ msgid ""
 "href=\"[site:url]admin/config/regional/language\">Viewing configured "
 "languages</a></li></ul></p>"
 msgstr ""
+"<p>Now that you have an overview of the \"Edit language\" feature, you can "
+"continue by:<ul><li>Editing a language</li><li><a "
+"href=\"[site:url]admin/config/regional/language\">Viewing configured "
+"languages</a></li></ul></p>"
 
 msgid ""
 "<p>Now that you have an overview of the \"Languages\" page, you can continue"
@@ -22215,6 +24228,10 @@ msgid ""
 "a language</a></li><li>Reordering languages</li><li>Editing a "
 "language</li><li>Deleting a language</li></ul></p>"
 msgstr ""
+"<p>Now that you have an overview of the \"Languages\" page, you can continue"
+" by:<ul><li><a href=\"[site:url]admin/config/regional/language/add\">Adding "
+"a language</a></li><li>Reordering languages</li><li>Editing a "
+"language</li><li>Deleting a language</li></ul></p>"
 
 msgid ""
 "This page allows you to translate the user interface or modify existing "
@@ -22223,6 +24240,11 @@ msgid ""
 "href=\"[site:url]admin/config/regional/language\">Languages page</a>, in "
 "order to use this page."
 msgstr ""
+"This page allows you to translate the user interface or modify existing "
+"translations. If you have installed your site initially in English, you must"
+" first add another language on the <a "
+"href=\"[site:url]admin/config/regional/language\">Languages page</a>, in "
+"order to use this page."
 
 msgid ""
 "The translations you have made here will be used on your site's user "
@@ -22233,6 +24255,13 @@ msgid ""
 "href=\"[site:url]admin/config/regional/translate/import\">import them</a> "
 "later."
 msgstr ""
+"The translations you have made here will be used on your site's user "
+"interface. If you want to use them on another site or modify them on an "
+"external translation editor, you can <a "
+"href=\"[site:url]admin/config/regional/translate/export\">export them</a> to"
+" a .po file and <a "
+"href=\"[site:url]admin/config/regional/translate/import\">import them</a> "
+"later."
 
 msgid ""
 "No front page content has been created yet.<br/>Follow the <a "
@@ -22240,31 +24269,39 @@ msgid ""
 "href=\"https://www.drupal.org/docs/user_guide/en/index.html\">User Guide</a>"
 " to start building your site."
 msgstr ""
+"No front page content has been created yet.<br/>Follow the <a "
+"target=\"_blank\" "
+"href=\"https://www.drupal.org/docs/user_guide/en/index.html\">User Guide</a>"
+" to start building your site."
 
 msgid ""
 "There is content for the entity type: @entity_type. <a href=\":url\">Remove "
 "@entity_type_plural</a>."
 msgstr ""
+"There is content for the entity type: @entity_type. <a href=\":url\">Remove "
+"@entity_type_plural</a>."
 
 msgid "HTML Week"
-msgstr ""
+msgstr "HTML Week"
 
 msgid ""
 "@site is currently under maintenance. We should be back shortly. Thank you "
 "for your patience."
 msgstr ""
+"@site is currently under maintenance. We should be back shortly. Thank you "
+"for your patience."
 
 msgid "Links related to the active user account"
-msgstr ""
+msgstr "Links related to the active user account"
 
 msgid "User tool links, often added by modules"
-msgstr ""
+msgstr "User tool links, often added by modules"
 
 msgid "Taxonomy term page"
-msgstr ""
+msgstr "Taxonomy term page"
 
 msgid "Compact"
-msgstr ""
+msgstr "Compact"
 
 msgid ""
 "[user:display-name],\n"
@@ -22281,6 +24318,19 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"A request to cancel your account has been made at [site:name].\n"
+"\n"
+"You may now cancel your account on [site:url-brief] by clicking this link or copying and pasting it into your browser:\n"
+"\n"
+"[user:cancel-url]\n"
+"\n"
+"NOTE: The cancellation of your account is not reversible.\n"
+"\n"
+"This link expires in one day and nothing will happen if it is not used.\n"
+"\n"
+"--  [site:name] team"
 
 msgid ""
 "[user:display-name],\n"
@@ -22327,9 +24377,14 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"Your account on [site:name] has been blocked.\n"
+"\n"
+"--  [site:name] team"
 
 msgid "Custom block library"
-msgstr ""
+msgstr "Custom block library"
 
 msgid ""
 "<p>Now that you have an overview of the \"Add languages\" feature, you can "
@@ -22338,30 +24393,35 @@ msgid ""
 "href=\"[site:url]admin/config/regional/language\">Viewing configured "
 "languages</a></li></ul></p>"
 msgstr ""
+"<p>Now that you have an overview of the \"Add languages\" feature, you can "
+"continue by:<ul><li>Adding a language</li><li>Adding a custom "
+"language</li><li><a "
+"href=\"[site:url]admin/config/regional/language\">Viewing configured "
+"languages</a></li></ul></p>"
 
 msgid "There are no custom blocks available."
-msgstr ""
+msgstr "There are no custom blocks available."
 
 msgid "Find and manage comments."
-msgstr ""
+msgstr "Find and manage comments."
 
 msgid "Language direction"
-msgstr ""
+msgstr "Language direction"
 
 msgid "Adding languages"
-msgstr ""
+msgstr "Adding languages"
 
 msgid "The approved comments listing."
-msgstr ""
+msgstr "The approved comments listing."
 
 msgid "Lists (Views)"
-msgstr ""
+msgstr "Lists (Views)"
 
 msgid "Watchdog"
-msgstr ""
+msgstr "Watchdog"
 
 msgid "Recent log messages"
-msgstr ""
+msgstr "Recent log messages"
 
 msgid ""
 "<p>To reorder the languages on your site, use the drag icons next to each "
@@ -22371,12 +24431,18 @@ msgid ""
 "done with reordering the languages, click the \"Save configuration\" button "
 "for the changes to take effect.</p>"
 msgstr ""
+"<p>To reorder the languages on your site, use the drag icons next to each "
+"language.</p><p>The order shown here is the display order for language lists"
+" on the site such as in the language switcher blocks provided by the "
+"Interface Translation and Content Translation modules.</p><p>When you are "
+"done with reordering the languages, click the \"Save configuration\" button "
+"for the changes to take effect.</p>"
 
 msgid "No log messages available."
-msgstr ""
+msgstr "No log messages available."
 
 msgid "Manage user accounts, roles, and permissions."
-msgstr ""
+msgstr "Manage user accounts, roles, and permissions."
 
 msgid ""
 "One translation file imported. %number translations were added, %update "
@@ -22385,35 +24451,39 @@ msgid_plural ""
 "@count translation files imported. %number translations were added, %update "
 "translations were updated and %delete translations were removed."
 msgstr[0] ""
+"Käännöstiedosto tuotiin. %number käännöstä lisättiin, %update käännöstä "
+"päivitettiin ja %delete käännöstä poistettiin."
 msgstr[1] ""
+"@count käännöstiedostoa tuotiin. %number käännöstä lisättiin, %update "
+"käännöstä päivitettiin ja %delete käännöstä poistettiin."
 
 msgid "Fid"
-msgstr ""
+msgstr "Fid"
 
 msgid "MIME type"
-msgstr ""
+msgstr "MIME type"
 
 msgid "Size"
-msgstr ""
+msgstr "Size"
 
 msgid "Items per page"
-msgstr ""
+msgstr "Items per page"
 
 msgid "Temporary"
 msgstr "Väliaikainen"
 
 msgid "1 place"
 msgid_plural "@count places"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 place"
+msgstr[1] "@count places"
 
 msgid "Registering module"
-msgstr ""
+msgstr "Registering module"
 
 msgid "1"
 msgid_plural "@count"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1"
+msgstr[1] "@count"
 
 msgid "User"
 msgstr "Käyttäjä"
@@ -22428,6 +24498,11 @@ msgid ""
 " additional form where you can provide the name, code, and direction of the "
 "language.</p>"
 msgstr ""
+"<p>Choose a language from the list, or choose \"Custom language...\" at the "
+"end of the list.</p><p>Click the \"Add language\" button when you are done "
+"choosing your language.</p><p>When adding a custom language, you will get an"
+" additional form where you can provide the name, code, and direction of the "
+"language.</p>"
 
 msgid ""
 "<p>You can change the default language of the site by choosing one of your "
@@ -22435,604 +24510,642 @@ msgid ""
 "situations where no choice is made but a language should be set, for example"
 " as the language of the displayed interface.</p>"
 msgstr ""
+"<p>You can change the default language of the site by choosing one of your "
+"configured languages as default. The site will use the default language in "
+"situations where no choice is made but a language should be set, for example"
+" as the language of the displayed interface.</p>"
 
 msgid "User interface translation"
-msgstr ""
+msgstr "User interface translation"
 
 msgid "Translation language"
-msgstr ""
+msgstr "Translation language"
 
 msgid "Monthly archive"
-msgstr ""
+msgstr "Monthly archive"
 
 msgid ""
 "A user is considered online for this long after they have last viewed a "
 "page."
 msgstr ""
+"A user is considered online for this long after they have last viewed a "
+"page."
 
 msgid "Main navigation"
-msgstr ""
+msgstr "Main navigation"
 
 msgid "Initializing."
-msgstr ""
+msgstr "Aloitetaan"
 
 msgid "Starting configuration update"
-msgstr ""
+msgstr "Aloitetaan asetusten päivitys"
 
 msgid "Custom block type"
-msgstr ""
+msgstr "Kustomoitu lohkotyyppi"
 
 msgctxt "View entity type"
 msgid "View"
-msgstr ""
+msgstr "View"
 
 msgid "No content available."
 msgstr "Sisältöä ei saatavilla."
 
 msgid "@type_label bundle"
-msgstr ""
+msgstr "@type_label bundle"
 
 msgid "Custom menu link"
-msgstr ""
+msgstr "Custom menu link"
 
 msgid "Small"
-msgstr ""
+msgstr "Pieni"
 
 msgid "Large"
-msgstr ""
+msgstr "Suuri"
 
 msgid "Author"
-msgstr ""
+msgstr "Author"
 
 msgid "Icons"
-msgstr ""
+msgstr "Ikonit"
 
 msgid "Down"
-msgstr ""
+msgstr "Alas"
 
 msgid "E-mail from name"
-msgstr ""
+msgstr "Sähköpostin lähettäjä"
 
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 msgid "Solid"
-msgstr ""
+msgstr "Kiinteä"
 
 msgid "Light"
-msgstr ""
+msgstr "Vaalea"
 
 msgid "Animation"
-msgstr ""
+msgstr "Animation"
 
 msgid "Local"
-msgstr ""
+msgstr "Paikallinen"
 
 msgid "Variants"
-msgstr ""
+msgstr "Muunnokset"
 
 msgid "Libraries"
-msgstr ""
+msgstr "Kirjastot"
 
 msgid ""
 "The %dependency library, which the %library library depends on, is not "
 "installed."
 msgstr ""
+"Kirjastoa %dependency, jonka kirjasto %library vaatii, ei ole asennettu."
 
 msgid ""
 "The version %dependency_version of the %dependency library is not compatible"
 " with the %library library."
 msgstr ""
+"Kirjaston %dependency versio %dependency_version ei ole yhteensopiva "
+"kirjaston %library kanssa."
 
 msgid "The %library library could not be found."
-msgstr ""
+msgstr "%library-kirjastoa ei löytynyt."
 
 msgid "The version of the %library library could not be detected."
-msgstr ""
+msgstr "%library-kirjaston versiota ei voitu tunnistaa."
 
 msgid ""
 "The installed version %version of the %library library is not supported."
-msgstr ""
+msgstr "%library-kirjaston asennettu versio %version ei ole tuettu."
 
 msgid "The %variant variant of the %library library could not be found."
-msgstr ""
+msgstr "%library-kirjaston %variant-muunnosta ei löytynyt."
 
 msgid "Accept"
-msgstr ""
+msgstr "Accept"
 
 msgid "E-mail from address"
-msgstr ""
+msgstr "Sähköpostin lähetysosoite"
 
 msgid "SMTP Authentication"
-msgstr ""
+msgstr "SMTP Authentication"
 
 msgid "Enable debugging"
-msgstr ""
+msgstr "Enable debugging"
 
 msgid "Use SSL"
-msgstr ""
+msgstr "Use SSL"
 
 msgid "Install options"
-msgstr ""
+msgstr "Install options"
 
 msgid "To uninstall this module you must turn it off here first."
-msgstr ""
+msgstr "To uninstall this module you must turn it off here first."
 
 msgid "SMTP server settings"
-msgstr ""
+msgstr "SMTP server settings"
 
 msgid "The address of your outgoing SMTP server."
-msgstr ""
+msgstr "The address of your outgoing SMTP server."
 
 msgid ""
 "The address of your outgoing SMTP backup server. If the primary server can't"
 " be found this one will be tried. This is optional."
 msgstr ""
+"The address of your outgoing SMTP backup server. If the primary server can't"
+" be found this one will be tried. This is optional."
 
 msgid "SMTP port"
-msgstr ""
+msgstr "SMTP port"
 
 msgid "Use TLS"
-msgstr ""
+msgstr "Use TLS"
 
 msgid ""
 "This allows connection to an SMTP server that requires SSL encryption such "
 "as Gmail."
 msgstr ""
+"This allows connection to an SMTP server that requires SSL encryption such "
+"as Gmail."
 
 msgid "Use encrypted protocol"
-msgstr ""
+msgstr "Use encrypted protocol"
 
 msgid "Leave blank if your SMTP server does not require authentication."
-msgstr ""
+msgstr "Leave blank if your SMTP server does not require authentication."
 
 msgid "SMTP Username."
-msgstr ""
+msgstr "SMTP Username."
 
 msgid "E-mail options"
-msgstr ""
+msgstr "E-mail options"
 
 msgid "Turn this module on or off"
-msgstr ""
+msgstr "Turn this module on or off"
 
 msgid "SMTP server"
-msgstr ""
+msgstr "SMTP server"
 
 msgid "SMTP backup server"
-msgstr ""
+msgstr "SMTP backup server"
 
 msgid "The e-mail address that all e-mails will be from."
-msgstr ""
+msgstr "The e-mail address that all e-mails will be from."
 
 msgid "Send test e-mail"
-msgstr ""
+msgstr "Send test e-mail"
 
 msgid "E-mail address to send a test e-mail to"
-msgstr ""
+msgstr "E-mail address to send a test e-mail to"
 
 msgid "Type in an address to have a test e-mail sent there."
-msgstr ""
+msgstr "Type in an address to have a test e-mail sent there."
 
 msgid ""
 "Checking this box will print SMTP messages from the server for every e-mail "
 "that is sent."
 msgstr ""
+"Checking this box will print SMTP messages from the server for every e-mail "
+"that is sent."
 
 msgid "You must enter an SMTP server address."
-msgstr ""
+msgstr "You must enter an SMTP server address."
 
 msgid "You must enter an SMTP port number."
-msgstr ""
+msgstr "You must enter an SMTP port number."
 
 msgid "The provided from e-mail address is not valid."
-msgstr ""
+msgstr "The provided from e-mail address is not valid."
 
 msgid "Sending mail to: @to"
-msgstr ""
+msgstr "Sending mail to: @to"
 
 msgid "Attahment could not be found or accessed."
-msgstr ""
+msgstr "Attahment could not be found or accessed."
 
 msgid "Attachment could not be found or accessed."
-msgstr ""
+msgstr "Attachment could not be found or accessed."
 
 msgid "Token"
-msgstr ""
+msgstr "Muuttuja"
 
 msgid "custom block"
-msgstr ""
+msgstr "custom block"
 
 msgid "content item"
-msgstr ""
+msgstr "content item"
 
 msgid "custom menu link"
-msgstr ""
+msgstr "custom menu link"
 
 msgid "Pathauto pattern"
-msgstr ""
+msgstr "Pathauto pattern"
 
 msgid "The first element of the array."
-msgstr ""
+msgstr "Arrayn ensimmäinen elementti."
 
 msgid "Update URL alias"
-msgstr ""
+msgstr "Päivitä osoitealias"
 
 msgid "Previous"
-msgstr ""
+msgstr "Edellinen"
 
 msgid "Information"
-msgstr ""
+msgstr "Tietoa"
 
 msgid "Add required context"
-msgstr ""
+msgstr "Lisää pakollinen konteksti"
 
 msgid "Finish"
-msgstr ""
+msgstr "Valmis"
 
 msgid "@description"
-msgstr ""
+msgstr "@description"
 
 msgid "Pager offset"
-msgstr ""
+msgstr "Sivutuksen aloitusarvo"
 
 msgid "The name of the menu."
-msgstr ""
+msgstr "Valikon nimi."
 
 msgid "Tokens"
-msgstr ""
+msgstr "Merkit"
 
 msgid "Available tokens"
-msgstr ""
+msgstr "Käytössä olevat merkinnät"
 
 msgid "No tokens available."
-msgstr ""
+msgstr "Ei käytettävissä olevia merkkejä."
 
 msgid "Click a token to insert it into the field you've last clicked."
-msgstr ""
+msgstr "Valitse valitsemaasi tekstiin syötettävä merkki."
 
 msgid "Insert this token into your form"
-msgstr ""
+msgstr "Lisää merkkejä kaavakkeeseesi"
 
 msgid "First click a text field to insert your tokens into."
-msgstr ""
+msgstr "Valitse ensin teksti johon merkit syötetään."
 
 msgid "The explanation of the most recent changes made to the node."
-msgstr ""
+msgstr "Selitys  solmuun tehdyistä viimeisimmistä muutoksista."
 
 msgid "The title of the current page."
-msgstr ""
+msgstr "Muokattavan sivun otsikko"
 
 msgid "The URL of the current page."
-msgstr ""
+msgstr "Tämänhetkisen sivun osoite."
 
 msgid "The page number of the current page when viewing paged lists."
-msgstr ""
+msgstr "Tämänhetkisen sivun numero näytettäessä sivutettuja listoja."
 
 msgid "The source node for this current node's translation set."
-msgstr ""
+msgstr "Tämänhetkisen solmun käännössarjan lähdesolmu."
 
 msgid "The URL of the confirm delete page for the user account."
-msgstr ""
+msgstr "Käyttäjätilin peruutuksen vahvistussivun osoite."
 
 msgid "The URL of the one-time login page for the user account."
 msgstr ""
+"Käyttäjän sisäänkirjautumisen kertakäyttöisen kirjautumissivun osoite."
 
 msgid "Tokens related to menu links."
-msgstr ""
+msgstr "Valikkolinkkeihin liittyvät merkit."
 
 msgid "The unique ID of the menu link."
-msgstr ""
+msgstr "Valikkolinkin yksilöllinen ID."
 
 msgid "The title of the menu link."
-msgstr ""
+msgstr "Valikkolinkin otsikko."
 
 msgid "The URL of the menu link."
-msgstr ""
+msgstr "Valikkolinkin osoite."
 
 msgid "The menu link's parent."
-msgstr ""
+msgstr "Valikkolinkin isäntä."
 
 msgid "Tokens related to the current page request."
-msgstr ""
+msgstr "Tämänhetkiseen sivupyyntöön liittyvät merkit."
 
 msgid "The book page associated with the node."
-msgstr ""
+msgstr "Solmuun liittyvä kirjasivu."
 
 msgid "The menu link for this node."
-msgstr ""
+msgstr "Solmun valikkolinkki."
 
 msgid "The menu link's root."
-msgstr ""
+msgstr "Valikkolinkin juuri."
 
 msgid "Tokens related to the current date and time."
-msgstr ""
+msgstr "Tämänhetkiseen päivämäärään ja kellonaikaan liittyvät korvauskuviot."
 
 msgid "The URL of the @entity."
-msgstr ""
+msgstr "Verkko-osoite entiteetille @entity."
 
 msgid "The content type of the node."
-msgstr ""
+msgstr "Solmun sisältötyyppi."
 
 msgid "Tokens related to content types."
-msgstr ""
+msgstr "Solmuihin liittyvät korvauskuviot."
 
 msgid "The name of the content type."
-msgstr ""
+msgstr "Sisältötyypin nimi."
 
 msgid "The unique machine-readable name of the content type."
-msgstr ""
+msgstr "Sisältötyypin yksilöllinen koneluettava nimi."
 
 msgid "The optional description of the content type."
-msgstr ""
+msgstr "Sisältötyypin valinnainen kuvaus."
 
 msgid "The number of nodes belonging to the content type."
-msgstr ""
+msgstr "Sisältötyyppiin kuuluvien solmujen määrä."
 
 msgid "The URL of the content type's edit page."
-msgstr ""
+msgstr "Sisältötyypin muokkaussivun verkko-osoite."
 
 msgid "The URL of the taxonomy term's edit page."
-msgstr ""
+msgstr "Luokittelutermin muokkaussivun verkko-osoite."
 
 msgid "The unique machine-readable name of the vocabulary."
-msgstr ""
+msgstr "Sanaston yksilöllinen koneluettava nimi."
 
 msgid "The URL of the vocabulary's edit page."
-msgstr ""
+msgstr "Sanaston muokkaussivun verkko-osoite."
 
 msgid ""
 "The specific argument of the current page (e.g. 'arg:1' on the page 'node/1'"
 " returns '1')."
 msgstr ""
+"Tämänhetkisen sivun argumentti (esim. 'arg:1' sivulla 'node/1' palauttaa "
+"'1')."
 
 msgid "Tokens related to URLs."
-msgstr ""
+msgstr "Verkko-osoitteisiin liittyvät korvauskuviot."
 
 msgid "The relative URL."
-msgstr ""
+msgstr "Suhteellinen verkko-osoite."
 
 msgid "The absolute URL."
-msgstr ""
+msgstr "Absoluuttinen verkko-osoite."
 
 msgid "Tokens related to menus."
-msgstr ""
+msgstr "Valikoihin liittyvät korvauskuviot."
 
 msgid "The unique machine-readable name of the menu."
-msgstr ""
+msgstr "Valikon yksilöllinen koneluettava nimi."
 
 msgid "The optional description of the menu."
-msgstr ""
+msgstr "Valikon valinnainen kuvaus."
 
 msgid "The number of menu links belonging to the menu."
-msgstr ""
+msgstr "Valikossa olevien valikkolinkkien määrä."
 
 msgid "The URL of the menu's edit page."
-msgstr ""
+msgstr "Valikon muokkaussivun verkko-osoite."
 
 msgid "The menu of the menu link."
-msgstr ""
+msgstr "Valikkolinkin valikko."
 
 msgid "The URL of the menu link's edit page."
-msgstr ""
+msgstr "Valikkolinkin muokkaussivun verkko-osoite."
 
 msgid "The user roles associated with the user account."
-msgstr ""
+msgstr "Käyttäjätiliin liitetyt käyttäjäroolit."
 
 msgid "The URL without the protocol and trailing backslash."
-msgstr ""
+msgstr "Verkko-osoite ilman protokollaa ja päättävää kautta-merkkiä."
 
 msgid "Tokens related to arrays of strings."
-msgstr ""
+msgstr "Merkkijonoja sisältäviin arrayhin liittyvät korvauskuviot."
 
 msgid "The last element of the array."
-msgstr ""
+msgstr "Arrayn viimeinen elementti."
 
 msgid "The number of elements in the array."
-msgstr ""
+msgstr "Elementtien lukumäärä arrayssä."
 
 msgid "The array reversed."
-msgstr ""
+msgstr "Array käänteisessä järjestyksessä."
 
 msgid "The array of keys of the array."
-msgstr ""
+msgstr "Arrayn avaimet arrayna."
 
 msgid ""
 "The values of the array joined together with a custom string in-between each"
 " value."
 msgstr ""
+"Arrayn arvot yhdistettynä kustomoidulla merkillä kunkin arvon välillä."
 
 msgid "A date in '@type' format. (%date)"
-msgstr ""
+msgstr "Päivämäärä '@type' muodossa. (%date)"
 
 msgid "The root term of the taxonomy term."
-msgstr ""
+msgstr "Luokittelutermin juuritermi."
 
 msgid "The size of the file, in bytes."
-msgstr ""
+msgstr "Tiedoston koko tavuina."
 
 msgid "SMTP Authentication Support"
-msgstr ""
+msgstr "SMTP Authentication Support"
 
 msgid "Chaos tool suite"
-msgstr ""
+msgstr "Chaos tool suite"
 
 msgid ""
 "Provides a user interface for the Token API and some missing core tokens."
 msgstr ""
+"Tarjoaa käyttöliittymän Merkit APIin sekä joitakin puuttuvia ytimen "
+"merkkejä."
 
 msgid "The value of a specific query string field of the current page."
-msgstr ""
+msgstr "Tämänhetkisen sivun tietyn kyselymerkkijonokentän arvo."
 
 msgid "A random number from 0 to @max."
-msgstr ""
+msgstr "Satunnaisluku välillä 0 ja @max."
 
 msgid "A random hash. The possible hashing algorithms are: @hash-algos."
 msgstr ""
+"Satunnainen tiivistemerkkijono. Mahdolliset tiivistysalgoritmit: @hash-"
+"algos."
 
 msgid ""
 "Attempting to perform token replacement for token type %type without "
 "required data"
 msgstr ""
+"Yritettiin suorittaa korvauskuviokorvaus korvauskuviotyypille %type ilman "
+"tarpeellista tietoa."
 
 msgid "@type field."
-msgstr ""
+msgstr "@type kenttä."
 
 msgid "No tokens available"
-msgstr ""
+msgstr "Korvauskuvioita ei ole saatavilla"
 
 msgid "Token registry caches cleared."
-msgstr ""
+msgstr "Korvauskuviorekisterin välimuistit tyhjennetty."
 
 msgid "The path component of the URL."
-msgstr ""
+msgstr "Verkko-osoitteen polkukomponentti."
 
 msgid "The unaliased URL."
-msgstr ""
+msgstr "Aliasoimaton verkko-osoite."
 
 msgid "The specific value of the array."
-msgstr ""
+msgstr "Arrayn tietty arvo."
 
 msgid ""
 "The list of available tokens that can be used in e-mails is provided below."
 msgstr ""
+"Sähköposteissa käytettävät korvauskuviot on listattu alla olevassa listassa."
 
 msgid "An array of all the term's parents, starting with the root."
-msgstr ""
+msgstr "Luokittelutermin isäntien nimet arrayna juuresta alkaen."
 
 msgid "An array of all the menu link's parents, starting with the root."
-msgstr ""
+msgstr "Valikkolinkkien isäntien nimet arrayna juuresta alkaen."
 
 msgid "The original @entity data if the @entity is being updated or saved."
-msgstr ""
+msgstr "Alkuperäinen @entity tieto jos @entity tallennetaan tai päivitetään."
 
 msgid "The base name of the file."
-msgstr ""
+msgstr "Tiedoston perusnimi."
 
 msgid "Tokens for lists of @type values."
-msgstr ""
+msgstr "Korvauskuviot @type arvojen listoille."
 
 msgid "Browse available tokens."
-msgstr ""
+msgstr "Selaa käytettävissä olevia korvauskuvioita."
 
 msgid "Conditions"
-msgstr ""
+msgstr "Ehdot"
 
 msgid "Verbose"
-msgstr ""
+msgstr "Näytä muutokset"
 
 msgid "Display alias changes (except during bulk updates)."
-msgstr ""
+msgstr "Näytä aliaksien muutokset (paitsi massapäivitykset)."
 
 msgid "Replace by separator"
-msgstr ""
+msgstr "Korvaa erottimella"
 
 msgid "Maximum alias length"
-msgstr ""
+msgstr "Aliaksen enimmäispituus"
 
 msgid "Maximum component length"
-msgstr ""
+msgstr "Komponentin enimmäispituus"
 
 msgid "Update action"
-msgstr ""
+msgstr "Toimenpide päivitettäessä"
 
 msgid "Strings to Remove"
-msgstr ""
+msgstr "Poistettavat merkkijonot"
 
 msgid "Pathauto"
-msgstr ""
+msgstr "Pathauto"
 
 msgid "Period"
-msgstr ""
+msgstr "Ajanjakso"
 
 msgid "Asterisk"
-msgstr ""
+msgstr "Asteriski"
 
 msgid ""
 "The automatically generated alias %original_alias conflicted with an "
 "existing alias. Alias changed to %alias."
 msgstr ""
+"Automaattisesti luotu alias %original_alias on jo käytössä. Alias muutettiin"
+" muotoon %alias."
 
 msgid "Delete aliases"
-msgstr ""
+msgstr "Poista aliakset"
 
 msgid "Automatic alias"
-msgstr ""
+msgstr "Automaattinen alias"
 
 msgid ""
 "Character used to separate words in titles. This will replace any spaces and"
 " punctuation characters. Using a space or + character can cause unexpected "
 "results."
 msgstr ""
+"Otsikoissa sanat erotteleva merkki. Tämä korvaa kaikki välilyönnit ja "
+"välimerkit. Välilyönnin tai + merkin käyttö voi johtaa odottamattomiin "
+"tuloksiin."
 
 msgid "Character case"
-msgstr ""
+msgstr "Kirjainkoko"
 
 msgid "Do nothing. Leave the old alias intact."
-msgstr ""
+msgstr "Älä tee mitään. Jätä vanha alias koskemattomaksi."
 
 msgid "Create a new alias. Leave the existing alias functioning."
-msgstr ""
+msgstr "Luo uusi alias. Jätä vanha alias järjestelmään."
 
 msgid "Create a new alias. Delete the old alias."
-msgstr ""
+msgstr "Luo uusi alias. Poista vanha alias."
 
 msgid "Transliterate prior to creating alias"
-msgstr ""
+msgstr "Transliteroi ennen aliaksen luontia"
 
 msgid ""
 "Filters the new alias to only letters and numbers found in the ASCII-96 set."
 msgstr ""
+"Suodattaa aliakset niin että ne sisältävät vain ASCII-96 merkistöstä "
+"löytyviä numeroita ja kirjaimia."
 
 msgid "No action (do not replace)"
-msgstr ""
+msgstr "Ei mitään (älä korvaa)"
 
 msgid "Delete all aliases. Number of aliases which will be deleted: %count."
-msgstr ""
+msgstr "Poista kaikki aliakset. Poistettavien aliaksien määrä: %count."
 
 msgid ""
 "Delete aliases for all @label. Number of aliases which will be deleted: "
 "%count."
 msgstr ""
+"Poista aliakset kaikille @label. Poistettavien aliaksien määrä: %count."
 
 msgid "Delete aliases now!"
-msgstr ""
+msgstr "Poista aliakset!"
 
 msgid "All of your path aliases have been deleted."
-msgstr ""
+msgstr "Kaikki polkualiaksesi on poistettu."
 
 msgid "Patterns"
-msgstr ""
+msgstr "Sisältöpolut"
 
 msgid "Colon"
-msgstr ""
+msgstr "Kaksoispiste"
 
 msgid "Semicolon"
-msgstr ""
+msgstr "Puolipiste"
 
 msgid "Slash"
-msgstr ""
+msgstr "Kauttaviiva"
 
 msgid "Punctuation"
-msgstr ""
+msgstr "Välimerkit"
 
 msgid ""
 "What should Pathauto do when updating an existing content item which already"
 " has an alias?"
 msgstr ""
+"Mitä pathauton tulisi tehdä päivittäessään aliasta sisällölle jolle on alias"
+" jo olemassa?"
 
 msgid "Reduce strings to letters and numbers"
-msgstr ""
+msgstr "Poista merkkijonoista muut merkit paitsi kirjaimet ja numerot"
 
 msgid ""
 "Words to strip out of the URL alias, separated by commas. Do not use this to"
 " remove punctuation."
 msgstr ""
+"Verkko-osoitteen aliaksesta poistettavat sanat pilkuin eroteltuna listana. "
+"Älä käytä tätä poistamaan välimerkkejä."
 
 msgid "Choose aliases to delete"
-msgstr ""
+msgstr "Valitse poistettava alias"
 
 msgid "All aliases"
-msgstr ""
+msgstr "Kaikki aliakset"
 
 msgid ""
 "<strong>Note:</strong> there is no confirmation. Be sure of your action "
@@ -23040,232 +25153,247 @@ msgid ""
 "make a backup of the database and/or the url_alias table prior to using this"
 " feature."
 msgstr ""
+"<strong>Huomio:</strong> varmennusta ei ole. Varmista toimenpiteesi "
+"ennenkuin klikkaat \"Poista aliakset!\" nappia.<br />On suositeltavaa ottaa "
+"tietokannastasi  varmuuskopio ennen ominaisuuden käyttöä."
 
 msgid "Ignoring alias %alias because it is the same as the internal path."
-msgstr ""
+msgstr "Hylätään alias %alias koska se on sama kuin sisäinen polku."
 
 msgid "Created new alias %alias for %source, replacing %old_alias."
 msgstr ""
+"Luotiin uusi alias %alias lähteelle %source, korvattiin vanha alias "
+"%old_alias."
 
 msgid "Created new alias %alias for %source."
-msgstr ""
+msgstr "Luotiin uusi alias %alias lähteelle %source."
 
 msgid "Administer pathauto"
-msgstr ""
+msgstr "Ylläpidä pathauto"
 
 msgid ""
 "Allows a user to configure patterns for automated aliases and bulk delete "
 "URL-aliases."
 msgstr ""
+"Salli käyttäjien määritellä automatisoitujen aliaksien kuviot ja mahdollista"
+" osoitealiaksien massapoisto."
 
 msgid "Notify of Path Changes"
-msgstr ""
+msgstr "Tiedota polkujen muutoksista"
 
 msgid "Determines whether or not users are notified."
-msgstr ""
+msgstr "Määrittää tiedotetaanko käyttäjille muutoksista vaiko ei."
 
 msgid "Bulk updating URL aliases"
-msgstr ""
+msgstr "Automaattipäivitetään osoitealiaksia"
 
 msgid "An error occurred while processing @operation with arguments : @args"
-msgstr ""
+msgstr "Virhe käsiteltäessä operaatiota @operation argumenteilla: @args"
 
 msgid "Generated 1 URL alias."
 msgid_plural "Generated @count URL aliases."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Luotiin 1 osoitealias"
+msgstr[1] "Luotiin @count osoitealiasta"
 
 msgid "Underscore"
-msgstr ""
+msgstr "Alaviiva"
 
 msgid "No new URL aliases to generate."
-msgstr ""
+msgstr "Uusia luotavia verkko-aliaksia ei löytynyt."
 
 msgid "Double quotation marks"
-msgstr ""
+msgstr "Lainausmerkit"
 
 msgid "Single quotation marks (apostrophe)"
-msgstr ""
+msgstr "Heittomerkki"
 
 msgid "Back tick"
-msgstr ""
+msgstr "Gravis"
 
 msgid "Hyphen"
-msgstr ""
+msgstr "Tavuviiva"
 
 msgid "Vertical bar (pipe)"
-msgstr ""
+msgstr "Pystyviiva (putki)"
 
 msgid "Left curly bracket"
-msgstr ""
+msgstr "Vasen aaltosulku"
 
 msgid "Left square bracket"
-msgstr ""
+msgstr "Vasen hakasulku"
 
 msgid "Right curly bracket"
-msgstr ""
+msgstr "Oikea aaltosulku"
 
 msgid "Right square bracket"
-msgstr ""
+msgstr "Oikea hakasulku"
 
 msgid "Plus sign"
-msgstr ""
+msgstr "Plus-merkki"
 
 msgid "Equal sign"
-msgstr ""
+msgstr "Yhtäkuin-merkki"
 
 msgid "Percent sign"
-msgstr ""
+msgstr "Prosenttimerkki"
 
 msgid "Caret"
-msgstr ""
+msgstr "Sirkumfleksi"
 
 msgid "Dollar sign"
-msgstr ""
+msgstr "Dollarimerkki"
 
 msgid "Number sign (pound sign, hash)"
-msgstr ""
+msgstr "Numeromerkki (punnan merkki, risuaita)"
 
 msgid "At sign"
-msgstr ""
+msgstr "Ät-merkki"
 
 msgid "Exclamation mark"
-msgstr ""
+msgstr "Huutomerkki"
 
 msgid "Tilde"
-msgstr ""
+msgstr "Aaltoviiva"
 
 msgid "Left parenthesis"
-msgstr ""
+msgstr "Vasen sulku"
 
 msgid "Right parenthesis"
-msgstr ""
+msgstr "Oikea sulku"
 
 msgid "Question mark"
-msgstr ""
+msgstr "Kysymysmerkki"
 
 msgid "Less-than sign"
-msgstr ""
+msgstr "Pienempi kuin -merkki"
 
 msgid "Greater-than sign"
-msgstr ""
+msgstr "Suurempi kuin -merkki"
 
 msgid "Backslash"
-msgstr ""
+msgstr "Kenoviiva"
 
 msgid "Generate automatic URL alias"
-msgstr ""
+msgstr "Luo automaattinen osoitealias"
 
 msgid "Uncheck this to create a custom alias below."
-msgstr ""
+msgstr "Älä valitse tätä jos haluat luoda kustomoidun aliaksen."
 
 msgid ""
 "The array values each cleaned by Pathauto and then joined with the slash "
 "into a string that resembles an URL."
 msgstr ""
+"Arrayn arvot jotka Pathauto siivoaa ja yhdistää kautta-merkillä verkko-"
+"osoitetta kuvaavaksi merkkijonoksi."
 
 msgid "General settings"
-msgstr ""
+msgstr "Yleiset asetukset"
 
 msgid "Red"
-msgstr ""
+msgstr "Punainen"
 
 msgid "Green"
-msgstr ""
+msgstr "Vihreä"
 
 msgid "Blue"
-msgstr ""
+msgstr "Sininen"
 
 msgid "Secret Key"
-msgstr ""
+msgstr "Turva-avain"
 
 msgid "Installation"
-msgstr ""
+msgstr "Asennus"
 
 msgid "Public Key"
-msgstr ""
+msgstr "Public Key"
 
 msgid "Orange"
-msgstr ""
+msgstr "Orange"
 
 msgid "Behavior"
-msgstr ""
+msgstr "Behavior"
 
 msgid "Captcha Point"
-msgstr ""
+msgstr "Captcha Point"
 
 msgid "Joined path"
-msgstr ""
+msgstr "Yhdistetty polku"
 
 msgid ""
 "Provides a mechanism for modules to automatically generate aliases for the "
 "content they manage."
 msgstr ""
+"Tarjoaa moduuleille mekanismin automaattisten aliaksien luomiseksi niiden "
+"hallinnoimalle sisällölle."
 
 msgid ""
 "This question is for testing whether or not you are a human visitor and to "
 "prevent automated spam submissions."
 msgstr ""
+"This question is for testing whether or not you are a human visitor and to "
+"prevent automated spam submissions."
 
 msgid "Example"
-msgstr ""
+msgstr "Esimerkki"
 
 msgid "normal"
-msgstr ""
+msgstr "normaali"
 
 msgid "Code length"
-msgstr ""
+msgstr "Koodin pituus"
 
 msgid "Font size"
-msgstr ""
+msgstr "Fontin koko"
 
 msgid "Characters to use in the code"
-msgstr ""
+msgstr "Koodissa käytettävät merkit"
 
 msgid "The list of characters to use should not contain spaces."
-msgstr ""
+msgstr "Käytettävän merkkilistan ei pitäisi sisältää välilyöntejä."
 
 msgid "Math question"
-msgstr ""
+msgstr "Laskutehtävä"
 
 msgid ""
 "Encountered an illegal byte while splitting an utf8 string in characters."
-msgstr ""
+msgstr "Havaittiin kielletty bitti kun jaettiin utf8 merkkijonoa merkkeihin."
 
 msgid "low"
-msgstr ""
+msgstr "alhainen"
 
 msgid "medium"
-msgstr ""
+msgstr "keskikokoinen"
 
 msgid "high"
-msgstr ""
+msgstr "korkea"
 
 msgid "Add CAPTCHA administration links to forms"
-msgstr ""
+msgstr "Lisää CAPTCHA ylläpitolinkit lomakkeille"
 
 msgid "Challenge description"
-msgstr ""
+msgstr "Tarkistuksen kuvaus"
 
 msgid "Persistence"
-msgstr ""
+msgstr "Pysyvyys"
 
 msgid "Always add a challenge."
-msgstr ""
+msgstr "Lisää tarkistus aina."
 
 msgid "Log wrong responses"
-msgstr ""
+msgstr "Kirjaa väärät vastaukset lokiin"
 
 msgid "Challenge type"
-msgstr ""
+msgstr "Tarkistustyyppi"
 
 msgid ""
 "This page gives an overview of all available challenge types, generated with"
 " their current settings."
 msgstr ""
+"Tämä sivu antaa yleiskatsauksen saatavilla olevista tarkistustyyppeistä, "
+"jotka on muodostettu nykyisillä asetuksilla."
 
 msgid "10 more examples of this challenge."
-msgstr ""
+msgstr "10 lisäesimerkkiä tarkistuksesta."
 
 msgid ""
 "\"CAPTCHA\" is an acronym for \"Completely Automated Public Turing test to "
@@ -23277,69 +25405,85 @@ msgid ""
 "for a human to solve correctly, but hard enough to keep automated scripts "
 "and spam bots out."
 msgstr ""
+"\"CAPTCHA\" on lyhenne sanoista \"Completely Automated Public Turing test to"
+" tell Computers and Humans Apart\".  Yleensä se on kysymys-vastaus testi, "
+"jolla määritetään, onko käyttäjä ihminen. CAPTCHA moduuli on työkalu "
+"taistelussa pahantahtoisten käyttäjien automatisoituja lähetyksiä (spamia) "
+"vastaan, esimerkiksi rekisteröitymislomakkeissa, vieraskirjalomakkeissa, "
+"jne.  Haluttuja lomakkeita voi laajentaa lisätarkistuksella, jonka ihmisten "
+"pitäisi olla helppo ratkaista oikein, mutta joka on riittävän vaikea "
+"pitämään automaattiset skriptit ja spam botit poissa."
 
 msgid "CAPTCHA is a trademark of Carnegie Mellon University."
-msgstr ""
+msgstr "CAPTCHA on Carnegie Mellon Yliopiston tavaramerkki."
 
 msgid "Enabled challenge"
-msgstr ""
+msgstr "Käyttöönotettu tarkistus"
 
 msgid "Place a CAPTCHA here for untrusted users."
-msgstr ""
+msgstr "Aseta tähän CAPTCHA epäluotetuille käyttäjille."
 
 msgid "The answer you entered for the CAPTCHA was not correct."
 msgstr "Virhe CAPTCHA-vastauksesi validoinnissa. "
 
 msgid ""
 "Solve this simple math problem and enter the result. E.g. for 1+3, enter 4."
-msgstr ""
+msgstr "Ratkaise tämä pieni laskutehtävä ja anna vastaus. Esim. 1+3, anna 4."
 
 msgid "Code settings"
-msgstr ""
+msgstr "Koodiasetukset"
 
 msgid ""
 "The code length influences the size of the image. Note that larger values "
 "make the image generation more CPU intensive."
 msgstr ""
+"Koodin pituus vaikuttaa kuvan kokoon. Huomaa, että suuremmat arvot tekevät "
+"kuvien muodostamisesta palvelinta kuormittavampaa."
 
 msgid "Font settings"
-msgstr ""
+msgstr "Fonttiasetukset"
 
 msgid "tiny"
-msgstr ""
+msgstr "hyvin pieni"
 
 msgid "small"
-msgstr ""
+msgstr "pieni"
 
 msgid "large"
-msgstr ""
+msgstr "suuri"
 
 msgid ""
 "The font size influences the size of the image. Note that larger values make"
 " the image generation more CPU intensive."
 msgstr ""
+"Fontin koko vaikuttaa kuvan kokoon. Huomaa, että suuremmat arvot tekevät "
+"kuvien muodostamisesta palvelinta kuormittavampaa."
 
 msgid "Character spacing"
-msgstr ""
+msgstr "Merkkien väli"
 
 msgid ""
 "Define the average spacing between characters. Note that larger values make "
 "the image generation more CPU intensive."
 msgstr ""
+"Määrittele keskimääräinen merkkien väli. Huomaa, että suuremmat arvot "
+"tekevät kuvien muodostamisesta palvelinta kuormittavampaa."
 
 msgid "Enter the hexadecimal code for the text color (e.g. #000 or #004283)."
-msgstr ""
+msgstr "Kirjoita tekstin värin heksadesimaalikoodi (e.g. #000 or #004283)."
 
 msgid "Additional variation of text color"
-msgstr ""
+msgstr "Ylimääräinen tekstin värin muuntelu"
 
 msgid ""
 "The different characters will have randomized colors in the specified range "
 "around the text color."
 msgstr ""
+"Eri merkeille tulevat satunnaiset värit tietyllä vaihteluvälillä tekstin "
+"väristä."
 
 msgid "Distortion and noise"
-msgstr ""
+msgstr "Väännös ja kohina"
 
 msgid ""
 "With these settings you can control the degree of obfuscation by distortion "
@@ -23347,64 +25491,72 @@ msgid ""
 "in the image is reasonably readable. For example, do not combine high levels"
 " of distortion and noise."
 msgstr ""
+"Näillä asetuksilla voit hallita sekoituksen määrää väännöksissä ja "
+"kohinassa. Älä lisää sekoitusta liikaa ja varmista, että kuva pysyy "
+"ymmärrettävästi luettavana.  Esimerkiksi, älä yhdistä korkeita väännöstasoja"
+" ja kohinaa."
 
 msgid "Distortion level"
-msgstr ""
+msgstr "Väännöstaso"
 
 msgid "severe"
-msgstr ""
+msgstr "rankka"
 
 msgid "Set the degree of wave distortion in the image."
-msgstr ""
+msgstr "Aseta asteluku kuvan aaltoväännölle."
 
 msgid "Smooth distortion"
-msgstr ""
+msgstr "Pehmeä väännös"
 
 msgid "This option adds randomly colored point noise."
-msgstr ""
+msgstr "Tämä valinta lisää satunnaisesti väritettyä pistekohinaa."
 
 msgid "Add line noise"
-msgstr ""
+msgstr "Lisää linjakohinaa"
 
 msgid "This option enables lines randomly drawn on top of the text code."
-msgstr ""
+msgstr "Tämä valinta piirtää satunnaislinjoja tekstin päälle."
 
 msgid "Noise level"
-msgstr ""
+msgstr "Kohinataso"
 
 msgid "Background color is not a valid hexadecimal color value."
-msgstr ""
+msgstr "Taustaväri ei ole kelvollinen heksadesimaali väriarvo."
 
 msgid "Text color is not a valid hexadecimal color value."
-msgstr ""
+msgstr "Tekstin väri ei ole kelvollinen heksadesimaali väriarvo."
 
 msgid ""
 "Generation of image CAPTCHA failed. Check your image CAPTCHA configuration "
 "and especially the used font."
 msgstr ""
+"CAPTCHAn kuvan luonti epäonnistui. Tarkista Kuva CAPTCHAn asetukset ja "
+"erityisesti käytetty fontti."
 
 msgid "Image CAPTCHA"
-msgstr ""
+msgstr "Kuva CAPTCHA"
 
 msgid "What code is in the image?"
-msgstr ""
+msgstr "Mikä koodi on kuvassa?"
 
 msgid "Enable statistics"
-msgstr ""
+msgstr "Ota käyttöön statistiikat"
 
 msgid "File format"
-msgstr ""
+msgstr "Tiedostomuoto"
 
 msgid "Fonts"
-msgstr ""
+msgstr "Fontit"
 
 msgid ""
 "This option enables bilinear interpolation of the distortion which makes the"
 " image look smoother, but it is more CPU intensive."
 msgstr ""
+"Tämä valinta ottaa käyttöön bilineaarisen interpoloinnin väännöksiin, joka "
+"tekee kuvasta pehmeämmän, mutta rasittaa palvelinta enemmän."
 
 msgid "Add salt and pepper noise"
-msgstr ""
+msgstr "Lisää suola & pippuri -kohinaa"
 
 msgid ""
 "The image CAPTCHA is a popular challenge where a random textual code is "
@@ -23412,194 +25564,229 @@ msgid ""
 "which is rather CPU intensive for the server. Be careful with the size and "
 "computation related settings."
 msgstr ""
+"Kuva CAPTCHA on suosittu tarkistuskysely, missä satunnainen koodi on "
+"muutettu epäselvennetyksi kuvaksi. Kuva muodostetaan lennossa erikseen joka "
+"sivulatauksella, mikä on melko palvelinta rasittavaa. Ole tarkkana koon ja "
+"muiden laskentaa vaativien asetusten suhteen."
 
 msgid "@type (from module @module)"
-msgstr ""
+msgstr "@type (moduuli @module)"
 
 msgid "Form protection"
-msgstr ""
+msgstr "Lomakkeen suojaus"
 
 msgid "Default challenge type"
-msgstr ""
+msgstr "Oletus tarkistustyyppi"
 
 msgid ""
 "Allow CAPTCHAs and CAPTCHA administration links on administrative pages"
-msgstr ""
+msgstr "Ota käyttöön CAPTCHAt ja CAPTCHAn ylläpitolinkit ylläpitosivuilla"
 
 msgid "Add a description to the CAPTCHA"
-msgstr ""
+msgstr "Lisää CAPTCHAlle kuvaus"
 
 msgid ""
 "Add a configurable description to explain the purpose of the CAPTCHA to the "
 "visitor."
-msgstr ""
+msgstr "Lisää muokattava kuvaus selittämään CAPTCHAn tarkoitusta käyttäjälle."
 
 msgid "Default CAPTCHA validation"
-msgstr ""
+msgstr "CAPTCHAn oletushyväksyntä"
 
 msgid ""
 "Define how the response should be processed by default. Note that the "
 "modules that provide the actual challenges can override or ignore this."
 msgstr ""
+"Määrittele miten vastauksia prosessoidaan oletusarvoisesti.  Huomaa, että "
+"moduulit jotka varsinaisesti tuottavat tarkistukset, voivat ohittaa tämän "
+"tai olla välittämättä tästä."
 
 msgid ""
 "Case sensitive validation: the response has to exactly match the solution."
 msgstr ""
+"Merkkikokoriippuvainen hyväksyntä: vastauksen täytyy vastata ratkaisua "
+"tarkasti."
 
 msgid "Case insensitive validation: lowercase/uppercase errors are ignored."
 msgstr ""
+"Merkkikokoriippumaton hyväksyntä: pieni/iso eroavuudesta syntyvät virheet "
+"jätetään huomiotta."
 
 msgid "CAPTCHA: challenge \"@type\" enabled"
-msgstr ""
+msgstr "CAPTCHA: tarkistus \"@type\" käytössä"
 
 msgid "CAPTCHA: no challenge enabled"
-msgstr ""
+msgstr "CAPTCHA: tarkistusta ei käytössä"
 
 msgid "Test one two three"
-msgstr ""
+msgstr "Testi yksi kaksi kolme"
 
 msgid "Already 1 blocked form submission"
 msgid_plural "Already @count blocked form submissions"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Jo 1 estetty lomakkeen lähetys"
+msgstr[1] "Jo @count estettyä lomakkeen lähetystä"
 
 msgid "Presolved image CAPTCHA example, generated with the current settings."
 msgstr ""
+"Esiratkaistu Kuva CAPTCHA esimerkki, muodostettu nykyisillä asetuksilla."
 
 msgid "extra large"
-msgstr ""
+msgstr "hyvin suuri"
 
 msgid "tight"
-msgstr ""
+msgstr "kapea"
 
 msgid "extra wide"
-msgstr ""
+msgstr "hyvin laaja"
 
 msgid ""
 "The built-in font only supports Latin2 characters. Only use \"a\" to \"z\" "
 "and numbers."
 msgstr ""
+"Sisäänrakennettu fontti tukee vain Latin2 merkkejä. Käytäö ainoastaan "
+"kirjaimia \"a - z\" sekä numeroita."
 
 msgid ""
 "CAPTCHA validation error: unknown CAPTCHA session ID. Contact the site "
 "administrator if this problem persists."
 msgstr ""
+"CAPTCHAn varmennusvirhe: tunnistamaton CAPTCHA session ID. Ongelman "
+"toistuessa ota yhteyttä sivuston ylläpitäjään."
 
 msgid "CAPTCHA validation error: unknown CAPTCHA session ID (%csid)."
-msgstr ""
+msgstr "CAPTCHAn validointivirhe: tuntematon CAPTCHA session ID (%csid)."
 
 msgid "Color and image settings"
-msgstr ""
+msgstr "Väri- ja kuva-asetukset"
 
 msgid ""
 "Configuration of the background, text colors and file format of the image "
 "CAPTCHA."
-msgstr ""
+msgstr "Kuva-CAPTCHA:n taustan, tekstivärien ja tiedostomuodon asetukset."
 
 msgid "Add URL redirect from this page to another location"
-msgstr ""
+msgstr "Lisää uudelleenohjaus tältä sivulta uuteen sijaintiin"
 
 msgid "Invalid number of redirects."
-msgstr ""
+msgstr "Uudelleenohjausten määrä ei kelpaa."
 
 msgid "Spam control"
-msgstr ""
+msgstr "Roskapostin hallinta"
 
 msgid ""
 "Enter the hexadecimal code for the background color (e.g. #FFF or #FFCE90). "
 "When using the PNG file format with transparent background, it is "
 "recommended to set this close to the underlying background color."
 msgstr ""
+"Syötä taustavärin heksadesimaalitunnus (esim. #FFF tai FFCE90). Käytettäessä"
+" tiedostomuotoa PNG läpinäkyvällä taustavärillä, on suositeltavaa asettaa "
+"tämä lähelle sivun taustaväriä."
 
 msgid ""
 "Select the file format for the image. JPEG usually results in smaller files,"
 " PNG allows tranparency."
 msgstr ""
+"Valitse kuvan muoto. JPEG usein tuottaa pienempiä kuvia kun taas PNG "
+"mahdollistaa kuvalle läpinäkyvän taustan."
 
 msgid "JPEG"
-msgstr ""
+msgstr "JPEG"
 
 msgid "PNG"
-msgstr ""
+msgstr "PNG"
 
 msgid "PNG with transparent background"
-msgstr ""
+msgstr "PNG läpinäkyvällä taustalla"
 
 msgid "@level - no distortion"
-msgstr ""
+msgstr "@level - ei vääristymää"
 
 msgid "@level - low"
-msgstr ""
+msgstr "@level - matala"
 
 msgid "@level - medium"
-msgstr ""
+msgstr "@level - keskiverto"
 
 msgid "@level - high"
-msgstr ""
+msgstr "@level - korkea"
 
 msgid "No TrueType support"
-msgstr ""
+msgstr "Ei TrueType tukea"
 
 msgid ""
 "The Image CAPTCHA module can not use TrueType fonts because your PHP setup "
 "does not support it. You can only use a PHP built-in bitmap font of fixed "
 "size."
 msgstr ""
+"Image CAPTCHA moduuli ei voi käyttää TrueType fontteja koska PHP-asennuksesi"
+" ei tue sitä. Voit käyttää PHP:n sisäänrakennettuja kiinteäkokoisia bitmap-"
+"fontteja."
 
 msgid "Font preview of @font (@file)"
-msgstr ""
+msgstr "Fontin @font esikatselu (@file)"
 
 msgid "Preview of built-in font"
-msgstr ""
+msgstr "Esikatsele sisäänrakennettua fonttia"
 
 msgid "You need to select at least one font."
-msgstr ""
+msgstr "Sinun on valittava vähintään yksi fontti."
 
 msgid "The following fonts are not readable: %fonts."
-msgstr ""
+msgstr "Seuraavat fontit eivät ole lukukelpoisia: %fonts."
 
 msgid "Enter the characters shown in the image."
-msgstr ""
+msgstr "Kirjoita kuvassa näkyvät merkit."
 
 msgid ""
 "CAPTCHA problem: unexpected result from hook_captcha() of module %module "
 "when trying to retrieve challenge type %type for form %form_id."
 msgstr ""
+"CAPTCHA ongelma: odottamaton tulos hook_captcha() funktiosta moduulissa "
+"%module yritettäessä hakea haastetta tyyppiä %type lomakkeelle %form_id."
 
 msgid ""
 "Omit challenges in a multi-step/preview workflow once the user successfully "
 "responds to a challenge."
 msgstr ""
+"Hylkää haasteet monivaiheisessa- tai esikatselutyönkulussa käyttäjän "
+"vastattua oikein yhteen haasteeseen."
 
 msgid ""
 "Omit challenges on a form type once the user successfully responds to a "
 "challenge on a form of that type."
 msgstr ""
+"Hylkää kaavaketyypin haasteet kun käyttäjä on vastannut oikein mihin tahansa"
+" haasteeseen jollakin sivuston kaavakkeella."
 
 msgid ""
 "Omit challenges on all forms once the user successfully responds to any "
 "challenge on the site."
 msgstr ""
+"Hylkää kaikkien muiden sivuston kaavakkeiden haasteet kun käyttäjä on "
+"vastannut oikein mihin tahansa haasteeseen sivustolla."
 
 msgid ""
 "Define if challenges should be omitted during the rest of a session once the"
 " user successfully responds to a challenge."
 msgstr ""
+"Määrittele, ohitetaanko sivustosi muut CAPTCHA haasteet käyttäjäsession "
+"aikana käyttäjän vastattua kertaalleen oikein johonkin sivustosi CAPTCHA "
+"haasteeseen."
 
 msgid "CAPTCHA session reuse attack detected."
-msgstr ""
+msgstr "CAPTCHA session uudelleenkäyttöhyökkäys tunnistettu."
 
 msgid "CAPTCHA placement caching"
-msgstr ""
+msgstr "CAPTCHAn sijoitteluvälimuisti"
 
 msgid "Administer CAPTCHA settings"
-msgstr ""
+msgstr "Ylläpidä CAPTCHAn asetuksia"
 
 msgid "Skip CAPTCHA"
-msgstr ""
+msgstr "Ohita CAPTCHA"
 
 msgid "Users with this permission will not be offered a CAPTCHA."
-msgstr ""
+msgstr "Käytäjille joilla on tämä käyttäjärooli ei tarjota CAPTCHAa."
 
 msgid ""
 "Select the fonts to use for the text in the image CAPTCHA. Apart from the "
@@ -23607,179 +25794,201 @@ msgid ""
 "extension .ttf) by putting them in %fonts_library_general or "
 "%fonts_library_specific."
 msgstr ""
+"Valitse Image CAPTCHAn kuvassa käytettävät fontit. Oletusfonttien lisäksi "
+"voit myös käyttää TrueType fontteja (tiedostopääte .ttf) lisäämällä ne "
+"%fonts_library_general tai %fonts_library_specific."
 
 msgid "RTL support"
-msgstr ""
+msgstr "RTL tuki"
 
 msgid "The CAPTCHA settings have been saved."
-msgstr ""
+msgstr "CAPTCHA asetukset tallennettu."
 
 msgid "Cleared the CAPTCHA placement cache."
-msgstr ""
+msgstr "Tyhjennetty CAPTCHAn sijoittelun välimuisti."
 
 msgid "The CAPTCHA type to use for this form."
-msgstr ""
+msgstr "Tässä lomakkeessa käytettävä CAPTCHAn tyyppi."
 
 msgid "Challenge %challenge by module %module"
-msgstr ""
+msgstr "Haaste %challenge moduulista %module"
 
 msgid "No variation"
-msgstr ""
+msgstr "Ei muuntelua"
 
 msgid "Little variation"
-msgstr ""
+msgstr "Vähän muuntelua"
 
 msgid "Medium variation"
-msgstr ""
+msgstr "Keskimäärä muuntelua"
 
 msgid "High variation"
-msgstr ""
+msgstr "Paljon muuntelua"
 
 msgid "Very high variation"
-msgstr ""
+msgstr "Hyvin paljon muuntelua"
 
 msgid ""
 "Enable this option to render the code from right to left for right to left "
 "languages."
 msgstr ""
+"Enable this option to render the code from right to left for right to left "
+"languages."
 
 msgid "Widget settings"
-msgstr ""
+msgstr "Widgettien asetukset"
 
 msgid "Dark"
-msgstr ""
+msgstr "Tumma"
 
 msgid "@error"
-msgstr ""
+msgstr "@error"
 
 msgid "Image (default)"
-msgstr ""
+msgstr "Image (default)"
 
 msgid "Delete redirect"
-msgstr ""
+msgstr "Poista uudelleenohjaus"
 
 msgid "Redirect"
-msgstr ""
+msgstr "Redirect"
 
 msgid "List of redirects"
-msgstr ""
+msgstr "List of redirects"
 
 msgid "Filter"
-msgstr ""
+msgstr "Filter"
 
 msgid "With selection"
-msgstr ""
+msgstr "Valinnalla"
 
 msgid "Status code"
-msgstr ""
+msgstr "Status code"
 
 msgid "300 Multiple Choices"
-msgstr ""
+msgstr "300 Useita valintoja"
 
 msgid "301 Moved Permanently"
-msgstr ""
+msgstr "301 Pysyvästi siirretty"
 
 msgid "302 Found"
-msgstr ""
+msgstr "302 Löydetty"
 
 msgid "303 See Other"
-msgstr ""
+msgstr "303 Kts. toinen"
 
 msgid "304 Not Modified"
-msgstr ""
+msgstr "304 Muuttamaton"
 
 msgid "305 Use Proxy"
-msgstr ""
+msgstr "305 Käytä proxyä"
 
 msgid "307 Temporary Redirect"
-msgstr ""
+msgstr "307 Tilapäinen uudelleenohjaus"
 
 msgid "Original language"
-msgstr ""
+msgstr "Original language"
 
 msgid "There is no redirect yet."
-msgstr ""
+msgstr "There is no redirect yet."
 
 msgid "Destination"
-msgstr ""
+msgstr "Kohde"
 
 msgid "Add redirect"
-msgstr ""
+msgstr "Lisää uudelleenohjaus"
 
 msgid "Status Code"
-msgstr ""
+msgstr "Tilakoodi"
 
 msgid ""
 "You are attempting to redirect the page to itself. This will result in an "
 "infinite loop."
 msgstr ""
+"Yrität uudelleenohjata sivua itseensä. Seurauksena on päättymätön looppi."
 
 msgid "Generate"
-msgstr ""
+msgstr "Luo"
 
 msgid "All languages"
-msgstr ""
+msgstr "Kaikki kielet"
 
 msgid ""
 "A redirect set for a specific language will always be used when requesting "
 "this page in that language, and takes precedence over redirects set for "
 "<em>All languages</em>."
 msgstr ""
+"Kielikohtaisesti asetettua uudelleenohjausta käytetään aina kun sivukutsu on"
+" tälle kielelle ja se ohittaa uudelleenohjaukset joiden kieliasetus on "
+"<em>Kaikki kielet</em>."
 
 msgid "Redirect status"
-msgstr ""
+msgstr "Uudelleenohjauksen tila"
 
 msgid "Display a warning message to users when they are redirected."
-msgstr ""
+msgstr "Näytä varoitusviesti käyttäjille kun heidät uudelleenohjataan."
 
 msgid "Automatically create redirects when URL aliases are changed."
-msgstr ""
+msgstr "Luo automaattisesti uudelleenohjauksia kun osoitealiakset muuttuvat."
 
 msgid "Default redirect status"
-msgstr ""
+msgstr "Uudelleenohjauksen oletustila"
 
 msgid "Configure behavior for URL redirects."
-msgstr ""
+msgstr "Säädä uudelleenohjauksien toimintaa."
 
 msgid ""
 "You can find more information about HTTP redirect status codes at <a href"
 "=\"@status-codes\">@status-codes</a>."
 msgstr ""
+"Saat lisätietoa HTTP uudelleenohjauksien tilakoodeista sivulta <a href"
+"=\"@status-codes\">@status-codes</a>."
 
 msgid "The redirect has been saved."
-msgstr ""
+msgstr "Uudelleenohjaus on tallennettu."
 
 msgid "No URL redirects available."
-msgstr ""
+msgstr "Uudelleenohjauksia ei ole saatavilla."
 
 msgid ""
 "The source path %source is already being redirected. Do you want to <a href"
 "=\"@edit-page\">edit the existing redirect</a>?"
 msgstr ""
+"Lähdepolku %source uudelleenohjataan jo. Haluatko <a href=\"@edit-"
+"page\">muokata olemassaolevaa uudelleenohjausta</a>?"
 
 msgid "How many URL redirects would you like to generate?"
-msgstr ""
+msgstr "Kuinka monta uudelleenohjausta haluat luoda?"
 
 msgid "Delete all URL redirects before generating new URL redirects."
 msgstr ""
+"Poista olemassaolevat uudelleenohjaukset ennen uusien uudelleenohjauksien "
+"luontia."
 
 msgid ""
 "The source path %path is likely a valid path. It is preferred to <a href"
 "=\"@url-alias\">create URL aliases</a> for existing paths rather than "
 "redirects."
 msgstr ""
+"Lähdepolku %path on todennäköisesti olemassaoleva polku. Uudelleenohjauksien"
+" sijaan on suositeltavampaa <a href=\"@url-alias\">luoda osoite-aliaksia</a>"
+" olemassaoleville poluille."
 
 msgid ""
 "The base source path %source is already being redirected. Do you want to <a "
 "href=\"@edit-page\">edit the existing redirect</a>?"
 msgstr ""
+"Lähdepolku %source uudelleenohjataan jo. Haluatko <a href=\"@edit-"
+"page\">muokata olemassaolevaa uudelleenohjausta</a>?"
 
 msgid ""
 "Are you sure you want to delete the URL redirect from %source to %redirect?"
 msgstr ""
+"Oletko varma että haluat poistaa uudelleenohjauksen osoitteesta %source "
+"osoitteeseen %redirect?"
 
 msgid "Retain query string through redirect."
-msgstr ""
+msgstr "Säilytä kyselymerkkijono uudelleenohjauksen ajan."
 
 msgid ""
 "For example, given a redirect from %source to %redirect, if a user visits "
@@ -23787,65 +25996,69 @@ msgid ""
 "in the redirection will always take precedence over the current query "
 "string."
 msgstr ""
+"Esimerkiksi jos on annettu uudelleenohjaus osoitteesta %source osoitteeseen "
+"%redirect, jos käyttäjä käy sivulla %sourcequery hänet uudelleenohjataan "
+"sivulle %redirectquery. Uudelleenohjauksessa olevat kyselymerkkijonot "
+"ohittavat aina tärkeysjärjestyksessä tämänhetkisen kyselymerkkijonon."
 
 msgid "(formerly Global Redirect features)"
-msgstr ""
+msgstr "(aiemmin Global Redirect -moduulin ominaisuuksia)"
 
 msgid "Allow redirections on admin paths."
-msgstr ""
+msgstr "Salli uudelleenohjaukset ylläpitopoluille."
 
 msgid "Last accessed"
-msgstr ""
+msgstr "Viimeksi käytetty"
 
 msgid "Filter 404s"
-msgstr ""
+msgstr "Suodata 404-osoitteita"
 
 msgid "Fix 404 pages"
-msgstr ""
+msgstr "Korjaa 404-sivut"
 
 msgid "Add redirects for 404 pages."
-msgstr ""
+msgstr "Lisää uudelleenohjaukset 404 sivuille."
 
 msgid "Fix 404 pages with URL redirects"
-msgstr ""
+msgstr "Korjaa 404-sivut uudelleenohjauksilla"
 
 msgid "‹ previous"
 msgstr "< edellinen"
 
 msgid "Redirect type"
-msgstr ""
+msgstr "Uudelleenohjauksen tyyppi"
 
 msgid "URL redirects"
-msgstr ""
+msgstr "Osoiteuudelleenohjaukset"
 
 msgid "Redirect users from one URL to another."
-msgstr ""
+msgstr "Uudelleenohjaa käyttäjät yhdestä URL:stä toiseen URL:ään."
 
 msgid "Deleted URL redirect @rid."
-msgstr ""
+msgstr "Poistettiin verkko-osoitteen uudelleenohjaus @rid."
 
 msgid "One URL redirect created."
 msgid_plural "@count URL redirects created."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Yksi verkko-osoitteen uudelleenohjaus luotu."
+msgstr[1] "@count verkko-osoitteen uudelleenohjausta luotu."
 
 msgid "Redirect module form elements"
-msgstr ""
+msgstr "Redirect-moduulin kaavake-elementit"
 
 msgid "URL Redirects"
-msgstr ""
+msgstr "Osoiteuudelleenohjaukset"
 
 msgid "The user ID of the node author."
-msgstr ""
+msgstr "Solmun luojan käyttäjä-ID."
 
 msgid "Add another"
-msgstr ""
+msgstr "Add another"
 
 msgid "Search server"
-msgstr ""
+msgstr "Search server"
 
 msgid "Fields indexed in this index"
-msgstr ""
+msgstr "Fields indexed in this index"
 
 msgid ""
 "This page lists which fields are indexed in this index, grouped by "
@@ -23854,33 +26067,47 @@ msgid ""
 "search displays based on the index. Fields with type \"Fulltext\" can also "
 "be used for fulltext searching."
 msgstr ""
+"This page lists which fields are indexed in this index, grouped by "
+"datasource. (Datasource-independent fields are listed under \"General\".) "
+"Indexed fields can be used to add filters or sorting to views or other "
+"search displays based on the index. Fields with type \"Fulltext\" can also "
+"be used for fulltext searching."
 
 msgid "Add fields"
-msgstr ""
+msgstr "Add fields"
 
 msgid ""
 "With the \"Add fields\" button you can add additional fields to this index."
 msgstr ""
+"With the \"Add fields\" button you can add additional fields to this index."
 
 msgid ""
 "A label for the field that will be used to refer to the field in most places"
 " in the user interface."
 msgstr ""
+"A label for the field that will be used to refer to the field in most places"
+" in the user interface."
 
 msgid ""
 "The internal ID to use for this field. Can safely be ignored by "
 "inexperienced users in most cases. Changing a field's machine name requires "
 "reindexing of the index."
 msgstr ""
+"The internal ID to use for this field. Can safely be ignored by "
+"inexperienced users in most cases. Changing a field's machine name requires "
+"reindexing of the index."
 
 msgid "Property path"
-msgstr ""
+msgstr "Property path"
 
 msgid ""
 "The internal relationship linking the indexed item to the field, with links "
 "being separated by colons (:). This can be useful information for advanced "
 "users, but can otherwise be ignored."
 msgstr ""
+"The internal relationship linking the indexed item to the field, with links "
+"being separated by colons (:). This can be useful information for advanced "
+"users, but can otherwise be ignored."
 
 msgid ""
 "The data type to use when indexing the field. Determines how a field can be "
@@ -23888,74 +26115,98 @@ msgid ""
 "=\"#search-api-data-types-table\">\"Data types\" box</a> at the bottom of "
 "the page."
 msgstr ""
+"The data type to use when indexing the field. Determines how a field can be "
+"used in searches. For information on the available types, see the <a href"
+"=\"#search-api-data-types-table\">\"Data types\" box</a> at the bottom of "
+"the page."
 
 msgid "Boost"
-msgstr ""
+msgstr "Boost"
 
 msgid ""
 "Only applicable for fulltext fields. Determines how \"important\" the field "
 "is compared to other fulltext fields, to influence scoring of fulltext "
 "searches."
 msgstr ""
+"Only applicable for fulltext fields. Determines how \"important\" the field "
+"is compared to other fulltext fields, to influence scoring of fulltext "
+"searches."
 
 msgid "Edit field"
-msgstr ""
+msgstr "Muokkaa kenttää"
 
 msgid ""
 "Some fields have additional configuration available, in which case an "
 "\"Edit\" link is displayed in the \"Operations\" column."
 msgstr ""
+"Some fields have additional configuration available, in which case an "
+"\"Edit\" link is displayed in the \"Operations\" column."
 
 msgid "Remove field"
-msgstr ""
+msgstr "Poista kenttä"
 
 msgid ""
 "Removes a field from the index again. (Note: Sometimes, a field is required "
 "(for example, by a processor) and cannot be removed.)"
 msgstr ""
+"Removes a field from the index again. (Note: Sometimes, a field is required "
+"(for example, by a processor) and cannot be removed.)"
 
 msgid "Save changes"
-msgstr ""
+msgstr "Tallenna muutokset"
 
 msgid ""
 "This saves all changes made to the fields for this index. Until this button "
 "is pressed, all added, changed or removed fields will only be stored "
 "temporarily and not effect the actual index used in the rest of the site."
 msgstr ""
+"This saves all changes made to the fields for this index. Until this button "
+"is pressed, all added, changed or removed fields will only be stored "
+"temporarily and not effect the actual index used in the rest of the site."
 
 msgid "Cancel changes"
-msgstr ""
+msgstr "Cancel changes"
 
 msgid ""
 "If you have made changes to the index's fields but not yet saved them, the "
 "\"Cancel\" link lets you discard those changes."
 msgstr ""
+"If you have made changes to the index's fields but not yet saved them, the "
+"\"Cancel\" link lets you discard those changes."
 
 msgid "Add or edit a Search API index"
-msgstr ""
+msgstr "Add or edit a Search API index"
 
 msgid "Adding or editing an index"
-msgstr ""
+msgstr "Adding or editing an index"
 
 msgid ""
 "This form can be used to edit an existing index or add a new index to your "
 "site. Indexes define a set of data that will be indexed and can then be "
 "searched."
 msgstr ""
+"This form can be used to edit an existing index or add a new index to your "
+"site. Indexes define a set of data that will be indexed and can then be "
+"searched."
 
 msgid "Index name"
-msgstr ""
+msgstr "Index name"
 
 msgid ""
 "Enter a name to identify this index. For example, \"Content index\". This "
 "will only be displayed in the admin user interface."
 msgstr ""
+"Enter a name to identify this index. For example, \"Content index\". This "
+"will only be displayed in the admin user interface."
 
 msgid ""
 "Datasources define the types of items that will be indexed in this index. By"
 " default, all content entities (like content, comments and taxonomy terms) "
 "will be available here, but modules can also add their own."
 msgstr ""
+"Datasources define the types of items that will be indexed in this index. By"
+" default, all content entities (like content, comments and taxonomy terms) "
+"will be available here, but modules can also add their own."
 
 msgid ""
 "An index's tracker is the system that keeps track of which items there are "
@@ -23963,48 +26214,64 @@ msgid ""
 "Changing the tracker of an existing index will lead to reindexing of all "
 "items."
 msgstr ""
+"An index's tracker is the system that keeps track of which items there are "
+"available for the index, and which of them still need to be indexed. "
+"Changing the tracker of an existing index will lead to reindexing of all "
+"items."
 
 msgid "If the index is attached to a server, this server is listed here."
-msgstr ""
+msgstr "If the index is attached to a server, this server is listed here."
 
 msgid ""
 "The search server that the index should use for indexing and searching. If "
 "no server is selected here, the index cannot be enabled. An index can only "
 "have one server, but a server can have any number of indexes."
 msgstr ""
+"The search server that the index should use for indexing and searching. If "
+"no server is selected here, the index cannot be enabled. An index can only "
+"have one server, but a server can have any number of indexes."
 
 msgid "Index description"
-msgstr ""
+msgstr "Index description"
 
 msgid ""
 "Optionally, enter a description to explain the function of the index in more"
 " detail. This will only be displayed in the admin user interface."
 msgstr ""
+"Optionally, enter a description to explain the function of the index in more"
+" detail. This will only be displayed in the admin user interface."
 
 msgid ""
 "These options allow more detailed configuration of index behavior, but can "
 "usually safely be ignored by inexperienced users."
 msgstr ""
+"These options allow more detailed configuration of index behavior, but can "
+"usually safely be ignored by inexperienced users."
 
 msgid "Processors used for this index"
-msgstr ""
+msgstr "Processors used for this index"
 
 msgid ""
 "Processors customize different aspects of an index's functionality. They can"
 " keep items from being indexed, change how certain fields are indexed and "
 "influence searches."
 msgstr ""
+"Processors customize different aspects of an index's functionality. They can"
+" keep items from being indexed, change how certain fields are indexed and "
+"influence searches."
 
 msgid "Enable processors"
-msgstr ""
+msgstr "Enable processors"
 
 msgid ""
 "This lists all processors available for this index and lets you choose the "
 "ones that should be active. (Note: Some processors cannot be disabled.)"
 msgstr ""
+"This lists all processors available for this index and lets you choose the "
+"ones that should be active. (Note: Some processors cannot be disabled.)"
 
 msgid "Processor order"
-msgstr ""
+msgstr "Processor order"
 
 msgid ""
 "This shows you which enabled processors will be active in the different "
@@ -24012,49 +26279,60 @@ msgid ""
 " should usually not be necessary, and only be used by advanced users as some"
 " processors will lead to unexpected results when used in the wrong order."
 msgstr ""
+"This shows you which enabled processors will be active in the different "
+"parts of the indexing/searching workflow, and lets you re-arrange them. This"
+" should usually not be necessary, and only be used by advanced users as some"
+" processors will lead to unexpected results when used in the wrong order."
 
 msgid "Processor settings"
-msgstr ""
+msgstr "Processor settings"
 
 msgid ""
 "Some processors have additional configuration available, which you are able "
 "to change here."
 msgstr ""
+"Some processors have additional configuration available, which you are able "
+"to change here."
 
 msgid "Information about an index"
-msgstr ""
+msgstr "Information about an index"
 
 msgid "This page shows a summary of a search index and its status."
-msgstr ""
+msgstr "This page shows a summary of a search index and its status."
 
 msgid "Index status"
-msgstr ""
+msgstr "Index status"
 
 msgid ""
 "This gives a summary about how many items are known for this index, and how "
 "many have been indexed in their latest version. Items that are not indexed "
 "yet cannot be found by searches."
 msgstr ""
+"This gives a summary about how many items are known for this index, and how "
+"many have been indexed in their latest version. Items that are not indexed "
+"yet cannot be found by searches."
 
 msgid "Shows whether the index is currently enabled or disabled."
-msgstr ""
+msgstr "Shows whether the index is currently enabled or disabled."
 
 msgid "Datasources"
-msgstr ""
+msgstr "Datasources"
 
 msgid "Lists all datasources that are enabled for this index."
-msgstr ""
+msgstr "Lists all datasources that are enabled for this index."
 
 msgid ""
 "The tracker used by the index. Only one (\"Default\") is available by "
 "default."
 msgstr ""
+"The tracker used by the index. Only one (\"Default\") is available by "
+"default."
 
 msgid "Server"
-msgstr ""
+msgstr "Palvelin"
 
 msgid "Server index status"
-msgstr ""
+msgstr "Server index status"
 
 msgid ""
 "For enabled indexes, the number of items that can actually be retrieved from"
@@ -24064,24 +26342,30 @@ msgid ""
 "/frequently-asked-questions#server-index-status\">see the module's "
 "documentation</a>."
 msgstr ""
+"For enabled indexes, the number of items that can actually be retrieved from"
+" the server is listed here. For reasons why this number might differ from "
+"the number under \"Index status\", <a "
+"href=\"https://www.drupal.org/docs/8/modules/search-api/getting-started"
+"/frequently-asked-questions#server-index-status\">see the module's "
+"documentation</a>."
 
 msgid "Cron batch size"
-msgstr ""
+msgstr "Cron batch size"
 
 msgid "The number of items that will be indexed at once during cron runs."
-msgstr ""
+msgstr "The number of items that will be indexed at once during cron runs."
 
 msgid "Start indexing now"
-msgstr ""
+msgstr "Start indexing now"
 
 msgid "Meta tags"
-msgstr ""
+msgstr "Meta-kentät"
 
 msgid "Country name"
-msgstr ""
+msgstr "Maan nimi"
 
 msgid "Relation"
-msgstr ""
+msgstr "Relaatio"
 
 msgid ""
 "The \"Start indexing now\" form allows indexing items manually right away, "
@@ -24089,9 +26373,13 @@ msgid ""
 "The form might be disabled if indexing is currently not possible for some "
 "reason, or not necessary."
 msgstr ""
+"The \"Start indexing now\" form allows indexing items manually right away, "
+"with a batch process. Otherwise, items are only indexed during cron runs. "
+"The form might be disabled if indexing is currently not possible for some "
+"reason, or not necessary."
 
 msgid "Track items for index"
-msgstr ""
+msgstr "Track items for index"
 
 msgid ""
 "In certain situations, the index's tracker doesn't have the latest state of "
@@ -24099,54 +26387,70 @@ msgid ""
 "during cron runs, but can also be manually triggered here, with the \"Track "
 "now\" button."
 msgstr ""
+"In certain situations, the index's tracker doesn't have the latest state of "
+"the items available for indexing. This will be automatically rectified "
+"during cron runs, but can also be manually triggered here, with the \"Track "
+"now\" button."
 
 msgid "Queue all items for reindexing"
-msgstr ""
+msgstr "Queue all items for reindexing"
 
 msgid ""
 "This will queue all items on this index for reindexing. Previously indexed "
 "data will remain on the search server, so searches on this index will "
 "continue to yield results."
 msgstr ""
+"This will queue all items on this index for reindexing. Previously indexed "
+"data will remain on the search server, so searches on this index will "
+"continue to yield results."
 
 msgid "Clear all indexed data"
-msgstr ""
+msgstr "Clear all indexed data"
 
 msgid ""
 "This will remove all indexed content for this index from the search server "
 "and queue it for reindexing. Searches on this index will not return any "
 "results until items are reindexed."
 msgstr ""
+"This will remove all indexed content for this index from the search server "
+"and queue it for reindexing. Searches on this index will not return any "
+"results until items are reindexed."
 
 msgid "Add or edit a Search API server"
-msgstr ""
+msgstr "Add or edit a Search API server"
 
 msgid "Adding or editing a Server"
-msgstr ""
+msgstr "Adding or editing a Server"
 
 msgid ""
 "This form can be used to edit an existing server or add a new server to your"
 " site. Servers will hold your indexed data."
 msgstr ""
+"This form can be used to edit an existing server or add a new server to your"
+" site. Servers will hold your indexed data."
 
 msgid "Server name"
-msgstr ""
+msgstr "Palvelimen nimi"
 
 msgid ""
 "Enter a name to identify this server. For example, \"Solr server\". This "
 "will only be displayed in the admin user interface."
 msgstr ""
+"Enter a name to identify this server. For example, \"Solr server\". This "
+"will only be displayed in the admin user interface."
 
 msgid "Server description"
-msgstr ""
+msgstr "Server description"
 
 msgid ""
 "Optionally, enter a description to explain the function of the server in "
 "more detail. This will only be displayed in the admin user interface."
 msgstr ""
+"Optionally, enter a description to explain the function of the server in "
+"more detail. This will only be displayed in the admin user interface."
 
 msgid "Server backend"
-msgstr ""
+msgstr "Server backend"
 
 msgid ""
 "Servers can be based on different technologies. These are called "
@@ -24156,33 +26460,42 @@ msgid ""
 "href=\"https://www.drupal.org/project/search_api_solr\">\"Solr\"</a>, which "
 "requires to be set up separately."
 msgstr ""
+"Servers can be based on different technologies. These are called "
+"\"backends\". A server uses exactly one backend and cannot change it later. "
+"You can make the \"Database\" backend available by enabling the \"Database "
+"Search\" module. Another very common backend is <a "
+"href=\"https://www.drupal.org/project/search_api_solr\">\"Solr\"</a>, which "
+"requires to be set up separately."
 
 msgid "Information about a server"
-msgstr ""
+msgstr "Information about a server"
 
 msgid "This page shows a summary of a search server."
-msgstr ""
+msgstr "This page shows a summary of a search server."
 
 msgid "Shows whether the server is currently enabled or disabled."
-msgstr ""
+msgstr "Shows whether the server is currently enabled or disabled."
 
 msgid "Backend class"
-msgstr ""
+msgstr "Backend class"
 
 msgid ""
 "The backend plugin used for this server. The backend plugin determines how "
 "items are indexed and searched – for example, using the database or an "
 "Apache Solr server."
 msgstr ""
+"The backend plugin used for this server. The backend plugin determines how "
+"items are indexed and searched – for example, using the database or an "
+"Apache Solr server."
 
 msgid "Search indexes"
-msgstr ""
+msgstr "Search indexes"
 
 msgid "Lists all search indexes that are attached to this server."
-msgstr ""
+msgstr "Lists all search indexes that are attached to this server."
 
 msgid "Delete all indexed data"
-msgstr ""
+msgstr "Delete all indexed data"
 
 msgid ""
 "This will permanently remove all data currently indexed on this server for "
@@ -24190,223 +26503,253 @@ msgid ""
 "reindexing occurs, searches for the affected indexes will not return any "
 "results."
 msgstr ""
+"This will permanently remove all data currently indexed on this server for "
+"indexes that aren't read-only. Items are queued for reindexing. Until "
+"reindexing occurs, searches for the affected indexes will not return any "
+"results."
 
 msgid "enabled"
-msgstr ""
+msgstr "käytössä"
 
 msgid "all"
-msgstr ""
+msgstr "kaikki"
 
 msgid "Total"
-msgstr ""
+msgstr "Yhteensä"
 
 msgid "Always"
-msgstr ""
+msgstr "Aina"
 
 msgid "Field ID"
-msgstr ""
+msgstr "Kentän ID"
 
 msgid "Transliteration"
-msgstr ""
+msgstr "Transliteraatio"
 
 msgid "Read only"
-msgstr ""
+msgstr "Vain luku"
 
 msgid "Exception"
-msgstr ""
+msgstr "Poikkeus"
 
 msgid ""
 "You must include at least one positive keyword with @count characters or "
 "more."
 msgstr ""
+"Sinun täytyy syöttää vähintään yksi positiivinen avainsana jossa on "
+"vähintään @count merkkiä."
 
 msgid "Add server"
-msgstr ""
+msgstr "Lisää palvelin"
 
 msgid "Unavailable"
-msgstr ""
+msgstr "Ei saatavilla"
 
 msgid "Data types"
-msgstr ""
+msgstr "Tietotyypit"
 
 msgid "Relevance"
-msgstr ""
+msgstr "Paremmuusjärjestys"
 
 msgid "HTML filter"
-msgstr ""
+msgstr "HTML-suodatin"
 
 msgid ""
 "The number of characters a word has to be to be indexed. A lower setting "
 "means better search result ranking, but also a larger database. Each search "
 "query must contain at least one keyword that is this size (or longer)."
 msgstr ""
+"Vain ne sanat, joissa on vähintään näin monta merkkiä indeksoidaan. Pienempi"
+" luku tuottaa parempia hakutuloksia, mutta myös suuremman tietokannan. "
+"Jokaisessa haussa tulee olla vähintään yksi sana, joka on näin pitkä tai "
+"pidempi."
 
 msgid "Indexed"
-msgstr ""
+msgstr "Indeksoitu"
 
 msgid "The changes were successfully saved."
-msgstr ""
+msgstr "Muutokset tallennettu onnistuneesti."
 
 msgid "Add index"
-msgstr ""
+msgstr "Lisää indeksi"
 
 msgid "Save and add fields"
-msgstr ""
+msgstr "Tallenna ja lisää kenttiä"
 
 msgid "Machine name: @name"
-msgstr ""
+msgstr "Koneluettava nimi: @name"
 
 msgid "Autocomplete settings"
-msgstr ""
+msgstr "Autocomplete settings"
 
 msgid "Ignore case"
-msgstr ""
+msgstr "Ignore case"
 
 msgid "Default content index"
-msgstr ""
+msgstr "Default content index"
 
 msgid "Default content index created by the Database Search Defaults module"
-msgstr ""
+msgstr "Default content index created by the Database Search Defaults module"
 
 msgid "Database Server"
-msgstr ""
+msgstr "Database Server"
 
 msgid "Default database server created by the Database Search Defaults module"
 msgstr ""
+"Default database server created by the Database Search Defaults module"
 
 msgid "Add tracking for specific roles"
-msgstr ""
+msgstr "Lisää jäljitys valituille rooleille"
 
 msgid "Search content"
-msgstr ""
+msgstr "Search content"
 
 msgid "A search page preconfigured to search through the content of your site"
 msgstr ""
+"A search page preconfigured to search through the content of your site"
 
 msgid "Please enter some keywords to search."
-msgstr ""
+msgstr "Please enter some keywords to search."
 
 msgid "Search Content"
-msgstr ""
+msgstr "Search Content"
 
 msgid "Displaying results @start - @end of @total"
-msgstr ""
+msgstr "Displaying results @start - @end of @total"
 
 msgid "Module %module granted %permission permission to authenticated users."
-msgstr ""
+msgstr "Module %module granted %permission permission to authenticated users."
 
 msgid "Opt-in or out of tracking"
-msgstr ""
+msgstr "Estä tai salli seuranta"
 
 msgid "Message type"
-msgstr ""
+msgstr "Viestin tyyppi"
 
 msgid "Downloads"
-msgstr ""
+msgstr "Lataukset"
 
 msgid "Privacy"
-msgstr ""
+msgstr "Yksityisyys"
 
 msgid "Not configured"
-msgstr ""
+msgstr "Ei asetettu"
 
 msgid "Create field"
-msgstr ""
+msgstr "Luo kenttä"
 
 msgid "Domains"
-msgstr ""
+msgstr "Domainit"
 
 msgid "@module (<span class=\"admin-enabled\">enabled</span>)"
-msgstr ""
+msgstr "@module (<span class=\"admin-enabled\">päällä</span>)"
 
 msgid "Add tracking to specific pages"
-msgstr ""
+msgstr "Lisää jäljitys valituille sivuille"
 
 msgid "Track translation sets as one unit"
-msgstr ""
+msgstr "Jäljitä käännössarjat yhtenä yksikkönä"
 
 msgid ""
 "When a node is part of a translation set, record statistics for the "
 "originating node instead. This allows for a translation set to be treated as"
 " a single unit."
 msgstr ""
+"Jos solmu on osa käännössarjaa, kirjaa tilastot alkuperäiselle solmulle eikä"
+" käännökselle. Tämä mahdollistaa käännössarjojen käsittelyn yksittäisinä "
+"yksikköinä."
 
 msgid "Track internal search"
-msgstr ""
+msgstr "Seuraa sisäisiä hakuja"
 
 msgid "Track AdSense ads"
-msgstr ""
+msgstr "Seuraa AdSense mainoksia"
 
 msgid ""
 "If checked, your AdSense ads will be tracked in your Google Analytics "
 "account."
 msgstr ""
+"Mikäli valittuna, AdSense mainoksesi seurataan Google Analytics tilissäsi."
 
 msgid "Custom JavaScript code"
-msgstr ""
+msgstr "Muokattu Javascript-koodi"
 
 msgid "Code snippet (before)"
-msgstr ""
+msgstr "Koodinpätkä (ennen)"
 
 msgid "Code snippet (after)"
-msgstr ""
+msgstr "Koodinpätkä (jälkeen)"
 
 msgid ""
 "Do not add the tracker code provided by Google into the javascript code "
 "snippets! This module already builds the tracker code based on your Google "
 "Analytics account number and settings."
 msgstr ""
+"Älä lisää Google Analyticsin tarjoamaa seurantakoodia Javascript-koodeihisi!"
+" Tämä moduuli lisää automaattisesti seurantakoodin tarvitsemat koodirivit "
+"perustuen Google Analytics tilisi numeroon ja asetuksiin."
 
 msgid ""
 "Do not include the &lt;script&gt; tags in the javascript code snippets."
-msgstr ""
+msgstr "Älä lisää &lt;script&gt; tageja javascript-koodinpätkiin."
 
 msgid "Users are tracked by default, but you are able to opt out."
 msgstr ""
+"Käyttäjie seuranta on oletusarvoisesti päällä mutta voit estää seurannan "
+"omalla kohdallasi."
 
 msgid "Enable user tracking"
-msgstr ""
+msgstr "Ota käyttöön käyttäjien seuranta"
 
 msgid "Users are <em>not</em> tracked by default, but you are able to opt in."
 msgstr ""
+"Käyttäjiä ei oletusarvoisesti seurata mutta voit erikseen ottaa käyttöön "
+"seurannan."
 
 msgid "Google Analytics"
-msgstr ""
+msgstr "Google Analytics"
 
 msgid "Google Analytics module"
-msgstr ""
+msgstr "Google Analytics moduuli"
 
 msgid ""
 "Specify pages by using their paths. Enter one path per line. The '*' "
 "character is a wildcard. Example paths are %blog for the blog page and "
 "%blog-wildcard for every personal blog. %front is the front page."
 msgstr ""
+"Määrittele sivut käyttäen niiden polkuja. Syötä yksi riviä kohti. Merkki '*'"
+" toimii villinä korttina. Esimerkkeinä %blog blogeille tai %blog-villikortti"
+" jokaiselle henkilökohtaiselle blogille. %front on etusivu."
 
 msgid "Pages on which this PHP code returns <code>TRUE</code> (experts only)"
 msgstr ""
+"Sivut joilla tämä PHP koodi palauttaa <code>TRUE</code> (vain "
+"asiantuntijoille)"
 
 msgid "Pages or PHP code"
-msgstr ""
+msgstr "Sivuja tai PHP koodia"
 
 msgid ""
 "If the PHP option is chosen, enter PHP code between %php. Note that "
 "executing incorrect PHP code can break your Drupal site."
 msgstr ""
+"Jos valittuna on PHP, syötä %php välissä oleva PHP koodi. Huomaa että "
+"virheellisen PHP koodin ajaminen saattaa rikkoa Drupal sivustosi."
 
 msgid "Not customizable"
-msgstr ""
+msgstr "Ei mukautettavissa"
 
 msgid "Colorbox"
-msgstr ""
+msgstr "Colorbox"
 
 msgid "Site search"
-msgstr ""
+msgstr "Sivustohaku"
 
 msgid "Web Property ID"
-msgstr ""
+msgstr "Verkko-ominaisuuden ID"
 
 msgid "Anonymize visitors IP address"
-msgstr ""
+msgstr "Piilota käyttäjien IP osoite"
 
 msgid ""
 "Tell Google Analytics to anonymize the information sent by the tracker "
@@ -24416,9 +26759,15 @@ msgid ""
 "information for privacy reasons and this setting may help you to comply with"
 " the local laws."
 msgstr ""
+"Kehota Google Analyticsiä piilottamaan tieto poistamalla IP-osoitteen "
+"viimeinen osa ennen tallennusta. Huomaa että tällä on pieni vaikutus "
+"maantieteellisen raportoinnin tarkkuudessa. Joissakin maissa on kiellettyä "
+"kerätä henkilön tunnistamiseen liittyvää tietoa yksityisyyssyistä ja tämä "
+"asetus voi auttaa sinua säätäään sivustosi paikallista lainsäädäntöä "
+"vastaavaksi."
 
 msgid "Locally cache tracking code file"
-msgstr ""
+msgstr "Tallenna seurantakooditiedosto lokaalisti välimuistiin"
 
 msgid ""
 "If checked, the tracking code file is retrieved from Google Analytics and "
@@ -24426,250 +26775,275 @@ msgid ""
 "to tracking code are reflected in the local copy. Do not activate this until"
 " after Google Analytics has confirmed that site tracking is working!"
 msgstr ""
+"Mikäli valittuna, seurantakooditiedosto haetaan Google Analyticsistä ja "
+"tallennetaan välimuistiin paikallisesti. Se päivitetään päivittäin Googlen "
+"palvelimilta jotta voidaan varmistaa että seurantakoodin muutokset tulevat "
+"voimaan myös paikallisessa kopiossa. Älä aktivoi tätä asetusta ennenkuin "
+"Google Analytics on varmentanut että sivustosi seuranta toimii!"
 
 msgid "Custom variables"
-msgstr ""
+msgstr "Kustomoidut muuttujat"
 
 msgid ""
 "The %element-title is using the following forbidden tokens with personal "
 "identifying information: @invalid-tokens."
 msgstr ""
+"Elementin %element otsikko käyttää seuraavia kiellettyjä korvauskuvioita "
+"henkilötiedon tunnistamisessa: @invalid-tokens."
 
 msgid ""
 "The role names the user account is a member of as comma separated list."
-msgstr ""
+msgstr "Käyttäjätilin roolien nimet pilkuin eroteltuna listana."
 
 msgid "The role ids the user account is a member of as comma separated list."
-msgstr ""
+msgstr "Käyttäjätilin roolien ID:t pilkuin eroteltuna listana."
 
 msgid "Locally cached tracking code file has been updated."
 msgstr ""
+"Paikallisesti välimuistiin tallennettu seurantakooditiedosto on päivitetty."
 
 msgid "Locally cached tracking code file has been saved."
 msgstr ""
+"Paikallisesti välimuistiin tallennettu seurantakooditiedosto on tallennettu."
 
 msgid "Local cache has been purged."
-msgstr ""
+msgstr "Paikallinen välimuisti on tyhjennetty."
 
 msgid "Tracking scope"
-msgstr ""
+msgstr "Jäljitystapa"
 
 msgid "Allow users to customize tracking on their account page"
-msgstr ""
+msgstr "Salli käyttäjien kustomoida seurantaa käyttäjäprofiilisivuillaan"
 
 msgid "No customization allowed"
-msgstr ""
+msgstr "Kustomointi on estetty"
 
 msgid "Tracking on by default, users with %permission permission can opt out"
 msgstr ""
+"Seuranta päällä oletuksena, käyttäjät joilla on %permission oikeus voivat "
+"ohittaa asetuksen"
 
 msgid "Tracking off by default, users with %permission permission can opt in"
 msgstr ""
+"Seuranta pois päältä oletuksena, käyttäjät joilla on %permission oikeus "
+"voivat ohittaa asetuksen"
 
 msgid "Every page except the listed pages"
-msgstr ""
+msgstr "Kaikki paitsi listatut sivut"
 
 msgid "The listed pages only"
-msgstr ""
+msgstr "Vain listatut sivut"
 
 msgid "Links and downloads"
-msgstr ""
+msgstr "Linkit ja lataukset"
 
 msgid "Track clicks on mailto links"
-msgstr ""
+msgstr "Seuraa mailto linkkien klikkauksia"
 
 msgid "Track downloads (clicks on file links) for the following extensions"
 msgstr ""
+"Seuraa latauksia (tiedostolinkkien klikkauksia) tiedostoissa joiden pääte on"
+" yksi seuraavista"
 
 msgid "List of download file extensions"
-msgstr ""
+msgstr "Lista ladattavien tiedostojen tiedostopäätteistä"
 
 msgid ""
 "A valid Google Analytics Web Property ID is case sensitive and formatted "
 "like UA-xxxxxxx-yy."
 msgstr ""
+"Kelvollinen Google Analytics verkkotunnisteen ID on kirjainkoosta "
+"riippuvainen ja muotoa UA-xxxxxxx-yy."
 
 msgid "Administer Google Analytics"
-msgstr ""
+msgstr "Ylläpidä Google Analyticsiä"
 
 msgid "Perform maintenance tasks for Google Analytics."
-msgstr ""
+msgstr "Suorita Google Analyticsin ylläpitotoimet."
 
 msgid "Allow users to decide if tracking code will be added to pages or not."
-msgstr ""
+msgstr "Salli käyttäjien päättää, lisätäänkö seurantakoodi sivuille vaiko ei."
 
 msgid "Use PHP for tracking visibility"
-msgstr ""
+msgstr "Käytä PHP:tä näkyvyyden seuraamisessa"
 
 msgid "On by default with opt out"
-msgstr ""
+msgstr "Päällä oletuksena, seurannan estäminen on mahdollista"
 
 msgid "Off by default with opt in"
-msgstr ""
+msgstr "Pois päältä oletuksena, seurannan salliminen on mahdollista"
 
 msgid "Not tracked"
-msgstr ""
+msgstr "Ei seurannassa"
 
 msgid "What are you tracking?"
-msgstr ""
+msgstr "Mitä jäljität?"
 
 msgid "A single domain (default)"
-msgstr ""
+msgstr "Yksittäinen domain (oletus)"
 
 msgid "Domain: @domain"
-msgstr ""
+msgstr "Domain: @domain"
 
 msgid "One domain with multiple subdomains"
-msgstr ""
+msgstr "Yksitäinen domain jolla on useampia alidomaineja"
 
 msgid "Examples: @domains"
-msgstr ""
+msgstr "Esimerkkejä: @domains"
 
 msgid "Multiple top-level domains"
-msgstr ""
+msgstr "Useita ylätason domaineja"
 
 msgid "List of top-level domains"
-msgstr ""
+msgstr "Lista ylätason domaineista"
 
 msgid "Add to the selected roles only"
-msgstr ""
+msgstr "Lisää vain valituille rooleille"
 
 msgid "Add to every role except the selected ones"
-msgstr ""
+msgstr "Lisää kaikille rooleille paitsi valituille"
 
 msgid ""
 "If none of the roles are selected, all users will be tracked. If a user has "
 "any of the roles checked, that user will be tracked (or excluded, depending "
 "on the setting above)."
 msgstr ""
+"Jos yksikään rooleista ei ole valittuna, kaikkia käyttäjiä seurataan. Jos "
+"käyttäjällä on jokin valituista rooleista, käyttäjää seurataan (tai ei "
+"seurata, ylläolevasta asetuksesta riippuen)."
 
 msgid "Track clicks on outbound links"
-msgstr ""
+msgstr "Seuraa sivuston ulkopuolelle osoittavia linkkejä"
 
 msgid ""
 "A list of top-level domains is required if <em>Multiple top-level "
 "domains</em> has been selected."
 msgstr ""
+"Lista ylätason domaineista on pakollinen jos käytössäsi on asetus <em>useita"
+" ylätason domaineja</em>."
 
 msgid "All pages with exceptions"
-msgstr ""
+msgstr "Kaikki sivut poikkeuksin"
 
 msgid "Excepted: @roles"
-msgstr ""
+msgstr "Poikkeukset: @roles"
 
 msgid "A single domain"
-msgstr ""
+msgstr "Yksittäinen domain"
 
 msgid "No privacy"
-msgstr ""
+msgstr "Ei yksityisyyttä"
 
 msgid "@items enabled"
-msgstr ""
+msgstr "@items käytössä"
 
 msgid "Outbound links"
-msgstr ""
+msgstr "Ulos osoittavat linkit"
 
 msgid "Enter PHP code in the field for tracking visibility settings."
-msgstr ""
+msgstr "Syötä PHP koodia kenttään seurataksesi näkyvyysasetuksia."
 
 msgid "Google Analytics module form element."
-msgstr ""
+msgstr "Google Analytics moduulin lomake-elementti."
 
 msgid "Mailto links"
-msgstr ""
+msgstr "Mailto linkit"
 
 msgid "AdSense ads"
-msgstr ""
+msgstr "AdSense mainokset"
 
 msgid "Anonymize IP"
-msgstr ""
+msgstr "Piilota IP"
 
 msgid "Track messages of type"
-msgstr ""
+msgstr "Seuraa viestejä joiden tyyppi on"
 
 msgid "Search and Advertising"
-msgstr ""
+msgstr "Haku ja mainostaminen"
 
 msgid "Metric"
-msgstr ""
+msgstr "Metric"
 
 msgid ""
 "To adjust global defaults, go to admin/config/search/metatag. If you need to"
 " set meta tags for a specific entity, edit its bundle and add the Metatag "
 "field."
 msgstr ""
+"To adjust global defaults, go to admin/config/search/metatag. If you need to"
+" set meta tags for a specific entity, edit its bundle and add the Metatag "
+"field."
 
 msgid "Metatag defaults"
-msgstr ""
+msgstr "Metatag defaults"
 
 msgid "403 access denied"
-msgstr ""
+msgstr "403 access denied"
 
 msgid "[node:title] | [site:name]"
-msgstr ""
+msgstr "[node:title] | [site:name]"
 
 msgid "404 page not found"
-msgstr ""
+msgstr "404 page not found"
 
 msgid "[site:url]"
-msgstr ""
+msgstr "[site:url]"
 
 msgid "[current-page:url]"
-msgstr ""
+msgstr "[current-page:url]"
 
 msgid "[current-page:title] | [site:name]"
-msgstr ""
+msgstr "[current-page:title] | [site:name]"
 
 msgid "[node:summary]"
-msgstr ""
+msgstr "[node:summary]"
 
 msgid "[node:url]"
-msgstr ""
+msgstr "[node:url]"
 
 msgid "[term:url]"
-msgstr ""
+msgstr "[term:url]"
 
 msgid "[term:description]"
-msgstr ""
+msgstr "[term:description]"
 
 msgid "[term:name] | [site:name]"
-msgstr ""
+msgstr "[term:name] | [site:name]"
 
 msgid "[user:url]"
-msgstr ""
+msgstr "[user:url]"
 
 msgid "[site:name]"
-msgstr ""
+msgstr "[site:name]"
 
 msgid "[user:display-name] | [site:name]"
-msgstr ""
+msgstr "[user:display-name] | [site:name]"
 
 msgid "Audience"
-msgstr ""
+msgstr "Yleisö"
 
 msgid "License"
-msgstr ""
+msgstr "Lisenssi"
 
 msgid "Date Created"
-msgstr ""
+msgstr "Luontipäivä"
 
 msgid "Id"
-msgstr ""
+msgstr "Tunniste"
 
 msgid "Latitude"
-msgstr ""
+msgstr "Leveyspiiri"
 
 msgid "Longitude"
-msgstr ""
+msgstr "Pituuspiiri"
 
 msgid "Phone number"
-msgstr ""
+msgstr "Puhelinnumero"
 
 msgid "Google"
-msgstr ""
+msgstr "Google"
 
 msgid "Street address"
-msgstr ""
+msgstr "Lähiosoite"
 
 msgid "Publisher"
 msgstr "Tuottaja"
@@ -24678,95 +27052,107 @@ msgid "Publisher URL"
 msgstr "Tuottajan URL"
 
 msgid "Rating"
-msgstr ""
+msgstr "Arvio"
 
 msgid "Creator"
-msgstr ""
+msgstr "Luoja"
 
 msgid ""
 "Allows your site to be tracked by Google Analytics by adding a Javascript "
 "tracking code to every page."
 msgstr ""
+"Sallii sivustosi seurannan Google Analyticsillä lisäämällä Javascript "
+"-jäljityskoodin jokaiselle sivulle."
 
 msgid "Image type"
-msgstr ""
+msgstr "Kuvan tyyppi"
 
 msgid "References"
-msgstr ""
+msgstr "Viittaukset"
 
 msgid "Canonical URL"
-msgstr ""
+msgstr "Kanoninen URL"
 
 msgid "Robots"
-msgstr ""
+msgstr "Hakurobotit"
 
 msgid "Bing"
-msgstr ""
+msgstr "Bing"
 
 msgid "Shortlink URL"
-msgstr ""
+msgstr "Lyhytlinkin osoite"
 
 msgid ""
 "Provides search engines with specific directions for what to do when this "
 "page is indexed."
 msgstr ""
+"Tarjoaa hakukoneille tarkkoja ohjeita siitä, miten sivu tulee indeksoida."
 
 msgid "Using defaults"
-msgstr ""
+msgstr "Käytetään oletusasetuksia"
 
 msgid "Image URL"
-msgstr ""
+msgstr "Image URL"
 
 msgid "Fax number"
-msgstr ""
+msgstr "Fax number"
 
 msgid "See also"
-msgstr ""
+msgstr "See also"
 
 msgid "Video width"
-msgstr ""
+msgstr "Video width"
 
 msgid "Video height"
-msgstr ""
+msgstr "Video height"
 
 msgid "Abstract"
-msgstr ""
+msgstr "Abstract"
 
 msgid "Origin"
-msgstr ""
+msgstr "Origin"
 
 msgid "Lifetime"
-msgstr ""
+msgstr "Elinaika"
 
 msgid "Honeypot"
-msgstr ""
+msgstr "Honeypot"
 
 msgid ""
 "Congratulations on installing Honeypot on your site! With just a few clicks, you can have your site well-protected against automated spam bots.\r\n"
 "\r\n"
 "Click Next to be guided through this configuration page."
 msgstr ""
+"Congratulations on installing Honeypot on your site! With just a few clicks, you can have your site well-protected against automated spam bots.\r\n"
+"\r\n"
+"Click Next to be guided through this configuration page."
 
 msgid "Protect all forms"
-msgstr ""
+msgstr "Protect all forms"
 
 msgid ""
 "Protecting all the forms is the easiest way to quickly cut down on spam on your site, but doing this disables Drupal's caching for every page where a form is displayed.\r\n"
 "\r\n"
 "Note: If you have the honeypot time limit enabled, this option may cause issues with Drupal Commerce product forms or similarly-sparse forms that are able to be completed in a very short time."
 msgstr ""
+"Protecting all the forms is the easiest way to quickly cut down on spam on your site, but doing this disables Drupal's caching for every page where a form is displayed.\r\n"
+"\r\n"
+"Note: If you have the honeypot time limit enabled, this option may cause issues with Drupal Commerce product forms or similarly-sparse forms that are able to be completed in a very short time."
 
 msgid "Log blocked form submissions"
-msgstr ""
+msgstr "Log blocked form submissions"
 
 msgid ""
 "Check this box to log every form submission using watchdog. If you have "
 "Database Logging enabled, you can view these log entries in the Recent log "
 "messages page under Reports."
 msgstr ""
+"Check this box to log every form submission using watchdog. If you have "
+"Database Logging enabled, you can view these log entries in the Recent log "
+"messages page under Reports."
 
 msgid "Honeypot Element Name"
-msgstr ""
+msgstr "Honeypot Element Name"
 
 msgid ""
 "Spam bots typically fill out any field they believe will help get links back"
@@ -24774,9 +27160,13 @@ msgid ""
 "'homepage', or 'link' makes it hard for them to resist filling in the "
 "field—and easy to catch them in the trap and reject their submissions!"
 msgstr ""
+"Spam bots typically fill out any field they believe will help get links back"
+" to their site, so tempting them with a field named something like 'url', "
+"'homepage', or 'link' makes it hard for them to resist filling in the "
+"field—and easy to catch them in the trap and reject their submissions!"
 
 msgid "Honeypot Time Limit"
-msgstr ""
+msgstr "Honeypot Time Limit"
 
 msgid ""
 "If you enter a positive value, Honeypot will require that all protected "
@@ -24784,27 +27174,34 @@ msgid ""
 "least 5-10 seconds to complete (if you're a human), so setting this to a "
 "value < 5 will help protect against spam bots. Set to 0 to disable."
 msgstr ""
+"If you enter a positive value, Honeypot will require that all protected "
+"forms take at least that many seconds long to fill out. Most forms take at "
+"least 5-10 seconds to complete (if you're a human), so setting this to a "
+"value < 5 will help protect against spam bots. Set to 0 to disable."
 
 msgid "Honeypot form-specific settings"
-msgstr ""
+msgstr "Honeypot form-specific settings"
 
 msgid ""
 "If you would like to choose particular forms to be protected by Honeypot, "
 "check the forms you wish to protect in this section. Most common types of "
 "forms are available for protection."
 msgstr ""
+"If you would like to choose particular forms to be protected by Honeypot, "
+"check the forms you wish to protect in this section. Most common types of "
+"forms are available for protection."
 
 msgid "Expiration"
-msgstr ""
+msgstr "Voimassaoloaika"
 
 msgid "seconds"
-msgstr ""
+msgstr "sekuntia"
 
 msgid "Footer_en"
-msgstr ""
+msgstr "Footer_en"
 
 msgid "Footer links (en)"
-msgstr ""
+msgstr "Footer links (en)"
 
 msgid "Thursday"
 msgstr "torstai"
@@ -24815,362 +27212,362 @@ msgstr "syyskuu"
 
 msgid "1 minute"
 msgid_plural "@count minutes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 minuutti"
+msgstr[1] "@count minuuttia"
 
 msgid "Contact message"
-msgstr ""
+msgstr "Yhteydenottoviesti"
 
 msgid "Search task"
-msgstr ""
+msgstr "Search task"
 
 msgid "Shortcut link"
-msgstr ""
+msgstr "Oikopolun linkki"
 
 msgid "Reusable"
-msgstr ""
+msgstr "Reusable"
 
 msgid "Form ID"
-msgstr ""
+msgstr "Form ID"
 
 msgid "The sender's name"
-msgstr ""
+msgstr "Lähettäjän nimi."
 
 msgid "The sender's email"
-msgstr ""
+msgstr "Lähettäjän sähköposti-osoite"
 
 msgid "Recipient ID"
-msgstr ""
+msgstr "Vastaanottajan ID"
 
 msgid "Redirect ID"
-msgstr ""
+msgstr "Uudelleenohjauksen ID"
 
 msgid "User ID"
-msgstr ""
+msgstr "Käyttäjän ID"
 
 msgid "Task type"
-msgstr ""
+msgstr "Task type"
 
 msgid "Server ID"
-msgstr ""
+msgstr "Server ID"
 
 msgid "Index ID"
-msgstr ""
+msgstr "Index ID"
 
 msgid "Task data"
-msgstr ""
+msgstr "Task data"
 
 msgid "Path"
-msgstr ""
+msgstr "Polku"
 
 msgid "Enabled"
-msgstr ""
+msgstr "Käytössä"
 
 msgid "Menu link title"
-msgstr ""
+msgstr "Valikon linkin otsikko"
 
 msgid "Indicates whether the menu link should be rediscovered"
-msgstr ""
+msgstr "Indicates whether the menu link should be rediscovered"
 
 msgid "Show as expanded"
-msgstr ""
+msgstr "Näytä laajennettuna"
 
 msgid "Parent plugin ID"
-msgstr ""
+msgstr "Parent plugin ID"
 
 msgid "Content types"
-msgstr ""
+msgstr "Sisältötyypit"
 
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 msgid "Array"
-msgstr ""
+msgstr "Jono"
 
 msgid "Random"
-msgstr ""
+msgstr "Satunnainen"
 
 msgid "Image with image style"
-msgstr ""
+msgstr "Image with image style"
 
 msgid "Menus"
-msgstr ""
+msgstr "Valikot"
 
 msgid "Nodes"
-msgstr ""
+msgstr "Solmut"
 
 msgid "Site information"
-msgstr ""
+msgstr "Sivuston tiedot"
 
 msgid "Taxonomy terms"
-msgstr ""
+msgstr "Luokittelutermit"
 
 msgid "Vocabularies"
-msgstr ""
+msgstr "Sanastot"
 
 msgid "Menu links"
-msgstr ""
+msgstr "Valikkolinkit"
 
 msgid "List of @type values"
-msgstr ""
+msgstr "Lista @type tyyppisistä arvoista"
 
 msgid "Translation source node"
-msgstr ""
+msgstr "Käännöksen lähdesolmu"
 
 msgid "Comment count"
-msgstr ""
+msgstr "Kommenttien lukumäärä"
 
 msgid "Menu link"
-msgstr ""
+msgstr "Valikkolinkki"
 
 msgid "Summary"
-msgstr ""
+msgstr "Yhteenveto"
 
 msgid "Original @entity"
-msgstr ""
+msgstr "Alkuperäinen @entity"
 
 msgid "Edit URL"
-msgstr ""
+msgstr "Muokkaa URLia"
 
 msgid "Date created"
-msgstr ""
+msgstr "Luontipäivämäärä"
 
 msgid "Date changed"
-msgstr ""
+msgstr "Muutospäivämäärä"
 
 msgid "Machine-readable name"
-msgstr ""
+msgstr "Koneellisesti luettava nimi"
 
 msgid "Parents"
-msgstr ""
+msgstr "Ylätermit"
 
 msgid "Root term"
-msgstr ""
+msgstr "Juuritermi"
 
 msgid "Term ID"
-msgstr ""
+msgstr "Termin ID"
 
 msgid "Parent term"
-msgstr ""
+msgstr "Isäntätermi"
 
 msgid "Vocabulary ID"
-msgstr ""
+msgstr "Sanaston ID"
 
 msgid "Term count"
-msgstr ""
+msgstr "Termien lukumäärä"
 
 msgid "Base name"
-msgstr ""
+msgstr "Perusnimi"
 
 msgid "File byte size"
-msgstr ""
+msgstr "Tiedostokoko tavuina"
 
 msgid "File ID"
-msgstr ""
+msgstr "Tiedoston ID"
 
 msgid "File name"
-msgstr ""
+msgstr "Tiedostonimi"
 
 msgid "File size"
-msgstr ""
+msgstr "Tiedoston koko"
 
 msgid "Owner"
 msgstr "Omistaja"
 
 msgid "Account cancellation URL"
-msgstr ""
+msgstr "Käyttäjätilin peruutusosoite"
 
 msgid "One-time login URL"
-msgstr ""
+msgstr "Kertakäyttöinen kirjautuminen"
 
 msgid "User role names"
-msgstr ""
+msgstr "Käyttäjäroolien nimet"
 
 msgid "User role ids"
-msgstr ""
+msgstr "Käyttäjäroolien ID:t"
 
 msgid "Deprecated: User Name"
-msgstr ""
+msgstr "Deprecated: User Name"
 
 msgid "Account Name"
-msgstr ""
+msgstr "Tilin nimi"
 
 msgid "Display Name"
-msgstr ""
+msgstr "Display Name"
 
 msgid "Email"
-msgstr ""
+msgstr "Sähköpostiosoite"
 
 msgid "Last login"
-msgstr ""
+msgstr "Viimeisin kirjautuminen"
 
 msgid "Link ID"
-msgstr ""
+msgstr "Linkin ID"
 
 msgid "Parent"
-msgstr ""
+msgstr "Isäntä"
 
 msgid "Root"
-msgstr ""
+msgstr "Päätaso"
 
 msgid "Page number"
-msgstr ""
+msgstr "Sivun numero"
 
 msgid "Query string value"
-msgstr ""
+msgstr "Kyselymerkkijonon arvo"
 
 msgid "Relative URL"
-msgstr ""
+msgstr "Suhteellinen verkko-osoite"
 
 msgid "Absolute URL"
-msgstr ""
+msgstr "Absoluuttinen verkko-osoite"
 
 msgid "Brief URL"
-msgstr ""
+msgstr "Tiivistetty verkko-osoite"
 
 msgid "Unaliased URL"
-msgstr ""
+msgstr "Aliasoimaton verkko-osoite"
 
 msgid "Arguments"
-msgstr ""
+msgstr "Argumentit"
 
 msgid "First"
-msgstr ""
+msgstr "Ensimmäinen"
 
 msgid "Last"
-msgstr ""
+msgstr "Viimeinen"
 
 msgid "Count"
-msgstr ""
+msgstr "Laskuri"
 
 msgid "Reversed"
-msgstr ""
+msgstr "Käänteistetty"
 
 msgid "Keys"
-msgstr ""
+msgstr "Avaimet"
 
 msgid "Imploded"
-msgstr ""
+msgstr "Tiivistetty"
 
 msgid "Value"
-msgstr ""
+msgstr "Arvo"
 
 msgid "Number"
-msgstr ""
+msgstr "Numero"
 
 msgid "Height"
-msgstr ""
+msgstr "Korkeus"
 
 msgid "Width"
-msgstr ""
+msgstr "Leveys"
 
 msgid "SEO"
-msgstr ""
+msgstr "SEO"
 
 msgid "URI"
-msgstr ""
+msgstr "URI"
 
 msgid "Comment ID"
-msgstr ""
+msgstr "Kommentin ID"
 
 msgid "IP Address"
-msgstr ""
+msgstr "IP-osoite"
 
 msgid "Email address"
 msgstr "Sähköpostiosoitteesi"
 
 msgid "Home page"
-msgstr ""
+msgstr "Kotisivu"
 
 msgid "Menu link count"
-msgstr ""
+msgstr "Valikkolinkkien määrä"
 
 msgid "Slogan"
-msgstr ""
+msgstr "Iskulause"
 
 msgid "URL (brief)"
-msgstr ""
+msgstr "URL (lyhyt muoto)"
 
 msgid "Login page"
-msgstr ""
+msgstr "Kirjautumissivu"
 
 msgid "Short format"
-msgstr ""
+msgstr "Lyhyt muoto"
 
 msgid "Medium format"
-msgstr ""
+msgstr "Keskipitkä muoto"
 
 msgid "Long format"
-msgstr ""
+msgstr "Pitkä muoto"
 
 msgid "Time-since"
-msgstr ""
+msgstr "Aikaa-sitten"
 
 msgid "Raw timestamp"
-msgstr ""
+msgstr "Aikaleima raakamuodossa"
 
 msgid "Total rows"
-msgstr ""
+msgstr "Rivien kokonaismäärä"
 
 msgid "@label ID"
-msgstr ""
+msgstr "@label ID"
 
 msgid "Text"
-msgstr ""
+msgstr "Teksti"
 
 msgid "Comment status"
-msgstr ""
+msgstr "Kommentoinnin tila"
 
 msgid "Last comment timestamp"
-msgstr ""
+msgstr "Viimeisen kommentin aikaleima"
 
 msgid "Last comment name"
-msgstr ""
+msgstr "Viimeisen kommentin nimi"
 
 msgid "Last comment user ID"
-msgstr ""
+msgstr "Viimeisimmän kommentin kirjoittajan käyttäjä ID"
 
 msgid "Number of comments"
-msgstr ""
+msgstr "Kommenttien määrä"
 
 msgid "Disqus status value"
-msgstr ""
+msgstr "Disqus status value"
 
 msgid "Disqus thread identifier"
-msgstr ""
+msgstr "Disqus thread identifier"
 
 msgid "Alternative text"
-msgstr ""
+msgstr "Vaihtoehtoinen teksti"
 
 msgid "@type type with delta @delta"
-msgstr ""
+msgstr "@type type with delta @delta"
 
 msgid "Link text"
 msgstr "Linkin teksti"
 
 msgid "Guide menu (en)"
-msgstr ""
+msgstr "Guide menu (en)"
 
 msgid "Menu for guide page (en)"
-msgstr ""
+msgstr "Menu for guide page (en)"
 
 msgid "Appears in: @bundles."
-msgstr ""
+msgstr "Esiintyy: @bundles."
 
 msgid "Also known as:"
-msgstr ""
+msgstr "Saatavilla myös:"
 
 msgid "@label (@name)"
-msgstr ""
+msgstr "@label (@name)"
 
 msgid "Main navigation (en)"
-msgstr ""
+msgstr "Main navigation (en)"
 
 msgid "User guide"
 msgstr "Käyttöopas"
 
 msgid "contact_message_event_form"
-msgstr ""
+msgstr "contact_message_event_form"
 
 msgid "Event"
 msgstr "Tapahtuma"
@@ -25215,40 +27612,40 @@ msgid "Guide search"
 msgstr "Etsi oppaasta"
 
 msgid "Guide search view"
-msgstr ""
+msgstr "Guide search view"
 
 msgid "Master"
-msgstr ""
+msgstr "Master"
 
 msgid "No matching results"
 msgstr "Hakuasi vastaavia tuloksia ei löytynyt. "
 
 msgid "Synchronizing configuration: @op @name."
-msgstr ""
+msgstr "Synkronoi asetukset: @op @name."
 
 msgid "Finalizing configuration synchronization."
-msgstr ""
+msgstr "Päätetään asetusten synkronointi."
 
 msgid "Unexpected error during import with operation @op for @name: @message"
-msgstr ""
+msgstr "Unexpected error during import with operation @op for @name: @message"
 
 msgid "This will also remove 1 placed block instance."
 msgid_plural "This will also remove @count placed block instances."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "This will also remove 1 placed block instance."
+msgstr[1] "This will also remove @count placed block instances."
 
 msgid "Upload requirements"
 msgstr "Latausvaatimukset"
 
 msgid "Deleted 1 comment."
 msgid_plural "Deleted @count comments."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Deleted 1 comment."
+msgstr[1] "Deleted @count comments."
 
 msgid "Deleted 1 post."
 msgid_plural "Deleted @count posts."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Deleted 1 post."
+msgstr[1] "Deleted @count posts."
 
 msgid "Recently modified"
 msgstr "Hiljattain muokattu"
@@ -25317,8 +27714,8 @@ msgstr "Artikkeleita ei löytynyt."
 
 msgid "1 block is available in the modified list."
 msgid_plural "@count blocks are available in the modified list."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 block is available in the modified list."
+msgstr[1] "@count blocks are available in the modified list."
 
 msgid ""
 "Events calendar displays various open data related events hosted in Finland "
@@ -25445,91 +27842,91 @@ msgid "Follow us"
 msgstr "Seuraa meitä"
 
 msgid "Updating translations for JavaScript and default configuration."
-msgstr ""
+msgstr "Päivitetään JavaScriptin ja oletusasetusten käännöksiä."
 
 msgid "Updated default configuration."
-msgstr ""
+msgstr "Updated default configuration."
 
 msgid "Finnish"
-msgstr ""
+msgstr "Finnish"
 
 msgid "Swedish"
-msgstr ""
+msgstr "Swedish"
 
 msgid "JavaScript"
-msgstr ""
+msgstr "JavaScript"
 
 msgid "Popovers"
-msgstr ""
+msgstr "Popovers"
 
 msgid "Tooltips"
-msgstr ""
+msgstr "Tooltips"
 
 msgid "Modals"
-msgstr ""
+msgstr "Modals"
 
 msgid "CDN (Content Delivery Network)"
-msgstr ""
+msgstr "CDN (Content Delivery Network)"
 
 msgid "Advanced Cache"
-msgstr ""
+msgstr "Advanced Cache"
 
 msgid "Custom URLs"
-msgstr ""
+msgstr "Custom URLs"
 
 msgid "Navbar"
-msgstr ""
+msgstr "Navbar"
 
 msgid "Region Wells"
-msgstr ""
+msgstr "Region Wells"
 
 msgid "Images"
-msgstr ""
+msgstr "Images"
 
 msgid "Container"
-msgstr ""
+msgstr "Container"
 
 msgid "Tables"
-msgstr ""
+msgstr "Tables"
 
 msgid "Etusivu"
-msgstr ""
+msgstr "Etusivu"
 
 msgid "Tietoaineistot"
-msgstr ""
+msgstr "Tietoaineistot"
 
 msgid "Organisaatiot"
-msgstr ""
+msgstr "Organisaatiot"
 
 msgid "Käyttösovellukset"
-msgstr ""
+msgstr "Käyttösovellukset"
 
 msgid "Ajankohtaista"
-msgstr ""
+msgstr "Ajankohtaista"
 
 msgid "Opas"
-msgstr ""
+msgstr "Opas"
 
 msgid "Lisää"
-msgstr ""
+msgstr "Lisää"
 
 msgid "Kirjaudu sisään"
-msgstr ""
+msgstr "Kirjaudu sisään"
 
 msgid "Rekisteröidy palveluun"
-msgstr ""
+msgstr "Rekisteröidy palveluun"
 
 msgid "Profiili"
-msgstr ""
+msgstr "Profiili"
 
 msgid "Kirjaudu ulos"
-msgstr ""
+msgstr "Kirjaudu ulos"
 
 msgid "Tapahtumakalenteri"
-msgstr ""
+msgstr "Tapahtumakalenteri"
 
 msgid "Avoindata.fi"
-msgstr ""
+msgstr "Avoindata.fi"
 
 msgid "All Finnish open data from one place."
 msgstr "Suomen kaikki avoin data yhdestä paikasta."
@@ -25575,216 +27972,237 @@ msgid "Register new account"
 msgstr "Rekisteröidy palveluun"
 
 msgid "Download feature"
-msgstr ""
+msgstr "Download feature"
 
 msgid "Add and configure"
-msgstr ""
+msgstr "Add and configure"
 
 msgid "Save and add"
-msgstr ""
+msgstr "Save and add"
 
 msgid "Update style"
-msgstr ""
+msgstr "Update style"
 
 msgid "Write"
-msgstr ""
+msgstr "Write"
 
 msgid "Restore"
-msgstr ""
+msgstr "Restore"
 
 msgid "Rebuild"
-msgstr ""
+msgstr "Rebuild"
 
 msgid "format"
-msgstr ""
+msgstr "format"
 
 msgid "Comment types"
-msgstr ""
+msgstr "Kommenttityypit"
 
 msgid "Form modes"
-msgstr ""
+msgstr "Lomakkeiden muodot"
 
 msgid "Disqus"
-msgstr ""
+msgstr "Disqus"
 
 msgid "Date and time formats"
-msgstr ""
+msgstr "Päivämäärä- ja aikamuodot"
 
 msgid "Search API"
-msgstr ""
+msgstr "Search API"
 
 msgid "Metatag"
-msgstr ""
+msgstr "Metatag"
 
 msgid "Easy Breadcrumb"
-msgstr ""
+msgstr "Easy Breadcrumb"
 
 msgid "Text formats and editors"
-msgstr ""
+msgstr "Tekstimuodot ja työkalut"
 
 msgid "Font Awesome Settings"
-msgstr ""
+msgstr "Font Awesome Settings"
 
 msgid "Honeypot configuration"
-msgstr ""
+msgstr "Honeypot configuration"
 
 msgid "CAPTCHA module settings"
-msgstr ""
+msgstr "CAPTCHA module settings"
 
 msgid "Field list"
-msgstr ""
+msgstr "Kenttälista"
 
 msgid "Available translation updates"
-msgstr ""
+msgstr "Käännösten saatavilla olevat päivitykset"
 
 msgid "List and edit site comments and the comment approval queue."
 msgstr ""
+"Listaa ja muokkaa sivuston kommentteja sekä hyväksyntää odottavien "
+"kommenttien jonoa."
 
 msgid "Manage custom form modes."
-msgstr ""
+msgstr "Hallitse kustomoituja lomakkeiden muotoja."
 
 msgid "Manage tagging, categorization, and classification of your content."
-msgstr ""
+msgstr "Luokittele ja järjestele sisältöä."
 
 msgid "Administer blocks, content types, menus, etc."
-msgstr ""
+msgstr "Ylläpidä lohkoja, sisältötyyppejä, valikoita jne."
 
 msgid "Administer how and where CAPTCHA is used."
-msgstr ""
+msgstr "Administer how and where CAPTCHA is used."
 
 msgid ""
 "Allow for site emails to be sent through an SMTP server of your choice."
 msgstr ""
+"Allow for site emails to be sent through an SMTP server of your choice."
 
 msgid ""
 "Configure tracking behavior to get insights into your website traffic and "
 "marketing effectiveness."
 msgstr ""
+"Säädä seuranta-asetuksiasi saadaksesi sisäpiirin tietoa sivustosi "
+"liikenteestä ja markkinoinnin tehokkuudesta."
 
 msgid "Manage automatic site maintenance tasks."
-msgstr ""
+msgstr "Ylläpidä sivuston automaattisia ylläpitotehtäviä."
 
 msgid "Configure basic site settings, actions, and cron."
-msgstr ""
+msgstr "Säädä sivuston perusasetuksia, toimenpiteitä ja cronia."
 
 msgid "Global settings for the display of Font Awesome icons."
-msgstr ""
+msgstr "Global settings for the display of Font Awesome icons."
 
 msgid ""
 "Configure Honeypot spam prevention and the forms on which Honeypot will be "
 "used."
 msgstr ""
+"Configure Honeypot spam prevention and the forms on which Honeypot will be "
+"used."
 
 msgid "Controls settings for the module Easy Breadcrumb"
-msgstr ""
+msgstr "Controls settings for the module Easy Breadcrumb"
 
 msgid ""
 "Choose which image toolkit to use if you have installed optional toolkits."
 msgstr ""
+"Valitse käytettävä kuvankäsittelykirjasto, jos olet asentanut ylimääräisiä "
+"kirjastoja."
 
 msgid "Configure Metatag defaults."
-msgstr ""
+msgstr "Configure Metatag defaults."
 
 msgid "Create and configure search indexes and servers."
-msgstr ""
+msgstr "Create and configure search indexes and servers."
 
 msgid "Provides configuration options for the Disqus comment system."
-msgstr ""
+msgstr "Provides configuration options for the Disqus comment system."
 
 msgid ""
 "Get a status report about available interface translations for your "
 "installed modules and themes."
 msgstr ""
+"Hae tilannekatsaus tämänhetkisten moduuliesi ja teemojesi "
+"käyttöliittymäkäännöksille."
 
 msgid "Overview of plugins used in all views."
-msgstr ""
+msgstr "Lista kaikista eri näkymissä käytetyistä laajennusosista."
 
 msgid "Profile"
-msgstr ""
+msgstr "Profile"
 
 msgid "Logout"
 msgstr "Kirjaudu ulos"
 
 msgid "CustomMessage: !customMessage"
-msgstr ""
+msgstr "CustomMessage: !customMessage"
 
 msgid "Allows users to translate content entities."
-msgstr ""
+msgstr "Salli käyttäjien kääntää sisältöentiteettejä."
 
 msgid "Tray @action."
-msgstr ""
+msgstr "Tray @action."
 
 msgid "!tour_item of !total"
-msgstr ""
+msgstr "!tour_item / !total"
 
 msgid "Random number generation"
-msgstr ""
+msgstr "Random number generation"
 
 msgid "Font Awesome 5"
-msgstr ""
+msgstr "Font Awesome 5"
 
 msgid "Trusted Host Settings"
-msgstr ""
+msgstr "Trusted Host Settings"
 
 msgid ""
 "External resources can be optimized automatically, which can reduce both the"
 " size and number of requests made to your website."
 msgstr ""
+"Ulkoiset lähteet voidaan optimoida automaattisesti mistä seuraa vähäisempi "
+"määrä kutsuja sivustollesi."
 
 msgid "Configure page caching strategy with APE."
-msgstr ""
+msgstr "Configure page caching strategy with APE."
 
 msgid ""
 "The CAPTCHA module will disable the caching of pages that contain a CAPTCHA "
 "element."
 msgstr ""
+"The CAPTCHA module will disable the caching of pages that contain a CAPTCHA "
+"element."
 
 msgid ""
 "Drupal provides an <a href=\":module_enable\">Internal Page Cache module</a>"
 " that is recommended for small to medium-sized websites."
 msgstr ""
+"Drupal provides an <a href=\":module_enable\">Internal Page Cache module</a>"
+" that is recommended for small to medium-sized websites."
 
 msgid "CAPTCHA"
-msgstr ""
+msgstr "CAPTCHA"
 
 msgid "Aggregate CSS files"
-msgstr ""
+msgstr "Yhdistä CSS-tiedostot"
 
 msgid "The website encountered an unexpected error. Please try again later."
-msgstr ""
+msgstr "Sivustolla tapahtui odottamaton virhe. Yritä myöhemmin uudelleen."
 
 msgid ""
 "The toolbar cannot be set to a horizontal orientation when it is locked."
-msgstr ""
+msgstr "Työkalupalkkia ei voi asettaa vaakasuuntaiseksi kun se on lukittu."
 
 msgid "@label"
-msgstr ""
+msgstr "@label"
 
 msgid "System maintenance"
-msgstr ""
+msgstr "System maintenance"
 
 msgid "System information"
-msgstr ""
+msgstr "System information"
 
 msgid ""
 "This page lists all configuration items on your site that have translatable "
 "text, like your site name, role names, etc."
 msgstr ""
+"This page lists all configuration items on your site that have translatable "
+"text, like your site name, role names, etc."
 
 msgid "Horizontal orientation"
-msgstr ""
+msgstr "Vaakasuuntainen"
 
 msgid "Tray \"@tray\" @action."
-msgstr ""
+msgstr "Tray \"@tray\" @action."
 
 msgid "Leave blank to show all strings. The search is case sensitive."
 msgstr ""
+"Jätä tyhjäksi näyttääksesi kaikki merkkijonot. Haku on riippuvainen "
+"kirjainten koosta."
 
 msgid "Go to page @key"
-msgstr ""
+msgstr "Go to page @key"
 
 msgid "Provides Drush commands for language manipulation"
-msgstr ""
+msgstr "Provides Drush commands for language manipulation"
 
 msgid ""
 "This page allows a translator to search for specific translated and "
@@ -25795,12 +28213,19 @@ msgid ""
 " translation editor.) Searches may be limited to strings in a specific "
 "language."
 msgstr ""
+"This page allows a translator to search for specific translated and "
+"untranslated strings, and is used when creating or editing translations. "
+"(Note: Because translation tasks involve many strings, it may be more "
+"convenient to <a title=\"User interface translation export\" "
+"href=\":export\">export</a> strings for offline editing in a desktop Gettext"
+" translation editor.) Searches may be limited to strings in a specific "
+"language."
 
 msgid "Source text only, no translations"
-msgstr ""
+msgstr "Source text only, no translations"
 
 msgid "Interface translation export"
-msgstr ""
+msgstr "Interface translation export"
 
 msgid ""
 "This page exports the translated strings used by your site. An export file "
@@ -25810,224 +28235,272 @@ msgid ""
 "includes the original strings only (used to create new translations with a "
 "Gettext translation editor)."
 msgstr ""
+"Tällä sivulla viedään sivustosi käännetyt merkkijonot tiedostoksi. Tiedosto "
+"voi olla Gettext Portable Object (<em>.po</em>) -muodossa, jolloin se "
+"sisältää alkuperäiskielen ja käännökset. Tämä sopii käännösten jakamiseen "
+"muiden kanssa. Se voi myös olla Gettext Portable Object Template "
+"(<em>.pot</em>) -muodossa, jolloin se se sisältää vain alkuperäiskielen. "
+"Tämä sopii uuden käännöksen aloittamiseen."
 
 msgid ""
 "There was a problem checking <a href=\":update-report\">available "
 "updates</a> for Drupal."
 msgstr ""
+"Drupalin <a href=\":update-report\">päivitysten</a> tarkistamisessa oli "
+"ongelma."
 
 msgid "Tuottajat"
-msgstr ""
+msgstr "Tuottajat"
 
 msgid "Field storage"
-msgstr ""
+msgstr "Field storage"
 
 msgid "Performance and scalability"
-msgstr ""
+msgstr "Suorituskyky ja skaalautuvuus"
 
 msgid "Examples"
-msgstr ""
+msgstr "Examples"
 
 msgid "Chaos tool suite (Experimental)"
-msgstr ""
+msgstr "Chaos tool suite (Experimental)"
 
 msgid "Enter a part of the module name or description"
-msgstr ""
+msgstr "Syötä osa moduulin nimestä tai kuvauksesta"
 
 msgid ""
 "Machine name: <span dir=\"ltr\" class=\"table-filter-text-source\">@machine-"
 "name</span>"
 msgstr ""
+"Machine name: <span dir=\"ltr\" class=\"table-filter-text-source\">@machine-"
+"name</span>"
 
 msgid ""
 "Aggregates syndicated content (RSS, RDF, and Atom feeds) from external "
 "sources."
 msgstr ""
+"Aggregates syndicated content (RSS, RDF, and Atom feeds) from external "
+"sources."
 
 msgid ""
 "Provides an automated way to run cron jobs, by executing them at the end of "
 "a server response."
 msgstr ""
+"Provides an automated way to run cron jobs, by executing them at the end of "
+"a server response."
 
 msgid "Configure <span class=\"visually-hidden\">the @module module</span>"
-msgstr ""
+msgstr "Configure <span class=\"visually-hidden\">the @module module</span>"
 
 msgid ""
 "Sends pages using the BigPipe technique that allows browsers to show them "
 "much faster."
 msgstr ""
+"Sends pages using the BigPipe technique that allows browsers to show them "
+"much faster."
 
 msgid ""
 "Controls the visual building blocks a page is constructed with. Blocks are "
 "boxes of content rendered into an area, or region, of a web page."
 msgstr ""
+"Kontrolloi visuaalisia rakennuspalikoita joista sivu koostuu. Lohkot ovat "
+"laatikoita jotka sisältävät sisältöä joka on renderöity alueelle, "
+"sisältöalueelle tai www-sivulle."
 
 msgid "Manage breakpoints and breakpoint groups for responsive designs."
-msgstr ""
+msgstr "Manage breakpoints and breakpoint groups for responsive designs."
 
 msgid "Allows administrators to manage configuration changes."
-msgstr ""
+msgstr "Allows administrators to manage configuration changes."
 
 msgid "Provides moderation states for content."
-msgstr ""
+msgstr "Provides moderation states for content."
 
 msgid "Allows administrators to create custom menu links."
-msgstr ""
+msgstr "Allows administrators to create custom menu links."
 
 msgid "Records which user has read which content."
-msgstr ""
+msgstr "Records which user has read which content."
 
 msgid ""
 "Places error messages adjacent to form inputs, for improved usability and "
 "accessibility."
 msgstr ""
+"Places error messages adjacent to form inputs, for improved usability and "
+"accessibility."
 
 msgid "Caches pages for any user, handling dynamic content correctly."
-msgstr ""
+msgstr "Caches pages for any user, handling dynamic content correctly."
 
 msgid ""
 "Caches pages for anonymous users. Use when an external page cache is not "
 "available."
 msgstr ""
+"Caches pages for anonymous users. Use when an external page cache is not "
+"available."
 
 msgid ""
 "Allows users to add and arrange blocks and content fields directly on the "
 "content."
 msgstr ""
+"Allows users to add and arrange blocks and content fields directly on the "
+"content."
 
 msgid "Provides a way for modules or themes to register layouts."
-msgstr ""
+msgstr "Provides a way for modules or themes to register layouts."
 
 msgid "Manages the creation, configuration, and display of media items."
-msgstr ""
+msgstr "Manages the creation, configuration, and display of media items."
 
 msgid ""
 "Enriches your content with metadata to let other applications (e.g. search "
 "engines, aggregators) better understand its relationships and attributes."
 msgstr ""
+"Rikastuttaa sisältöäsi metatiedolla joka auttaa sovelluksia (esimerkiksi "
+"hakukoneet) paremmin ymmärtämään sisällön suhdetta toisiinsa."
 
 msgid ""
 "Allows users to directly edit the configuration of blocks on the current "
 "page."
 msgstr ""
+"Allows users to directly edit the configuration of blocks on the current "
+"page."
 
 msgid "Logs content statistics for your site."
-msgstr ""
+msgstr "Logs content statistics for your site."
 
 msgid ""
 "Provides a means to associate text formats with text editor libraries such "
 "as WYSIWYGs or toolbars."
 msgstr ""
+"Provides a means to associate text formats with text editor libraries such "
+"as WYSIWYGs or toolbars."
 
 msgid ""
 "Provides a toolbar that shows the top-level administration menu items and "
 "links from other modules."
 msgstr ""
+"Tarjoaa työkalupalkin joka näyttää ylätason hallintavaihtoehdot ja linkittää"
+" muista moduuleista."
 
 msgid "Create customized lists and queries from your database."
-msgstr ""
+msgstr "Luo yksilöityjä listoja ja kyselyitä tietokannastasi."
 
 msgid ""
 "Provides UI and API for managing workflows. This module can be used with the"
 " Content moderation module to add highly customizable workflows to content."
 msgstr ""
+"Provides UI and API for managing workflows. This module can be used with the"
+" Content moderation module to add highly customizable workflows to content."
 
 msgid ""
 "Provides a number of utility and helper APIs for Drupal developers and site "
 "builders."
 msgstr ""
+"Provides a number of utility and helper APIs for Drupal developers and site "
+"builders."
 
 msgid ""
 "Provides improvements to blocks that will one day be added to Drupal core."
 msgstr ""
+"Provides improvements to blocks that will one day be added to Drupal core."
 
 msgid ""
 "A set of improvements to the core Views code that allows for greater control"
 " over Blocks."
 msgstr ""
+"A set of improvements to the core Views code that allows for greater control"
+" over Blocks."
 
 msgid ""
 "Allows users to configure the display and form display by arranging fields "
 "in several columns."
 msgstr ""
+"Allows users to configure the display and form display by arranging fields "
+"in several columns."
 
 msgid ""
 "Enhances the media list with additional features to more easily find and use"
 " existing media items."
 msgstr ""
+"Enhances the media list with additional features to more easily find and use"
+" existing media items."
 
 msgid "Provides a requirement for multilingual migrations."
-msgstr ""
+msgstr "Provides a requirement for multilingual migrations."
 
 msgid ""
 "Allows users to stage content or preview a full site by using multiple "
 "workspaces on a single site."
 msgstr ""
+"Allows users to stage content or preview a full site by using multiple "
+"workspaces on a single site."
 
 msgid "Creates app feed component"
-msgstr ""
+msgstr "Creates app feed component"
 
 msgid "Shows Articles page"
-msgstr ""
+msgstr "Shows Articles page"
 
 msgid "Creates categories component"
-msgstr ""
+msgstr "Creates categories component"
 
 msgid "Creates dataset list component"
-msgstr ""
+msgstr "Creates dataset list component"
 
 msgid "Shows Events page"
-msgstr ""
+msgstr "Shows Events page"
 
 msgid "Creates footer component"
-msgstr ""
+msgstr "Creates footer component"
 
 msgid "Manages the guide and its menu"
-msgstr ""
+msgstr "Manages the guide and its menu"
 
 msgid "Creates a header"
-msgstr ""
+msgstr "Creates a header"
 
 msgid "Creates a hero component"
-msgstr ""
+msgstr "Creates a hero component"
 
 msgid "Creates infobox component"
-msgstr ""
+msgstr "Creates infobox component"
 
 msgid "Creates news feed component"
-msgstr ""
+msgstr "Creates news feed component"
 
 msgid "Creates servicemessage component"
-msgstr ""
+msgstr "Creates servicemessage component"
 
 msgid "Modifies user validation"
-msgstr ""
+msgstr "Modifies user validation"
 
 msgid "Examples of how Drupal 8 migration compares to previous versions."
-msgstr ""
+msgstr "Examples of how Drupal 8 migration compares to previous versions."
 
 msgid "Specialized examples of Drupal 8 migration."
-msgstr ""
+msgstr "Specialized examples of Drupal 8 migration."
 
 msgid "Simple JSON Migration example"
-msgstr ""
+msgstr "Simple JSON Migration example"
 
 msgid "Defines datetime form elements and a datetime field type."
-msgstr ""
+msgstr "Defines datetime form elements and a datetime field type."
 
 msgid "Provides the ability to store end dates."
-msgstr ""
+msgstr "Provides the ability to store end dates."
 
 msgid "Defines an image field type and provides image manipulation tools."
-msgstr ""
+msgstr "Defines an image field type and provides image manipulation tools."
 
 msgid "Provides a simple link field type."
-msgstr ""
+msgstr "Provides a simple link field type."
 
 msgid ""
 "Offers an implementation of the Search API that uses database tables for "
 "indexing content."
 msgstr ""
+"Offers an implementation of the Search API that uses database tables for "
+"indexing content."
 
 msgid ""
 "Enable this module for a best-practice default setup of Search API with the "
@@ -26035,82 +28508,94 @@ msgid ""
 "module again for performance reasons. The provided configuration will not be"
 " removed."
 msgstr ""
+"Enable this module for a best-practice default setup of Search API with the "
+"Database backend. After installation it is recommended to uninstall this "
+"module again for performance reasons. The provided configuration will not be"
+" removed."
 
 msgid "Provides a generic framework for modules offering search capabilities."
 msgstr ""
+"Provides a generic framework for modules offering search capabilities."
 
 msgid "Drush support for direct upgrades from older Drupal versions."
-msgstr ""
+msgstr "Drush support for direct upgrades from older Drupal versions."
 
 msgid "Handles migrations"
-msgstr ""
+msgstr "Handles migrations"
 
 msgid "Contains migrations from older Drupal versions."
-msgstr ""
+msgstr "Contains migrations from older Drupal versions."
 
 msgid "Provides a user interface for migrating from older Drupal versions."
-msgstr ""
+msgstr "Provides a user interface for migrating from older Drupal versions."
 
 msgid "Enhancements to core migration support"
-msgstr ""
+msgstr "Enhancements to core migration support"
 
 msgid "Tools to assist in developing and running migrations."
-msgstr ""
+msgstr "Tools to assist in developing and running migrations."
 
 msgid "Provides a translation interface for configuration."
-msgstr ""
+msgstr "Provides a translation interface for configuration."
 
 msgid "Uses the Disqus web service to enhance comments."
-msgstr ""
+msgstr "Uses the Disqus web service to enhance comments."
 
 msgid "Provides configurable path based breadcrumbs."
-msgstr ""
+msgstr "Provides configurable path based breadcrumbs."
 
 msgid ""
 "Allows an entity type to borrow the fields and display configuration of "
 "another entity type."
 msgstr ""
+"Allows an entity type to borrow the fields and display configuration of "
+"another entity type."
 
 msgid "The most popular icon set and toolkit on the web."
-msgstr ""
+msgstr "The most popular icon set and toolkit on the web."
 
 msgid "Adds a Font Awesome Media Entity Type."
-msgstr ""
+msgstr "Adds a Font Awesome Media Entity Type."
 
 msgid "Allows version-dependent and shared usage of external libraries."
 msgstr ""
+"Sallii versioriippumattomien ja jaettujen ulkoisten kirjastojen käytön."
 
 msgid "Allows users to redirect from old URLs to new URLs."
 msgstr ""
+"Sallii käyttäjien luoda uudelleenohjauksia vanhoista verkko-osoitteista "
+"uusiin osoitteisiin."
 
 msgid ""
 "Logs 404 errors and allows users to create redirects for often requested but"
 " missing pages."
 msgstr ""
+"Logs 404 errors and allows users to create redirects for often requested but"
+" missing pages."
 
 msgid "Allows users to redirect between domains."
-msgstr ""
+msgstr "Allows users to redirect between domains."
 
 msgid "Twig filters for value(s) and label."
-msgstr ""
+msgstr "Twig filters for value(s) and label."
 
 msgid "Provides some extra Twig functions and filters."
-msgstr ""
+msgstr "Provides some extra Twig functions and filters."
 
 msgid "Allows finer control of the Cache Control header."
-msgstr ""
+msgstr "Allows finer control of the Cache Control header."
 
 msgid "Adds endpoints and functionality for testing ape."
-msgstr ""
+msgstr "Adds endpoints and functionality for testing ape."
 
 msgid "Manage meta tags for all entities."
-msgstr ""
+msgstr "Manage meta tags for all entities."
 
 msgid "Provides metatag support for Page Manager variants."
-msgstr ""
+msgstr "Provides metatag support for Page Manager variants."
 
 msgid "Provides support for applinks.org meta tags."
-msgstr ""
+msgstr "Provides support for applinks.org meta tags."
 
 msgid ""
 "Provides the fifteen <a "
@@ -26118,130 +28603,156 @@ msgid ""
 "Set 1.1</a> meta tags from the <a href=\"http://dublincore.org/\">Dublin "
 "Core Metadata Institute</a>."
 msgstr ""
+"Provides the fifteen <a "
+"href=\"http://dublincore.org/documents/dces/\">Dublin Core Metadata Element "
+"Set 1.1</a> meta tags from the <a href=\"http://dublincore.org/\">Dublin "
+"Core Metadata Institute</a>."
 
 msgid ""
 "Provides forty additional meta tags from the <a "
 "href=\"http://dublincore.org/\">Dublin Core Metadata Institute</a>."
 msgstr ""
+"Provides forty additional meta tags from the <a "
+"href=\"http://dublincore.org/\">Dublin Core Metadata Institute</a>."
 
 msgid ""
 "A set of meta tags specially for controlling advanced functionality with "
 "Facebook."
 msgstr ""
+"A set of meta tags specially for controlling advanced functionality with "
+"Facebook."
 
 msgid "Provides support for many different favicons."
-msgstr ""
+msgstr "Provides support for many different favicons."
 
 msgid "Provides support for meta tags used for Google Custom Search Engine."
-msgstr ""
+msgstr "Provides support for meta tags used for Google Custom Search Engine."
 
 msgid "Provides support for Google's Plus meta tags."
-msgstr ""
+msgstr "Provides support for Google's Plus meta tags."
 
 msgid ""
 "Provides support for the hreflang meta tag with some extra logic to simplify"
 " it."
 msgstr ""
+"Provides support for the hreflang meta tag with some extra logic to simplify"
+" it."
 
 msgid ""
 "Provides support for meta tags used to control the mobile browser "
 "experience."
 msgstr ""
+"Provides support for meta tags used to control the mobile browser "
+"experience."
 
 msgid "Provides support for Open Graph Protocol meta tags."
-msgstr ""
+msgstr "Provides support for Open Graph Protocol meta tags."
 
 msgid ""
 "Provides additional Open Graph Protocol meta tags for describing products."
 msgstr ""
+"Provides additional Open Graph Protocol meta tags for describing products."
 
 msgid "Provides support for Pinterest's custom meta tags."
-msgstr ""
+msgstr "Provides support for Pinterest's custom meta tags."
 
 msgid "Provides support for Twitter's Card meta tags."
-msgstr ""
+msgstr "Provides support for Twitter's Card meta tags."
 
 msgid "Verifies ownership of a site for search engines and other services."
-msgstr ""
+msgstr "Verifies ownership of a site for search engines and other services."
 
 msgid "Provides views integration for metatags."
-msgstr ""
+msgstr "Provides views integration for metatags."
 
 msgid "Provides the CAPTCHA API for adding challenges to arbitrary forms."
-msgstr ""
+msgstr "Provides the CAPTCHA API for adding challenges to arbitrary forms."
 
 msgid "Mitigates spam form submissions using the honeypot method."
-msgstr ""
+msgstr "Mitigates spam form submissions using the honeypot method."
 
 msgid "Provides an image based CAPTCHA."
-msgstr ""
+msgstr "Tarjoaa kuvapohjaisen CAPTCHAn."
 
 msgid ""
 "Protect your website from spam and abuse while letting real people pass "
 "through with ease."
 msgstr ""
+"Protect your website from spam and abuse while letting real people pass "
+"through with ease."
 
 msgid "FontAwesome Menu Icons"
-msgstr ""
+msgstr "FontAwesome Menu Icons"
 
 msgid "Serializes entities using Hypertext Application Language."
-msgstr ""
+msgstr "Serializes entities using Hypertext Application Language."
 
 msgid "Provides the HTTP Basic authentication provider"
-msgstr ""
+msgstr "Provides the HTTP Basic authentication provider"
 
 msgid "Exposes entities as a JSON:API-specification-compliant web API."
-msgstr ""
+msgstr "Exposes entities as a JSON:API-specification-compliant web API."
 
 msgid "Exposes entities and other resources as RESTful web API"
-msgstr ""
+msgstr "Exposes entities and other resources as RESTful web API"
 
 msgid ""
 "Provides a service for (de)serializing data to/from formats such as JSON and"
 " XML"
 msgstr ""
+"Provides a service for (de)serializing data to/from formats such as JSON and"
+" XML"
 
 msgid ""
 "Regularly review and install <a href=\":updates\">available updates</a> to "
 "maintain a secure and current site. Always run the <a href=\":update-"
 "php\">update script</a> each time a module is updated."
 msgstr ""
+"Regularly review and install <a href=\":updates\">available updates</a> to "
+"maintain a secure and current site. Always run the <a href=\":update-"
+"php\">update script</a> each time a module is updated."
 
 msgid "Disqus comment"
-msgstr ""
+msgstr "Disqus comment"
 
 msgid ""
 "Provides a filter plugin that is in use in the following filter formats: "
 "%formats"
 msgstr ""
+"Provides a filter plugin that is in use in the following filter formats: "
+"%formats"
 
 msgid "content items"
-msgstr ""
+msgstr "content items"
 
 msgid "shortcut links"
-msgstr ""
+msgstr "shortcut links"
 
 msgid ""
 "The following modules will be completely uninstalled from your site, and "
 "<em>all data from these modules will be lost</em>!"
 msgstr ""
+"Seuraavat moduulit poistetaan sivustolta kokonaan, ja kaikki moduuleihin "
+"liittyvä tieto menetetään!"
 
 msgid "!modules modules are available in the modified list."
-msgstr ""
+msgstr "!modules modules are available in the modified list."
 
 msgid "Applicationsasd"
-msgstr ""
+msgstr "Applicationsasd"
 
 msgid "News"
 msgstr "Ajankohtaista"
 
 msgid "The callback URL is not local and not trusted: !url"
-msgstr ""
+msgstr "The callback URL is not local and not trusted: !url"
 
 msgid "Show all columns"
-msgstr ""
+msgstr "Näytä kaikki sarakkeet"
 
 msgid ""
 "Show table cells that were hidden to make the table fit within a small "
 "screen."
 msgstr ""
+"Näytä taulukon solut jotka olivat piilotettuja jotta taulukko mahtuisi "
+"pienelle ruudulle."

--- a/ansible/roles/drupal/files/i18n/sv/drupal8.po
+++ b/ansible/roles/drupal/files/i18n/sv/drupal8.po
@@ -4,13 +4,14 @@
 # Teemu Leivo <teemu.leivo@gofore.com>, 2019
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2019
 # Meeri Hakala <meeri.hakala@vrk.fi>, 2019
+# Zharktas <jari-pekka.voutilainen@gofore.com>, 2019
 # 
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "POT-Creation-Date: 2019-09-12 06:38+0000\n"
 "PO-Revision-Date: 2018-10-17 06:12+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@vrk.fi>, 2019\n"
+"Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2019\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -19,433 +20,435 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 msgid "Next"
-msgstr ""
+msgstr "Nästa"
 
 msgid "Pages"
-msgstr ""
+msgstr "Sidor"
 
 msgid "delete"
-msgstr ""
+msgstr "radera"
 
 msgid "Create a new user account."
-msgstr ""
+msgstr "Skapa ett nytt användarkonto"
 
 msgid "Markup"
-msgstr ""
+msgstr "Uppmärkning"
 
 msgid "Prefix"
-msgstr ""
+msgstr "Prefix"
 
 msgid "Suffix"
-msgstr ""
+msgstr "Suffix"
 
 msgid "Approve"
-msgstr ""
+msgstr "Godkänn"
 
 msgid "Moderated content"
-msgstr ""
+msgstr "Modererat innehåll"
 
 msgid "Attribute"
-msgstr ""
+msgstr "Egenskap"
 
 msgid "Groups"
-msgstr ""
+msgstr "Grupper"
 
 msgid "Group"
-msgstr ""
+msgstr "Grupp"
 
 msgid "Replies"
-msgstr ""
+msgstr "Svar"
 
 msgid "Closed"
-msgstr ""
+msgstr "Stängd"
 
 msgid "yes"
-msgstr ""
+msgstr "ja"
 
 msgid "Send email"
-msgstr ""
+msgstr "Skicka e-post"
 
 msgid "Actions"
-msgstr ""
+msgstr "Åtgärder"
 
 msgid "disabled"
-msgstr ""
+msgstr "ej aktiverad"
 
 msgid "Last comment"
-msgstr ""
+msgstr "Sista kommentar"
 
 msgid "Enable"
-msgstr ""
+msgstr "Aktivera"
 
 msgid "Disable"
-msgstr ""
+msgstr "Inaktivera"
 
 msgid "Explanation or submission guidelines"
-msgstr ""
+msgstr "Förklaring eller riktlinjer för inlägg"
 
 msgid "Email settings"
-msgstr ""
+msgstr "Inställningar för e-post"
 
 msgid "Disabled"
-msgstr ""
+msgstr "Ej aktiverad"
 
 msgid "Articles"
-msgstr ""
+msgstr "Artiklar"
 
 msgid "footer"
-msgstr ""
+msgstr "sidfot"
 
 msgid "not verified"
-msgstr ""
+msgstr "ej verifierad"
 
 msgid "Last updated"
-msgstr ""
+msgstr "Senast uppdaterad"
 
 msgid "For"
-msgstr ""
+msgstr "För"
 
 msgid "new"
-msgstr ""
+msgstr "nytt"
 
 msgid "Block title"
-msgstr ""
+msgstr "Blocktitel"
 
 msgid "The title of the block as shown to the user."
-msgstr ""
+msgstr "Titeln på ett block såsom det visas för användaren."
 
 msgid "Logging"
-msgstr ""
+msgstr "Loggning"
 
 msgid "Yes"
-msgstr ""
+msgstr "Ja"
 
 msgid "No"
-msgstr ""
+msgstr "Nej"
 
 msgid "Homepage"
-msgstr ""
+msgstr "Hemsida"
 
 msgid "Version"
-msgstr ""
+msgstr "Version"
 
 msgid "view"
-msgstr ""
+msgstr "visa"
 
 msgid "unpublished"
-msgstr ""
+msgstr "ej publicerad"
 
 msgid "updated"
-msgstr ""
+msgstr "uppdaterad"
 
 msgid "Overview"
-msgstr ""
+msgstr "Översikt"
 
 msgid "File information"
-msgstr ""
+msgstr "Filinformation"
 
 msgid "Tag"
-msgstr ""
+msgstr "Etikett"
 
 msgid "File path"
-msgstr ""
+msgstr "Filsökväg"
 
 msgid "Release notes"
-msgstr ""
+msgstr "Anteckningar om utgåvan"
 
 msgid "Links"
-msgstr ""
+msgstr "Länkar"
 
 msgid "Daily"
-msgstr ""
+msgstr "Dagligen"
 
 msgid "Weekly"
-msgstr ""
+msgstr "Veckovis"
 
 msgid "Monthly"
-msgstr ""
+msgstr "Månadsvis"
 
 msgid "None"
-msgstr ""
+msgstr "Ingen"
 
 msgid "Display settings"
-msgstr ""
+msgstr "Inställningar för visning"
 
 msgid "This action cannot be undone."
-msgstr ""
+msgstr "Denna åtgärd kan inte ångras."
 
 msgid "Test"
-msgstr ""
+msgstr "Test"
 
 msgid "Block settings"
-msgstr ""
+msgstr "Blockinställningar"
 
 msgid "- None -"
-msgstr ""
+msgstr "- Ingen -"
 
 msgid "Country"
-msgstr ""
+msgstr "Land"
 
 msgid "Center"
-msgstr ""
+msgstr "Centrerad"
 
 msgid "Help text"
-msgstr ""
+msgstr "Hjälptext"
 
 msgid "Types"
-msgstr ""
+msgstr "Typer"
 
 msgid "Multiple"
-msgstr ""
+msgstr "Flerval"
 
 msgid "Required"
-msgstr ""
+msgstr "Obligatoriskt"
 
 msgid "root"
-msgstr ""
+msgstr "rot"
 
 msgid "Pages at a given level are ordered first by weight and then by title."
 msgstr ""
+"Sidor på en given nivå ordnas i första hand efter vikt och sedan efter "
+"titel."
 
 msgid "Depth"
-msgstr ""
+msgstr "Djup"
 
 msgid "none"
-msgstr ""
+msgstr "ingen"
 
 msgid "Category"
-msgstr ""
+msgstr "Kategori"
 
 msgid "Add container"
-msgstr ""
+msgstr "Lägg till forumgrupp"
 
 msgid "edit container"
-msgstr ""
+msgstr "redigera gruppering"
 
 msgid "edit"
-msgstr ""
+msgstr "redigera"
 
 msgid "Go to previous page"
-msgstr ""
+msgstr "Gå till föregående sida"
 
 msgid "Go to parent page"
-msgstr ""
+msgstr "Gå till ovanliggande sida"
 
 msgid "Book"
-msgstr ""
+msgstr "Bok"
 
 msgid "Description field"
-msgstr ""
+msgstr "Beskrivningsfält"
 
 msgid "settings"
-msgstr ""
+msgstr "inställningar"
 
 msgid "Back"
-msgstr ""
+msgstr "Tillbaka"
 
 msgid "Node ID"
-msgstr ""
+msgstr "Nod-ID"
 
 msgid "Outline"
-msgstr ""
+msgstr "Disposition"
 
 msgid "header"
-msgstr ""
+msgstr "sidhuvud"
 
 msgid "Session opened for %name."
-msgstr ""
+msgstr "Session startad för %name."
 
 msgid "Image settings"
-msgstr ""
+msgstr "Bildinställningar"
 
 msgid "True"
-msgstr ""
+msgstr "Sant"
 
 msgid "False"
-msgstr ""
+msgstr "Falskt"
 
 msgid "Move"
-msgstr ""
+msgstr "Flytta"
 
 msgid "Open"
-msgstr ""
+msgstr "Öppen"
 
 msgid "Blank"
-msgstr ""
+msgstr "Tomt"
 
 msgid "Tags"
 msgstr "Nyckelord"
 
 msgid "Forms"
-msgstr ""
+msgstr "Formulär"
 
 msgid "On"
-msgstr ""
+msgstr "På"
 
 msgid "Body"
-msgstr ""
+msgstr "Brödtext"
 
 msgid "Language"
-msgstr ""
+msgstr "Språk"
 
 msgid "Comments"
-msgstr ""
+msgstr "Kommentarer"
 
 msgid "Article"
-msgstr ""
+msgstr "Artikel"
 
 msgid "Default"
-msgstr ""
+msgstr "Förvald"
 
 msgid "Administration"
-msgstr ""
+msgstr "Administration"
 
 msgid "Register"
-msgstr ""
+msgstr "Registrera"
 
 msgid "Taxonomy term"
-msgstr ""
+msgstr "Taxonomiterm"
 
 msgid "Feed"
-msgstr ""
+msgstr "Innehållsflöde"
 
 msgid "Action"
-msgstr ""
+msgstr "Åtgärd"
 
 msgid "Subject"
-msgstr ""
+msgstr "Ämne"
 
 msgid "Description"
-msgstr ""
+msgstr "Beskrivning"
 
 msgid "More"
-msgstr ""
+msgstr "Mer"
 
 msgid "Reset"
-msgstr ""
+msgstr "Återställ"
 
 msgid "Date"
-msgstr ""
+msgstr "Datum"
 
 msgid "Message"
-msgstr ""
+msgstr "Meddelande"
 
 msgid "Name"
-msgstr ""
+msgstr "Namn"
 
 msgid "Use count"
-msgstr ""
+msgstr "Antal använd"
 
 msgid "Title"
-msgstr ""
+msgstr "Titel"
 
 msgid "Operations"
-msgstr ""
+msgstr "Funktioner"
 
 msgid "more"
-msgstr ""
+msgstr "mer"
 
 msgid "Type"
-msgstr ""
+msgstr "Typ"
 
 msgid "File"
-msgstr ""
+msgstr "Fil"
 
 msgid "Username"
 msgstr "Användarnamn"
 
 msgid "List"
-msgstr ""
+msgstr "Lista"
 
 msgid "Preview"
-msgstr ""
+msgstr "Förhandsgranska"
 
 msgid "Save"
-msgstr ""
+msgstr "Spara"
 
 msgid "user"
-msgstr ""
+msgstr "användare"
 
 msgid "Content"
-msgstr ""
+msgstr "Innehåll"
 
 msgid "Go to next page"
-msgstr ""
+msgstr "Gå till nästa sida"
 
 msgid "Label"
-msgstr ""
+msgstr "Etikett"
 
 msgid "Advanced options"
-msgstr ""
+msgstr "Fler alternativ"
 
 msgid "Weight"
-msgstr ""
+msgstr "Vikt"
 
 msgid "Link"
-msgstr ""
+msgstr "Länk"
 
 msgid "Search"
-msgstr ""
+msgstr "Sök"
 
 msgid "Submit"
-msgstr ""
+msgstr "Skicka"
 
 msgid "Password"
 msgstr "Lösenord"
 
 msgid "Save configuration"
-msgstr ""
+msgstr "Spara konfiguration"
 
 msgid "Confirm"
-msgstr ""
+msgstr "Bekräfta"
 
 msgid "Settings"
-msgstr ""
+msgstr "Inställningar"
 
 msgid "Delete"
-msgstr ""
+msgstr "Radera"
 
 msgid "Remove"
-msgstr ""
+msgstr "Ta bort"
 
 msgid "Export"
-msgstr ""
+msgstr "Exportera"
 
 msgid "Import"
-msgstr ""
+msgstr "Importera"
 
 msgid "Update"
-msgstr ""
+msgstr "Uppdatera"
 
 msgid "Download"
-msgstr ""
+msgstr "Ladda ned"
 
 msgid "Edit"
-msgstr ""
+msgstr "Redigera"
 
 msgid "Cancel"
-msgstr ""
+msgstr "Avbryt"
 
 msgid "Taxonomy"
-msgstr ""
+msgstr "Taxonomi"
 
 msgid "Development"
-msgstr ""
+msgstr "Utveckling"
 
 msgid "User interface"
-msgstr ""
+msgstr "Användargränssnitt"
 
 msgid "The configuration options have been saved."
-msgstr ""
+msgstr "Inställningarna har sparats."
 
 msgid "closed"
-msgstr ""
+msgstr "stängd"
 
 msgid "Field"
-msgstr ""
+msgstr "Fält"
 
 msgid "Home"
-msgstr ""
+msgstr "Hem"
 
 msgid "Sunday"
 msgstr "söndag"
@@ -454,413 +457,413 @@ msgid "Saturday"
 msgstr "lördag"
 
 msgid "High"
-msgstr ""
+msgstr "Hög"
 
 msgid "Low"
-msgstr ""
+msgstr "Låg"
 
 msgid "Album"
-msgstr ""
+msgstr "Album"
 
 msgid "Artist"
-msgstr ""
+msgstr "Artist"
 
 msgid "Add new"
-msgstr ""
+msgstr "Lägg till ny"
 
 msgid "Time"
-msgstr ""
+msgstr "Tid"
 
 msgid "Access"
-msgstr ""
+msgstr "Åtkomst"
 
 msgid "View"
-msgstr ""
+msgstr "Visa"
 
 msgid "Length"
-msgstr ""
+msgstr "Längd"
 
 msgid "Format"
-msgstr ""
+msgstr "Format"
 
 msgid "History"
-msgstr ""
+msgstr "Historik"
 
 msgid "hidden"
-msgstr ""
+msgstr "dold"
 
 msgid "File extensions"
-msgstr ""
+msgstr "Filändelse"
 
 msgid "Modules"
-msgstr ""
+msgstr "Moduler"
 
 msgid "Clear index"
-msgstr ""
+msgstr "Rensa index"
 
 msgid "General discussion"
-msgstr ""
+msgstr "Allmän diskussion"
 
 msgid "edit forum"
-msgstr ""
+msgstr "redigera forum"
 
 msgid "Forum name"
-msgstr ""
+msgstr "Namn på forum"
 
 msgid "forum"
-msgstr ""
+msgstr "forum"
 
 msgid "Refresh"
-msgstr ""
+msgstr "Uppdatera"
 
 msgid "Region"
-msgstr ""
+msgstr "Region"
 
 msgid "link"
-msgstr ""
+msgstr "länk"
 
 msgid "Anchor"
-msgstr ""
+msgstr "Anchor"
 
 msgid "Display"
-msgstr ""
+msgstr "Visa"
 
 msgid "Advanced settings"
-msgstr ""
+msgstr "Utökade inställningar"
 
 msgid "GUID"
-msgstr ""
+msgstr "GUID"
 
 msgid "never"
-msgstr ""
+msgstr "aldrig"
 
 msgid "actions"
-msgstr ""
+msgstr "åtgärder"
 
 msgid "Theme"
-msgstr ""
+msgstr "Tema"
 
 msgid "Layout"
-msgstr ""
+msgstr "Layout"
 
 msgid "Select a layout"
-msgstr ""
+msgstr "Välj en layout"
 
 msgid "aggregator"
-msgstr ""
+msgstr "innehållssamlare"
 
 msgid "Update interval"
-msgstr ""
+msgstr "Uppdateringsintervall"
 
 msgid "The fully-qualified URL of the feed."
-msgstr ""
+msgstr "Nyhetsflödets fullständiga URL."
 
 msgid "Add forum"
-msgstr ""
+msgstr "Lägg till forum"
 
 msgid "Add term"
-msgstr ""
+msgstr "Lägg till term"
 
 msgid "Search keywords"
-msgstr ""
+msgstr "Nyckelord för sökning"
 
 msgid "Timestamp"
-msgstr ""
+msgstr "Tidsstämpel"
 
 msgid "Keywords"
-msgstr ""
+msgstr "Nyckelord"
 
 msgid "Search Keywords"
-msgstr ""
+msgstr "Nyckelord för sökning"
 
 msgid "Preview comment"
-msgstr ""
+msgstr "Förhandsgranska kommentar"
 
 msgid "Component"
-msgstr ""
+msgstr "Komponent"
 
 msgid "Advanced search"
-msgstr ""
+msgstr "Avancerad sökning"
 
 msgid "You are not authorized to access this page."
-msgstr ""
+msgstr "Du har inte behörighet till denna sida."
 
 msgid "Unknown"
-msgstr ""
+msgstr "Okänd"
 
 msgid "States"
-msgstr ""
+msgstr "States"
 
 msgid "n/a"
-msgstr ""
+msgstr "inte tillgänglig"
 
 msgid "Upload image"
-msgstr ""
+msgstr "Ladda upp bild"
 
 msgid "Taxonomy settings"
-msgstr ""
+msgstr "Inställningar för taxonomi"
 
 msgid "Before"
-msgstr ""
+msgstr "Före"
 
 msgid "After"
-msgstr ""
+msgstr "Efter"
 
 msgid "Database type"
-msgstr ""
+msgstr "Typ av databas"
 
 msgid "action"
-msgstr ""
+msgstr "åtgärd"
 
 msgid "Continue"
-msgstr ""
+msgstr "Fortsätt"
 
 msgid "Error"
-msgstr ""
+msgstr "Fel"
 
 msgid "no"
-msgstr ""
+msgstr "nej"
 
 msgid "New user: %name %email."
-msgstr ""
+msgstr "Ny användare: %name %email."
 
 msgid "Node"
-msgstr ""
+msgstr "Nod"
 
 msgid "Sent email to %recipient"
-msgstr ""
+msgstr "Skickade e-post till %recipient"
 
 msgid "The subject of the message."
-msgstr ""
+msgstr "Meddelandets ämnesrad."
 
 msgid "Number of columns"
-msgstr ""
+msgstr "Antal kolumner"
 
 msgid "Data type"
-msgstr ""
+msgstr "Datatyp"
 
 msgid "Separator"
-msgstr ""
+msgstr "Avskiljare"
 
 msgid "Include"
-msgstr ""
+msgstr "Inkludera"
 
 msgid "Exclude"
-msgstr ""
+msgstr "Uteslut"
 
 msgid "Horizontal"
-msgstr ""
+msgstr "Horisontell"
 
 msgid "Vertical"
-msgstr ""
+msgstr "Vertikal"
 
 msgid "Open link in new window"
-msgstr ""
+msgstr "Öppna länk i ett nytt fönster"
 
 msgid "vocabularies"
-msgstr ""
+msgstr "vocabularies"
 
 msgid "term"
-msgstr ""
+msgstr "term"
 
 msgid "Expanded"
-msgstr ""
+msgstr "Utfällt"
 
 msgid "Parent item"
-msgstr ""
+msgstr "Ovanliggande val"
 
 msgid "Add child page"
-msgstr ""
+msgstr "Lägg till underliggande sida"
 
 msgid "Printer-friendly version"
-msgstr ""
+msgstr "Utskriftsvänlig version"
 
 msgid "Content type for child pages"
-msgstr ""
+msgstr "Innehållstyp för underliggande sidor"
 
 msgid "Update options"
-msgstr ""
+msgstr "Alternativ för uppdatering"
 
 msgid "Remove from outline"
-msgstr ""
+msgstr "Radera från bokdispositionen"
 
 msgid "Unknown export format."
-msgstr ""
+msgstr "Okänt exporteringsformat."
 
 msgid "Done"
-msgstr ""
+msgstr "Färdig"
 
 msgid "Last post"
-msgstr ""
+msgstr "Senaste inlägg"
 
 msgid "Access denied"
-msgstr ""
+msgstr "Åtkomst nekad"
 
 msgid "Year"
-msgstr ""
+msgstr "År"
 
 msgid "Add content"
-msgstr ""
+msgstr "Lägg till innehåll"
 
 msgid "Area"
-msgstr ""
+msgstr "Område"
 
 msgid "Override title"
-msgstr ""
+msgstr "Åsidosätt titel"
 
 msgid "CSS class"
-msgstr ""
+msgstr "CSS-klass"
 
 msgid "Add view"
-msgstr ""
+msgstr "Lägg till vy"
 
 msgid "Pager ID"
-msgstr ""
+msgstr "Pager-ID"
 
 msgid "View arguments"
-msgstr ""
+msgstr "Argument för vy"
 
 msgid "Configuration saved."
-msgstr ""
+msgstr "Inställningarna sparades."
 
 msgid "Logo"
-msgstr ""
+msgstr "Logotyp"
 
 msgid "Site name"
-msgstr ""
+msgstr "Webbplatsens namn"
 
 msgid "Site slogan"
-msgstr ""
+msgstr "Webbplatsens slogan"
 
 msgid "Good"
-msgstr ""
+msgstr "Bra"
 
 msgid "Node types"
-msgstr ""
+msgstr "Nodtyper"
 
 msgid "User settings"
-msgstr ""
+msgstr "Användarinställningar"
 
 msgid "Site"
-msgstr ""
+msgstr "Webbplats"
 
 msgid "Web Server"
-msgstr ""
+msgstr "Webbserver"
 
 msgid "Database"
-msgstr ""
+msgstr "Databas"
 
 msgid "Drupal"
-msgstr ""
+msgstr "Drupal"
 
 msgid "Not found"
-msgstr ""
+msgstr "Hittades ej"
 
 msgid "Module"
-msgstr ""
+msgstr "Modul"
 
 msgid "Host"
-msgstr ""
+msgstr "Värd"
 
 msgid "Options"
-msgstr ""
+msgstr "Alternativ"
 
 msgid "Off"
-msgstr ""
+msgstr "Av"
 
 msgid "Picture"
-msgstr ""
+msgstr "Bild"
 
 msgid "RSS"
-msgstr ""
+msgstr "RSS"
 
 msgid "Teaser"
-msgstr ""
+msgstr "Ingress"
 
 msgid "Updated"
-msgstr ""
+msgstr "Uppdaterad"
 
 msgid "All"
-msgstr ""
+msgstr "Alla"
 
 msgid "Icon"
-msgstr ""
+msgstr "Ikon"
 
 msgid "Files"
-msgstr ""
+msgstr "Filer"
 
 msgid "Filename"
-msgstr ""
+msgstr "Filnamn"
 
 msgid "Menu"
-msgstr ""
+msgstr "Meny"
 
 msgid "Archive"
-msgstr ""
+msgstr "Arkiv"
 
 msgid "Content type"
-msgstr ""
+msgstr "Innehållstyp"
 
 msgid "Attachment"
-msgstr ""
+msgstr "Bilaga"
 
 msgid "Active"
-msgstr ""
+msgstr "Aktiv"
 
 msgid "Date format"
-msgstr ""
+msgstr "Datumformat"
 
 msgid "file"
-msgstr ""
+msgstr "fil"
 
 msgid "ID"
-msgstr ""
+msgstr "ID"
 
 msgid "Created"
-msgstr ""
+msgstr "Skapad"
 
 msgid "Page"
-msgstr ""
+msgstr "Sida"
 
 msgid "Components"
-msgstr ""
+msgstr "Komponenter"
 
 msgid "Contact"
 msgstr "Kontakta oss"
 
 msgid "Upload"
-msgstr ""
+msgstr "Ladda upp"
 
 msgid "Add"
-msgstr ""
+msgstr "Lägg till"
 
 msgid "Create"
-msgstr ""
+msgstr "Skapa"
 
 msgid "Manage"
-msgstr ""
+msgstr "Hantera"
 
 msgid "Configure"
-msgstr ""
+msgstr "Konfigurera"
 
 msgid "Views"
-msgstr ""
+msgstr "Vyer"
 
 msgid "PHP"
-msgstr ""
+msgstr "PHP"
 
 msgid "Breadcrumb"
-msgstr ""
+msgstr "Länkstig"
 
 msgid "1 hour"
 msgid_plural "@count hours"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 timme"
+msgstr[1] "@count timmar"
 
 msgid "1 day"
 msgid_plural "@count days"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 dag"
+msgstr[1] "@count dagar"
 
 msgid "Friday"
 msgstr "fredag"
@@ -875,4614 +878,4703 @@ msgid "Wednesday"
 msgstr "onsdag"
 
 msgid "Mail"
-msgstr ""
+msgstr "E-post"
 
 msgid "Statistics"
-msgstr ""
+msgstr "Statistik"
 
 msgid "Core"
-msgstr ""
+msgstr "Kärna"
 
 msgid "PostgreSQL"
-msgstr ""
+msgstr "PostgreSQL"
 
 msgid "Manual update check"
-msgstr ""
+msgstr "Sök efter uppdateringar manuellt"
 
 msgid "Never"
-msgstr ""
+msgstr "Aldrig"
 
 msgid "Check manually"
-msgstr ""
+msgstr "Kontrollera manuellt"
 
 msgid "Update available"
-msgstr ""
+msgstr "Uppdatering tillgänglig"
 
 msgid "Out of date"
-msgstr ""
+msgstr "Föråldrad"
 
 msgid "Header"
-msgstr ""
+msgstr "Sidhuvud"
 
 msgid "Left sidebar"
-msgstr ""
+msgstr "Vänster sidospalt"
 
 msgid "Right sidebar"
-msgstr ""
+msgstr "Höger sidospalt"
 
 msgid "Inline"
-msgstr ""
+msgstr "Löpande"
 
 msgid "Recipients"
-msgstr ""
+msgstr "Mottagare"
 
 msgid "Selected"
-msgstr ""
+msgstr "Vald"
 
 msgid "Your name"
-msgstr ""
+msgstr "Ditt namn"
 
 msgid "Aggregator feed"
-msgstr ""
+msgstr "Flöde för nyhetssamlare"
 
 msgid "Aggregator feed ID"
-msgstr ""
+msgstr "ID-nummer för nyhetssamlare"
 
 msgid "Feed description"
-msgstr ""
+msgstr "Beskrivning av nyhetsflöde"
 
 msgid "Aggregator item"
-msgstr ""
+msgstr "Objekt för nyhetssamlare"
 
 msgid "Aggregator item ID"
-msgstr ""
+msgstr "ID-nummer för objekt i innehållssamlare"
 
 msgid "Throttle"
-msgstr ""
+msgstr "Lastbegränsning"
 
 msgid "Visibility"
-msgstr ""
+msgstr "Synlighet"
 
 msgid "Role ID"
-msgstr ""
+msgstr "ID för roll"
 
 msgid "Hostname"
-msgstr ""
+msgstr "Värdnamn"
 
 msgid "Score"
-msgstr ""
+msgstr "Poäng"
 
 msgid "Signature"
-msgstr ""
+msgstr "Signatur"
 
 msgid "Cacheable"
-msgstr ""
+msgstr "Cachbar"
 
 msgid "Location"
-msgstr ""
+msgstr "Plats"
 
 msgid "Locale"
-msgstr ""
+msgstr "Språkanpassning"
 
 msgid "Title field label"
-msgstr ""
+msgstr "Etikett på titelfält"
 
 msgid "Sticky at top of lists"
-msgstr ""
+msgstr "Alltid överst i listan"
 
 msgid "Revisions"
-msgstr ""
+msgstr "Versioner"
 
 msgid "Log message"
-msgstr ""
+msgstr "Loggmeddelande"
 
 msgid "URL alias"
-msgstr ""
+msgstr "URL-alias"
 
 msgid "File MIME type"
-msgstr ""
+msgstr "Typ av MIME för filen"
 
 msgid "Node revision ID"
-msgstr ""
+msgstr "Versions-ID för nod"
 
 msgid "Vocabulary name"
-msgstr ""
+msgstr "Vokabulärnamn"
 
 msgid "Term"
-msgstr ""
+msgstr "Term"
 
 msgid "User role"
-msgstr ""
+msgstr "Användarroll"
 
 msgid "Role name"
-msgstr ""
+msgstr "Rollnamn"
 
 msgid "Time zone"
-msgstr ""
+msgstr "Tidszon"
 
 msgid "Field name"
-msgstr ""
+msgstr "Fältnamn"
 
 msgid "Field type"
-msgstr ""
+msgstr "Fälttyp"
 
 msgid "Global settings"
-msgstr ""
+msgstr "Globala inställningar"
 
 msgid "Multiple values"
-msgstr ""
+msgstr "Flera värden"
 
 msgid "Widget type"
-msgstr ""
+msgstr "Typ av widget"
 
 msgid "Contains"
-msgstr ""
+msgstr "Innehåller"
 
 msgid "Does not contain"
-msgstr ""
+msgstr "Innehåller inte"
 
 msgid "Is less than"
-msgstr ""
+msgstr "Är mindre än"
 
 msgid "Is less than or equal to"
-msgstr ""
+msgstr "Är mindre än eller lika med"
 
 msgid "Is equal to"
-msgstr ""
+msgstr "Är lika med"
 
 msgid "Is greater than or equal to"
-msgstr ""
+msgstr "Är större än eller lika med"
 
 msgid "Is greater than"
-msgstr ""
+msgstr "Är större än"
 
 msgid "Is not equal to"
-msgstr ""
+msgstr "Är inte lika med"
 
 msgid "Average"
-msgstr ""
+msgstr "Genomsnitt"
 
 msgid "Overridden"
-msgstr ""
+msgstr "Åsidosatt"
 
 msgid "Add action"
-msgstr ""
+msgstr "Lägg till åtgärd"
 
 msgid "Set name"
-msgstr ""
+msgstr "Uppsättningens namn"
 
 msgid "Original image"
-msgstr ""
+msgstr "Originalbild"
 
 msgid "Link to URL"
-msgstr ""
+msgstr "Link to URL"
 
 msgid "Search settings"
-msgstr ""
+msgstr "Inställningar för sökning"
 
 msgid "Mode"
-msgstr ""
+msgstr "Läge"
 
 msgid "Warning"
-msgstr ""
+msgstr "Varning"
 
 msgid "blocked"
-msgstr ""
+msgstr "spärrad"
 
 msgid "active"
-msgstr ""
+msgstr "aktiv"
 
 msgid "N/A"
-msgstr ""
+msgstr "Inte tillgänglig"
 
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 msgid "OPML feed"
-msgstr ""
+msgstr "OPML-flöde"
 
 msgid "Number of news items in block"
-msgstr ""
+msgstr "Antal nyhetsinlägg i block"
 
 msgid "View this feed's recent news."
-msgstr ""
+msgstr "Visa senaste nytt för detta flöde."
 
 msgid "Feed overview"
-msgstr ""
+msgstr "Översikt över nyhetsflöden"
 
 msgid "Items"
-msgstr ""
+msgstr "Poster"
 
 msgid "Next update"
-msgstr ""
+msgstr "Nästa uppdatering"
 
 msgid "%time ago"
-msgstr ""
+msgstr "%time sedan"
 
 msgid "%time left"
-msgstr ""
+msgstr "%time återstår"
 
 msgid "Authored by"
-msgstr ""
+msgstr "Författad av"
 
 msgid "Processor"
-msgstr ""
+msgstr "Processor"
 
 msgid "The feed %feed has been updated."
-msgstr ""
+msgstr "Flödet %feed har uppdaterats."
 
 msgid "Feed %feed added."
-msgstr ""
+msgstr "Flödet %feed lades till."
 
 msgid "The feed %feed has been added."
-msgstr ""
+msgstr "Flödet %feed har lagts till."
 
 msgid "Disclaimer"
-msgstr ""
+msgstr "Disclaimer"
 
 msgid "Sort order"
-msgstr ""
+msgstr "Sorteringsordning"
 
 msgid "Up"
-msgstr ""
+msgstr "Upp"
 
 msgid "Textfield"
-msgstr ""
+msgstr "Textfält"
 
 msgid "Display options"
-msgstr ""
+msgstr "Alternativ för visning"
 
 msgid "Maximum"
-msgstr ""
+msgstr "Största"
 
 msgid "Scale"
-msgstr ""
+msgstr "Skala"
 
 msgid "Thumbnail"
-msgstr ""
+msgstr "Miniatyr"
 
 msgid "Medium"
-msgstr ""
+msgstr "Mellan"
 
 msgid "Sortable"
-msgstr ""
+msgstr "Sorteringsbar"
 
 msgid "standard"
-msgstr ""
+msgstr "standard"
 
 msgid "Month"
-msgstr ""
+msgstr "Månad"
 
 msgid "Details"
-msgstr ""
+msgstr "Detaljer"
 
 msgid "Widget"
-msgstr ""
+msgstr "Widget"
 
 msgid "Last reply"
-msgstr ""
+msgstr "Senaste svar"
 
 msgid "Prev"
-msgstr ""
+msgstr "Föreg"
 
 msgid "Domain"
-msgstr ""
+msgstr "Domän"
 
 msgid "Processors"
-msgstr ""
+msgstr "Bearbetare"
 
 msgid "Unlimited"
-msgstr ""
+msgstr "Obegränsad"
 
 msgid "Current"
-msgstr ""
+msgstr "Nuvarande"
 
 msgid "State"
-msgstr ""
+msgstr "Läge"
 
 msgid "Filter by"
-msgstr ""
+msgstr "Filtrera på"
 
 msgid "Enter a valid username."
-msgstr ""
+msgstr "Ange ett giltigt användarnamn."
 
 msgid "Recipient"
-msgstr ""
+msgstr "Mottagare"
 
 msgid "OR"
-msgstr ""
+msgstr "ELLER"
 
 msgid "Add a role to the selected users"
-msgstr ""
+msgstr "Lägg till en roll för de markerade användarna"
 
 msgid "Remove a role from the selected users"
-msgstr ""
+msgstr "Radera en roll för de markerade användarna"
 
 msgid "node"
-msgstr ""
+msgstr "nod"
 
 msgid "Administer content"
-msgstr ""
+msgstr "Administrera innehåll"
 
 msgid "Directory"
-msgstr ""
+msgstr "Katalog"
 
 msgid "Method"
-msgstr ""
+msgstr "Metod"
 
 msgid "Egypt"
-msgstr ""
+msgstr "Egypten"
 
 msgid "Namibia"
-msgstr ""
+msgstr "Namibia"
 
 msgid "To"
-msgstr ""
+msgstr "Till"
 
 msgid "Comment"
-msgstr ""
+msgstr "Kommentar"
 
 msgid "Plain text"
-msgstr ""
+msgstr "Ren text"
 
 msgid "Footer"
-msgstr ""
+msgstr "Sidfot"
 
 msgid "Last access"
-msgstr ""
+msgstr "Senast åtkomst"
 
 msgid "From"
-msgstr ""
+msgstr "Från"
 
 msgid "Revision ID"
-msgstr ""
+msgstr "Versions-ID"
 
 msgid "Severity"
-msgstr ""
+msgstr "Grad"
 
 msgid "Published"
-msgstr ""
+msgstr "Publicerad"
 
 msgid "Last update"
-msgstr ""
+msgstr "Senaste uppdatering"
 
 msgid "Roles"
-msgstr ""
+msgstr "Roller"
 
 msgid "Vocabulary"
-msgstr ""
+msgstr "Vokabulär"
 
 msgid "Fields"
-msgstr ""
+msgstr "Fält"
 
 msgid "Advanced"
-msgstr ""
+msgstr "Utökad"
 
 msgid ", "
-msgstr ""
+msgstr ", "
 
 msgid "Desc"
-msgstr ""
+msgstr "Fallande"
 
 msgid "General"
-msgstr ""
+msgstr "Allmän"
 
 msgid "Media"
-msgstr ""
+msgstr "Media"
 
 msgid "Performance"
-msgstr ""
+msgstr "Prestanda"
 
 msgid "System"
-msgstr ""
+msgstr "System"
 
 msgid "Available updates"
-msgstr ""
+msgstr "Tillgängliga uppdateringar"
 
 msgid "Drupal core update status"
-msgstr ""
+msgstr "Uppdateringsstatus för Drupals kärna"
 
 msgid "Caching"
-msgstr ""
+msgstr "Cachning"
 
 msgid "Source string"
-msgstr ""
+msgstr "Källsträng"
 
 msgid "Up to date"
-msgstr ""
+msgstr "Aktuell"
 
 msgid "Custom"
-msgstr ""
+msgstr "Anpassad"
 
 msgid "Israel"
-msgstr ""
+msgstr "Israel"
 
 msgid "Iran"
-msgstr ""
+msgstr "Iran"
 
 msgid "New Zealand"
-msgstr ""
+msgstr "Nya Zeeland"
 
 msgid "Tonga"
-msgstr ""
+msgstr "Tonga"
 
 msgid "Cuba"
-msgstr ""
+msgstr "Kuba"
 
 msgid "Brazil"
-msgstr ""
+msgstr "Brasilien"
 
 msgid "Chile"
-msgstr ""
+msgstr "Chile"
 
 msgid "Paraguay"
-msgstr ""
+msgstr "Paraguay"
 
 msgid "Jamaica"
-msgstr ""
+msgstr "Jamaica"
 
 msgid "Japan"
-msgstr ""
+msgstr "Japan"
 
 msgid "Libya"
-msgstr ""
+msgstr "Libyen"
 
 msgid "Poland"
-msgstr ""
+msgstr "Polen"
 
 msgid "Portugal"
-msgstr ""
+msgstr "Portugal"
 
 msgid "Singapore"
-msgstr ""
+msgstr "Singapore"
 
 msgid "Turkey"
-msgstr ""
+msgstr "Turkiet"
 
 msgid "Day"
-msgstr ""
+msgstr "Dag"
 
 msgid "Table"
-msgstr ""
+msgstr "Tabell"
 
 msgid "Sat"
-msgstr ""
+msgstr "lör"
 
 msgid "Sun"
-msgstr ""
+msgstr "sön"
 
 msgid "May"
-msgstr ""
+msgstr "maj"
 
 msgid "am"
-msgstr ""
+msgstr "fm"
 
 msgid "pm"
-msgstr ""
+msgstr "em"
 
 msgid "Start date"
-msgstr ""
+msgstr "Startdatum"
 
 msgid "End date"
-msgstr ""
+msgstr "Slutdatum"
 
 msgid "Forum"
-msgstr ""
+msgstr "Forum"
 
 msgid "Security"
-msgstr ""
+msgstr "Säkerhet"
 
 msgid "Align"
-msgstr ""
+msgstr "Justera"
 
 msgid "Loop"
-msgstr ""
+msgstr "Loop"
 
 msgid "Display title"
-msgstr ""
+msgstr "Titel för visning"
 
 msgid "Background color"
-msgstr ""
+msgstr "Bakgrundsfärg"
 
 msgid "Text color"
-msgstr ""
+msgstr "Textfärg"
 
 msgid "Navigation"
-msgstr ""
+msgstr "Navigering"
 
 msgid "Basic"
-msgstr ""
+msgstr "Grundläggande"
 
 msgid "Color"
-msgstr ""
+msgstr "Färg"
 
 msgid "Link URL"
-msgstr ""
+msgstr "URL för länk"
 
 msgid "List type"
-msgstr ""
+msgstr "Typ av lista"
 
 msgid "Attributes"
-msgstr ""
+msgstr "Egenskaper"
 
 msgid "Select all"
-msgstr ""
+msgstr "Välj alla"
 
 msgid "Allow"
-msgstr ""
+msgstr "Tillåt"
 
 msgid "Ignore"
-msgstr ""
+msgstr "Ignorera"
 
 msgid "User data"
-msgstr ""
+msgstr "Användardata"
 
 msgid "User login"
-msgstr ""
+msgstr "Användarinloggning"
 
 msgid "Updated URL for feed %title to %url."
-msgstr ""
+msgstr "Uppdaterade URL:en för flödet %title till %url."
 
 msgid "Add new comment"
-msgstr ""
+msgstr "Lägg till ny kommentar"
 
 msgid "No terms available."
-msgstr ""
+msgstr "Inga termer tillgängliga."
 
 msgid "Counter"
-msgstr ""
+msgstr "Räknare"
 
 msgid "String"
-msgstr ""
+msgstr "Sträng"
 
 msgid "Case"
-msgstr ""
+msgstr "Skiftläge"
 
 msgid "Not installed"
-msgstr ""
+msgstr "Inte installerad."
 
 msgid "Referrer"
-msgstr ""
+msgstr "Hänvisad från"
 
 msgid "Default front page"
-msgstr ""
+msgstr "Förvald startsida"
 
 msgid "Button"
-msgstr ""
+msgstr "Knapp"
 
 msgid "Square"
-msgstr ""
+msgstr "Ruta"
 
 msgid "Both"
-msgstr ""
+msgstr "Båda"
 
 msgid "Maximum length"
-msgstr ""
+msgstr "Längsta längd"
 
 msgid "Rows"
-msgstr ""
+msgstr "Rader"
 
 msgid "Cache"
-msgstr ""
+msgstr "Cache"
 
 msgid "Argument"
-msgstr ""
+msgstr "Argument"
 
 msgid "Provider"
-msgstr ""
+msgstr "Leverantör"
 
 msgid "Save and edit"
-msgstr ""
+msgstr "Spara och redigera"
 
 msgid "Edit view"
-msgstr ""
+msgstr "Redigera vy"
 
 msgid "Administer views"
-msgstr ""
+msgstr "Administrera vyer"
 
 msgid "Ascending"
-msgstr ""
+msgstr "Stigande"
 
 msgid "Descending"
-msgstr ""
+msgstr "Fallande"
 
 msgid "Normal menu item"
-msgstr ""
+msgstr "Vanligt menyval"
 
 msgid "Expose"
-msgstr ""
+msgstr "Exponera"
 
 msgid "Option"
-msgstr ""
+msgstr "Val"
 
 msgid "Operator"
-msgstr ""
+msgstr "Operator"
 
 msgid "Filters"
-msgstr ""
+msgstr "Filter"
 
 msgid "Optional"
-msgstr ""
+msgstr "Valfritt"
 
 msgid "Exposed Filters"
-msgstr ""
+msgstr "Exponerade filter"
 
 msgid "Order"
-msgstr ""
+msgstr "Ordning"
 
 msgid "Views UI"
-msgstr ""
+msgstr "Views UI"
 
 msgid "Uncategorized"
-msgstr ""
+msgstr "Ej kategoriserad"
 
 msgid "Plain"
-msgstr ""
+msgstr "Enkel"
 
 msgid "Position"
-msgstr ""
+msgstr "Position"
 
 msgid "Integer"
-msgstr ""
+msgstr "Heltal"
 
 msgid "Pattern"
-msgstr ""
+msgstr "Mönster"
 
 msgid "The comment and all its replies have been deleted."
-msgstr ""
+msgstr "Kommentaren inklusive alla dess svar har raderats."
 
 msgid "Cron settings"
-msgstr ""
+msgstr "Inställningar för schemalagd aktiviteter"
 
 msgid "Preformatted"
-msgstr ""
+msgstr "Förformaterat"
 
 msgid "Anonymous users"
-msgstr ""
+msgstr "Anonyma användare"
 
 msgid "Found"
-msgstr ""
+msgstr "Hittad"
 
 msgid "fields"
-msgstr ""
+msgstr "fält"
 
 msgid "Add group"
-msgstr ""
+msgstr "Lägg till grupp"
 
 msgid "Save settings"
-msgstr ""
+msgstr "Spara inställningar"
 
 msgid "UID"
-msgstr ""
+msgstr "UID"
 
 msgid "Duration"
-msgstr ""
+msgstr "Varaktighet"
 
 msgid "Multiplier"
-msgstr ""
+msgstr "Multiplikator"
 
 msgid "Session closed for %name."
-msgstr ""
+msgstr "Sessionen avslutad för %name."
 
 msgid "Defaults"
-msgstr ""
+msgstr "Förvalt"
 
 msgid "Your search yielded no results."
-msgstr ""
+msgstr "Din sökning gav inget resultat."
 
 msgid "="
-msgstr ""
+msgstr "="
 
 msgid "Germany"
-msgstr ""
+msgstr "Tyskland"
 
 msgid "Created date"
-msgstr ""
+msgstr "Skapad datum"
 
 msgid "Updated date"
-msgstr ""
+msgstr "Uppdaterad datum"
 
 msgid "comments"
-msgstr ""
+msgstr "kommentarer"
 
 msgid "1 new"
 msgid_plural "@count new"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 nytt"
+msgstr[1] "@count nya"
 
 msgid "Default language"
-msgstr ""
+msgstr "Förvalt språk"
 
 msgid "Condition"
-msgstr ""
+msgstr "Villkor"
 
 msgid "Afghanistan"
-msgstr ""
+msgstr "Afghanistan"
 
 msgid "Albania"
-msgstr ""
+msgstr "Albanien"
 
 msgid "Algeria"
-msgstr ""
+msgstr "Algeriet"
 
 msgid "American Samoa"
-msgstr ""
+msgstr "Amerikanska Samoa"
 
 msgid "Angola"
-msgstr ""
+msgstr "Angola"
 
 msgid "Anguilla"
-msgstr ""
+msgstr "Anguilla"
 
 msgid "Antarctica"
-msgstr ""
+msgstr "Antarktis"
 
 msgid "Antigua and Barbuda"
-msgstr ""
+msgstr "Antigua och Barbuda"
 
 msgid "Argentina"
-msgstr ""
+msgstr "Argentina"
 
 msgid "Armenia"
-msgstr ""
+msgstr "Armenien"
 
 msgid "Aruba"
-msgstr ""
+msgstr "Aruba"
 
 msgid "Australia"
-msgstr ""
+msgstr "Australien"
 
 msgid "Austria"
-msgstr ""
+msgstr "Österrike"
 
 msgid "Azerbaijan"
-msgstr ""
+msgstr "Azerbajdzjan"
 
 msgid "Bahamas"
-msgstr ""
+msgstr "Bahamas"
 
 msgid "Bahrain"
-msgstr ""
+msgstr "Bahrain"
 
 msgid "Bangladesh"
-msgstr ""
+msgstr "Bangladesh"
 
 msgid "Barbados"
-msgstr ""
+msgstr "Barbados"
 
 msgid "Belarus"
-msgstr ""
+msgstr "Vitryssland"
 
 msgid "Belgium"
-msgstr ""
+msgstr "Belgien"
 
 msgid "Belize"
-msgstr ""
+msgstr "Belize"
 
 msgid "Benin"
-msgstr ""
+msgstr "Benin"
 
 msgid "Bermuda"
-msgstr ""
+msgstr "Bermuda"
 
 msgid "Bhutan"
-msgstr ""
+msgstr "Bhutan"
 
 msgid "Bolivia"
-msgstr ""
+msgstr "Bolivia"
 
 msgid "Bosnia and Herzegovina"
-msgstr ""
+msgstr "Bosnien och Hercegovina"
 
 msgid "Botswana"
-msgstr ""
+msgstr "Botswana"
 
 msgid "Bouvet Island"
-msgstr ""
+msgstr "Bouvetön"
 
 msgid "Brunei"
-msgstr ""
+msgstr "Brunei"
 
 msgid "Thu"
-msgstr ""
+msgstr "tors"
 
 msgid "Anonymous"
-msgstr ""
+msgstr "Gäst"
 
 msgid "Full"
-msgstr ""
+msgstr "Fullständig"
 
 msgid "Tracker"
-msgstr ""
+msgstr "Spårare"
 
 msgid "Recent comments"
-msgstr ""
+msgstr "Senaste kommentarer"
 
 msgid "Users"
-msgstr ""
+msgstr "Användare"
 
 msgid "Role"
-msgstr ""
+msgstr "Roll"
 
 msgid "Sort Criteria"
-msgstr ""
+msgstr "Sortera kriterium"
 
 msgid "Log in"
 msgstr "Logga in"
 
 msgid "External"
-msgstr ""
+msgstr "Extern"
 
 msgid "Sort by"
-msgstr ""
+msgstr "Sortera efter"
 
 msgid "Uninstall"
-msgstr ""
+msgstr "Avinstallera"
 
 msgid "Install"
-msgstr ""
+msgstr "Installera"
 
 msgid "Appearance"
-msgstr ""
+msgstr "Utseende"
 
 msgid "Configuration"
-msgstr ""
+msgstr "Konfiguration"
 
 msgid "Clear cache"
-msgstr ""
+msgstr "Töm cache"
 
 msgid "Mon"
-msgstr ""
+msgstr "mån"
 
 msgid "Fri"
-msgstr ""
+msgstr "fre"
 
 msgid "Tue"
-msgstr ""
+msgstr "tis"
 
 msgid "Wed"
-msgstr ""
+msgstr "ons"
 
 msgid "Other"
-msgstr ""
+msgstr "Övriga"
 
 msgid "Close"
-msgstr ""
+msgstr "Stäng"
 
 msgid "Bulgaria"
-msgstr ""
+msgstr "Bulgarien"
 
 msgid "Burkina Faso"
-msgstr ""
+msgstr "Burkina Faso"
 
 msgid "Burundi"
-msgstr ""
+msgstr "Burundi"
 
 msgid "Cambodia"
-msgstr ""
+msgstr "Kambodja"
 
 msgid "Cameroon"
-msgstr ""
+msgstr "Kamerun"
 
 msgid "Canada"
-msgstr ""
+msgstr "Kanada"
 
 msgid "Cape Verde"
-msgstr ""
+msgstr "Kap Verde"
 
 msgid "Cayman Islands"
-msgstr ""
+msgstr "Caymanöarna"
 
 msgid "Central African Republic"
-msgstr ""
+msgstr "Centralafrikanska republiken"
 
 msgid "Chad"
-msgstr ""
+msgstr "Tchad"
 
 msgid "China"
-msgstr ""
+msgstr "Kina"
 
 msgid "Christmas Island"
-msgstr ""
+msgstr "Julön"
 
 msgid "Colombia"
-msgstr ""
+msgstr "Colombia"
 
 msgid "Comoros"
-msgstr ""
+msgstr "Komorerna"
 
 msgid "Cook Islands"
-msgstr ""
+msgstr "Cooköarna"
 
 msgid "Costa Rica"
-msgstr ""
+msgstr "Costa Rica"
 
 msgid "Cyprus"
-msgstr ""
+msgstr "Cypern"
 
 msgid "Czech Republic"
-msgstr ""
+msgstr "Tjeckien"
 
 msgid "Denmark"
-msgstr ""
+msgstr "Danmark"
 
 msgid "Djibouti"
-msgstr ""
+msgstr "Djibouti"
 
 msgid "Dominica"
-msgstr ""
+msgstr "Dominica"
 
 msgid "Dominican Republic"
-msgstr ""
+msgstr "Dominikanska republiken"
 
 msgid "Ecuador"
-msgstr ""
+msgstr "Ecuador"
 
 msgid "El Salvador"
-msgstr ""
+msgstr "El Salvador"
 
 msgid "Equatorial Guinea"
-msgstr ""
+msgstr "Ekvatorialguinea"
 
 msgid "Eritrea"
-msgstr ""
+msgstr "Eritrea"
 
 msgid "Estonia"
-msgstr ""
+msgstr "Estland"
 
 msgid "Ethiopia"
-msgstr ""
+msgstr "Etiopien"
 
 msgid "Faroe Islands"
-msgstr ""
+msgstr "Färöarna"
 
 msgid "Finland"
-msgstr ""
+msgstr "Finland"
 
 msgid "France"
-msgstr ""
+msgstr "Frankrike"
 
 msgid "French Guiana"
-msgstr ""
+msgstr "Franska Guyana"
 
 msgid "French Polynesia"
-msgstr ""
+msgstr "Franska Polynesien"
 
 msgid "Gabon"
-msgstr ""
+msgstr "Gabon"
 
 msgid "Gambia"
-msgstr ""
+msgstr "Gambia"
 
 msgid "Georgia"
-msgstr ""
+msgstr "Georgien"
 
 msgid "Ghana"
-msgstr ""
+msgstr "Ghana"
 
 msgid "Gibraltar"
-msgstr ""
+msgstr "Gibraltar"
 
 msgid "Greece"
-msgstr ""
+msgstr "Grekland"
 
 msgid "Greenland"
-msgstr ""
+msgstr "Grönland"
 
 msgid "Grenada"
-msgstr ""
+msgstr "Grenada"
 
 msgid "Guadeloupe"
-msgstr ""
+msgstr "Guadeloupe"
 
 msgid "Guam"
-msgstr ""
+msgstr "Guam"
 
 msgid "Guatemala"
-msgstr ""
+msgstr "Guatemala"
 
 msgid "Guinea"
-msgstr ""
+msgstr "Guinea"
 
 msgid "Guinea-Bissau"
-msgstr ""
+msgstr "Guinea-Bissau"
 
 msgid "Guyana"
-msgstr ""
+msgstr "Guyana"
 
 msgid "Haiti"
-msgstr ""
+msgstr "Haiti"
 
 msgid "Heard Island and McDonald Islands"
-msgstr ""
+msgstr "Heard- och McDonaldsöarna"
 
 msgid "Honduras"
-msgstr ""
+msgstr "Honduras"
 
 msgid "Hungary"
-msgstr ""
+msgstr "Ungern"
 
 msgid "Iceland"
-msgstr ""
+msgstr "Island"
 
 msgid "India"
-msgstr ""
+msgstr "Indien"
 
 msgid "Indonesia"
-msgstr ""
+msgstr "Indonesien"
 
 msgid "Iraq"
-msgstr ""
+msgstr "Irak"
 
 msgid "Ireland"
-msgstr ""
+msgstr "Irland"
 
 msgid "Italy"
-msgstr ""
+msgstr "Italien"
 
 msgid "Jordan"
-msgstr ""
+msgstr "Jordanien"
 
 msgid "Kazakhstan"
-msgstr ""
+msgstr "Kazakstan"
 
 msgid "Kenya"
-msgstr ""
+msgstr "Kenya"
 
 msgid "Kiribati"
-msgstr ""
+msgstr "Kiribati"
 
 msgid "Kuwait"
-msgstr ""
+msgstr "Kuwait"
 
 msgid "Kyrgyzstan"
-msgstr ""
+msgstr "Kirgizistan"
 
 msgid "Laos"
-msgstr ""
+msgstr "Laos"
 
 msgid "Latvia"
-msgstr ""
+msgstr "Lettland"
 
 msgid "Lebanon"
-msgstr ""
+msgstr "Libanon"
 
 msgid "Lesotho"
-msgstr ""
+msgstr "Lesotho"
 
 msgid "Liberia"
-msgstr ""
+msgstr "Liberia"
 
 msgid "Liechtenstein"
-msgstr ""
+msgstr "Liechtenstein"
 
 msgid "Lithuania"
-msgstr ""
+msgstr "Litauen"
 
 msgid "Luxembourg"
-msgstr ""
+msgstr "Luxemburg"
 
 msgid "Madagascar"
-msgstr ""
+msgstr "Madagaskar"
 
 msgid "Malawi"
-msgstr ""
+msgstr "Malawi"
 
 msgid "Malaysia"
-msgstr ""
+msgstr "Malaysia"
 
 msgid "Maldives"
-msgstr ""
+msgstr "Maldiverna"
 
 msgid "Mali"
-msgstr ""
+msgstr "Mali"
 
 msgid "Malta"
-msgstr ""
+msgstr "Malta"
 
 msgid "Marshall Islands"
-msgstr ""
+msgstr "Marshallöarna"
 
 msgid "Martinique"
-msgstr ""
+msgstr "Martinique"
 
 msgid "Mauritania"
-msgstr ""
+msgstr "Mauretanien"
 
 msgid "Mauritius"
-msgstr ""
+msgstr "Mauritius"
 
 msgid "Mayotte"
-msgstr ""
+msgstr "Mayotte"
 
 msgid "Mexico"
-msgstr ""
+msgstr "Mexiko"
 
 msgid "Micronesia"
-msgstr ""
+msgstr "Mikronesien"
 
 msgid "Moldova"
-msgstr ""
+msgstr "Moldavien"
 
 msgid "Monaco"
-msgstr ""
+msgstr "Monaco"
 
 msgid "Mongolia"
-msgstr ""
+msgstr "Mongoliet"
 
 msgid "Montserrat"
-msgstr ""
+msgstr "Montserrat"
 
 msgid "Morocco"
-msgstr ""
+msgstr "Marocko"
 
 msgid "Mozambique"
-msgstr ""
+msgstr "Moçambique"
 
 msgid "Nauru"
-msgstr ""
+msgstr "Nauru"
 
 msgid "Nepal"
-msgstr ""
+msgstr "Nepal"
 
 msgid "Netherlands"
-msgstr ""
+msgstr "Nederländerna"
 
 msgid "Netherlands Antilles"
-msgstr ""
+msgstr "Nederländska Antillerna"
 
 msgid "New Caledonia"
-msgstr ""
+msgstr "Nya Kaledonien"
 
 msgid "Nicaragua"
-msgstr ""
+msgstr "Nicaragua"
 
 msgid "Niger"
-msgstr ""
+msgstr "Niger"
 
 msgid "Nigeria"
-msgstr ""
+msgstr "Nigeria"
 
 msgid "Niue"
-msgstr ""
+msgstr "Niue"
 
 msgid "Norfolk Island"
-msgstr ""
+msgstr "Norfolkön"
 
 msgid "North Korea"
-msgstr ""
+msgstr "Nordkorea"
 
 msgid "Northern Mariana Islands"
-msgstr ""
+msgstr "Nordmarianerna"
 
 msgid "Norway"
-msgstr ""
+msgstr "Norge"
 
 msgid "Oman"
-msgstr ""
+msgstr "Oman"
 
 msgid "Pakistan"
-msgstr ""
+msgstr "Pakistan"
 
 msgid "Palau"
-msgstr ""
+msgstr "Palau"
 
 msgid "Panama"
-msgstr ""
+msgstr "Panama"
 
 msgid "Papua New Guinea"
-msgstr ""
+msgstr "Papua Nya Guinea"
 
 msgid "Peru"
-msgstr ""
+msgstr "Peru"
 
 msgid "Philippines"
-msgstr ""
+msgstr "Filippinerna"
 
 msgid "Pitcairn Islands"
-msgstr ""
+msgstr "Pitcairnöarna"
 
 msgid "Puerto Rico"
-msgstr ""
+msgstr "Puerto Rico"
 
 msgid "Qatar"
-msgstr ""
+msgstr "Qatar"
 
 msgid "Romania"
-msgstr ""
+msgstr "Rumänien"
 
 msgid "Russia"
-msgstr ""
+msgstr "Ryssland"
 
 msgid "Rwanda"
-msgstr ""
+msgstr "Rwanda"
 
 msgid "Samoa"
-msgstr ""
+msgstr "Samoa"
 
 msgid "San Marino"
-msgstr ""
+msgstr "San Marino"
 
 msgid "Saudi Arabia"
-msgstr ""
+msgstr "Saudiarabien"
 
 msgid "Senegal"
-msgstr ""
+msgstr "Senegal"
 
 msgid "Seychelles"
-msgstr ""
+msgstr "Seychellerna"
 
 msgid "Sierra Leone"
-msgstr ""
+msgstr "Sierra Leone"
 
 msgid "Slovakia"
-msgstr ""
+msgstr "Slovakien"
 
 msgid "Slovenia"
-msgstr ""
+msgstr "Slovenien"
 
 msgid "Solomon Islands"
-msgstr ""
+msgstr "Salomonöarna"
 
 msgid "Somalia"
-msgstr ""
+msgstr "Somalia"
 
 msgid "South Africa"
-msgstr ""
+msgstr "Sydafrika"
 
 msgid "South Georgia and the South Sandwich Islands"
-msgstr ""
+msgstr "Sydgeorgien och Sydsandwichöarna"
 
 msgid "Spain"
-msgstr ""
+msgstr "Spanien"
 
 msgid "Sri Lanka"
-msgstr ""
+msgstr "Sri Lanka"
 
 msgid "Sudan"
-msgstr ""
+msgstr "Sudan"
 
 msgid "Suriname"
-msgstr ""
+msgstr "Surinam"
 
 msgid "Svalbard and Jan Mayen"
-msgstr ""
+msgstr "Svalbard och Jan Mayen"
 
 msgid "Swaziland"
-msgstr ""
+msgstr "Swaziland"
 
 msgid "Sweden"
-msgstr ""
+msgstr "Sverige"
 
 msgid "Switzerland"
-msgstr ""
+msgstr "Schweiz"
 
 msgid "Syria"
-msgstr ""
+msgstr "Syrien"
 
 msgid "Taiwan"
-msgstr ""
+msgstr "Taiwan"
 
 msgid "Tajikistan"
-msgstr ""
+msgstr "Tadzjikistan"
 
 msgid "Tanzania"
-msgstr ""
+msgstr "Tanzania"
 
 msgid "Thailand"
-msgstr ""
+msgstr "Thailand"
 
 msgid "Togo"
-msgstr ""
+msgstr "Togo"
 
 msgid "Tokelau"
-msgstr ""
+msgstr "Tokelauöarna"
 
 msgid "Trinidad and Tobago"
-msgstr ""
+msgstr "Trinidad och Tobago"
 
 msgid "Tunisia"
-msgstr ""
+msgstr "Tunisien"
 
 msgid "Turkmenistan"
-msgstr ""
+msgstr "Turkmenistan"
 
 msgid "Turks and Caicos Islands"
-msgstr ""
+msgstr "Turks- och Caicosöarna"
 
 msgid "Tuvalu"
-msgstr ""
+msgstr "Tuvalu"
 
 msgid "Uganda"
-msgstr ""
+msgstr "Uganda"
 
 msgid "Ukraine"
-msgstr ""
+msgstr "Ukraina"
 
 msgid "United Arab Emirates"
-msgstr ""
+msgstr "Förenade Arabemiraten"
 
 msgid "United Kingdom"
-msgstr ""
+msgstr "Storbritannien"
 
 msgid "United States"
-msgstr ""
+msgstr "Förenta Staterna"
 
 msgid "Uruguay"
-msgstr ""
+msgstr "Uruguay"
 
 msgid "Uzbekistan"
-msgstr ""
+msgstr "Uzbekistan"
 
 msgid "Vanuatu"
-msgstr ""
+msgstr "Vanuatu"
 
 msgid "Vatican City"
-msgstr ""
+msgstr "Vatikanstaten"
 
 msgid "Venezuela"
-msgstr ""
+msgstr "Venezuela"
 
 msgid "Wallis and Futuna"
-msgstr ""
+msgstr "Wallis- och Futunaöarna"
 
 msgid "Yemen"
-msgstr ""
+msgstr "Jemen"
 
 msgid "Zambia"
-msgstr ""
+msgstr "Zambia"
 
 msgid "Zimbabwe"
-msgstr ""
+msgstr "Zimbabwe"
 
 msgid "Identity"
-msgstr ""
+msgstr "Identitet"
 
 msgid "Database username"
-msgstr ""
+msgstr "Användarnamn för databasen"
 
 msgid "Database password"
-msgstr ""
+msgstr "Lösenord för databasen"
 
 msgid "Database name"
-msgstr ""
+msgstr "Databasens namn"
 
 msgid "Add user"
-msgstr ""
+msgstr "Lägg till användare"
 
 msgid "Port"
-msgstr ""
+msgstr "Port"
 
 msgid "Regular expression"
-msgstr ""
+msgstr "Reguljärt uttryck"
 
 msgid "Size of textfield"
-msgstr ""
+msgstr "Storlek på textfält"
 
 msgid "Authoring information"
-msgstr ""
+msgstr "Författarinformation"
 
 msgid "Authored on"
-msgstr ""
+msgstr "Författad"
 
 msgid "Leave blank for %anonymous."
-msgstr ""
+msgstr "Lämna detta tomt för %anonymous."
 
 msgid "Hidden"
-msgstr ""
+msgstr "Dold"
 
 msgid "Are you sure you want to delete %name?"
-msgstr ""
+msgstr "Är du säker på att du vill radera %name?"
 
 msgid "Undefined"
-msgstr ""
+msgstr "Ej definierad"
 
 msgid "Queued"
-msgstr ""
+msgstr "Köad"
 
 msgid "Syslog"
-msgstr ""
+msgstr "Syslog"
 
 msgid "Other queries"
-msgstr ""
+msgstr "Andra frågor"
 
 msgid "Key"
-msgstr ""
+msgstr "Nyckel"
 
 msgid "Link to node"
-msgstr ""
+msgstr "Länka till nod"
 
 msgid "File Upload"
-msgstr ""
+msgstr "Filuppladdning"
 
 msgid "block"
-msgstr ""
+msgstr "block"
 
 msgid "Site language"
-msgstr ""
+msgstr "Språk för webbplats"
 
 msgid "Change"
-msgstr ""
+msgstr "Ändra"
 
 msgid "Spanish"
-msgstr ""
+msgstr "Spanska"
 
 msgid "in"
-msgstr ""
+msgstr "i"
 
 msgid "Messages"
-msgstr ""
+msgstr "Meddelanden"
 
 msgid "Edit term"
-msgstr ""
+msgstr "Redigera term"
 
 msgid "Switch"
-msgstr ""
+msgstr "Byt"
 
 msgid "Import OPML"
-msgstr ""
+msgstr "Importera OPML"
 
 msgid "OPML File"
-msgstr ""
+msgstr "OPML-fil"
 
 msgid "Allowed HTML tags"
-msgstr ""
+msgstr "Tillåtna HTML-taggar"
 
 msgid "Sources"
-msgstr ""
+msgstr "Källor"
 
 msgid "1 item"
 msgid_plural "@count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 artikel"
+msgstr[1] "@count artiklar"
 
 msgid "Feed items"
-msgstr ""
+msgstr "Objekt i innehållsflöde"
 
 msgid "Add menu"
-msgstr ""
+msgstr "Lägg till meny"
 
 msgid "menu"
-msgstr ""
+msgstr "meny"
 
 msgid "No items selected."
-msgstr ""
+msgstr "Inga inlägg valda."
 
 msgid "The update has been performed."
-msgstr ""
+msgstr "Uppdateringen har genomförts."
 
 msgid "Node title"
-msgstr ""
+msgstr "Titel för nod"
 
 msgid "Result"
-msgstr ""
+msgstr "Resultat"
 
 msgid "Browser"
-msgstr ""
+msgstr "Webbläsare"
 
 msgid "View user profile."
-msgstr ""
+msgstr "Visa användarprofil."
 
 msgid "Titles only"
-msgstr ""
+msgstr "Endast titlar"
 
 msgid "Full text"
-msgstr ""
+msgstr "Fulltext"
 
 msgid "Feed settings"
-msgstr ""
+msgstr "Inställningar för flöde"
 
 msgid "Source"
-msgstr ""
+msgstr "Källa"
 
 msgid "Add Block"
-msgstr ""
+msgstr "Lägg till block"
 
 msgid "published"
-msgstr ""
+msgstr "publicerad"
 
 msgid "The changes have been saved."
-msgstr ""
+msgstr "Ändringarna har sparats."
 
 msgid "Undo"
-msgstr ""
+msgstr "Ångra"
 
 msgid "@time ago"
-msgstr ""
+msgstr "@time sedan"
 
 msgid "No users selected."
-msgstr ""
+msgstr "Inga användare valda."
 
 msgid "Select all rows in this table"
-msgstr ""
+msgstr "Markera alla rader i tabellen"
 
 msgid "Deselect all rows in this table"
-msgstr ""
+msgstr "Avmarkera alla rader i tabellen"
 
 msgid "User search"
-msgstr ""
+msgstr "Användarsökning"
 
 msgid "Search results"
-msgstr ""
+msgstr "Sökresultat"
 
 msgid "Please enter some keywords."
-msgstr ""
+msgstr "Var vänlig ange några nyckelord."
 
 msgid "Replacement patterns"
-msgstr ""
+msgstr "Ersättningsmönster"
 
 msgid "Deleted"
-msgstr ""
+msgstr "Borttaget"
 
 msgid "Successful"
-msgstr ""
+msgstr "Successful"
 
 msgid "Display name"
-msgstr ""
+msgstr "Visningsnamn"
 
 msgid "Topics"
-msgstr ""
+msgstr "Ämnen"
 
 msgid "Topic"
-msgstr ""
+msgstr "Ämne"
 
 msgid "Definition"
-msgstr ""
+msgstr "Definition"
 
 msgid "Allowed values list"
-msgstr ""
+msgstr "Lista med tillåtna värden"
 
 msgid "Textfield size"
-msgstr ""
+msgstr "Storlek på textfält"
 
 msgid "Today"
-msgstr ""
+msgstr "Idag"
 
 msgid "Activity"
-msgstr ""
+msgstr "Aktivitet"
 
 msgid "Edit menu"
-msgstr ""
+msgstr "Redigera meny"
 
 msgid "Delete menu"
-msgstr ""
+msgstr "Radera meny"
 
 msgid "Publishing options"
-msgstr ""
+msgstr "Publiceringsalternativ"
 
 msgid "Create new revision"
-msgstr ""
+msgstr "Skapa ny version"
 
 msgid "Lists"
-msgstr ""
+msgstr "Listor"
 
 msgid "Limit"
-msgstr ""
+msgstr "Begränsning"
 
 msgid "Minimum height"
-msgstr ""
+msgstr "Minsta höjd"
 
 msgid "Minimum width"
-msgstr ""
+msgstr "Minsta bredd"
 
 msgid "Query"
-msgstr ""
+msgstr "Databasfråga"
 
 msgid "Locale settings"
-msgstr ""
+msgstr "Platsinställningar"
 
 msgid "Search fields"
-msgstr ""
+msgstr "Sökfält"
 
 msgid "Configure block"
-msgstr ""
+msgstr "Konfigurera block"
 
 msgid "Block name"
-msgstr ""
+msgstr "Blocknamn"
 
 msgid "How many content items to display in \"day\" list."
-msgstr ""
+msgstr "Antalet innehållsposter som skall visas under \"I dag\"."
 
 msgid "Jan"
-msgstr ""
+msgstr "jan"
 
 msgid "Feb"
-msgstr ""
+msgstr "feb"
 
 msgid "Mar"
-msgstr ""
+msgstr "mar"
 
 msgid "Apr"
-msgstr ""
+msgstr "apr"
 
 msgid "Jun"
-msgstr ""
+msgstr "jun"
 
 msgid "Jul"
-msgstr ""
+msgstr "jul"
 
 msgid "Aug"
-msgstr ""
+msgstr "aug"
 
 msgid "Sep"
-msgstr ""
+msgstr "sep"
 
 msgid "Oct"
-msgstr ""
+msgstr "okt"
 
 msgid "Nov"
-msgstr ""
+msgstr "nov"
 
 msgid "Dec"
-msgstr ""
+msgstr "dec"
 
 msgid "Hour"
-msgstr ""
+msgstr "Timma"
 
 msgid "Minute"
-msgstr ""
+msgstr "Minut"
 
 msgid "Second"
-msgstr ""
+msgstr "Sekund"
 
 msgid "Select list"
-msgstr ""
+msgstr "Rullgardinsmeny"
 
 msgid "Text field"
-msgstr ""
+msgstr "Textfält"
 
 msgid "Granularity"
-msgstr ""
+msgstr "Noggrannhet"
 
 msgid "Posts"
-msgstr ""
+msgstr "Inlägg"
 
 msgid "Map"
-msgstr ""
+msgstr "Karta"
 
 msgid "Node settings"
-msgstr ""
+msgstr "Inställningar för noder"
 
 msgid "Alignment"
-msgstr ""
+msgstr "Placering"
 
 msgid "Randomize"
-msgstr ""
+msgstr "Slumpa"
 
 msgid "Link label"
-msgstr ""
+msgstr "Länkens etikett"
 
 msgid "author"
-msgstr ""
+msgstr "författare"
 
 msgid "AND"
-msgstr ""
+msgstr "OCH"
 
 msgid "Fixed"
-msgstr ""
+msgstr "Fast"
 
 msgid "Revert"
-msgstr ""
+msgstr "Återställ"
 
 msgid "Negate"
-msgstr ""
+msgstr "Negera"
 
 msgid "Empty"
-msgstr ""
+msgstr "Töm"
 
 msgid "Existing system path"
-msgstr ""
+msgstr "Befintlig systemsökväg"
 
 msgid "Path alias"
-msgstr ""
+msgstr "Sökvägsalias"
 
 msgid "Greater than"
-msgstr ""
+msgstr "Större än"
 
 msgid "Less than"
-msgstr ""
+msgstr "Mindre än"
 
 msgid "Notice"
-msgstr ""
+msgstr "Notering"
 
 msgid "Caption"
-msgstr ""
+msgstr "Bildtext"
 
 msgid "Number of day's top views to display"
-msgstr ""
+msgstr "Antalet rader som skall visas under \"I dag\""
 
 msgid "Number of all time views to display"
-msgstr ""
+msgstr "Antalet rader som skall visas under \"Någonsin\""
 
 msgid "Number of most recent views to display"
-msgstr ""
+msgstr "Hur många av de senaste sidvisningarna som skall visas"
 
 msgid "characters"
-msgstr ""
+msgstr "tecken"
 
 msgid "Su"
-msgstr ""
+msgstr "sön"
 
 msgid "Mo"
-msgstr ""
+msgstr "mån"
 
 msgid "Tu"
-msgstr ""
+msgstr "tis"
 
 msgid "We"
-msgstr ""
+msgstr "ons"
 
 msgid "Th"
-msgstr ""
+msgstr "tor"
 
 msgid "Fr"
-msgstr ""
+msgstr "fre"
 
 msgid "Sa"
-msgstr ""
+msgstr "lör"
 
 msgid "First day of week"
-msgstr ""
+msgstr "Första dagen i veckan"
 
 msgid "Add workflow"
-msgstr ""
+msgstr "Lägg till ett arbetsflöde"
 
 msgid "Add state"
-msgstr ""
+msgstr "Add state"
 
 msgid "Transition"
-msgstr ""
+msgstr "Övergång"
 
 msgid "Left"
-msgstr ""
+msgstr "Vänster"
 
 msgid "Right"
-msgstr ""
+msgstr "Höger"
 
 msgid "Buttons"
-msgstr ""
+msgstr "Knappar"
 
 msgid "next ›"
-msgstr ""
+msgstr "nästa ›"
 
 msgid "Front page"
-msgstr ""
+msgstr "Startsida"
 
 msgid "Entity"
-msgstr ""
+msgstr "Objekt"
 
 msgid "Languages"
-msgstr ""
+msgstr "Språk"
 
 msgid "Member for"
-msgstr ""
+msgstr "Medlem i"
 
 msgid "Log out"
-msgstr ""
+msgstr "Logga ut"
 
 msgid "Workflow"
-msgstr ""
+msgstr "Arbetsflöde"
 
 msgid "Modified"
-msgstr ""
+msgstr "Modifierad"
 
 msgid "Show"
-msgstr ""
+msgstr "Visa"
 
 msgid "Configure permissions"
-msgstr ""
+msgstr "Konfigurera behörigheter"
 
 msgid "Extend"
-msgstr ""
+msgstr "Utöka"
 
 msgid "Create new account"
-msgstr ""
+msgstr "Skapa nytt konto"
 
 msgid "Seconds"
-msgstr ""
+msgstr "Sekunder"
 
 msgid "role"
-msgstr ""
+msgstr "roll"
 
 msgid "User registration"
-msgstr ""
+msgstr "Användarregistrering"
 
 msgid "Info"
-msgstr ""
+msgstr "Information"
 
 msgid "Created new term %term."
-msgstr ""
+msgstr "Skapade ny term: %term."
 
 msgid "Deleted term %name."
-msgstr ""
+msgstr "Raderade termen %name."
 
 msgid "Notify user when account is activated"
-msgstr ""
+msgstr "Meddela användare när konto är aktiverat"
 
 msgid "Notify user when account is blocked"
-msgstr ""
+msgstr "Meddela användare när konto är spärrat"
 
 msgid "Reference"
-msgstr ""
+msgstr "Referens"
 
 msgid "Enabled filters"
-msgstr ""
+msgstr "Aktiverade filter"
 
 msgid "Updating"
-msgstr ""
+msgstr "Uppdaterar"
 
 msgid "or"
-msgstr ""
+msgstr "eller"
 
 msgid "Getting Started"
-msgstr ""
+msgstr "Komma igång"
 
 msgid "Convert"
-msgstr ""
+msgstr "Konvertera"
 
 msgid "Binary"
-msgstr ""
+msgstr "Binär"
 
 msgid "Delete term"
-msgstr ""
+msgstr "Radera term"
 
 msgid "List terms"
-msgstr ""
+msgstr "Lista termer"
 
 msgid ""
 "Deleting a term will delete all its children if there are any. This action "
 "cannot be undone."
 msgstr ""
+"När en term raderas raderas även alla befintliga undertermer. Denna åtgärd "
+"kan inte ångras."
 
 msgid "Parent terms"
-msgstr ""
+msgstr "Ovanliggande termer"
 
 msgid "Syndicate"
-msgstr ""
+msgstr "Dela ut nyhetsflöde"
 
 msgid "Books"
-msgstr ""
+msgstr "Böcker"
 
 msgid "Style"
-msgstr ""
+msgstr "Stil"
 
 msgid "Forums"
-msgstr ""
+msgstr "Forum"
 
 msgid "Superscript"
-msgstr ""
+msgstr "Upphöjd"
 
 msgid "Revisions for %title"
-msgstr ""
+msgstr "Versioner för %title"
 
 msgid "Revision"
-msgstr ""
+msgstr "Version"
 
 msgid "The specified passwords do not match."
-msgstr ""
+msgstr "De angivna lösenorden stämmer inte överens."
 
 msgid "Session"
-msgstr ""
+msgstr "Session"
 
 msgid "Missing"
-msgstr ""
+msgstr "Saknas"
 
 msgid "No forums defined"
-msgstr ""
+msgstr "Inga forum är angivna"
 
 msgid "This topic has been moved"
-msgstr ""
+msgstr "Detta diskussionsämne har flyttats"
 
 msgid "roles"
-msgstr ""
+msgstr "roller"
 
 msgid "Your settings have been saved."
-msgstr ""
+msgstr "Dina inställningar har sparats."
 
 msgid "Plugin"
-msgstr ""
+msgstr "Insticksprogram"
 
 msgid "Link color"
-msgstr ""
+msgstr "Länkfärg"
 
 msgid "Duplicate"
-msgstr ""
+msgstr "Dubblett"
 
 msgid "Display label"
-msgstr ""
+msgstr "Etikett för visning"
 
 msgid "Reverse"
-msgstr ""
+msgstr "Omvänd"
 
 msgid "Testing"
-msgstr ""
+msgstr "Test"
 
 msgid "Standard"
-msgstr ""
+msgstr "Standard"
 
 msgid "Interval"
-msgstr ""
+msgstr "Intervall"
 
 msgid "Ascension Island"
-msgstr ""
+msgstr "Ascension Island"
 
 msgid "Fiji"
-msgstr ""
+msgstr "Fiji"
 
 msgid "Falkland Islands"
-msgstr ""
+msgstr "Falklandsöarna"
 
 msgid "Saint Kitts and Nevis"
-msgstr ""
+msgstr "Saint Kitts och Nevis"
 
 msgid "South Korea"
-msgstr ""
+msgstr "Sydkorea"
 
 msgid "Saint Lucia"
-msgstr ""
+msgstr "Saint Lucia"
 
 msgid "Saint Helena"
-msgstr ""
+msgstr "Sankta Helena"
 
 msgid "French Southern Territories"
-msgstr ""
+msgstr "Franska sydterritorierna"
 
 msgid "Saint Vincent and the Grenadines"
-msgstr ""
+msgstr "Saint Vincent and the Grenadines"
 
 msgid "U.S. Virgin Islands"
-msgstr ""
+msgstr "Amerikanska Jungfruöarna"
 
 msgid "Vietnam"
-msgstr ""
+msgstr "Vietnam"
 
 msgid "Guernsey"
-msgstr ""
+msgstr "Guernsey"
 
 msgid "Jersey"
-msgstr ""
+msgstr "Jersey"
 
 msgid "User name"
-msgstr ""
+msgstr "Användarnamn"
 
 msgid "Theme settings"
-msgstr ""
+msgstr "Inställningar för tema"
 
 msgid "Authentication"
-msgstr ""
+msgstr "Verifiering"
 
 msgid "Not published"
-msgstr ""
+msgstr "Inte publicerad"
 
 msgid "File settings"
-msgstr ""
+msgstr "Inställningar för filer"
 
 msgid "Menu settings"
-msgstr ""
+msgstr "Inställningar för meny"
 
 msgid "Color scheme"
-msgstr ""
+msgstr "Färgschema"
 
 msgid "width"
-msgstr ""
+msgstr "bredd"
 
 msgid "height"
-msgstr ""
+msgstr "höjd"
 
 msgid "Unformatted"
-msgstr ""
+msgstr "Oformaterad"
 
 msgid "Formats"
-msgstr ""
+msgstr "Format"
 
 msgid "@type: deleted %title."
-msgstr ""
+msgstr "@type: raderade %title."
 
 msgid "RSS Feed"
-msgstr ""
+msgstr "RSS-flöde"
 
 msgid "Allowed file extensions"
-msgstr ""
+msgstr "Tillåtna filändelser"
 
 msgid "New comments"
-msgstr ""
+msgstr "Nya kommentarer"
 
 msgid "New"
-msgstr ""
+msgstr "Ny"
 
 msgid "Redirect to URL"
-msgstr ""
+msgstr "Omdirigera till URL"
 
 msgid "Top left"
-msgstr ""
+msgstr "Längst upp till vänster"
 
 msgid "Top right"
-msgstr ""
+msgstr "Längst upp till höger"
 
 msgid "Bottom right"
-msgstr ""
+msgstr "Längst ned till höger"
 
 msgid "Bottom left"
-msgstr ""
+msgstr "Längst ned till vänster"
 
 msgid "Relationships"
-msgstr ""
+msgstr "Relationer"
 
 msgid "Relationship"
-msgstr ""
+msgstr "Relation"
 
 msgid "relationships"
-msgstr ""
+msgstr "relationer"
 
 msgid "Migrate"
-msgstr ""
+msgstr "Migrera"
 
 msgid "The username %name has not been activated or is blocked."
-msgstr ""
+msgstr "Användarnamnet %name har inte aktiverats eller är spärrat."
 
 msgid "Login attempt failed for %user."
-msgstr ""
+msgstr "Inloggning misslyckades för %user."
 
 msgid "Oldest first"
-msgstr ""
+msgstr "Äldsta först"
 
 msgid "Sort criteria"
-msgstr ""
+msgstr "Sorteringskriterier"
 
 msgid "Base path"
-msgstr ""
+msgstr "Grundsökväg"
 
 msgid "Revision of %title from %date"
-msgstr ""
+msgstr "Version av %title från %date"
 
 msgid "Parent menu item"
-msgstr ""
+msgstr "Ovanliggande menyval"
 
 msgid "The username of the user to which you would like to assign ownership."
 msgstr ""
+"Användarnamnet för den användare som du vill tilldela ägarskapet till."
 
 msgid "Delete action"
-msgstr ""
+msgstr "Radera åtgärd"
 
 msgid "The action has been successfully saved."
-msgstr ""
+msgstr "Åtgärden har sparats."
 
 msgid "Themes"
-msgstr ""
+msgstr "Teman"
 
 msgid "JPEG quality"
-msgstr ""
+msgstr "Kvalitet för JPEG"
 
 msgid "%"
-msgstr ""
+msgstr "%"
 
 msgid "Content options"
-msgstr ""
+msgstr "Alternativ för innehåll"
 
 msgid "Last changed"
-msgstr ""
+msgstr "Senast ändrad"
 
 msgid "not published"
-msgstr ""
+msgstr "ej publicerad"
 
 msgid "Loading..."
-msgstr ""
+msgstr "Laddar..."
 
 msgid "Protected"
-msgstr ""
+msgstr "Skyddad"
 
 msgid "Comment settings"
-msgstr ""
+msgstr "Inställningar för kommentarer"
 
 msgid "Sticky"
-msgstr ""
+msgstr "Klistrad"
 
 msgid "Default options"
-msgstr ""
+msgstr "Standardval"
 
 msgid "Ok"
-msgstr ""
+msgstr "Ok"
 
 msgid "Contact settings"
-msgstr ""
+msgstr "Kontaktinställningar"
 
 msgid "Ban"
-msgstr ""
+msgstr "Spärra"
 
 msgid "Processing"
-msgstr ""
+msgstr "Bearbetar"
 
 msgid "Temporary directory"
-msgstr ""
+msgstr "Tillfällig katalog"
 
 msgid "File upload error. Could not move uploaded file."
-msgstr ""
+msgstr "Uppladdningsfel. Kunde inte flytta den uppladdade filen."
 
 msgid "User status"
-msgstr ""
+msgstr "Status för användare"
 
 msgid "Shortcut"
-msgstr ""
+msgstr "Genväg"
 
 msgid "Default value"
-msgstr ""
+msgstr "Förvalt värde"
 
 msgid "Timezone"
-msgstr ""
+msgstr "Tidszon"
 
 msgid "Password strength:"
-msgstr ""
+msgstr "Lösenordsstyrka:"
 
 msgid "Passwords match:"
-msgstr ""
+msgstr "Lösenorden stämmer överens:"
 
 msgid "The name used to indicate anonymous users."
-msgstr ""
+msgstr "Beteckningen på anonyma användare."
 
 msgid "Image crop"
-msgstr ""
+msgstr "Bildbeskärning"
 
 msgid "@message"
-msgstr ""
+msgstr "@message"
 
 msgid "‹ Previous"
-msgstr ""
+msgstr "‹ Föregående"
 
 msgid "comment"
-msgstr ""
+msgstr "kommentar"
 
 msgid "Anonymous user"
-msgstr ""
+msgstr "Anonym användare"
 
 msgid "Next ›"
-msgstr ""
+msgstr "Nästa ›"
 
 msgid "Published comments"
-msgstr ""
+msgstr "Publicerade kommentarer"
 
 msgid "Author Name"
-msgstr ""
+msgstr "Författarnamn"
 
 msgid "Unpublished"
-msgstr ""
+msgstr "Ej publicerad"
 
 msgid "Glossary"
-msgstr ""
+msgstr "Ordlista"
 
 msgid "People"
-msgstr ""
+msgstr "Personer"
 
 msgid "Blocked"
-msgstr ""
+msgstr "Spärrad"
 
 msgid "Output format"
-msgstr ""
+msgstr "Utmatningsformat"
 
 msgid "Reset password"
 msgstr "Glömt ditt lösenord?"
 
 msgid "Next page"
-msgstr ""
+msgstr "Nästa sida"
 
 msgid "Cron"
-msgstr ""
+msgstr "Schemalagda aktiviteter"
 
 msgid "Shortcuts"
-msgstr ""
+msgstr "Genvägar"
 
 msgid "Aggregate JavaScript files"
-msgstr ""
+msgstr "Samla ihop filer av typ JavaScript"
 
 msgid "Changed"
-msgstr ""
+msgstr "Ändrad"
 
 msgid "Multilingual"
-msgstr ""
+msgstr "Flerspråkighet"
 
 msgid "Installed"
-msgstr ""
+msgstr "Installerad"
 
 msgid "Permissions"
-msgstr ""
+msgstr "Behörigheter"
 
 msgid "Enabled modules"
-msgstr ""
+msgstr "Aktiverade moduler"
 
 msgid "Not translated"
-msgstr ""
+msgstr "Ej översatt"
 
 msgid "Select"
-msgstr ""
+msgstr "Välj"
 
 msgid "Translatable"
-msgstr ""
+msgstr "Översättningsbar"
 
 msgid "Location of comment submission form"
-msgstr ""
+msgstr "Placering av kommentarsformuläret"
 
 msgid "Show blocks"
-msgstr ""
+msgstr "Visa block"
 
 msgid "Go to first page"
-msgstr ""
+msgstr "Gå till första sidan"
 
 msgid "Enter the terms you wish to search for."
-msgstr ""
+msgstr "Ange de termer du vill söka efter."
 
 msgid "Bold"
-msgstr ""
+msgstr "Fet"
 
 msgid "Underlined"
-msgstr ""
+msgstr "Understruket"
 
 msgid "Variables"
-msgstr ""
+msgstr "Variabler"
 
 msgid "Tasks"
-msgstr ""
+msgstr "Uppgifter"
 
 msgid "Plugins"
-msgstr ""
+msgstr "Insticksprogram"
 
 msgid "Delete role"
-msgstr ""
+msgstr "Radera roll"
 
 msgid "PHP Code"
-msgstr ""
+msgstr "PHP-kod"
 
 msgid "Basic configuration"
-msgstr ""
+msgstr "Grundläggande inställningar"
 
 msgid "Recipe"
-msgstr ""
+msgstr "Recipe"
 
 msgid "Ingredients"
-msgstr ""
+msgstr "Ingredients"
 
 msgid "Recipes"
-msgstr ""
+msgstr "Recept"
 
 msgid "No caching"
-msgstr ""
+msgstr "Ingen caching"
 
 msgid "British Indian Ocean Territory"
-msgstr ""
+msgstr "Brittiska territoriet i Indiska oceanen"
 
 msgid "Croatia"
-msgstr ""
+msgstr "Kroatien"
 
 msgid "Macedonia"
-msgstr ""
+msgstr "Makedonien"
 
 msgid "Western Sahara"
-msgstr ""
+msgstr "Västsahara"
 
 msgid "Language switcher"
-msgstr ""
+msgstr "Språkväljare"
 
 msgid "Source field"
-msgstr ""
+msgstr "Källfält"
 
 msgid "Translation status"
-msgstr ""
+msgstr "Status för översättning"
 
 msgid "Blocks"
-msgstr ""
+msgstr "Block"
 
 msgid "Delete block"
-msgstr ""
+msgstr "Radera block"
 
 msgid "Save blocks"
-msgstr ""
+msgstr "Spara block"
 
 msgid "The block settings have been updated."
-msgstr ""
+msgstr "Blockinställningarna har uppdaterats."
 
 msgid "Save block"
-msgstr ""
+msgstr "Spara block"
 
 msgid "The block configuration has been saved."
-msgstr ""
+msgstr "Blockinställningarna har sparats."
 
 msgid "Any customizations will be lost. This action cannot be undone."
 msgstr ""
+"Alla anpassningar kommer att gå förlorade. Denna åtgärd kan inte ångras."
 
 msgid "Add vocabulary"
-msgstr ""
+msgstr "Lägg till vokabulär"
 
 msgid "Edit vocabulary"
-msgstr ""
+msgstr "Redigera vokabulär"
 
 msgid "Created new vocabulary %name."
-msgstr ""
+msgstr "Skapade vokabulären %name."
 
 msgid "Updated vocabulary %name."
-msgstr ""
+msgstr "Uppdaterade vokabulären %name."
 
 msgid "Are you sure you want to delete the vocabulary %title?"
-msgstr ""
+msgstr "Är du säker på att du vill radera vokabulären %title?"
 
 msgid ""
 "Deleting a vocabulary will delete all the terms in it. This action cannot be"
 " undone."
 msgstr ""
+"När en vokabulär raderas raderas även alla dess termer. Denna åtgärd kan "
+"inte ångras."
 
 msgid "Deleted vocabulary %name."
-msgstr ""
+msgstr "Raderade vokabulären %name."
 
 msgid "Above"
-msgstr ""
+msgstr "Ovanför"
 
 msgid "@min and @max"
-msgstr ""
+msgstr "@min och @max"
 
 msgid "Default time zone"
-msgstr ""
+msgstr "Förvald tidszon"
 
 msgid "Manage fields"
-msgstr ""
+msgstr "Hantera fält"
 
 msgid "Add field"
-msgstr ""
+msgstr "Lägg till fält"
 
 msgid "Trimmed"
-msgstr ""
+msgstr "Nedkortad"
 
 msgid "Text area"
-msgstr ""
+msgstr "Textfält"
 
 msgid "Add a new field"
-msgstr ""
+msgstr "Lägg till ett nytt fält"
 
 msgid "Save field settings"
-msgstr ""
+msgstr "Spara fältinställningar"
 
 msgid "The update has encountered an error."
-msgstr ""
+msgstr "Uppdateringen stötte på ett fel."
 
 msgid "1 item successfully processed:"
 msgid_plural "@count items successfully processed:"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 inlägg behandlades utan problem:"
+msgstr[1] "@count inlägg behandlades utan problem:"
 
 msgid "Provide a comma separated list of arguments to pass to the view."
-msgstr ""
+msgstr "Ange en kommaseparerad lista av argument att skicka till vyn."
 
 msgid "Decimal"
-msgstr ""
+msgstr "Decimaltal"
 
 msgid "Float"
-msgstr ""
+msgstr "Flyttal"
 
 msgid "Minimum"
-msgstr ""
+msgstr "Lägsta"
 
 msgid "Precision"
-msgstr ""
+msgstr "Precision"
 
 msgid ""
 "The total number of digits to store in the database, including those to the "
 "right of the decimal."
 msgstr ""
+"Det totala antalet siffror att lagra i databasen, inklusive de till höger om"
+" decimalen."
 
 msgid "The number of digits to the right of the decimal."
-msgstr ""
+msgstr "Antalet siffror till höger om decimalen."
 
 msgid "Decimal marker"
-msgstr ""
+msgstr "Decimaltecken"
 
 msgid "Check boxes/radio buttons"
-msgstr ""
+msgstr "Kryssrutor/envalsknappar"
 
 msgid "Single on/off checkbox"
-msgstr ""
+msgstr "Ensam kryssruta för av/på"
 
 msgid "Text area (multiple rows)"
-msgstr ""
+msgstr "Textfält (flera rader)"
 
 msgid "Index"
-msgstr ""
+msgstr "Förteckning"
 
 msgid "Permalink"
-msgstr ""
+msgstr "Permanent länk"
 
 msgid "Theme-engine-specific settings"
-msgstr ""
+msgstr "Inställningar specifika för temamotorer"
 
 msgid "Form"
-msgstr ""
+msgstr "Formulär"
 
 msgid "Debug"
-msgstr ""
+msgstr "Felsök"
 
 msgid "Exceptions"
-msgstr ""
+msgstr "Undantag"
 
 msgid "The parent comment"
-msgstr ""
+msgstr "Den ovanliggande kommentaren"
 
 msgid "1 minute"
-msgstr ""
+msgstr "1 minut"
 
 msgid "@module module"
-msgstr ""
+msgstr "Modulen @module"
 
 msgid "More information"
-msgstr ""
+msgstr "Mer information"
 
 msgid "Grid"
-msgstr ""
+msgstr "Rutnät"
 
 msgid "Redo"
-msgstr ""
+msgstr "Upprepa"
 
 msgid "Italic"
-msgstr ""
+msgstr "Kursiv"
 
 msgid "Editor"
-msgstr ""
+msgstr "Redigerare"
 
 msgid "Date range"
-msgstr ""
+msgstr "Intervall för datum"
 
 msgid "Anonymous commenting"
-msgstr ""
+msgstr "Kommentering för gäster"
 
 msgid "Anonymous posters may not enter their contact information"
-msgstr ""
+msgstr "Gäster som skriver kan inte ange sina kontaktuppgifter"
 
 msgid "Anonymous posters may leave their contact information"
-msgstr ""
+msgstr "Gäster som skriver kan ange sina kontaktuppgifter"
 
 msgid "Anonymous posters must leave their contact information"
-msgstr ""
+msgstr "Gäster som skriver måste ange sin kontaktinformation"
 
 msgid "Default comment setting"
-msgstr ""
+msgstr "Förvald inställning för kommentarer"
 
 msgid ""
 "The content of this field is kept private and will not be shown publicly."
 msgstr ""
+"Innehållet i detta fält är privat och kommer inte att visas offentligt."
 
 msgid "parent"
-msgstr ""
+msgstr "ovanliggande"
 
 msgid "Date - newest first"
-msgstr ""
+msgstr "Datum - nyaste först"
 
 msgid "Date - oldest first"
-msgstr ""
+msgstr "Datum - äldsta först"
 
 msgid "1 comment"
 msgid_plural "@count comments"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 kommentar"
+msgstr[1] "@count kommentarer"
 
 msgid "1 new comment"
 msgid_plural "@count new comments"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 ny kommentar"
+msgstr[1] "@count nya kommentarer"
 
 msgid "Save content type"
-msgstr ""
+msgstr "Spara innehållstyp"
 
 msgid "Show descriptions"
-msgstr ""
+msgstr "Visa beskrivningar"
 
 msgid "Subtitle"
-msgstr ""
+msgstr "Underrubrik"
 
 msgid "Copyright"
-msgstr ""
+msgstr "Copyright"
 
 msgid "Not present"
-msgstr ""
+msgstr "Finns ej"
 
 msgid "Source code"
-msgstr ""
+msgstr "Källkod"
 
 msgid "Contact link"
-msgstr ""
+msgstr "Kontaktlänk"
 
 msgid "Edit container"
-msgstr ""
+msgstr "Redigera forumgrupp"
 
 msgid "Plugin settings"
-msgstr ""
+msgstr "Inställningar för insticksprogram"
 
 msgid "Subscript"
-msgstr ""
+msgstr "Nedsänkt"
 
 msgid "Indent"
-msgstr ""
+msgstr "Indentera"
 
 msgid "Outdent"
-msgstr ""
+msgstr "Minska indrag"
 
 msgid "Unlink"
-msgstr ""
+msgstr "Ta bort länk"
 
 msgid "Thread"
-msgstr ""
+msgstr "Tråd"
 
 msgid "Reply"
-msgstr ""
+msgstr "Besvara"
 
 msgid "Hot topic threshold"
-msgstr ""
+msgstr "Tröskelvärde för hett ämne"
 
 msgid "Publish"
-msgstr ""
+msgstr "Publicera"
 
 msgid "Apply"
-msgstr ""
+msgstr "Verkställ"
 
 msgid "Block description"
-msgstr ""
+msgstr "Blockbeskrivning"
 
 msgid "Used in"
-msgstr ""
+msgstr "Används i"
 
 msgid "Language code"
-msgstr ""
+msgstr "Språkkod"
 
 msgid "Translation"
-msgstr ""
+msgstr "Översättning"
 
 msgid "Permission"
-msgstr ""
+msgstr "Behörighet"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Avpublicera"
 
 msgid "Copy"
-msgstr ""
+msgstr "Kopiera"
 
 msgid "Global"
-msgstr ""
+msgstr "Globalt"
 
 msgid "Menu name"
-msgstr ""
+msgstr "Menynamn"
 
 msgid "Add another item"
-msgstr ""
+msgstr "Lägg till ytterligare alternativ"
 
 msgid "Go to last page"
-msgstr ""
+msgstr "Gå till sista sidan"
 
 msgid "1 second"
 msgid_plural "@count seconds"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 second"
+msgstr[1] "@count seconds"
 
 msgid ""
 "Configure what block content appears in your site's sidebars and other "
 "regions."
 msgstr ""
+"Ställ in vilka block som visas i webbplatsens sidospalter och andra "
+"regioner."
 
 msgid "Edit profile"
-msgstr ""
+msgstr "Redigera profil"
 
 msgid "Hide"
-msgstr ""
+msgstr "Dölj"
 
 msgid "Text Editor"
-msgstr ""
+msgstr "Textredigerare"
 
 msgid "Allows administrators to customize the site navigation menu."
-msgstr ""
+msgstr "Tillåter administratörer att anpassa webbplatsens navigationsmeny."
 
 msgid ""
 "Defines selection, check box and radio button widgets for text and numeric "
 "fields."
 msgstr ""
+"Anger widgets för listvals-, kryssrute- och envalsknappar för text och "
+"numeriska fält."
 
 msgid "Defines simple text field types."
-msgstr ""
+msgstr "Definierar enkla typer av textfält."
 
 msgid "Please wait..."
-msgstr ""
+msgstr "Vänligen vänta..."
 
 msgid "Topics per page"
-msgstr ""
+msgstr "Ämnen per sida"
 
 msgid "Posts - most active first"
-msgstr ""
+msgstr "Inlägg - mest aktiva först"
 
 msgid "Posts - least active first"
-msgstr ""
+msgstr "Inlägg - minst aktiva först"
 
 msgid "URL path settings"
-msgstr ""
+msgstr "Inställningar för URL-alias"
 
 msgid "Title text"
-msgstr ""
+msgstr "Text för titel"
 
 msgid "Mapping"
-msgstr ""
+msgstr "Mappning"
 
 msgid "Are you sure you want to revert to the revision from %revision-date?"
 msgstr ""
+"Är du säker på att du vill återställa till versionen från %revision-date?"
 
 msgid "Are you sure you want to delete the revision from %revision-date?"
-msgstr ""
+msgstr "Är du säker på att du vill radera versionen från %revision-date?"
 
 msgid "Distinct"
-msgstr ""
+msgstr "Distinkt"
 
 msgid "Maximum upload size"
-msgstr ""
+msgstr "Största uppladdningsstorlek"
 
 msgid "Space"
-msgstr ""
+msgstr "Blanksteg"
 
 msgid "New forum topics"
-msgstr ""
+msgstr "Nya diskussionsämnen"
 
 msgid "@type: deleted %title revision %revision."
-msgstr ""
+msgstr "@type: raderade version %revision av %title."
 
 msgid "Page not found"
-msgstr ""
+msgstr "Sidan hittades inte"
 
 msgid "More help"
-msgstr ""
+msgstr "Mer hjälp"
 
 msgid "Bullet list"
-msgstr ""
+msgstr "Punktlista"
 
 msgid "Account blocked"
-msgstr ""
+msgstr "Konto spärrat"
 
 msgid "Expand"
-msgstr ""
+msgstr "Fäll ut"
 
 msgid "Change layout"
-msgstr ""
+msgstr "Ändra layout"
 
 msgid "Provided by"
-msgstr ""
+msgstr "Tillhandahålls av"
 
 msgid "Aggregate"
-msgstr ""
+msgstr "Gruppera"
 
 msgid "Node access"
-msgstr ""
+msgstr "Nodåtkomst"
 
 msgid "Sizes"
-msgstr ""
+msgstr "Storlekar"
 
 msgid "Add terms"
-msgstr ""
+msgstr "Lägg till termer"
 
 msgid "Resize"
-msgstr ""
+msgstr "Ändra storlek"
 
 msgid "Zip"
-msgstr ""
+msgstr "Postnummer"
 
 msgid "The directory %directory does not exist."
-msgstr ""
+msgstr "Katalogen %directory finns inte."
 
 msgid "Blockquote"
-msgstr ""
+msgstr "Blockcitat"
 
 msgid "Activate"
-msgstr ""
+msgstr "Aktivera"
 
 msgid "empty"
-msgstr ""
+msgstr "tom"
 
 msgid "Rebuild permissions"
-msgstr ""
+msgstr "Bygg om behörigheter"
 
 msgid "@type: updated %title."
-msgstr ""
+msgstr "@type: uppdaterade %title."
 
 msgid "@type: added %title."
-msgstr ""
+msgstr "@type: lade till %title."
 
 msgid "Telephone"
-msgstr ""
+msgstr "Telefon"
 
 msgid "Add role"
-msgstr ""
+msgstr "Lägg till roll"
 
 msgid "Path to custom logo"
-msgstr ""
+msgstr "Sökväg för egen logotyp"
 
 msgid "Supported formats"
-msgstr ""
+msgstr "Stödda format"
 
 msgid "Updated term %term."
-msgstr ""
+msgstr "Uppdaterade termen %term."
 
 msgid "- None selected -"
-msgstr ""
+msgstr "- Ingen vald -"
 
 msgid "Parser"
-msgstr ""
+msgstr "Tolkare"
 
 msgid "Discard items older than"
-msgstr ""
+msgstr "Ta bort poster äldre än"
 
 msgid "Aggregator"
-msgstr ""
+msgstr "Nyhetssamlare"
 
 msgid "There is no new syndicated content from %site."
-msgstr ""
+msgstr "Det finns inget nytt utdelat innehåll från %site."
 
 msgid "There is new syndicated content from %site."
-msgstr ""
+msgstr "Det finns nytt utdelat innehåll från %site."
 
 msgid "URL to the feed."
-msgstr ""
+msgstr "URL till innehållsflödet."
 
 msgid "Last time feed was checked for new items, as Unix timestamp."
 msgstr ""
+"Senaste gången flöde kontrollerades efter nya poster. Som UNIX-tidsstämpel."
 
 msgid "An image representing the feed."
-msgstr ""
+msgstr "En bild som representerar flödet."
 
 msgid "Entity tag HTTP response header, used for validating cache."
 msgstr ""
+"HTTP-svar på sidhuvud för objektsetikett. Används för att bekräfta cache."
 
 msgid "When the feed was last modified, as a Unix timestamp."
-msgstr ""
+msgstr "När flödet senast ändrades. Som en UNIX-tidsstämpel."
 
 msgid "Primary Key: Unique ID for feed item."
-msgstr ""
+msgstr "Primär nyckel: Unikt ID-nummer för objekt i innehållsflöde."
 
 msgid "Title of the feed item."
-msgstr ""
+msgstr "Titeln på innehållsflödets objekt."
 
 msgid "Link to the feed item."
-msgstr ""
+msgstr "Länka till objektet i innehållsflödet."
 
 msgid "Author of the feed item."
-msgstr ""
+msgstr "Författare till objektet i innehållsflödet."
 
 msgid "Body of the feed item."
-msgstr ""
+msgstr "Brödtexten till objektet i innehållsflödet."
 
 msgid "Post date of feed item, as a Unix timestamp."
-msgstr ""
+msgstr "Inlagd datum för objekt i innehållsflöde, som en UNIX-tidsstämpel."
 
 msgid "Unique identifier for the feed item."
-msgstr ""
+msgstr "Unik identifierare för posten på flödet."
 
 msgid "Alias"
-msgstr ""
+msgstr "Alias"
 
 msgid "Values"
-msgstr ""
+msgstr "Värden"
 
 msgid "Enter your keywords"
-msgstr ""
+msgstr "Ange dina nyckelord"
 
 msgid "Clean URLs"
-msgstr ""
+msgstr "Rena URL:er"
 
 msgid "Number of topics"
-msgstr ""
+msgstr "Antal ämnen"
 
 msgid "Active forum topics"
-msgstr ""
+msgstr "Aktiva diskussionsämnen"
 
 msgid "Read the latest forum topics."
-msgstr ""
+msgstr "Läs de senaste diskussionsämnena."
 
 msgid "HTTP authentication"
-msgstr ""
+msgstr "HTTP autentisiering"
 
 msgid "Attach to"
-msgstr ""
+msgstr "Bifoga till"
 
 msgid "Context"
-msgstr ""
+msgstr "Sammanhang"
 
 msgid "Book navigation"
-msgstr ""
+msgstr "Boknavigering"
 
 msgid "Pager"
-msgstr ""
+msgstr "Paginerare"
 
 msgid "Identifier"
-msgstr ""
+msgstr "Identifierare"
 
 msgid "Remove this item"
-msgstr ""
+msgstr "Ta bort detta alternativ"
 
 msgid "Keyword"
-msgstr ""
+msgstr "Nyckelord"
 
 msgid "1 year"
 msgid_plural "@count years"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 år"
+msgstr[1] "@count år"
 
 msgid "1 week"
 msgid_plural "@count weeks"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 vecka"
+msgstr[1] "@count veckor"
 
 msgid "1 sec"
 msgid_plural "@count sec"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 sekund"
+msgstr[1] "@count sekunder"
 
 msgid "Columns"
-msgstr ""
+msgstr "Kolumner"
 
 msgid "Module name"
-msgstr ""
+msgstr "Modulnamn"
 
 msgid "Layout settings"
-msgstr ""
+msgstr "Inställningar för layout"
 
 msgid "Page settings"
-msgstr ""
+msgstr "Inställningar för sida"
 
 msgid "Use pager"
-msgstr ""
+msgstr "Använd paginering"
 
 msgid "Items to display"
-msgstr ""
+msgstr "Inlägg att visa"
 
 msgid "More link"
-msgstr ""
+msgstr "Länk \"mer\""
 
 msgid "More link text"
-msgstr ""
+msgstr "Text för länk \"mer\""
 
 msgid "Top level book"
-msgstr ""
+msgstr "Bok på översta nivån"
 
 msgid "No temporary directories to remove."
-msgstr ""
+msgstr "Inga tillfälliga kataloger att ta bort."
 
 msgid "German"
-msgstr ""
+msgstr "Tyska"
 
 msgid "Link to file"
-msgstr ""
+msgstr "Länk till fil"
 
 msgid "contains"
-msgstr ""
+msgstr "innehåller"
 
 msgid "Send message"
-msgstr ""
+msgstr "Skicka meddelande"
 
 msgid "Allow Upscaling"
-msgstr ""
+msgstr "Tillåt uppskalning"
 
 msgid "Rotation angle"
-msgstr ""
+msgstr "Rotationsvinkel"
 
 msgid ""
 "The number of degrees the image should be rotated. Positive numbers are "
 "clockwise, negative are counter-clockwise."
 msgstr ""
+"Det antal grader som bilden skall roteras. Positiva tal är medsols, negativa"
+" tal är motsols."
 
 msgid ""
 "Randomize the rotation angle for each image. The angle specified above is "
 "used as a maximum."
 msgstr ""
+"Slumpa rotationsvinkeln för varje bild. Vinkeln angiven ovan används som "
+"högsta gräns."
 
 msgid "Flush"
-msgstr ""
+msgstr "Töm"
 
 msgid "Print"
-msgstr ""
+msgstr "Utskrift"
 
 msgid "Field mapping"
-msgstr ""
+msgstr "Field mapping"
 
 msgid "The file could not be created."
-msgstr ""
+msgstr "Filen kunde inte skapas."
 
 msgid "Locked"
-msgstr ""
+msgstr "Låst"
 
 msgid "Password reset instructions mailed to %name at %email."
 msgstr ""
+"Instruktioner för att återställa lösenord skickat till %name (%email)."
 
 msgid "types"
-msgstr ""
+msgstr "typer"
 
 msgid "Data"
-msgstr ""
+msgstr "Data"
 
 msgid "Selection type"
-msgstr ""
+msgstr "Typ av urval"
 
 msgid "Any"
-msgstr ""
+msgstr "Alla"
 
 msgid "Check for updates"
-msgstr ""
+msgstr "Sök efter uppdateringar"
 
 msgid "All newer versions"
-msgstr ""
+msgstr "Alla nyare versioner"
 
 msgid "Only security updates"
-msgstr ""
+msgstr "Endast säkerhetsuppdateringar"
 
 msgid "No update data available"
-msgstr ""
+msgstr "Ingen information om uppdatering tillgänglig"
 
 msgid "Not secure!"
-msgstr ""
+msgstr "Ej säker!"
 
 msgid "Revoked!"
-msgstr ""
+msgstr "Återkallad!"
 
 msgid "Unsupported release"
-msgstr ""
+msgstr "Utgåva utan stöd"
 
 msgid "Can not determine status"
-msgstr ""
+msgstr "Kan inte fastställa status"
 
 msgid "(version @version available)"
-msgstr ""
+msgstr "(version @version tillgänglig)"
 
 msgid "See the available updates page for more information:"
-msgstr ""
+msgstr "Se sidan med tillgängliga uppdateringar för mer information."
 
 msgid ""
 "There is a security update available for your version of Drupal. To ensure "
 "the security of your server, you should update immediately!"
 msgstr ""
+"Det finns en säkerhetsuppdatering tillgänglig för din version av Drupal. För"
+" att försäkra dig om din servers säkerhet bör du omedelbart uppdatera!"
 
 msgid "Display the depth of the comment if it is threaded."
-msgstr ""
+msgstr "Visa djupet på kommentaren om den är trådad."
 
 msgid "Taxonomy vocabulary"
-msgstr ""
+msgstr "Vokabulär för taxonomi"
 
 msgid "No comments available."
-msgstr ""
+msgstr "Inga kommentarer tillgängliga."
 
 msgid "last »"
-msgstr ""
+msgstr "sista »"
 
 msgid "Extension"
-msgstr ""
+msgstr "Filändelse"
 
 msgid "Account settings"
-msgstr ""
+msgstr "Kontoinställningar"
 
 msgid "« first"
-msgstr ""
+msgstr "« första"
 
 msgid "Machine name"
-msgstr ""
+msgstr "Maskinläsbart namn"
 
 msgid "Offset"
-msgstr ""
+msgstr "Kompensera"
 
 msgid "My account"
-msgstr ""
+msgstr "Mitt konto"
 
 msgid "GD library"
-msgstr ""
+msgstr "GD-biblioteket"
 
 msgid "1 min"
 msgid_plural "@count min"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 min"
+msgstr[1] "@count minuter"
 
 msgid "Defines a file field type."
-msgstr ""
+msgstr "Definierar en filfältstyp."
 
 msgid ""
 "Your version of Drupal has been revoked and is no longer available for "
 "download. Upgrading is strongly recommended!"
 msgstr ""
+"Din version av Drupal har återkallats och finns inte längre tillgänglig för "
+"nedladdning. Uppgradering rekommenderas starkt!"
 
 msgid ""
 "The installed version of at least one of your modules or themes has been "
 "revoked and is no longer available for download. Upgrading or disabling is "
 "strongly recommended!"
 msgstr ""
+"Den installerade versionen av åtminstone en av dina moduler eller teman har "
+"återkallats och finns inte längre tillgänglig för nedladdning. Uppgradering "
+"eller inaktivering rekommenderas starkt!"
 
 msgid ""
 "Your version of Drupal is no longer supported. Upgrading is strongly "
 "recommended!"
 msgstr ""
+"Din version av Drupal stöds inte längre. Uppgradering rekommenderas starkt!"
 
 msgid ""
 "There are updates available for your version of Drupal. To ensure the proper"
 " functioning of your site, you should update as soon as possible."
 msgstr ""
+"Det finns uppdateringar för din version av Drupal. För att försäkra dig om "
+"att din webbplats fungerar ordentligt bör du uppdatera så snart som möjligt."
 
 msgid "Project not secure"
-msgstr ""
+msgstr "Projektet inte säkert"
 
 msgid ""
 "This project has been labeled insecure by the Drupal security team, and is "
 "no longer available for download. Immediately disabling everything included "
 "by this project is strongly recommended!"
 msgstr ""
+"Detta projekt har betecknats som osäkert av Drupals säkerhetsgrupp och finns"
+" inte längre tillgängligt för nedladdning. Det rekommenderas starkt att du "
+"omedelbart inaktiverar allt som har med detta projekt att göra!"
 
 msgid "Project revoked"
-msgstr ""
+msgstr "Projektet återkallat"
 
 msgid ""
 "This project has been revoked, and is no longer available for download. "
 "Disabling everything included by this project is strongly recommended!"
 msgstr ""
+"Detta projekt har återkallats och finns inte längre tillgängligt för "
+"nedladdning. Det rekommenderas starkt att du inaktiverar allt som har med "
+"detta projekt att göra!"
 
 msgid "Project not supported"
-msgstr ""
+msgstr "Projektet saknar stöd"
 
 msgid ""
 "This project is no longer supported, and is no longer available for "
 "download. Disabling everything included by this project is strongly "
 "recommended!"
 msgstr ""
+"Detta projekt stöds inte längre och finns inte längre tillgängligt för "
+"nedladdning. Det rekommenderas starkt att du inaktiverar allt som har med "
+"detta projekt att göra!"
 
 msgid "No available releases found"
-msgstr ""
+msgstr "Ingen tillgänglig utgåva hittades"
 
 msgid "Release revoked"
-msgstr ""
+msgstr "Utgåvan återkallad"
 
 msgid ""
 "Your currently installed release has been revoked, and is no longer "
 "available for download. Disabling everything included in this release or "
 "upgrading is strongly recommended!"
 msgstr ""
+"Din nuvarande installerade utgåva har återkallats, och finns inte längre "
+"tillgänglig för nedladdning. Det rekommenderas starkt att du inaktiverar "
+"allt som har med denna utgåva att göra eller också uppgraderar!"
 
 msgid "Release not supported"
-msgstr ""
+msgstr "Utgåvan saknar stöd"
 
 msgid ""
 "Your currently installed release is now unsupported, and is no longer "
 "available for download. Disabling everything included in this release or "
 "upgrading is strongly recommended!"
 msgstr ""
+"Din nuvarande installerade utgåva stöds inte längre, och finns inte längre "
+"tillgänglig för nedladdning. Det rekommenderas starkt att du inaktiverar "
+"allt som har med denna utgåva att göra eller också uppgraderar!"
 
 msgid "Invalid info"
-msgstr ""
+msgstr "Ogiltig information"
 
 msgid "Security update required!"
-msgstr ""
+msgstr "Säkerhetsuppdatering krävs!"
 
 msgid "Not supported!"
-msgstr ""
+msgstr "Saknar stöd!"
 
 msgid "Recommended version:"
-msgstr ""
+msgstr "Rekommenderad version:"
 
 msgid "Security update:"
-msgstr ""
+msgstr "Säkerhetsuppdatering:"
 
 msgid "Latest version:"
-msgstr ""
+msgstr "Senaste version:"
 
 msgid "Development version:"
-msgstr ""
+msgstr "Utvecklingsversion:"
 
 msgid "Also available:"
-msgstr ""
+msgstr "Också tillgänglig:"
 
 msgid "No name"
-msgstr ""
+msgstr "Inget namn"
 
 msgid "File MIME"
-msgstr ""
+msgstr "MIME för fil"
 
 msgid "User Role"
-msgstr ""
+msgstr "Roll för användare"
 
 msgid "Search help"
-msgstr ""
+msgstr "Sökhjälp"
 
 msgid "Field settings"
-msgstr ""
+msgstr "Inställningar för fält"
 
 msgid "Edit forum"
-msgstr ""
+msgstr "Redigera forum"
 
 msgid "Default order"
-msgstr ""
+msgstr "Förvald ordning"
 
 msgid ""
 "This is the designated forum vocabulary. Some of the normal vocabulary "
 "options have been removed."
 msgstr ""
+"Detta är den speciella vokabulären för forum. Några av de vanliga "
+"alternativen för vokabulärer har tagits bort."
 
 msgid "Leave shadow copy"
-msgstr ""
+msgstr "Lämna kvar skuggkopia"
 
 msgid ""
 "If you move this topic, you can leave a link in the old forum to the new "
 "forum."
 msgstr ""
+"Om du flyttar detta ämne kan du lämna en länk i det gamla forumet till det "
+"nya."
 
 msgid "Container name"
-msgstr ""
+msgstr "Namn på forumgrupp"
 
 msgid "forum container"
-msgstr ""
+msgstr "forumgrupp"
 
 msgid "Created new @type %term."
-msgstr ""
+msgstr "Skapade ny(tt) @type: %term."
 
 msgid "The @type %term has been updated."
-msgstr ""
+msgstr "@type %term har uppdaterats."
 
 msgid "AJAX"
-msgstr ""
+msgstr "AJAX"
 
 msgid "Emails"
-msgstr ""
+msgstr "E-post"
 
 msgid "Favicon"
-msgstr ""
+msgstr "Bokmärkesikon"
 
 msgid "Containing any of the words"
-msgstr ""
+msgstr "Innehåller något av orden"
 
 msgid "Containing the phrase"
-msgstr ""
+msgstr "Innehåller frasen"
 
 msgid "Containing none of the words"
-msgstr ""
+msgstr "Innehåller inget av orden"
 
 msgid "Only of the type(s)"
-msgstr ""
+msgstr "Endast av typen/typerna"
 
 msgid "Content ranking"
-msgstr ""
+msgstr "Rangordning av innehåll"
 
 msgid "Keyword relevance"
-msgstr ""
+msgstr "Sökordsrelevans"
 
 msgid "Number of views"
-msgstr ""
+msgstr "Antal visningar"
 
 msgid "Factor"
-msgstr ""
+msgstr "Faktor"
 
 msgid "Content search"
-msgstr ""
+msgstr "Sökning på innehåll"
 
 msgid "Expand layout to include descriptions."
-msgstr ""
+msgstr "Utöka utformningen så den innehåller beskrivningar."
 
 msgid "Or"
-msgstr ""
+msgstr "Eller"
 
 msgid "Color set"
-msgstr ""
+msgstr "Färguppsättning"
 
 msgid "Underline"
-msgstr ""
+msgstr "Understruken"
 
 msgid "Cut"
-msgstr ""
+msgstr "Klipp ut"
 
 msgid "Paste"
-msgstr ""
+msgstr "Klistra in"
 
 msgid "Ordered list"
-msgstr ""
+msgstr "Ordnad lista"
 
 msgid "Unordered list"
-msgstr ""
+msgstr "Punktlista"
 
 msgid "Case sensitive"
-msgstr ""
+msgstr "Skiftlägeskänslig"
 
 msgid "Maximum link text length"
-msgstr ""
+msgstr "Största längd för länktext"
 
 msgid ""
 "URLs longer than this number of characters will be truncated to prevent long"
 " strings that break formatting. The link itself will be retained; just the "
 "text portion of the link will be truncated."
 msgstr ""
+"URL:er som är längre än detta antal tecken kommer att kortas av för att "
+"förhindra att långa strängar stör formateringen. Själva länken påverkas "
+"inte, det är bara texten som kortas av."
 
 msgid "Setting"
-msgstr ""
+msgstr "Inställning"
 
 msgid ""
 "If you don't have direct file access to the server, use this field to upload"
 " your logo."
 msgstr ""
+"Använd detta fält för att ladda upp din logotyp om du inte har direkt "
+"tillgång till filerna på servern."
 
 msgid "Link class"
-msgstr ""
+msgstr "Klass för länk"
 
 msgid "Install profile"
-msgstr ""
+msgstr "Installationsprofil"
 
 msgid "%percentage of the site has been indexed."
-msgstr ""
+msgstr "%percentage av webbplatsen har indexerats."
 
 msgid "File directory"
-msgstr ""
+msgstr "Filkatalog"
 
 msgid "Default theme"
-msgstr ""
+msgstr "Standardtema"
 
 msgid "Teaser length"
-msgstr ""
+msgstr "Längd på ingress"
 
 msgid "not set"
-msgstr ""
+msgstr "ej satt"
 
 msgid "Memory limit"
-msgstr ""
+msgstr "Minnesgräns"
 
 msgid "regex"
-msgstr ""
+msgstr "reguljärt uttryck"
 
 msgid "Indexes"
-msgstr ""
+msgstr "Index"
 
 msgid "Cardinality"
-msgstr ""
+msgstr "Huvudsaklig"
 
 msgid "There is 1 item left to index."
 msgid_plural "There are @count items left to index."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Det finns 1 post kvar att indexera."
+msgstr[1] "Det finns @count poster kvar att indexera."
 
 msgid "The content access permissions have been rebuilt."
-msgstr ""
+msgstr "Behörigheterna för innehåll har byggts om."
 
 msgid "Column"
-msgstr ""
+msgstr "Kolumn"
 
 msgid "Default sort"
-msgstr ""
+msgstr "Förvald sortering"
 
 msgid "sort by @s"
-msgstr ""
+msgstr "Sortera efter @s"
 
 msgid "and"
-msgstr ""
+msgstr "och"
 
 msgid "Manage actions"
-msgstr ""
+msgstr "Hantera åtgärder"
 
 msgid "Action type"
-msgstr ""
+msgstr "Typ av åtgärd"
 
 msgid "Display a message to the user"
-msgstr ""
+msgstr "Visa ett meddelande för användaren"
 
 msgid "Unpublish comment containing keyword(s)"
-msgstr ""
+msgstr "Avpublicera kommentarer som innehåller nyckelord(en)"
 
 msgid "Page path"
-msgstr ""
+msgstr "Sökväg till sida"
 
 msgid "Banner image"
-msgstr ""
+msgstr "Banner image"
 
 msgid "- Select -"
-msgstr ""
+msgstr "- Välj -"
 
 msgid "Content language"
-msgstr ""
+msgstr "Språk för innehåll"
 
 msgid "Path prefix"
-msgstr ""
+msgstr "Sökvägsprefix"
 
 msgid "Auto-reply"
-msgstr ""
+msgstr "Automatiskt svar"
 
 msgid ""
 "Optional auto-reply. Leave empty if you do not want to send the user an "
 "auto-reply message."
 msgstr ""
+"Valfritt automatiskt svar. Lämna detta tomt om du inte vill skicka ett "
+"automatiskt svarsmeddelande."
 
 msgid "Add @type"
-msgstr ""
+msgstr "Lägg till @type"
 
 msgid "Synchronize"
-msgstr ""
+msgstr "Synkronisera"
 
 msgid "Set as default"
-msgstr ""
+msgstr "Ställ in som förvalt"
 
 msgid "Not promoted"
-msgstr ""
+msgstr "Visas inte på startsidan"
 
 msgid "Not sticky"
-msgstr ""
+msgstr "Ej klistrad"
 
 msgid "Errors"
-msgstr ""
+msgstr "Fel"
 
 msgid "Nid"
-msgstr ""
+msgstr "Nid"
 
 msgid "Parent comment"
-msgstr ""
+msgstr "Ovanliggande kommentar"
 
 msgid "Author's website"
-msgstr ""
+msgstr "Författarens hemsida"
 
 msgid "Content ID"
-msgstr ""
+msgstr "ID-nummer för innehåll"
 
 msgid "Publish content"
-msgstr ""
+msgstr "Publicera innehåll"
 
 msgid "Node count"
-msgstr ""
+msgstr "Antal noder"
 
 msgid "Skip to main content"
-msgstr ""
+msgstr "Hoppa till huvudinnehåll"
 
 msgid "Reports"
-msgstr ""
+msgstr "Rapporter"
 
 msgid "Web server"
-msgstr ""
+msgstr "Webbserver"
 
 msgid "Compress layout by hiding descriptions."
-msgstr ""
+msgstr "Komprimera utformning genom att dölja beskrivningar."
 
 msgid "Hide descriptions"
-msgstr ""
+msgstr "Dölj beskrivningar"
 
 msgid "Enables the categorization of content."
-msgstr ""
+msgstr "Möjliggör kategorisering av innehåll."
 
 msgid ""
 "Sort by the threaded order. This will keep child comments together with "
 "their parents."
 msgstr ""
+"Sortera efter den trådade ordningen. På så sätt hålls underliggande "
+"kommentarer ihop med sina ovanliggande."
 
 msgid "Provide a simple link to reply to the comment."
-msgstr ""
+msgstr "Tillhandahåll en enkel länk för att besvara kommentaren."
 
 msgid "Text to display"
-msgstr ""
+msgstr "Text att visa"
 
 msgid "UI settings"
-msgstr ""
+msgstr "Inställningar för användargränssnitt"
 
 msgid "Newest first"
-msgstr ""
+msgstr "Nyaste först"
 
 msgid "field"
-msgstr ""
+msgstr "fält"
 
 msgid "Update settings"
-msgstr ""
+msgstr "Uppdatera inställningar"
 
 msgid "nodes"
-msgstr ""
+msgstr "noder"
 
 msgid "Formatter"
-msgstr ""
+msgstr "Formaterare"
 
 msgid "Some required modules must be enabled"
-msgstr ""
+msgstr "Andra moduler måste vara aktiverade"
 
 msgid "New posts"
-msgstr ""
+msgstr "Nya inlägg"
 
 msgid "View settings"
-msgstr ""
+msgstr "Inställningar för vy"
 
 msgid "Week @week"
-msgstr ""
+msgstr "Vecka @week"
 
 msgid "mm/dd/yy"
-msgstr ""
+msgstr "yy-mm-dd"
 
 msgid "Delete view"
-msgstr ""
+msgstr "Ta bort vy"
 
 msgid "Accessibility features"
-msgstr ""
+msgstr "Funktioner för tillgänglighet"
 
 msgid "Translation file"
-msgstr ""
+msgstr "Översättningsfil"
 
 msgid "File to import not found."
-msgstr ""
+msgstr "Fil att importera hittades inte."
 
 msgid "Cache options"
-msgstr ""
+msgstr "Alternativ för cache"
 
 msgid "Target"
-msgstr ""
+msgstr "Mål"
 
 msgid "Time ago"
-msgstr ""
+msgstr "Tid sedan"
 
 msgid "Create @name"
-msgstr ""
+msgstr "Skapa @name"
 
 msgid "Crop"
-msgstr ""
+msgstr "Beskär"
 
 msgid "Not enabled"
-msgstr ""
+msgstr "Ej aktiverat"
 
 msgid "Insert Image"
-msgstr ""
+msgstr "Infoga bild"
 
 msgid ""
 "Instructions to present to the user below this field on the editing form.<br"
 " />Allowed HTML tags: @tags"
 msgstr ""
+"Instruktioner att visa för användaren nedanför detta fält i "
+"redigeringsformuläret.<br />Tillåtna HTML-taggar: @tags"
 
 msgid "Sort direction"
-msgstr ""
+msgstr "Riktning för sortering"
 
 msgid "Element"
-msgstr ""
+msgstr "Element"
 
 msgid "Radios"
-msgstr ""
+msgstr "Envalsknappar"
 
 msgid "Field options"
-msgstr ""
+msgstr "Alternativ för fält"
 
 msgid "Save permissions"
-msgstr ""
+msgstr "Spara behörigheter"
 
 msgid "Effect"
-msgstr ""
+msgstr "Effekt"
 
 msgid "Route"
-msgstr ""
+msgstr "Rutt"
 
 msgid "Sequence"
-msgstr ""
+msgstr "Sekvens"
 
 msgid "starting from @count"
-msgstr ""
+msgstr "med början från @count"
 
 msgid "Embed"
-msgstr ""
+msgstr "Bädda in"
 
 msgid "Menu block"
-msgstr ""
+msgstr "Menyblock"
 
 msgid "Test settings"
-msgstr ""
+msgstr "Testa inställningarna"
 
 msgid "Quick edit"
-msgstr ""
+msgstr "Snabb redigering"
 
 msgid "Change book (update list of parents)"
-msgstr ""
+msgstr "Byt bok (uppdatera lista med ovanliggande)"
 
 msgid "Manage your site's book outlines."
-msgstr ""
+msgstr "Hantera webbplatsens bokdispositioner."
 
 msgid "For security reasons, your upload has been renamed to %filename."
-msgstr ""
+msgstr "Din uppladdade fil har döpts om till %filename av säkerhetsskäl."
 
 msgid "vocabulary"
-msgstr ""
+msgstr "vocabulary"
 
 msgid "Installed version"
-msgstr ""
+msgstr "Installerad version"
 
 msgid "Recommended version"
-msgstr ""
+msgstr "Rekommenderad version"
 
 msgid "User roles"
-msgstr ""
+msgstr "Användarroller"
 
 msgid "Acronym"
-msgstr ""
+msgstr "Akronym"
 
 msgid "More link path"
-msgstr ""
+msgstr "Sökväg för \"mer\"-länk"
 
 msgid "No vocabularies available."
-msgstr ""
+msgstr "Inga vokabulärer tillgängliga."
 
 msgid "original"
-msgstr ""
+msgstr "ursprunglig"
 
 msgid "Starting level"
-msgstr ""
+msgstr "Startnivå"
 
 msgid "Title only"
-msgstr ""
+msgstr "Enbart titel"
 
 msgid "Notification settings"
-msgstr ""
+msgstr "Inställningar för meddelanden"
 
 msgid "Not defined"
-msgstr ""
+msgstr "Ej angiven"
 
 msgid "Validator"
-msgstr ""
+msgstr "Validerare"
 
 msgid "Debugging"
-msgstr ""
+msgstr "Avsöker"
 
 msgid "Inherit"
-msgstr ""
+msgstr "Ärv"
 
 msgid "No preview"
-msgstr ""
+msgstr "Ingen förhandsgranskning"
 
 msgid "Save as"
-msgstr ""
+msgstr "Spara som"
 
 msgid "Preview image"
-msgstr ""
+msgstr "Förhandsgranska bilden"
 
 msgid "pixels"
-msgstr ""
+msgstr "pixlar"
 
 msgid "Use default"
-msgstr ""
+msgstr "Använd standard"
 
 msgid "1 month"
 msgid_plural "@count months"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 månad"
+msgstr[1] "@count månader"
 
 msgid "Parameter"
-msgstr ""
+msgstr "Parameter"
 
 msgid "done"
-msgstr ""
+msgstr "färdig"
 
 msgid "Display format"
-msgstr ""
+msgstr "Visningsformat"
 
 msgid "Current state"
-msgstr ""
+msgstr "Current state"
 
 msgid "The date the node was last updated."
-msgstr ""
+msgstr "Datum då noden senast uppdaterades."
 
 msgid "Direction"
-msgstr ""
+msgstr "Riktning"
 
 msgid "Drupal core"
-msgstr ""
+msgstr "Drupals kärna"
 
 msgid "Book navigation block display"
-msgstr ""
+msgstr "Visning av blocket för boknavigering"
 
 msgid "Relations"
-msgstr ""
+msgstr "Relationer"
 
 msgid "Invalid display id @display"
-msgstr ""
+msgstr "Ogiltig ID för visningen @display"
 
 msgid "Error: handler for @table > @field doesn't exist!"
-msgstr ""
+msgstr "Fel: hanteraren för @table > @field existerar inte!"
 
 msgid "Do not use a relationship"
-msgstr ""
+msgstr "Använd inte en relation"
 
 msgid "Password field is required."
-msgstr ""
+msgstr "Lösenordsfältet är obligatoriskt."
 
 msgid "Display type"
-msgstr ""
+msgstr "Typ av visning"
 
 msgid "Confirm password"
 msgstr "Bekräfta lösenord"
 
 msgid "button"
-msgstr ""
+msgstr "knapp"
 
 msgid "Default display order"
-msgstr ""
+msgstr "Förvald visningsordning"
 
 msgid "Administration theme"
-msgstr ""
+msgstr "Administrationstema"
 
 msgid "The cache has been cleared."
-msgstr ""
+msgstr "Cachen har tömts."
 
 msgid "Isle of Man"
-msgstr ""
+msgstr "Isle of Man"
 
 msgid "Montenegro"
-msgstr ""
+msgstr "Montenegro"
 
 msgid "Saint Pierre and Miquelon"
-msgstr ""
+msgstr "Saint-Pierre och Miquelon"
 
 msgid "Serbia"
-msgstr ""
+msgstr "Serbien"
 
 msgid "Uri"
-msgstr ""
+msgstr "URI"
 
 msgid "Kosovo"
-msgstr ""
+msgstr "Kosovo"
 
 msgid "Diego Garcia"
-msgstr ""
+msgstr "Diego Garcia"
 
 msgid "Tristan da Cunha"
-msgstr ""
+msgstr "Tristan da Cunha"
 
 msgid "Role ID."
-msgstr ""
+msgstr "ID-nummer för roll."
 
 msgid "Run cron"
-msgstr ""
+msgstr "Kör schemalagda aktiviteter"
 
 msgid "Run updates"
-msgstr ""
+msgstr "Kör uppdateringar"
 
 msgid "Combine"
-msgstr ""
+msgstr "Kombinera"
 
 msgid "of"
-msgstr ""
+msgstr "av"
 
 msgid "Title field"
-msgstr ""
+msgstr "Titelfält"
 
 msgid "The file %file could not be saved. An unknown error has occurred."
-msgstr ""
+msgstr "Filen %fil kunde inte sparas. Ett okänt fel inträffade."
 
 msgid "The specified file %name could not be uploaded."
-msgstr ""
+msgstr "Den angivna filen %name kunde inte laddas upp."
 
 msgid "The file's name is empty. Please give a name to the file."
-msgstr ""
+msgstr "Filnamnet är tomt. Var vänlig ange ett namn för filen."
 
 msgid "Only files with the following extensions are allowed: %files-allowed."
-msgstr ""
+msgstr "Endast filer med följande filändelser tillåts: %files-allowed."
 
 msgid "The file is %filesize exceeding the maximum file size of %maxsize."
-msgstr ""
+msgstr "Filen är %filesize och överstiger den maximala filstorleken %maxsize."
 
 msgid "The file is %filesize which would exceed your disk quota of %quota."
-msgstr ""
+msgstr "Filen är %filesize vilket skulle överstiga din diskkvot på %quota."
 
 msgid ""
 "Upload error. Could not move uploaded file %file to destination "
 "%destination."
 msgstr ""
+"Uppladdningsfel. Kunde inte flytta den uppladdade filen %file till "
+"destinationen %destination."
 
 msgid "Add to book outline"
-msgstr ""
+msgstr "Lägg till i bokdispositionen"
 
 msgid "Stark"
-msgstr ""
+msgstr "Stark"
 
 msgid "New set"
-msgstr ""
+msgstr "Ny uppsättning"
 
 msgid "No link"
-msgstr ""
+msgstr "Ingen länk"
 
 msgid "Add Link"
-msgstr ""
+msgstr "Lägg till länk"
 
 msgid "Edit Link"
-msgstr ""
+msgstr "Redigera länk"
 
 msgid "outdated"
-msgstr ""
+msgstr "föråldrad"
 
 msgid "Is not one of"
-msgstr ""
+msgstr "Är inte en av"
 
 msgid "Re-index site"
-msgstr ""
+msgstr "Indexera om webbplatsen"
 
 msgid "Log searches"
-msgstr ""
+msgstr "Logga sökningar"
 
 msgid "Are you sure you want to re-index the site?"
-msgstr ""
+msgstr "Är du säker på att du vill indexera om webbplatsen?"
 
 msgid "cURL"
-msgstr ""
+msgstr "cURL"
 
 msgid "No test results to display."
-msgstr ""
+msgstr "Inga testresultat att visa."
 
 msgid "Save and continue"
-msgstr ""
+msgstr "Spara och gå vidare"
 
 msgid "Dates"
-msgstr ""
+msgstr "Datum"
 
 msgid "Not applicable"
-msgstr ""
+msgstr "Ej tillämpligt"
 
 msgid "User account"
-msgstr ""
+msgstr "Användarkonto"
 
 msgid "Block type"
-msgstr ""
+msgstr "Typ av block"
 
 msgid "Entity type"
-msgstr ""
+msgstr "Objektstyp"
 
 msgid "Translate"
-msgstr ""
+msgstr "Översätt"
 
 msgid "Custom format"
-msgstr ""
+msgstr "Anpassat format"
 
 msgid "Web services"
-msgstr ""
+msgstr "Webbtjänster"
 
 msgid "@module (<span class=\"admin-disabled\">disabled</span>)"
-msgstr ""
+msgstr "@module (<span class=\"admin-disabled\">inaktiverad</span>)"
 
 msgid "Admin menu"
-msgstr ""
+msgstr "Administratörsmeny"
 
 msgid "Tour"
-msgstr ""
+msgstr "Rundtur"
 
 msgid "Save translations"
-msgstr ""
+msgstr "Spara översättningar"
 
 msgid "Warning message"
-msgstr ""
+msgstr "Varningsmeddelande"
 
 msgid "Error message"
-msgstr ""
+msgstr "Felmeddelande"
 
 msgid "Row"
-msgstr ""
+msgstr "Rad"
 
 msgid "Date settings"
-msgstr ""
+msgstr "Inställningar för datum"
 
 msgid "Table name prefix"
-msgstr ""
+msgstr "Prefix för tabellnamn"
 
 msgid "Maximum height"
-msgstr ""
+msgstr "Största höjd"
 
 msgid "Maximum width"
-msgstr ""
+msgstr "Största bredd"
 
 msgid "Autocomplete matching"
-msgstr ""
+msgstr "Automatiskt kompletterande som överensstämmer"
 
 msgid "Starts with"
-msgstr ""
+msgstr "Börjar med"
 
 msgid "Link options"
-msgstr ""
+msgstr "Länkalternativ"
 
 msgid "Timor-Leste"
-msgstr ""
+msgstr "Östtimor"
 
 msgid "Åland Islands"
-msgstr ""
+msgstr "Åland"
 
 msgid "Properties"
-msgstr ""
+msgstr "Egenskaper"
 
 msgid "Cached"
-msgstr ""
+msgstr "Cachad"
 
 msgid "Autocomplete"
-msgstr ""
+msgstr "Automatiskt kompletterande"
 
 msgid "Boolean"
-msgstr ""
+msgstr "Boolesk"
 
 msgid "Maximum image resolution"
-msgstr ""
+msgstr "Största bildupplösning"
 
 msgid ""
 "An illegal choice has been detected. Please contact the site administrator."
 msgstr ""
+"Ett ogiltig val upptäcktes. Var vänlig kontakta webbplatsens administratör."
 
 msgid "Tips"
-msgstr ""
+msgstr "Tips"
 
 msgid "Bundles"
-msgstr ""
+msgstr "Hopsamlingar"
 
 msgid "Not writable"
-msgstr ""
+msgstr "Ej skrivbar"
 
 msgid "Bundle"
-msgstr ""
+msgstr "Hopsamling"
 
 msgid "Decimal point"
-msgstr ""
+msgstr "Decimalkomma"
 
 msgid "Configuration name"
-msgstr ""
+msgstr "Namn på konfiguration"
 
 msgid "Custom date format"
-msgstr ""
+msgstr "Anpassat datumformat"
 
 msgid "Drupal version"
-msgstr ""
+msgstr "Version av Drupal"
 
 msgid "Book outline"
-msgstr ""
+msgstr "Bokdisposition"
 
 msgid "This will be the top-level page in this book."
-msgstr ""
+msgstr "Denna sida kommer att bli huvudsidan på den översta nivån i boken."
 
 msgid "Revision information"
-msgstr ""
+msgstr "Information om versionshantering"
 
 msgid "Notify user of new account"
-msgstr ""
+msgstr "Skicka meddelande om det nya kontot till användaren"
 
 msgid "Created timestamp"
-msgstr ""
+msgstr "Skapade tidsstämpel"
 
 msgid "Is one of"
-msgstr ""
+msgstr "Är en av"
 
 msgid "View comment"
-msgstr ""
+msgstr "Visa kommentar"
 
 msgid "Access will be granted to users with the specified permission string."
 msgstr ""
+"Åtkomst kommer att ges till användare som har den behörighet som anges i "
+"textsträngen."
 
 msgid "Decimal value"
-msgstr ""
+msgstr "Decimalvärde"
 
 msgid "Comma"
-msgstr ""
+msgstr "Komma"
 
 msgid "Show All"
-msgstr ""
+msgstr "Visa allt"
 
 msgid "Uses"
-msgstr ""
+msgstr "Använder"
 
 msgid "Path to custom icon"
-msgstr ""
+msgstr "Sökväg till egen ikon"
 
 msgid "Your email address"
-msgstr ""
+msgstr "Din e-postadress"
 
 msgid "‹"
-msgstr ""
+msgstr "‹"
 
 msgid "›"
-msgstr ""
+msgstr "›"
 
 msgid "Users who have created accounts on your site."
-msgstr ""
+msgstr "Användare som har skapat konton på din webbplats."
 
 msgid "Digest"
-msgstr ""
+msgstr "Sammandrag"
 
 msgid "Default display mode"
-msgstr ""
+msgstr "Förvalt visningsläge"
 
 msgid "Default comments per page"
-msgstr ""
+msgstr "Förvalt antal kommentarer per sida"
 
 msgid "Comment controls"
-msgstr ""
+msgstr "Styrningar för kommentarer"
 
 msgid "Comment subject field"
-msgstr ""
+msgstr "Ämnesfält för kommentarer"
 
 msgid ""
 "Any replies to this comment will be lost. This action cannot be undone."
 msgstr ""
+"Alla svar på denna kommentar kommer att förloras. Denna åtgärd kan inte "
+"ångras."
 
 msgid "Publish the selected comments"
-msgstr ""
+msgstr "Publicera de valda kommentarerna"
 
 msgid "Unpublish the selected comments"
-msgstr ""
+msgstr "Avpublicera de valda kommentarerna"
 
 msgid "(No subject)"
-msgstr ""
+msgstr "(Inget ämne)"
 
 msgid "!="
-msgstr ""
+msgstr "!="
 
 msgid "Is empty (NULL)"
-msgstr ""
+msgstr "Är tom (INNEHÅLLSLÖS)"
 
 msgid "not empty"
-msgstr ""
+msgstr "inte tom"
 
 msgid "Access type"
-msgstr ""
+msgstr "Behörighetsttyp"
 
 msgid "Default image"
-msgstr ""
+msgstr "Standardbild"
 
 msgid "Add feed"
-msgstr ""
+msgstr "Lägg till flöde"
 
 msgid "List links"
-msgstr ""
+msgstr "Visa länkar"
 
 msgid "Text settings"
-msgstr ""
+msgstr "Textinställningar"
 
 msgid "Ends with"
-msgstr ""
+msgstr "Slutar med"
 
 msgid "Toolbar"
-msgstr ""
+msgstr "Verktygsrad"
 
 msgid ""
 "Comment: unauthorized comment submitted or comment submitted to a closed "
 "post %subject."
 msgstr ""
+"Kommentar: obehörig kommentar skickad eller kommentar skickad till stängt "
+"inlägg %subject."
 
 msgid "Link this field to its user"
-msgstr ""
+msgstr "Länka detta fält till dess användare"
 
 msgid "Parent ID"
-msgstr ""
+msgstr "Ovanliggande ID"
 
 msgid "Default style"
-msgstr ""
+msgstr "Standardstil"
 
 msgid "The node ID of the node."
-msgstr ""
+msgstr "Nodens ID."
 
 msgid "Tab weight"
-msgstr ""
+msgstr "Vikt på flik"
 
 msgid "Files directory"
-msgstr ""
+msgstr "Filkatalog"
 
 msgid "Delete all revisions"
-msgstr ""
+msgstr "Radera alla versioner"
 
 msgid "No role"
-msgstr ""
+msgstr "Ingen roll"
 
 msgid "Block title."
-msgstr ""
+msgstr "Titel för block."
 
 msgid "1 view"
 msgid_plural "@count views"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 visning"
+msgstr[1] "@count visningar"
 
 msgid "The file's MIME type."
-msgstr ""
+msgstr "Typ av MIME för filen."
 
 msgid "The size of the file."
-msgstr ""
+msgstr "Filens storlek."
 
 msgid "The MIME type of the file."
-msgstr ""
+msgstr "Typ av MIME för filen."
 
 msgid "@type %title has been created."
-msgstr ""
+msgstr "%title (@type) har skapats."
 
 msgid "@type %title has been updated."
-msgstr ""
+msgstr "%title (@type) har uppdaterats."
 
 msgid "The post could not be saved."
-msgstr ""
+msgstr "Inlägget kunde inte sparas."
 
 msgid "Menu link ID"
-msgstr ""
+msgstr "ID för menylänk"
 
 msgid "1 character"
 msgid_plural "@count characters"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 tecken"
+msgstr[1] "@count tecken"
 
 msgid "Filter settings"
-msgstr ""
+msgstr "Filterinställningar"
 
 msgid "You do not have any administrative items."
-msgstr ""
+msgstr "Du har inga administrativa alternativ."
 
 msgid "No help is available for module %module."
-msgstr ""
+msgstr "Ingen hjälp finns tillgänglig för modulen %module."
 
 msgid "@module administration pages"
-msgstr ""
+msgstr "Administrationssidor för modulen @module"
 
 msgid "Filter the view to the currently logged in user."
-msgstr ""
+msgstr "Filtrera vyn till den nuvarande inloggade användaren."
 
 msgid "Save translation"
-msgstr ""
+msgstr "Spara översättning"
 
 msgid "Add language"
-msgstr ""
+msgstr "Lägg till språk"
 
 msgid "AM"
-msgstr ""
+msgstr "FM"
 
 msgid "PM"
-msgstr ""
+msgstr "EM"
 
 msgid "Comments per page"
-msgstr ""
+msgstr "Kommentarer per sida"
 
 msgid "The file could not be uploaded."
-msgstr ""
+msgstr "Filen kunde inte laddas upp."
 
 msgid "Export configuration"
-msgstr ""
+msgstr "Exportera konfiguration"
 
 msgid "FTP"
-msgstr ""
+msgstr "FTP"
 
 msgid "Collaboration"
-msgstr ""
+msgstr "Samarbete"
 
 msgid "Administration pages"
-msgstr ""
+msgstr "Administrationssidor"
 
 msgid "Capitalize first letter"
-msgstr ""
+msgstr "Omvandla första bokstaven till stor"
 
 msgid "Run tests"
-msgstr ""
+msgstr "Kör tester"
 
 msgid "Clean test environment"
-msgstr ""
+msgstr "Rensa testmiljö"
 
 msgid "Clean environment"
-msgstr ""
+msgstr "Rensa miljö"
 
 msgid "No tests to display."
-msgstr ""
+msgstr "Inga tester att visa."
 
 msgid "Processing test @num of @max - %test."
-msgstr ""
+msgstr "Bearbetar test @num av @max - %test."
 
 msgid "Processed test @num of @max - %test."
-msgstr ""
+msgstr "Bearbetade test @num av @max - %test."
 
 msgid "1 pass"
 msgid_plural "@count passes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 godkännande"
+msgstr[1] "@count godkännanden"
 
 msgid "1 fail"
 msgid_plural "@count fails"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 misslyckande"
+msgstr[1] "@count misslyckanden"
 
 msgid "1 exception"
 msgid_plural "@count exceptions"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 undantag"
+msgstr[1] "@count undantag"
 
 msgid "User %name used one-time login link at time %timestamp."
 msgstr ""
+"Användaren %name använde en engångslänk för inloggning vid %timestamp."
 
 msgid "Registration successful. You are now logged in."
-msgstr ""
+msgstr "Registreringen lyckades. Du är nu inloggad."
 
 msgid "Uid"
-msgstr ""
+msgstr "Uid"
 
 msgid "Custom text"
-msgstr ""
+msgstr "Anpassad text"
 
 msgid "Sum"
-msgstr ""
+msgstr "Summa"
 
 msgid "The comment body."
-msgstr ""
+msgstr "Kommentarens brödtext."
 
 msgid "Default argument"
-msgstr ""
+msgstr "Förvalt argument"
 
 msgid "Form mode"
-msgstr ""
+msgstr "Formulärläge"
 
 msgid "Secondary tabs"
-msgstr ""
+msgstr "Sekundära flikar"
 
 msgid "Delete comment"
-msgstr ""
+msgstr "Radera kommentar"
 
 msgid "Publish comment"
-msgstr ""
+msgstr "Publicera kommentarer"
 
 msgid "Search index"
-msgstr ""
+msgstr "Sökindex"
 
 msgid "Posted in"
-msgstr ""
+msgstr "Inlagt i"
 
 msgid "Permanent"
-msgstr ""
+msgstr "Permanent"
 
 msgid "Upload date"
-msgstr ""
+msgstr "Datum för uppladdning"
 
 msgid "No files available."
-msgstr ""
+msgstr "Inga filer tillgängliga."
 
 msgid "Frontpage"
-msgstr ""
+msgstr "Startsida"
 
 msgid "Current user"
-msgstr ""
+msgstr "Nuvarande användare"
 
 msgid "IP address"
-msgstr ""
+msgstr "IP-adress"
 
 msgid "Enter your @s username."
-msgstr ""
+msgstr "Ange ditt användarnamn på @s."
 
 msgid "File system"
-msgstr ""
+msgstr "Filsystem"
 
 msgid "Status report"
-msgstr ""
+msgstr "Statusrapport"
 
 msgid "PHP extensions"
-msgstr ""
+msgstr "PHP-tillägg"
 
 msgid "RDF mapping"
-msgstr ""
+msgstr "RDF-mappning"
 
 msgid "Migration"
-msgstr ""
+msgstr "Migrering"
 
 msgid "Provides a framework for unit and functional testing."
-msgstr ""
+msgstr "Tillhandahåller ett ramverk för grupp- och funktionstestning."
 
 msgid "sorted by"
-msgstr ""
+msgstr "sorterade efter"
 
 msgid "Feed display options"
-msgstr ""
+msgstr "Alternativ för visning av innehållsflöde"
 
 msgid "Available actions"
-msgstr ""
+msgstr "Tillgängliga åtgärder"
 
 msgid "Remove group"
-msgstr ""
+msgstr "Ta bort grupp"
 
 msgid "The comment ID."
-msgstr ""
+msgstr "Kommentarens ID."
 
 msgid "Add link"
-msgstr ""
+msgstr "Lägg till länk"
 
 msgid "Link settings"
-msgstr ""
+msgstr "Inställningar för länk"
 
 msgid "Numbered list"
-msgstr ""
+msgstr "Numrerad lista"
 
 msgid "View comments"
-msgstr ""
+msgstr "Visa kommentarer"
 
 msgid "Not set"
-msgstr ""
+msgstr "Ej inställd"
 
 msgid "Set password"
-msgstr ""
+msgstr "Ange lösenord"
 
 msgid "%name: this field cannot hold more than @count values."
-msgstr ""
+msgstr "%name: detta fält får inte innehålla fler än @count värden."
 
 msgid "No fields available."
-msgstr ""
+msgstr "Inga fält tillgängliga."
 
 msgid "Content author"
-msgstr ""
+msgstr "Innehållets författare"
 
 msgid "Vertical Tabs"
-msgstr ""
+msgstr "Vertikala flikar"
 
 msgid "Not in book"
-msgstr ""
+msgstr "Ej i bok"
 
 msgid "New book"
-msgstr ""
+msgstr "Ny bok"
 
 msgid "By @name on @date"
-msgstr ""
+msgstr "Av @name @date"
 
 msgid "By @name"
-msgstr ""
+msgstr "Av @name"
 
 msgid "Not in menu"
-msgstr ""
+msgstr "Ej i meny"
 
 msgid "Alias: @alias"
-msgstr ""
+msgstr "Alias: @alias"
 
 msgid "No alias"
-msgstr ""
+msgstr "Inga alias"
 
 msgid "Source language"
-msgstr ""
+msgstr "Källspråk"
 
 msgid "An error has occurred."
-msgstr ""
+msgstr "Ett fel har uppstått."
 
 msgid "Your page will be a part of the selected book."
-msgstr ""
+msgstr "Din sida kommer att vara en del av den valda boken."
 
 msgid "Numeric"
-msgstr ""
+msgstr "Numerisk"
 
 msgid "mobile"
-msgstr ""
+msgstr "mobil"
 
 msgid "Media settings"
-msgstr ""
+msgstr "Inställningar för media"
 
 msgid "Custom URL"
-msgstr ""
+msgstr "Anpassad URL"
 
 msgid "Notify user"
-msgstr ""
+msgstr "Meddela användare"
 
 msgid "0 sec"
-msgstr ""
+msgstr "0 sek"
 
 msgid "Submit button text"
-msgstr ""
+msgstr "Text på skicka-knapp"
 
 msgid "Card"
-msgstr ""
+msgstr "Card"
 
 msgid "Is published"
-msgstr ""
+msgstr "Är publicerad"
 
 msgid "Configure @block"
-msgstr ""
+msgstr "Konfigurera @block"
 
 msgid "Filter log messages"
-msgstr ""
+msgstr "Filtrera logg efter meddelandetyp"
 
 msgid "You must select something to filter by."
-msgstr ""
+msgstr "Du måste välja något att filtrera på."
 
 msgid "New revision"
-msgstr ""
+msgstr "Ny version"
 
 msgid "Callback"
-msgstr ""
+msgstr "Återanrop"
 
 msgid ""
 "To change the current user password, enter the new password in both fields."
 msgstr ""
+"För att byta nuvarande användarlösenord, ange det nya lösenordet i båda "
+"fälten."
 
 msgid ""
 "You have tried to use a one-time login link that has expired. Please request"
 " a new one using the form below."
 msgstr ""
+"Du har försökt använda en engångslänk för inloggning som inte är giltig "
+"längre. Var vänlig begär en ny med formuläret nedan."
 
 msgid "This login can be used only once."
-msgstr ""
+msgstr "Denna inloggning kan bara användas en gång."
 
 msgid "Add comment link"
-msgstr ""
+msgstr "Länk för \"Lägg till kommentar\""
 
 msgid "Strike-through"
-msgstr ""
+msgstr "Genomstruken"
 
 msgid "Align left"
-msgstr ""
+msgstr "Vänsterjustera"
 
 msgid "Align center"
-msgstr ""
+msgstr "Centrera"
 
 msgid "Align right"
-msgstr ""
+msgstr "Högerjustera"
 
 msgid "Justify"
-msgstr ""
+msgstr "Justera"
 
 msgid "Horizontal rule"
-msgstr ""
+msgstr "Horisontell linje"
 
 msgid "Paste Text"
-msgstr ""
+msgstr "Klistra in text"
 
 msgid "Paste from Word"
-msgstr ""
+msgstr "Klistra in från Word"
 
 msgid "Remove format"
-msgstr ""
+msgstr "Ta bort format"
 
 msgid "Character map"
-msgstr ""
+msgstr "Teckenkarta"
 
 msgid "HTML block format"
-msgstr ""
+msgstr "Blockformat för HTML"
 
 msgid "Font style"
-msgstr ""
+msgstr "Fontstil"
 
 msgid "Abbreviation"
-msgstr ""
+msgstr "Förkortning"
 
 msgid "Inserted"
-msgstr ""
+msgstr "Infogat"
 
 msgid "Provide a password for the new account in both fields."
-msgstr ""
+msgstr "Ange ett lösenord för det nya kontot i båda fälten."
 
 msgid "Changes cannot be made to a locked view."
-msgstr ""
+msgstr "Ändringar kan inte göras till en låst vy."
 
 msgid "Broken/missing handler"
-msgstr ""
+msgstr "Trasig/saknad hanterare"
 
 msgid "Current node's creation time"
-msgstr ""
+msgstr "Tid då aktuell nod skapades"
 
 msgid "Current node's update time"
-msgstr ""
+msgstr "Tid då aktuell nod uppdaterades"
 
 msgid "Do not display items with no value in summary"
-msgstr ""
+msgstr "Visa inte alternativ utan innehåll i sammanfattningen"
 
 msgid "Invalid input"
-msgstr ""
+msgstr "Ogiltig inmatning"
 
 msgid "Fail basic validation if any argument is given"
-msgstr ""
+msgstr "Underkänn grundläggande validering om ett argument är givet."
 
 msgid ""
 "By checking this field, you can use this to make sure views with more "
 "arguments than necessary fail validation."
 msgstr ""
+"Genom att kryssa för det här fältet kan du använda det för att försäkra dig "
+"om att valideringen av vyer med fler argument än nödvändigt underkänns."
 
 msgid "Glossary mode"
-msgstr ""
+msgstr "Läge för ordlista"
 
 msgid "Character limit"
-msgstr ""
+msgstr "Teckenbegränsning"
 
 msgid "No transform"
-msgstr ""
+msgstr "Ingen förändring"
 
 msgid "Upper case"
-msgstr ""
+msgstr "Stora bokstäver"
 
 msgid "Lower case"
-msgstr ""
+msgstr "Små bokstäver"
 
 msgid "Capitalize each word"
-msgstr ""
+msgstr "Omvandla varje ord till stora bokstäver"
 
 msgid "Case in path"
-msgstr ""
+msgstr "Skiftläge i sökväg"
 
 msgid "Transform spaces to dashes in URL"
-msgstr ""
+msgstr "Ändra mellanslag till bindestreck i URL:er"
 
 msgid "Exclude from display"
-msgstr ""
+msgstr "Undanta från visning."
 
 msgid "Link path"
-msgstr ""
+msgstr "Sökväg för länk"
 
 msgid ""
 "The Drupal path or absolute URL for this link. You may enter data from this "
 "view as per the \"Replacement patterns\" below."
 msgstr ""
+"Drupals sökväg eller fullständig URL för denna länk. Du kan ange data från "
+"denna vy enligt \"Ersättningsmönster\" nedan."
 
 msgid "The CSS class to apply to the link."
-msgstr ""
+msgstr "CSS-klassen att lägga till på länken."
 
 msgid "Prefix text"
-msgstr ""
+msgstr "Text för prefix"
 
 msgid "Suffix text"
-msgstr ""
+msgstr "Text för suffix"
 
 msgid "Any text to display after this link. You may include HTML."
-msgstr ""
+msgstr "En text att visas efter denna länk. Du kan använda HTML."
 
 msgid "Trim only on a word boundary"
-msgstr ""
+msgstr "Bryt endast texten mellan två ord"
 
 msgid ""
 "If checked, this field be trimmed only on a word boundary. This is "
 "guaranteed to be the maximum characters stated or less. If there are no word"
 " boundaries this could trim a field to nothing."
 msgstr ""
+"If checked, this field be trimmed only on a word boundary. This is "
+"guaranteed to be the maximum characters stated or less. If there are no word"
+" boundaries this could trim a field to nothing."
 
 msgid "Strip HTML tags"
-msgstr ""
+msgstr "Ta bort HTML-taggar"
 
 msgid "Field can contain HTML"
-msgstr ""
+msgstr "Fält får innehålla HTML"
 
 msgid "File size display"
-msgstr ""
+msgstr "Visningsläge för filstorlek"
 
 msgid "Formatted (in KB or MB)"
-msgstr ""
+msgstr "Formaterad (i KB eller MB)"
 
 msgid "Raw bytes"
-msgstr ""
+msgstr "Obearbetade bytes"
 
 msgid "If checked, true will be displayed as false."
-msgstr ""
+msgstr "Om ikryssad, kommer sant att visas som falskt."
 
 msgid "Time ago (with \"ago\" appended)"
-msgstr ""
+msgstr "Tid sedan (med \"sedan\" tillagt)"
 
 msgid "Time span (with \"ago/hence\" appended)"
-msgstr ""
+msgstr "Tidsintervall (med \"sedan/från nu\" tillagt)"
 
 msgid "Round"
-msgstr ""
+msgstr "Avrundning"
 
 msgid "If checked, the number will be rounded."
-msgstr ""
+msgstr "Om ikryssad, kommer talet att avrundas."
 
 msgid "Specify how many digits to print after the decimal point."
-msgstr ""
+msgstr "Ange hur många siffror som skall skrivas ut efter decimalkommat."
 
 msgid "What single character to use as a decimal point."
-msgstr ""
+msgstr "Vilket enskilt tecken att använda som decimalkomma."
 
 msgid "What single character to use as the thousands separator."
-msgstr ""
+msgstr "Vilket enskilt tecken att använda som avskiljare för tusental."
 
 msgid "Text to put before the number, such as currency symbol."
-msgstr ""
+msgstr "Text att sätta framför numret, såsom en valutasymbol."
 
 msgid "Text to put after the number, such as currency symbol."
-msgstr ""
+msgstr "Text att sätta efter numret, såsom en valutasymbol."
 
 msgid "Simple separator"
-msgstr ""
+msgstr "Enkel avskiljare"
 
 msgid "Display as link"
-msgstr ""
+msgstr "Visa som länk"
 
 msgid "Operator identifier"
-msgstr ""
+msgstr "Identifierare för operator"
 
 msgid "This will appear in the URL after the ? to identify this operator."
 msgstr ""
+"Detta kommer att synas i URL:en efter tecknet \"?\" för att identifiera "
+"denna operand."
 
 msgid "Filter identifier"
-msgstr ""
+msgstr "Identifierare för filter"
 
 msgid ""
 "This exposed filter is optional and will have added options to allow it not "
 "to be set."
 msgstr ""
+"Detta exponerade filter är ej obligatoriskt, och kommer ha tillagda "
+"alternativ som tillåter att det inte behöver anges."
 
 msgid "Remember"
-msgstr ""
+msgstr "Kom ihåg"
 
 msgid "Remember the last setting the user gave this filter."
 msgstr ""
+"Kom ihåg den senaste inställningen användaren gjorde för detta filter."
 
 msgid "The identifier is required if the filter is exposed."
-msgstr ""
+msgstr "Identifieraren krävs om filtret är exponerat."
 
 msgid "This identifier is not allowed."
-msgstr ""
+msgstr "Denna identifierare är inte tillåten."
 
 msgid "- Any -"
-msgstr ""
+msgstr "- Alla -"
 
 msgid "exposed"
-msgstr ""
+msgstr "exponerad"
 
 msgid "Value type"
-msgstr ""
+msgstr "Typ av värde"
 
 msgid ""
 "A date in any machine readable format. CCYY-MM-DD HH:MM:SS is preferred."
 msgstr ""
+"Ett datum i ett maskinläsbart format. CCYY-MM-DD HH:MM:SS är att föredra."
 
 msgid "Invalid date format."
-msgstr ""
+msgstr "Ej godkänt datumformat."
 
 msgid "Limit list to selected items"
-msgstr ""
+msgstr "Begränsa listan till valda alternativ"
 
 msgid "Delete the selected comments"
-msgstr ""
+msgstr "Radera de valda kommentarerna"
 
 msgid "Current date"
-msgstr ""
+msgstr "Nuvarande datum"
 
 msgid ""
 "If checked, the only items presented to the user will be the ones selected "
 "here."
 msgstr ""
+"Om valt, kommer endast de valda alternativen att visas för användaren."
 
 msgid "not in"
-msgstr ""
+msgstr "inte i"
 
 msgid "<>"
-msgstr ""
+msgstr "<>"
 
 msgid "Is all of"
-msgstr ""
+msgstr "Är alla av"
 
 msgid "Is none of"
-msgstr ""
+msgstr "Är ingen av"
 
 msgid "not"
-msgstr ""
+msgstr "inte"
 
 msgid "<"
-msgstr ""
+msgstr "<"
 
 msgid "<="
-msgstr ""
+msgstr "<="
 
 msgid ">="
-msgstr ""
+msgstr ">="
 
 msgid ">"
-msgstr ""
+msgstr ">"
 
 msgid "Is between"
-msgstr ""
+msgstr "Är mellan"
 
 msgid "between"
-msgstr ""
+msgstr "mellan"
 
 msgid "Is not between"
-msgstr ""
+msgstr "Är inte mellan"
 
 msgid "not between"
-msgstr ""
+msgstr "inte mellan"
 
 msgid "Min"
-msgstr ""
+msgstr "minsta"
 
 msgid "And max"
-msgstr ""
+msgstr "och maximalt"
 
 msgid "And"
-msgstr ""
+msgstr "och"
 
 msgid "Contains any word"
-msgstr ""
+msgstr "Innehåller vilket ord som helst"
 
 msgid "has word"
-msgstr ""
+msgstr "har ord"
 
 msgid "Contains all words"
-msgstr ""
+msgstr "Innehåller alla ord"
 
 msgid "has all"
-msgstr ""
+msgstr "har alla"
 
 msgid "begins"
-msgstr ""
+msgstr "börjar"
 
 msgid "ends"
-msgstr ""
+msgstr "slutar"
 
 msgid "!has"
-msgstr ""
+msgstr "!has"
 
 msgid "Require this relationship"
-msgstr ""
+msgstr "Kräv denna relation"
 
 msgid "asc"
-msgstr ""
+msgstr "stigande"
 
 msgid "desc"
-msgstr ""
+msgstr "fallande"
 
 msgid ""
 "The granularity is the smallest unit to use when determining whether two "
@@ -5490,78 +5582,81 @@ msgid ""
 "dates in 1999, regardless of when they fall in 1999, will be considered the "
 "same date."
 msgstr ""
+"Noggrannheten är den minsta enheten att använda när man ska avgöra om två "
+"datum är samma. Exempelvis om noggrannheten är \"År\" kommer alla datum för "
+"1999, oavsett när de uppträder under 1999, att anses vara samma datum."
 
 msgid "Broken"
-msgstr ""
+msgstr "Trasig"
 
 msgid "Displays"
-msgstr ""
+msgstr "Visningar"
 
 msgid "These queries were run during view rendering:"
-msgstr ""
+msgstr "Dessa frågor kördes under vyns rendering:"
 
 msgid "This display has no path."
-msgstr ""
+msgstr "Denna visning har ingen sökväg."
 
 msgid "Query build time"
-msgstr ""
+msgstr "Tid för att bygga databasfrågan"
 
 msgid "@time ms"
-msgstr ""
+msgstr "@time ms"
 
 msgid "Query execute time"
-msgstr ""
+msgstr "Tid för att köra databasfrågan"
 
 msgid "View render time"
-msgstr ""
+msgstr "Genereringstid för vyn"
 
 msgid "No query was run"
-msgstr ""
+msgstr "Ingen databasfråga kördes"
 
 msgid "Unable to preview due to validation errors."
-msgstr ""
+msgstr "Kan inte förhandsgranska på grund av valideringsfel."
 
 msgid "View name"
-msgstr ""
+msgstr "Namn på vyn"
 
 msgid "Break lock"
-msgstr ""
+msgstr "Öppna lås"
 
 msgid "The lock has been broken and you may now edit this view."
-msgstr ""
+msgstr "Låsningen har öppnats och du kan nu redigera den här vyn."
 
 msgid "Go to the real page for this display"
-msgstr ""
+msgstr "Gå till den riktiga sidan för denna visning"
 
 msgid "Missing style plugin"
-msgstr ""
+msgstr "Stilplugin saknas"
 
 msgid "Change settings for this style"
-msgstr ""
+msgstr "Ändra inställningar för denna stil"
 
 msgid "View analysis"
-msgstr ""
+msgstr "Analys av vy"
 
 msgid "Rearrange @type"
-msgstr ""
+msgstr "Arrangera om @type"
 
 msgid "Broken field @id"
-msgstr ""
+msgstr "Trasigt fält @id"
 
 msgid "There are no @types available to add."
-msgstr ""
+msgstr "Det finns inga @types tillgängliga att lägga till."
 
 msgid "Configure extra settings for @type %item"
-msgstr ""
+msgstr "Konfigurera extra inställningar för @type %item"
 
 msgid "Clear Views' cache"
-msgstr ""
+msgstr "Töm Views cache"
 
 msgid "Add Views signature to all SQL queries"
-msgstr ""
+msgstr "Lägg till Views signatur till alla SQL-frågor"
 
 msgid "Disable views data caching"
-msgstr ""
+msgstr "Inaktivera views cachning av data"
 
 msgid ""
 "Views caches data about tables, modules and views available, to increase "
@@ -5569,368 +5664,410 @@ msgid ""
 "rebuild this data when needed. This can have a serious performance impact on"
 " your site."
 msgstr ""
+"Views cachar data om tillgängliga tabeller, moduler och vyer, för att öka "
+"prestanda. Genom att kryssa i denna ruta kommer Views hoppa över denna cache"
+" och alltid bygga om sin data vid behov. Detta kan allvarligt påverka din "
+"webbplats prestanda."
 
 msgid "Show other queries run during render during live preview"
 msgstr ""
+"Visa andra databasfrågor som körs under generering i förhandsgranskning"
 
 msgid ""
 "Drupal has the potential to run many queries while a view is being rendered."
 " Checking this box will display every query run during view render as part "
 "of the live preview."
 msgstr ""
+"Drupal har möjligheten att köra många databasfrågor medan en vy renderas. Om"
+" du kryssar i denna ruta kommer varje databasfråga som körs under "
+"genereringen av vyn att visas som en del av förhandsgranskningen."
 
 msgid "View analysis can find nothing to report."
-msgstr ""
+msgstr "Analysen hittade inte något att rapportera."
 
 msgid ""
 "This view has only a default display and therefore will not be placed "
 "anywhere on your site; perhaps you want to add a page or a block display."
 msgstr ""
+"Denna vy har enbart en förvald visning och kommer därför inte att placeras "
+"någonstans på din webbplats. Kanske vill du lägga till en visning av typen "
+"sida eller block."
 
 msgid "Reduce duplicates"
-msgstr ""
+msgstr "Reducera dubletter"
 
 msgid "Default settings for this view."
-msgstr ""
+msgstr "Förvalda inställningar för denna vy."
 
 msgid "Display the view as a page, with a URL and menu links."
-msgstr ""
+msgstr "Visa vyn som en sida, med en URL och menyval."
 
 msgid "Display the view as a block."
-msgstr ""
+msgstr "Visa vyn som ett block."
 
 msgid ""
 "Attachments added to other displays to achieve multiple views in the same "
 "view."
 msgstr ""
+"Bilagor tillagda till andra visningar för att erhålla flera visningar i "
+"samma vy."
 
 msgid "Display the view as a feed, such as an RSS feed."
-msgstr ""
+msgstr "Visa vyn som ett flöde, t.ex. ett RSS-flöde."
 
 msgid "Displays rows one after another."
-msgstr ""
+msgstr "Visar rader efter varandra."
 
 msgid "HTML List"
-msgstr ""
+msgstr "HTML-lista"
 
 msgid "Displays rows in a grid."
-msgstr ""
+msgstr "Visa rader i ett rutnät."
 
 msgid "Displays rows in a table."
-msgstr ""
+msgstr "Visa rader i en tabell."
 
 msgid "Displays the default summary as a list."
-msgstr ""
+msgstr "Visar den förvalda summeringen som en lista."
 
 msgid ""
 "Displays the summary unformatted, with option for one after another or "
 "inline."
 msgstr ""
+"Visar summeringen oformaterad, med alternativ för över varandra eller på "
+"samma rad."
 
 msgid "Generates an RSS feed from a view."
-msgstr ""
+msgstr "Genererar ett RSS-flöde från en vy."
 
 msgid "Displays the fields with an optional template."
-msgstr ""
+msgstr "Visar fältet med en valfri mall."
 
 msgid "Will be available to all users."
-msgstr ""
+msgstr "Kommer att vara tillgänglig för alla användare."
 
 msgid "Access will be granted to users with any of the specified roles."
 msgstr ""
+"Åtkomst kommer att ges till användare med någon av de specificerade "
+"rollerna."
 
 msgid "No caching of Views data."
-msgstr ""
+msgstr "Spara inte data för Views i cache."
 
 msgid "Time-based"
-msgstr ""
+msgstr "Tidsbaserad"
 
 msgid "Simple time-based caching of data."
-msgstr ""
+msgstr "Enkel tidsbaserad cachning av data."
 
 msgid "sort criteria"
-msgstr ""
+msgstr "sorteringskriterier"
 
 msgid "Sort criterion"
-msgstr ""
+msgstr "Sorteringskriterium"
 
 msgid "sort criterion"
-msgstr ""
+msgstr "sorteringskriterium"
 
 msgid "Aggregator items are imported from external RSS and Atom news feeds."
 msgstr ""
+"Objekt för nyhetssamlaren importeras från externa flöden av typen RSS och "
+"Atom."
 
 msgid "The title of the aggregator item."
-msgstr ""
+msgstr "Titeln på nyhetssamlarens objekt."
 
 msgid "The link to the original source URL of the item."
-msgstr ""
+msgstr "Länken till orginalkällan för objektet."
 
 msgid "The author of the original imported item."
-msgstr ""
+msgstr "Författaren till den ursprungliga importerade posten."
 
 msgid "The actual content of the imported item."
-msgstr ""
+msgstr "Det faktiska innehållet på det importerade alternativet."
 
 msgid ""
 "The date the original feed item was posted. (With some feeds, this will be "
 "the date it was imported.)"
 msgstr ""
+"Datumet som det ursprungliga nyhetsposten lades in. (Med några flöden kommer"
+" detta vara datumet som posten importerades.)"
 
 msgid "Feed ID"
-msgstr ""
+msgstr "ID på flödet"
 
 msgid "The unique ID of the aggregator feed."
-msgstr ""
+msgstr "Unikt ID på nyhetssamlarens flöde."
 
 msgid "The title of the aggregator feed."
-msgstr ""
+msgstr "Titeln på nyhetssamlarens flöde."
 
 msgid "The link to the source URL of the feed."
-msgstr ""
+msgstr "Länken till källans URL för flödet."
 
 msgid "The date the feed was last checked for new content."
-msgstr ""
+msgstr "Datumet då flödet senast kontrollerades för nytt innehåll."
 
 msgid "The description of the aggregator feed."
-msgstr ""
+msgstr "Beskrivningen för nyhetssamlarens flöde."
 
 msgid "Display the aggregator item using the data from the original source."
 msgstr ""
+"Visa innehållssamlarens post genom att använda data från den ursprungliga "
+"källan."
 
 msgid "The book the node is in."
-msgstr ""
+msgstr "Boken denna nod tillhör."
 
 msgid "The weight of the book page."
-msgstr ""
+msgstr "Vikten på boksidan."
 
 msgid ""
 "The depth of the book page in the hierarchy; top level books have a depth of"
 " 1."
 msgstr ""
+"Djupet på boksidan i hierarkin. Böcker på den översta nivån har ett djup på "
+"1."
 
 msgid "The parent book node."
-msgstr ""
+msgstr "Ovanliggande nod för boken."
 
 msgid "The title of the comment."
-msgstr ""
+msgstr "Kommentarens titel."
 
 msgid ""
 "The name of the comment's author. Can be rendered as a link to the author's "
 "homepage."
 msgstr ""
+"Namnet på kommentarens författare. Kan genereras som en länk till "
+"författarens hemsida."
 
 msgid ""
 "The website address of the comment's author. Can be rendered as a link. Will"
 " be empty if the author is a registered user."
 msgstr ""
+"Webbadress för kommentarens författare. Kan genereras som en länk. Kommer "
+"att vara tom om författaren är en registrerad användare."
 
 msgid "Post date"
-msgstr ""
+msgstr "Datum för inlägg"
 
 msgid "Node link"
-msgstr ""
+msgstr "Nodlänk"
 
 msgid "The User ID of the comment's author."
-msgstr ""
+msgstr "Användar-ID för kommentarens författare."
 
 msgid "Parent CID"
-msgstr ""
+msgstr "Ovanliggande CID"
 
 msgid "Last comment time"
-msgstr ""
+msgstr "Tid för senaste kommentar"
 
 msgid "Date and time of when the last comment was posted."
-msgstr ""
+msgstr "Datum och tid för när den senaste kommentaren lades in."
 
 msgid "Last comment author"
-msgstr ""
+msgstr "Senaste kommentarens författare"
 
 msgid "The name of the author of the last posted comment."
-msgstr ""
+msgstr "Namnet på författaren för den senast inlagda kommentaren."
 
 msgid "The number of comments a node has."
-msgstr ""
+msgstr "Antal kommentarer en nod har."
 
 msgid "Updated/commented date"
-msgstr ""
+msgstr "Datum för senaste uppdatering/kommentar"
 
 msgid "The number of new comments on the node."
-msgstr ""
+msgstr "Antalet nya kommentarer till noden."
 
 msgid "User posted or commented"
-msgstr ""
+msgstr "Användare skrev eller kommenterade"
 
 msgid "Display nodes only if a user posted the node or commented on the node."
 msgstr ""
+"Visar noder enbart om en användare lagt in en nod eller kommenterat på den."
 
 msgid "Display the comment as RSS."
-msgstr ""
+msgstr "Visa kommentarer som RSS."
 
 msgid "Provide a simple link to the user contact page."
-msgstr ""
+msgstr "Tillhandahåll en länk till användarens kontaktsida."
 
 msgid "Whether or not the node is published."
-msgstr ""
+msgstr "Huruvida noden är publicerad eller ej."
 
 msgid "Created year + month"
-msgstr ""
+msgstr "Skapad år + månad"
 
 msgid "Created year"
-msgstr ""
+msgstr "Skapad år"
 
 msgid "Created month"
-msgstr ""
+msgstr "Skapad månad"
 
 msgid "Created day"
-msgstr ""
+msgstr "Skapad dag"
 
 msgid "Created week"
-msgstr ""
+msgstr "Skapad vecka"
 
 msgid "Updated year + month"
-msgstr ""
+msgstr "År + månad för uppdatering"
 
 msgid "Updated year"
-msgstr ""
+msgstr "År för uppdatering"
 
 msgid "Updated month"
-msgstr ""
+msgstr "Månad för uppdatering"
 
 msgid "Updated day"
-msgstr ""
+msgstr "Dag för uppdatering"
 
 msgid "Updated week"
-msgstr ""
+msgstr "Vecka för uppdatering"
 
 msgid "Provide a simple link to revert to the revision."
-msgstr ""
+msgstr "Tillhandahåll en enkel länk för att återställa till versionen."
 
 msgid "Filter by access."
-msgstr ""
+msgstr "Filtrera efter åtkomst."
 
 msgid "Has new content"
-msgstr ""
+msgstr "Har nytt innehåll"
 
 msgid ""
 "Display %display has no access control but does not contain a filter for "
 "published nodes."
 msgstr ""
+"Visningen %display har inte någon åtkomstkontroll, men innehåller inte något"
+" filter för publicerade noder."
 
 msgid ""
 "The score of the search item. This will not be used if the search filter is "
 "not also present."
 msgstr ""
+"Poängen för sökalternativet. Detta kommer inte att användas om inte "
+"sökfiltret används."
 
 msgid "Total views"
-msgstr ""
+msgstr "Totalt antal visningar"
 
 msgid "The total number of times the node has been viewed."
-msgstr ""
+msgstr "Det totala antalet gånger som noden har visats."
 
 msgid "Views today"
-msgstr ""
+msgstr "Visningar idag"
 
 msgid "The total number of times the node has been viewed today."
-msgstr ""
+msgstr "Det totala antalet gånger som noden har visats idag."
 
 msgid "Most recent view"
-msgstr ""
+msgstr "Den senaste visningen"
 
 msgid "The most recent time the node has been viewed."
-msgstr ""
+msgstr "Den senaste tiden som noden har visats."
 
 msgid "Files maintained by Drupal and various modules."
-msgstr ""
+msgstr "Filer som hanteras av Drupal och diverse moduler."
 
 msgid "Taxonomy terms are attached to nodes."
-msgstr ""
+msgstr "Taxonomitermer bifogas till noder."
 
 msgid "Filter the results of \"Taxonomy: Term\" to a particular vocabulary."
-msgstr ""
+msgstr "Filtrera resultatet för \"Taxonomi: Term\" till ett speciellt vokabulär."
 
 msgid ""
 "Display all taxonomy terms associated with a node from specified "
 "vocabularies."
 msgstr ""
+"Visa alla taxonomitermer som associerats med en nod från valda vokabulärer."
 
 msgid ""
 "The parent term of the term. This can produce duplicate entries if you are "
 "using a vocabulary that allows multiple parents."
 msgstr ""
+"Den ovanliggande termen för termen. Detta kan skapa dubbla inlägg om du "
+"använder ett vokabulär som tillåter flera ovanliggande relationer."
 
 msgid "The user ID"
-msgstr ""
+msgstr "Användarens ID"
 
 msgid "The user or author name."
-msgstr ""
+msgstr "Användar- eller författarnamnet."
 
 msgid ""
 "Email address for a given user. This field is normally not shown to users, "
 "so be cautious when using it."
 msgstr ""
+"E-postadress för en given användare. Detta fält visas normalt inte för "
+"användare, så var försiktig när du använder det."
 
 msgid "User ID from URL"
-msgstr ""
+msgstr "ID för användaren från URL"
 
 msgid "User ID from logged in user"
-msgstr ""
+msgstr "Den inloggade användarens ID"
 
 msgid "Randomize the display order."
-msgstr ""
+msgstr "Slumpa ordningen för visning."
 
 msgid "Null"
-msgstr ""
+msgstr "Innehållslös"
 
 msgid "Provide custom text or link."
-msgstr ""
+msgstr "Tillhandahåll en anpassad text eller länk."
 
 msgid "View result counter"
-msgstr ""
+msgstr "Visa resultaträknare"
 
 msgid "Displays the actual position of the view result"
-msgstr ""
+msgstr "Visar den faktiska positionen för vyresultatet"
 
 msgid "No user"
-msgstr ""
+msgstr "Ingen användare"
 
 msgid "Show teaser-style link"
-msgstr ""
+msgstr "Visa ingresslänk"
 
 msgid "Link this field to new comments"
-msgstr ""
+msgstr "Länka detta fält till nya kommentarer"
 
 msgid "contact"
-msgstr ""
+msgstr "kontakt"
 
 msgid "Contact %user"
-msgstr ""
+msgstr "Kontakta %user"
 
 msgid "Unknown language"
-msgstr ""
+msgstr "Okänt språk"
 
 msgid "Check for new comments as well"
-msgstr ""
+msgstr "Kontrollera även för nya kommentarer"
 
 msgid "Alternative sort"
-msgstr ""
+msgstr "Alternativ sorteringsordning"
 
 msgid "Alternate sort order"
-msgstr ""
+msgstr "Byt sorteringsordning"
 
 msgid "On empty input"
-msgstr ""
+msgstr "Vid tom inmatning"
 
 msgid "Show None"
-msgstr ""
+msgstr "Visa inget"
 
 msgid ""
 "Search for either of the two terms with uppercase <strong>OR</strong>. For "
 "example, <strong>cats OR dogs</strong>."
 msgstr ""
+"Sök efter vilket som av de två angivna orden med hjälp av "
+"<strong>OR</strong> med stora bokstäver. Exempel: <strong>katter OR "
+"hundar</strong>."
 
 msgid "Link this field to download the file"
-msgstr ""
+msgstr "Länka detta fält för att ladda ned filen"
 
 msgid ""
 "The depth will match nodes tagged with terms in the hierarchy. For example, "
@@ -5940,134 +6077,146 @@ msgid ""
 "true; searching for \"apple\" will also pick up nodes tagged with \"fruit\" "
 "if depth is -1 (or lower)."
 msgstr ""
+"Djupet kommer att passa ihop noder märkta med termer i hierarkin. Till "
+"exempel: Du har termen \"frukt\" och en underliggande term \"äpple\", med "
+"ett djup av 1 (eller högre). Filtrerar man då efter termen \"frukt\" kommer "
+"man att få noder som är märkta med \"äpple\" såväl som \"frukt\". Är djupet "
+"negativt så gäller det omvända. Söker man efter \"äpple\" får man även upp "
+"noder märkta med \"frukt\" om djupet är -1 (eller lägre)."
 
 msgid "No vocabulary"
-msgstr ""
+msgstr "Inget vokabulär"
 
 msgid "Link this field to its term page"
-msgstr ""
+msgstr "Link this field to its term page"
 
 msgid "Limit terms by vocabulary"
-msgstr ""
+msgstr "Begränsa termer genom vokabulär"
 
 msgid "Select which vocabulary to show terms for in the regular options."
 msgstr ""
+"Välj vilket vokabulär som termer skall visas i, under de allmäna "
+"alternativen."
 
 msgid "Dropdown"
-msgstr ""
+msgstr "Rullgardinsmeny"
 
 msgid "Show hierarchy in dropdown"
-msgstr ""
+msgstr "Visa hierarki i rullgardinsmeny"
 
 msgid "An invalid vocabulary is selected. Please change it in the options."
-msgstr ""
+msgstr "Ett ogiltigt vokabulär är valt. Var vänlig ändra det i alternativen."
 
 msgid "Select terms from vocabulary @voc"
-msgstr ""
+msgstr "Välj termer från vokabulär @voc"
 
 msgid "Select terms"
-msgstr ""
+msgstr "Välj termer"
 
 msgid "Is the logged in user"
-msgstr ""
+msgstr "Är den inloggade användaren"
 
 msgid "Usernames"
-msgstr ""
+msgstr "Användarnamn"
 
 msgid "Enter a comma separated list of user names."
-msgstr ""
+msgstr "Ange en kommaseparerad lista med användarnamn."
 
 msgid "Also look for a node and use the node author"
-msgstr ""
+msgstr "Leta även efter en nod och använd nodens författare"
 
 msgid "Restrict user based on role"
-msgstr ""
+msgstr "Begränsa användare baserat på roll"
 
 msgid "Restrict to the selected roles"
-msgstr ""
+msgstr "Begränsa till valda roller"
 
 msgid "If no roles are selected, users from any role will be allowed."
 msgstr ""
+"Om ingen roll är vald kommer användare från vilken roll som helst att "
+"tillåtas."
 
 msgid "Unrestricted"
-msgstr ""
+msgstr "Inga restriktioner"
 
 msgid "No role(s) selected"
-msgstr ""
+msgstr "Inga roller valda"
 
 msgid "Multiple roles"
-msgstr ""
+msgstr "Flera roller"
 
 msgid "You must select at least one role if type is \"by role\""
-msgstr ""
+msgstr "Du måste välja åtminstone en roll om typen är \"per roll\""
 
 msgid "PHP validate code"
-msgstr ""
+msgstr "PHP-kod för validering"
 
 msgid "Never cache"
-msgstr ""
+msgstr "Lagra aldrig i cache"
 
 msgid "Query results"
-msgstr ""
+msgstr "Databasfrågans resultat"
 
 msgid "The length of time raw query results should be cached."
-msgstr ""
+msgstr "Tidslängden som obearbetade databasresultat skall cachas."
 
 msgid "Rendered output"
-msgstr ""
+msgstr "Renderad utdata"
 
 msgid "The length of time rendered HTML output should be cached."
-msgstr ""
+msgstr "Tiden som renderad HTML skall sparas i cache."
 
 msgid "Broken field"
-msgstr ""
+msgstr "Trasigt fält"
 
 msgid "Change the title that this display will use."
-msgstr ""
+msgstr "Ändra titeln som denna visning kommer att använda."
 
 msgid "Use AJAX"
-msgstr ""
+msgstr "Använd AJAX"
 
 msgid "Change whether or not this display will use AJAX."
-msgstr ""
+msgstr "Ändra huruvida denna visning kommer att använda AJAX."
 
 msgid "Mini"
-msgstr ""
+msgstr "Mini"
 
 msgid "Change this display's pager setting."
-msgstr ""
+msgstr "Ändra denna vys inställning för paginerare."
 
 msgid "Specify whether this display will provide a \"more\" link."
-msgstr ""
+msgstr "Ange om denna visning skall innehålla en länk \"mer\"."
 
 msgid "Specify access control type for this display."
-msgstr ""
+msgstr "Ange typ av behörighet för denna visning."
 
 msgid "Change settings for this access type."
-msgstr ""
+msgstr "Ändra inställningar för denna behörighetstyp."
 
 msgid "Specify caching type for this display."
-msgstr ""
+msgstr "Ange cachetyp för denna visning."
 
 msgid "Change settings for this caching type."
-msgstr ""
+msgstr "Ändra inställningarna för denna cachetyp."
 
 msgid "Link display"
-msgstr ""
+msgstr "Visningslänk"
 
 msgid "Exposed form in block"
-msgstr ""
+msgstr "Exponerat formulär i block"
 
 msgid "Allow the exposed form to appear in a block instead of the view."
-msgstr ""
+msgstr "Låter ett exponerat formulär visas i ett block istället för i vyn."
 
 msgid "The title of this view"
-msgstr ""
+msgstr "Titeln på denna vy"
 
 msgid ""
 "This title will be displayed with the view, wherever titles are normally "
 "displayed; i.e, as the page title, block title, etc."
 msgstr ""
+"Denna titel visas tillsammans med vyn där titlar normalt visas, t.ex. som "
+"sid- och blocktitel etc."
 
 msgid ""
 "Unless you're experiencing problems with pagers related to this view, you "
@@ -6076,15 +6225,20 @@ msgid ""
 "array. Large values will add a lot of commas to your URLs, so avoid if "
 "possible."
 msgstr ""
+"Så länge du inte upplever problem med paginerare relaterade till denna vy "
+"bör du lämna detta som 0. Om flera pagineringar används på en sida kan du "
+"behöva ange ett högre värde så det inte uppstår en konflikt i ?page= array. "
+"Höga värden kommer lägga till många kommatecken till dina URL:er, så undvik "
+"detta om möjligt."
 
 msgid "Add a more link to the bottom of the display."
-msgstr ""
+msgstr "Lägg till en länk \"mer\" längst ned i visningen."
 
 msgid "Create more link"
-msgstr ""
+msgstr "Skapa en länk \"mer\""
 
 msgid "The text to display for the more link."
-msgstr ""
+msgstr "Texten att visa för länken \"mer\"."
 
 msgid ""
 "This will make the view display only distinct items. If there are multiple "
@@ -6092,46 +6246,55 @@ msgid ""
 "and remove duplicates from a view, though it does not always work. Note that"
 " this can slow queries down, so use it with caution."
 msgstr ""
+"Detta kommer göra att vyn endast visar distinkta poster. Om det finns flera "
+"identiska poster kommer var och en enbart att visas en gång. Du kan använda "
+"detta för att försöka ta bort dubletter från en vy, däremot fungerar det "
+"inte alltid. Observera att detta kan slöa ned databasfrågor så använd det "
+"med försiktighet."
 
 msgid "Access restrictions"
-msgstr ""
+msgstr "Begränsningar av åtkomst"
 
 msgid "Access options"
-msgstr ""
+msgstr "Alternativ för åtkomst"
 
 msgid "Caching options"
-msgstr ""
+msgstr "Alternativ för cachning"
 
 msgid "Display even if view has no result"
-msgstr ""
+msgstr "Visa även om vyn inte har något resultat"
 
 msgid "How should this view be styled"
-msgstr ""
+msgstr "Hur skall denna vy utformas."
 
 msgid ""
 "If the style you choose has settings, be sure to click the settings button "
 "that will appear next to it in the View summary."
 msgstr ""
+"Om stilen du väljer har inställningar, se till att klicka på "
+"inställningsknappen som kommer att visas bredvid den i vyns summering."
 
 msgid "Style options"
-msgstr ""
+msgstr "Alternativ för stil"
 
 msgid "Row style options"
-msgstr ""
+msgstr "Alternativ för radutformning"
 
 msgid "How should each row in this view be styled"
-msgstr ""
+msgstr "Hur skall varje rad i denna vy vara utformad"
 
 msgid "Which display to use for path"
-msgstr ""
+msgstr "Vilken visning att använda för sökvägen"
 
 msgid ""
 "Which display to use to get this display's path for things like summary "
 "links, rss feed links, more links, etc."
 msgstr ""
+"Vilken visning att använda för denna visnings sökväg för saker såsom länk "
+"för summering, RSS, mer, etc."
 
 msgid "Put the exposed form in a block"
-msgstr ""
+msgstr "Visa det exponerade formuläret i ett block"
 
 msgid ""
 "If set, any exposed widgets will not appear with this view. Instead, a block"
@@ -6139,88 +6302,99 @@ msgid ""
 "exposed form will appear there. Note that this block must be enabled "
 "manually, Views will not enable it for you."
 msgstr ""
+"Om angett så kommer inga exponerade gränssnittskomponenter att visas med "
+"denna vy. Istället kommer ett block att göras tillgängligt till Drupals "
+"system för administration av block, och exponerade formulär kommer att visas"
+" där. Observera att detta block måste aktiveras manuellt. Views kommer inte "
+"aktivera det åt dig."
 
 msgid ""
 "Display \"@display\" uses fields but there are none defined for it or all "
 "are excluded."
 msgstr ""
+"Visning \"@display\" använder fält, men det finns inga angivna för den, "
+"eller så är alla uteslutna."
 
 msgid "Display \"@display\" uses a path but the path is undefined."
-msgstr ""
+msgstr "Visning \"@display\" använder en sökväg, men den är inte angiven."
 
 msgid "Display \"@display\" has an invalid style plugin."
-msgstr ""
+msgstr "Visning \"@display\" har ett ogiltigt stilplugin."
 
 msgid "Exposed form: @view-@display_id"
-msgstr ""
+msgstr "Exponerat formulär: @view-@display_id"
 
 msgid "Attachment settings"
-msgstr ""
+msgstr "Inställningar för bilaga"
 
 msgid "Inherit exposed filters"
-msgstr ""
+msgstr "Ärv exponerade filter"
 
 msgid "Multiple displays"
-msgstr ""
+msgstr "Flera visningar"
 
 msgid ""
 "Should this display inherit its exposed filter values from the parent "
 "display to which it is attached?"
 msgstr ""
+"Skall denna visning ärva sina exponerade filtervärden från den ovanliggande "
+"visningen som den är bifogad till?"
 
 msgid "Attach before or after the parent display?"
-msgstr ""
+msgstr "Bifoga före eller efter den ovanliggande visningen?"
 
 msgid "Select which display or displays this should attach to."
-msgstr ""
+msgstr "Välj vilken eller vilka visningar denna skall bifogas till."
 
 msgid "@view: @display"
-msgstr ""
+msgstr "@view: @display"
 
 msgid "Block admin description"
-msgstr ""
+msgstr "Beskrivning för administrering av block"
 
 msgid "Using the site name"
-msgstr ""
+msgstr "Använder webbplatsens namn"
 
 msgid "Use the site name for the title"
-msgstr ""
+msgstr "Använd webbplatsens namn som titel"
 
 msgid "The feed icon will be available only to the selected displays."
 msgstr ""
+"Ikonen för nyhetsflöde kommer enbart att vara tillgänglig för valda "
+"visningar."
 
 msgid "No menu"
-msgstr ""
+msgstr "Ingen meny"
 
 msgid "Normal: @title"
-msgstr ""
+msgstr "Normal: @title"
 
 msgid "Tab: @title"
-msgstr ""
+msgstr "Flik: @title"
 
 msgid "Change settings for the parent menu"
-msgstr ""
+msgstr "Ändra inställningar för det ovanliggande menyvalet"
 
 msgid "The menu path or URL of this view"
-msgstr ""
+msgstr "Menyns sökväg eller URL för denna vy"
 
 msgid "Menu item entry"
-msgstr ""
+msgstr "Inlägg i menyval"
 
 msgid "No menu entry"
-msgstr ""
+msgstr "Inget inlägg i meny"
 
 msgid "Normal menu entry"
-msgstr ""
+msgstr "Vanligt inlägg i meny"
 
 msgid "Menu tab"
-msgstr ""
+msgstr "Menyflik"
 
 msgid "Default menu tab"
-msgstr ""
+msgstr "Förvald menyflik"
 
 msgid "Default tab options"
-msgstr ""
+msgstr "Inställningar för standardflik"
 
 msgid ""
 "When providing a menu item as a tab, Drupal needs to know what the parent "
@@ -6230,79 +6404,98 @@ msgid ""
 "to this view is <em>foo/bar/baz</em>, the parent path would be "
 "<em>foo/bar</em>."
 msgstr ""
+"När man tillhandahåller ett menyval som en flik måste Drupal veta vad det "
+"ovanliggande menyvalet på fliken skall vara. Ibland finns redan ett "
+"ovanliggande menyval, men andra gånger måste du skapa ett. Sökvägen för ett "
+"ovanliggande alternativ kommer alltid att vara sökväg med den sista delen "
+"lämnad. Till exempel om sökvägen till denna vy är <em>foo/bar/baz</em>, så "
+"är den ovanliggande sökvägen <em>foo/bar</em>."
 
 msgid "Already exists"
-msgstr ""
+msgstr "Existerar redan"
 
 msgid "If creating a parent menu item, enter the title of the item."
-msgstr ""
+msgstr "Om du skapar ett ovanliggande menyval, ange titeln för menyvalet."
 
 msgid "If creating a parent menu item, enter the description of the item."
 msgstr ""
+"Om du skapar ett ovanliggande menyval, ange beskrivningen för menyvalet."
 
 msgid "\"%\" may not be used for the first segment of a path."
-msgstr ""
+msgstr "\"%\" får inte användas som det första segmentet för en sökväg."
 
 msgid "Views cannot create normal menu items for paths with a % in them."
 msgstr ""
+"Views kan inte skapa ett vanligt menyval för sökvägar som innehåller ett %."
 
 msgid "A display whose path ends with a % cannot be a tab."
-msgstr ""
+msgstr "En visning vars sökväg slutar med % kan inte vara en flik."
 
 msgid "Title is required for this menu type."
-msgstr ""
+msgstr "Titel krävs för denna typ av meny."
 
 msgid "Inline fields"
-msgstr ""
+msgstr "Radvisa fält"
 
 msgid ""
 "The separator may be placed between inline fields to keep them from "
 "squishing up next to each other. You can use HTML in this field."
 msgstr ""
+"Avskiljaren kan placeras mellan fält av typen inline för att hindra dem från"
+" att klämmas ihop bredvid varandra. Du får använda HTML i detta fält."
 
 msgid ""
 "You may optionally specify a field by which to group the records. Leave "
 "blank to not group."
 msgstr ""
+"Du kan ange ett fält att gruppera raderna med. Lämna tomt för att inte "
+"gruppera."
 
 msgid "Style @style requires a row style but the row plugin is invalid."
-msgstr ""
+msgstr "Stilen @style kräver en radstil, men radpluginet är inte giltigt."
 
 msgid ""
 "Horizontal alignment will place items starting in the upper left and moving "
 "right. Vertical alignment will place items starting in the upper left and "
 "moving down."
 msgstr ""
+"Horisontell justering kommer att placera poster med början längst uppe till "
+"vänster och sen röra sig åt höger. Vertikal justering kommer att placera "
+"poster med början längst upp till vänster och sen röra sig nedåt."
 
 msgid "RSS description"
-msgstr ""
+msgstr "RSS-beskrivning"
 
 msgid "This will appear in the RSS feed itself."
-msgstr ""
+msgstr "Detta kommer synas i RSS-flödet."
 
 msgid "Display record count with link"
-msgstr ""
+msgstr "Visa antal poster med länken"
 
 msgid "Override number of items to display"
-msgstr ""
+msgstr "Åsidosätt antalet inlägg att visa"
 
 msgid "Display items inline"
-msgstr ""
+msgstr "Visa objekt på samma rad"
 
 msgid ""
 "You need at least one field before you can configure your table settings"
 msgstr ""
+"Du behöver åtminstone ett fält innan du kan konfigurera dina inställningar "
+"för tabellen"
 
 msgid "Override normal sorting if click sorting is used"
-msgstr ""
+msgstr "Åsidosätt normal sortering om klickvis sortering används"
 
 msgid "Enable Drupal style \"sticky\" table headers (Javascript)"
-msgstr ""
+msgstr "Aktivera Drupals \"klistrade\" tabellrubriker (JavaScript)"
 
 msgid ""
 "(Sticky header effects will not be active for preview below, only on live "
 "output.)"
 msgstr ""
+"(Effekten för klistrade rubriker kommer inte att vara aktiverat för "
+"förhandsgranskningen nedan, endast på den riktiga utmatningen.)"
 
 msgid ""
 "Place fields into columns; you may combine multiple fields into the same "
@@ -6312,269 +6505,291 @@ msgid ""
 " sorted by default, if any. You may control column order and field labels in"
 " the fields section."
 msgstr ""
+"Placera fält i kolumner. Du kan kombinera flera fält till en och samma "
+"kolumn. Om du gör det kommer avskiljaren i den angivna kolumnen att användas"
+" för att separera fälten. Kryssa för sorterbar för att göra kolumnen "
+"sorterbar genom klick på rubriken, och välj radioknappen för den kolumn som "
+"skall sorteras som standard (om så ska ske). Du kan styra ordningen på "
+"kolumner och fältnamn i fältsektionen."
 
 msgid "Parent link ID"
-msgstr ""
+msgstr "Ovanliggande ID för länk"
 
 msgid "Placeholder"
-msgstr ""
+msgstr "Platshållare"
 
 msgid "Language settings"
-msgstr ""
+msgstr "Språkinställningar"
 
 msgid "Attempting to re-run cron while it is already running."
-msgstr ""
+msgstr "Försök att köra schemalagda aktiviteter när körningen redan är igång."
 
 msgid "Cron run completed."
-msgstr ""
+msgstr "Körning av schemalagda aktiviteter färdig."
 
 msgid "Visitors"
-msgstr ""
+msgstr "Besökare"
 
 msgid "Allow multiple values"
-msgstr ""
+msgstr "Tillåt flera värden"
 
 msgid "The maximum length of the field in characters."
-msgstr ""
+msgstr "Det största antalet tecken i fältet."
 
 msgid "Module dependencies"
-msgstr ""
+msgstr "Modulberoenden"
 
 msgid "Update translations"
-msgstr ""
+msgstr "Uppdatera översättningar"
 
 msgid "Indexing throttle"
-msgstr ""
+msgstr "Indexeringsbegränsning"
 
 msgid "Administration menu"
-msgstr ""
+msgstr "Administrationsmeny"
 
 msgid "››"
-msgstr ""
+msgstr "››"
 
 msgid "‹‹"
-msgstr ""
+msgstr "‹‹"
 
 msgid "- All -"
-msgstr ""
+msgstr "- Alla -"
 
 msgid "A boolean indicating whether this translation needs to be updated."
 msgstr ""
+"En boolesk som indikerar huruvida denna översättning behöver uppdateras "
+"eller ej."
 
 msgid "Publishing status"
-msgstr ""
+msgstr "Status för publicering"
 
 msgid "Edit language"
-msgstr ""
+msgstr "Redigera språk"
 
 msgid "External links only"
-msgstr ""
+msgstr "Enbart externa länkar"
 
 msgid "Filter criteria"
-msgstr ""
+msgstr "Filterkriterier"
 
 msgid "The content type %name has been updated."
-msgstr ""
+msgstr "Innehållstypen %name har uppdaterats."
 
 msgid "The content type %name has been added."
-msgstr ""
+msgstr "Innehållstypen %name har lagts till."
 
 msgid "Drag to re-order"
-msgstr ""
+msgstr "Drag för att ordna om"
 
 msgid "Block Content"
-msgstr ""
+msgstr "Innehåll i block"
 
 msgid "Blue Lagoon (default)"
-msgstr ""
+msgstr "Blå lagun (förvald)"
 
 msgid "The requested page could not be found."
-msgstr ""
+msgstr "Den valda sidan kunde inte hittas."
 
 msgid "Standard deviation"
-msgstr ""
+msgstr "Förvald avvikelse"
 
 msgid "The user account %id does not exist."
-msgstr ""
+msgstr "Användarkontot %id finns inte."
 
 msgid "Attempted to cancel non-existing user account: %id."
-msgstr ""
+msgstr "Försökte ta bort användarkonto som inte existerar: %id."
 
 msgid "Requirements problem"
-msgstr ""
+msgstr "Systemkravsproblem"
 
 msgid "Database configuration"
-msgstr ""
+msgstr "Databasinställningar"
 
 msgid "Select an installation profile"
-msgstr ""
+msgstr "Välj en installationsprofil"
 
 msgid "Choose language"
-msgstr ""
+msgstr "Välj språk"
 
 msgid "No profiles available"
-msgstr ""
+msgstr "Inga profiler tillgängliga"
 
 msgid "Drupal already installed"
-msgstr ""
+msgstr "Drupal är redan installerat"
 
 msgid "Installing @drupal"
-msgstr ""
+msgstr "Installerar @drupal"
 
 msgid "The installation has encountered an error."
-msgstr ""
+msgstr "Ett fel har inträffat under installationen."
 
 msgid "Configure site"
-msgstr ""
+msgstr "Konfigurera webbplats"
 
 msgid "Installed %module module."
-msgstr ""
+msgstr "Installerade modul %module."
 
 msgid "Choose profile"
-msgstr ""
+msgstr "Välj profil"
 
 msgid "Verify requirements"
-msgstr ""
+msgstr "Verifiera systemkrav"
 
 msgid "Set up database"
-msgstr ""
+msgstr "Ställ in databas"
 
 msgid "Set up translations"
-msgstr ""
+msgstr "Installera översättningar"
 
 msgid "Install site"
-msgstr ""
+msgstr "Installera webbplats"
 
 msgid "Finish translations"
-msgstr ""
+msgstr "Slutför översättningar"
 
 msgid "Check for updates automatically"
-msgstr ""
+msgstr "Sök efter uppdateringar automatiskt"
 
 msgid "1 byte"
 msgid_plural "@count bytes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 byte"
+msgstr[1] "@count byte"
 
 msgid "Illegal choice %choice in %name element."
-msgstr ""
+msgstr "Ogiltigt val (%choice) i elementet %name."
 
 msgid "GD2 image manipulation toolkit"
-msgstr ""
+msgstr "Bildhanteringsverktyget GD2"
 
 msgid ""
 "Define the image quality for JPEG manipulations. Ranges from 0 to 100. "
 "Higher values mean better image quality but bigger files."
 msgstr ""
+"Ange bildkvaliteten för JPEG-manipulationer. Kvaliteten anges som ett värde "
+"mellan 0 och 100. Högre värden betyder bättre bildkvalitet men större filer."
 
 msgid "Right to left"
-msgstr ""
+msgstr "Höger till vänster"
 
 msgid "Left to right"
-msgstr ""
+msgstr "Vänster till höger"
 
 msgid "Add custom language"
-msgstr ""
+msgstr "Lägg till anpassat språk"
 
 msgid "Save language"
-msgstr ""
+msgstr "Spara språk"
 
 msgid "Direction that text in this language is presented."
-msgstr ""
+msgstr "Skrivriktning som text på detta språk presenteras i."
 
 msgid "Languages not yet added"
-msgstr ""
+msgstr "Språken är ännu inte tillagda."
 
 msgid "The language %language has been created."
-msgstr ""
+msgstr "Språket %language har skapats."
 
 msgid "The submitted string contains disallowed HTML: %string"
-msgstr ""
+msgstr "Den skickade textsträngen innehåller otillåten HTML: %string"
 
 msgid "Importing interface translations"
-msgstr ""
+msgstr "Importerar gränssnittsöversättningar"
 
 msgid "Error importing interface translations"
-msgstr ""
+msgstr "Ett fel uppstod under importen av gränssnittsöversättningar"
 
 msgid ""
 "Attempted submission of a translation string with disallowed HTML: %string"
-msgstr ""
+msgstr "Försökte spara en textsträng med otillåten HTML: %string"
 
 msgid "Updated JavaScript translation file for the language %language."
-msgstr ""
+msgstr "Uppdaterade översättningsfil för JavaScript åt språket %language."
 
 msgid "Created JavaScript translation file for the language %language."
-msgstr ""
+msgstr "Skapade översättningsfil för JavaScript åt språket %language."
 
 msgid ""
 "An error occurred during creation of the JavaScript translation file for the"
 " language %language."
 msgstr ""
+"Ett fel uppstod när översättningsfilen för JavaScript åt språket %language "
+"skapades."
 
 msgid "Standard PHP"
-msgstr ""
+msgstr "Standard-PHP"
 
 msgid "PHP Mbstring Extension"
-msgstr ""
+msgstr "PHP:s komponent Mbstring"
 
 msgid "Could not convert XML encoding %s to UTF-8."
-msgstr ""
+msgstr "Kunde inte konvertera XML-kodningen %s till UTF-8."
 
 msgid "The name of the feed (or the name of the website providing the feed)."
 msgstr ""
+"Nyhetsflödets namn (eller namnet på den webbplats du samlar innehåll från)."
 
 msgid "Add a feed in RSS, RDF or Atom format. A feed may only have one entry."
 msgstr ""
+"Skapa ett nyhetsflöde i formatet RSS, RDF eller Atom. Ett flöde kan bara ha "
+"en post."
 
 msgid "Update items"
-msgstr ""
+msgstr "Uppdatera poster"
 
 msgid "No blocks in this region"
-msgstr ""
+msgstr "Inga block i denna region"
 
 msgid ""
 "The block %info was assigned to the invalid region %region and has been "
 "disabled."
 msgstr ""
+"Blocket %info var tilldelat till den ogiltiga regionen %region och har "
+"blivit inaktiverat."
 
 msgid ""
 "The content type for the %add-child link must be one of those selected as an"
 " allowed book outline type."
 msgstr ""
+"Innehållstypen för länken %add-child måste vara en av de som valts som "
+"tillåtna typer för bokdisposition."
 
 msgid ""
 "This book has been modified by another user, the changes could not be saved."
 msgstr ""
+"Denna bok har ändrats av en annan användare, ändringarna kunde inte sparas."
 
 msgid "Title changed from %original to %current."
-msgstr ""
+msgstr "Titeln ändrades från %original till %current."
 
 msgid "Updated book %title."
-msgstr ""
+msgstr "Uppdaterade boken %title."
 
 msgid "book: updated %title."
-msgstr ""
+msgstr "book: updated %title."
 
 msgid "Update book outline"
-msgstr ""
+msgstr "Uppdatera bokdispositionen"
 
 msgid "Remove from book outline"
-msgstr ""
+msgstr "Radera från bokdispositionen"
 
 msgid "No changes were made"
-msgstr ""
+msgstr "Inga ändringar gjordes"
 
 msgid ""
 "The post has been added to the selected book. You may now position it "
 "relative to other pages."
 msgstr ""
+"Inlägget har lagts till den valda boken. Du kan nu placera det relativt till"
+" andra sidor."
 
 msgid "The book outline has been updated."
-msgstr ""
+msgstr "Bokdispositionen har uppdaterats."
 
 msgid "There was an error adding the post to the book."
-msgstr ""
+msgstr "Ett fel uppstod när inlägget lades till i boken."
 
 msgid ""
 "%title has associated child pages, which will be relocated automatically to "
@@ -6582,24 +6797,30 @@ msgid ""
 "before removing this page), %title may be added again using the Outline tab,"
 " and each of its former child pages will need to be relocated manually."
 msgstr ""
+"%title har associerade underliggande sidor som automatiskt kommer att "
+"flyttas för att behålla sitt samband med boken. För att återskapa hierarkin "
+"(som den var innan denna sida flyttades), kan %title läggas till igen med "
+"hjälp av Dispositionsfliken. Var och en av dess tidigare underliggande sidor"
+" måste då flyttas manuellt."
 
 msgid "%title may be added to hierarchy again using the Outline tab."
-msgstr ""
+msgstr "%title kan läggas till hierarkin igen med Dispositionsfliken."
 
 msgid "Are you sure you want to remove %title from the book hierarchy?"
-msgstr ""
+msgstr "Är du säker på att du vill ta bort %title från bokhierarkin?"
 
 msgid "The post has been removed from the book."
-msgstr ""
+msgstr "Inlägget har raderats från boken."
 
 msgid "Show a printer-friendly version of this book page and its sub-pages."
 msgstr ""
+"Visa en utskriftsvänligt version av denna boksida och dess undersidor."
 
 msgid "Show block on all pages"
-msgstr ""
+msgstr "Visa block på alla sidor"
 
 msgid "Show block only on book pages"
-msgstr ""
+msgstr "Visa block endast på boksidor"
 
 msgid ""
 "If <em>Show block on all pages</em> is selected, the block will contain the "
@@ -6610,72 +6831,82 @@ msgid ""
 "visibility settings</em> or other visibility settings can be used in "
 "addition to selectively display this block."
 msgstr ""
+"Om <em>Visa block på alla sidor</em> är valt kommer blocket att innehålla "
+"automatiskt skapade menyer för alla webbplatsens böcker. Om <em>Visa block "
+"endast på boksidor</em> är vald kommer blocket att endast innehålla en meny "
+"som motsvarar den aktuella sidans bok. Ifall den aktuella sidan inte hör "
+"till någon bok kommer inget block att visas. <em>Sidspecifik "
+"synlighetsinställning</em> eller annan synlighetsinställning kan dessutom "
+"användas förutom att selektivt visa detta block."
 
 msgid "This is the top-level page in this book."
-msgstr ""
+msgstr "Detta är huvudsidan på den översta nivån i boken."
 
 msgid "No book selected."
-msgstr ""
+msgstr "Ingen bok vald."
 
 msgid ""
 "%title is part of a book outline, and has associated child pages. If you "
 "proceed with deletion, the child pages will be relocated automatically."
 msgstr ""
+"%title är en del av en bokdisposition och har associerade undersidor. Om du "
+"fortsätter med borttagningen kommer undersidorna att flyttas automatiskt."
 
 msgid "Re-order book pages and change titles"
-msgstr ""
+msgstr "Omorganisera boksidor och ändra titlar"
 
 msgid "Book page"
-msgstr ""
+msgstr "Boksida"
 
 msgid "Contact form"
-msgstr ""
+msgstr "Kontaktformulär"
 
 msgid "Language name"
-msgstr ""
+msgstr "Namn på språk"
 
 msgid "Who's new"
-msgstr ""
+msgstr "Vilka är nya?"
 
 msgid "Update notifications"
-msgstr ""
+msgstr "Meddelanden om uppdateringar"
 
 msgid "Unicode library"
-msgstr ""
+msgstr "Unicode-bibliotek"
 
 msgid "String contains"
-msgstr ""
+msgstr "Textsträng innehåller"
 
 msgid "Both translated and untranslated strings"
-msgstr ""
+msgstr "Både översatta och ej översatta textsträngar"
 
 msgid "Only translated strings"
-msgstr ""
+msgstr "Endast översatta textsträngar"
 
 msgid "Only untranslated strings"
-msgstr ""
+msgstr "Endast ej översatta textsträngar"
 
 msgid "Search in"
-msgstr ""
+msgstr "Sök i"
 
 msgid "Pagination"
-msgstr ""
+msgstr "Paginering"
 
 msgid ""
 "Changes made in this table will not be saved until the form is submitted."
 msgstr ""
+"Ändringar som görs i denna tabell sparas inte förrän formuläret skickas."
 
 msgid "Example: 'website feedback' or 'product information'."
-msgstr ""
+msgstr "Exempel: \"feedback\" eller \"produktinformation\"."
 
 msgid "No roles may use this format"
-msgstr ""
+msgstr "Inga roller får använda detta format"
 
 msgid "Allowed HTML tags: @tags"
-msgstr ""
+msgstr "Tillåtna HTML-taggar: @tags"
 
 msgid "Anchors are used to make links to other pages."
-msgstr ""
+msgstr "Ankare används för att skapa länkar till andra sidor."
 
 msgid ""
 "By default line break tags are automatically added, so use this tag to add "
@@ -6683,436 +6914,472 @@ msgid ""
 " open/close pair like all the others. Use the extra \" /\" inside the tag to"
 " maintain XHTML 1.0 compatibility"
 msgstr ""
+"Som standard läggs radbrytningstaggar till automatiskt, så använd denna tagg"
+" för att lägga till flera. Den här taggen används lite annorlunda i och med "
+"att den inte har en start- och sluttagg som övriga taggar. Använd ett extra "
+"\"/\" inuti taggen för att behålla kompatibiliteten med XHTML 1.0."
 
 msgid "Text with <br />line break"
-msgstr ""
+msgstr "Text med <br />radbrytning"
 
 msgid ""
 "By default paragraph tags are automatically added, so use this tag to add "
 "additional ones."
 msgstr ""
+"Som standard läggs stycketaggar till automatiskt. Använd denna tagg för att "
+"lägga till flera."
 
 msgid "Paragraph one."
-msgstr ""
+msgstr "Första stycket."
 
 msgid "Paragraph two."
-msgstr ""
+msgstr "Andra stycket."
 
 msgid "Strong"
-msgstr ""
+msgstr "Stark"
 
 msgid "Emphasized"
-msgstr ""
+msgstr "Betonat/kursivt"
 
 msgid "Cited"
-msgstr ""
+msgstr "Citerat"
 
 msgid "Coded text used to show programming source code"
-msgstr ""
+msgstr "Kodad text som används för att visa programkällkod."
 
 msgid "Coded"
-msgstr ""
+msgstr "Kodat"
 
 msgid "Bolded"
-msgstr ""
+msgstr "Fet"
 
 msgid "Italicized"
-msgstr ""
+msgstr "Kursiverat"
 
 msgid "Superscripted"
-msgstr ""
+msgstr "Upphöjt"
 
 msgid "<sup>Super</sup>scripted"
-msgstr ""
+msgstr "<sup>Upp</sup>höjt"
 
 msgid "Subscripted"
-msgstr ""
+msgstr "Nedsänkt"
 
 msgid "<sub>Sub</sub>scripted"
-msgstr ""
+msgstr "<sub>Ned</sub>sänkt"
 
 msgid "<abbr title=\"Abbreviation\">Abbrev.</abbr>"
-msgstr ""
+msgstr "<abbr title=\"Förkortning\">Förkortn.</abbr>"
 
 msgid "<acronym title=\"Three-Letter Acronym\">TLA</acronym>"
-msgstr ""
+msgstr "<acronym title=\"Trebokstävers-akronym\">TLA</acronym>"
 
 msgid "Block quoted"
-msgstr ""
+msgstr "Blockciterat"
 
 msgid "Quoted inline"
-msgstr ""
+msgstr "Citat i löpande text"
 
 msgid "Table header"
-msgstr ""
+msgstr "Tabellhuvud"
 
 msgid "Table cell"
-msgstr ""
+msgstr "Tabellcell"
 
 msgid "Ordered list - use the &lt;li&gt; to begin each list item"
 msgstr ""
+"Numrerad lista - använd &lt;li&gt; för att påbörja varje ny post i listan"
 
 msgid "First item"
-msgstr ""
+msgstr "Första posten"
 
 msgid "Second item"
-msgstr ""
+msgstr "Andra posten"
 
 msgid "Unordered list - use the &lt;li&gt; to begin each list item"
-msgstr ""
+msgstr "Punktlista - använd &lt;li&gt; för att påbörja varje ny post i listan"
 
 msgid ""
 "Definition lists are similar to other HTML lists. &lt;dl&gt; begins the "
 "definition list, &lt;dt&gt; begins the definition term and &lt;dd&gt; begins"
 " the definition description."
 msgstr ""
+"Definitionslistor liknar andra listor i HTML. &lt;dl&gt; inleder listan, "
+"&lt;dt&gt; inleder definitionstermen och &lt;dd&gt; inleder "
+"definitionsbeskrivningen."
 
 msgid "First term"
-msgstr ""
+msgstr "Första termen"
 
 msgid "First definition"
-msgstr ""
+msgstr "Första definitionen"
 
 msgid "Second term"
-msgstr ""
+msgstr "Andra termen"
 
 msgid "Second definition"
-msgstr ""
+msgstr "Andra definitionen"
 
 msgid "Subtitle three"
-msgstr ""
+msgstr "Tredje rubrik"
 
 msgid "Subtitle four"
-msgstr ""
+msgstr "Fjärde rubrik"
 
 msgid "Subtitle five"
-msgstr ""
+msgstr "Femte rubrik"
 
 msgid "Subtitle six"
-msgstr ""
+msgstr "Sjätte rubrik"
 
 msgid "Tag Description"
-msgstr ""
+msgstr "Taggbeskrivning"
 
 msgid "You Type"
-msgstr ""
+msgstr "Du skriver"
 
 msgid "You Get"
-msgstr ""
+msgstr "Du får"
 
 msgid "No help provided for tag %tag."
-msgstr ""
+msgstr "Ingen hjälp finns tillgänglig för taggen %tag."
 
 msgid "Ampersand"
-msgstr ""
+msgstr "Tecknet &"
 
 msgid "Quotation mark"
-msgstr ""
+msgstr "Citationstecken"
 
 msgid "Character Description"
-msgstr ""
+msgstr "Teckenbeskrivning"
 
 msgid "Lines and paragraphs break automatically."
-msgstr ""
+msgstr "Rader och stycken bryts automatiskt."
 
 msgid "Compose tips"
-msgstr ""
+msgstr "Skrivtips"
 
 msgid "Short but meaningful name for this collection of threaded discussions."
 msgstr ""
+"Kort men meningsfullt namn för den här samlingen av trådade diskussioner."
 
 msgid "Description and guidelines for discussions within this forum."
-msgstr ""
+msgstr "Beskrivning och riktlinjer för diskussioner inom det här forumet."
 
 msgid "Short but meaningful name for this collection of related forums."
-msgstr ""
+msgstr "Kort men meningsfullt namn för den här samlingen av relaterade forum."
 
 msgid "Default number of forum topics displayed per page."
-msgstr ""
+msgstr "Förvalt antal av diskussionsämnen som visas per sida."
 
 msgid "Default display order for topics."
-msgstr ""
+msgstr "Förvald visningsordning för ämnen."
 
 msgid ""
 "Containers are usually placed at the top (root) level, but may also be "
 "placed inside another container or forum."
 msgstr ""
+"Forumgrupper placeras vanligtvis på översta nivån (rotnivån), men kan också "
+"placeras inuti en annan forumgrupp eller forum."
 
 msgid ""
 "Forums may be placed at the top (root) level, or inside another container or"
 " forum."
 msgstr ""
+"Forum kan placeras på översta nivån (roten), eller inuti en annan gruppering"
+" eller forum."
 
 msgid "Forum topic"
-msgstr ""
+msgstr "Diskussionsämne"
 
 msgid "You are not allowed to post new content in the forum."
-msgstr ""
+msgstr "Du har inte tillåtelse att lägga till nytt innehåll i forumet."
 
 msgid "Submission form settings"
-msgstr ""
+msgstr "Inställningar för inskrivningsformulär"
 
 msgid ""
 "The machine-readable name must contain only lowercase letters, numbers, and "
 "underscores."
 msgstr ""
+"Det maskinläsbara namnet får bara innehållasmå bokstäver, siffror och "
+"understreck."
 
 msgid "Added content type %name."
-msgstr ""
+msgstr "Innehållstyp %name lades till."
 
 msgid "Changed the content type of 1 post from %old-type to %type."
 msgid_plural ""
 "Changed the content type of @count posts from %old-type to %type."
-msgstr[0] ""
+msgstr[0] "Ändrade innehållstypen hos ett inlägg från %old-type till %type."
 msgstr[1] ""
+"Ändrade innehållstypen hos @count inlägg från %old-type till %type."
 
 msgid "Are you sure you want to rebuild the permissions on site content?"
-msgstr ""
+msgstr "Är du säker på att du vill bygga om behörigheterna på webbplatsen?"
 
 msgid ""
 "This action rebuilds all permissions on site content, and may be a lengthy "
 "process. This action cannot be undone."
 msgstr ""
+"Denna åtgärd bygger om alla behörigheter för webbplatsens innehåll, och "
+"detta kan ta lång tid. Du kan inte ångra åtgärden."
 
 msgid "language"
-msgstr ""
+msgstr "språk"
 
 msgid "An error occurred and processing did not complete."
-msgstr ""
+msgstr "Ett fel inträffade och behandlingen fullföljdes inte."
 
 msgid "Copy of the revision from %date."
-msgstr ""
+msgstr "Kopia av versionen från %date."
 
 msgid "Revision from %revision-date of @type %title has been deleted."
-msgstr ""
+msgstr "Versionen från %revision-date av %title (@type) har raderats."
 
 msgid "@type: reverted %title revision %revision."
-msgstr ""
+msgstr "@type: återställde version %revision av %title."
 
 msgid "The content access permissions need to be rebuilt."
-msgstr ""
+msgstr "Åtkomstreglerna för innehåll måste byggas om."
 
 msgid "Rebuilding content access permissions"
-msgstr ""
+msgstr "Bygger om behörigheter för innehåll"
 
 msgid "Content permissions have been rebuilt."
-msgstr ""
+msgstr "Behörigheter för innehåll har byggts om."
 
 msgid "The content access permissions have not been properly rebuilt."
-msgstr ""
+msgstr "Behörigheterna för innehåll har inte byggts om på rätt sätt."
 
 msgid "Add content type"
-msgstr ""
+msgstr "Lägg till innehållstyp"
 
 msgid "Revert to earlier revision"
-msgstr ""
+msgstr "Återgå till tidigare version"
 
 msgid "Delete earlier revision"
-msgstr ""
+msgstr "Radera tidigare version"
 
 msgid "The alias %alias is already in use in this language."
-msgstr ""
+msgstr "Aliaset %alias används redan för detta språk."
 
 msgid "The alias has been saved."
-msgstr ""
+msgstr "Aliaset har sparats."
 
 msgid "Are you sure you want to delete path alias %title?"
-msgstr ""
+msgstr "Är du säker på att du vill radera URL-aliaset %title?"
 
 msgid "Filter aliases"
-msgstr ""
+msgstr "Filtrera alias"
 
 msgid ""
 "Enter the path you wish to create the alias for, followed by the name of the"
 " new alias."
 msgstr ""
+"Skriv in den sökväg som du vill skapa ett alias för, följt av namnet på det "
+"nya aliaset."
 
 msgid "Edit alias"
-msgstr ""
+msgstr "Redigera alias"
 
 msgid "Delete alias"
-msgstr ""
+msgstr "Radera alias"
 
 msgid "Add alias"
-msgstr ""
+msgstr "Lägg till alias"
 
 msgid "URL aliases"
-msgstr ""
+msgstr "URL-alias"
 
 msgid "Top 'page not found' errors"
-msgstr ""
+msgstr "Vanligaste felmeddelanden: \"sidan hittades inte\""
 
 msgid "Top 'access denied' errors"
-msgstr ""
+msgstr "Vanligaste felmeddelanden: \"åtkomst nekad\""
 
 msgid "View events that have recently been logged."
-msgstr ""
+msgstr "Visa händelser som nyligen har loggats."
 
 msgid "View 'access denied' errors (403s)."
-msgstr ""
+msgstr "Visa felmeddelanden: \"åtkomst nekad\" (403)."
 
 msgid "View 'page not found' errors (404s)."
-msgstr ""
+msgstr "Visa felmeddelanden: \"sidan hittades inte\" (404)."
 
 msgid "Allows users to comment on and discuss published content."
-msgstr ""
+msgstr "Låter användare kommentera och diskutera publicerat innehåll."
 
 msgid "Enables the use of both personal and site-wide contact forms."
 msgstr ""
+"Aktiverar kontaktformulär för både enskilda användare och hela webbplatsen."
 
 msgid "Logs and records system events to the database."
-msgstr ""
+msgstr "Loggar och registrerar systemhändelser till databasen."
 
 msgid "Manages the display of online help."
-msgstr ""
+msgstr "Hanterar visning av hjälp online."
 
 msgid "Allows content to be submitted to the site and displayed on pages."
-msgstr ""
+msgstr "Gör det möjligt att lägga till och visa innehåll på webbplatsen."
 
 msgid "Allows users to rename URLs."
-msgstr ""
+msgstr "Tillåter användare att döpa om URL:er."
 
 msgid "Number of items to index per cron run"
-msgstr ""
+msgstr "Antalet poster som skall indexeras per schemalagd körning"
 
 msgid "Indexing settings"
-msgstr ""
+msgstr "Inställningar för indexering"
 
 msgid "Minimum word length to index"
-msgstr ""
+msgstr "Minsta ordlängd att indexera"
 
 msgid "Simple CJK handling"
-msgstr ""
+msgstr "Enkel CJK-hantering"
 
 msgid ""
 "Whether to apply a simple Chinese/Japanese/Korean tokenizer based on "
 "overlapping sequences. Turn this off if you want to use an external "
 "preprocessor for this instead. Does not affect other languages."
 msgstr ""
+"Huruvida en enkel kinesisk/japansk/koreansk teckenhanterare som baseras på "
+"överlappande sekvenser skall användas eller ej. Stäng av detta om du vill "
+"använda en extern hanterare för detta istället. Påverkar inte övriga språk."
 
 msgid "Search form"
-msgstr ""
+msgstr "Sökformulär"
 
 msgid "Top search phrases"
-msgstr ""
+msgstr "Topplista sökord"
 
 msgid "View most popular search phrases."
-msgstr ""
+msgstr "Visa de populäraste sökorden"
 
 msgid "Content viewing counter settings"
-msgstr ""
+msgstr "Inställningar för visningsräknaren"
 
 msgid "Count content views"
-msgstr ""
+msgstr "Räkna antal gånger innehåll visas"
 
 msgid "Increment a counter each time content is viewed."
-msgstr ""
+msgstr "Räkna varje gång någon tittar på ett innehåll."
 
 msgid "Popular content"
-msgstr ""
+msgstr "Populärt innehåll"
 
 msgid "How many content items to display in \"all time\" list."
-msgstr ""
+msgstr "Antalet innehållsposter som skall visas under \"Någonsin\"."
 
 msgid "How many content items to display in \"recently viewed\" list."
-msgstr ""
+msgstr "Hur många innehållsposter som skall visas under \"Senast visade\"."
 
 msgid "Today's:"
-msgstr ""
+msgstr "I dag:"
 
 msgid "All time:"
-msgstr ""
+msgstr "Någonsin:"
 
 msgid "Last viewed:"
-msgstr ""
+msgstr "Senast visade:"
 
 msgid "User pictures in posts"
-msgstr ""
+msgstr "Användarbilder i inlägg"
 
 msgid "User pictures in comments"
-msgstr ""
+msgstr "Användarbilder i kommentarer"
 
 msgid "Shortcut icon"
-msgstr ""
+msgstr "Bokmärkesikon"
 
 msgid "Upload logo image"
-msgstr ""
+msgstr "Ladda upp logotypbild"
 
 msgid "Shortcut icon settings"
-msgstr ""
+msgstr "Inställningar för bokmärkesikon"
 
 msgid ""
 "If you don't have direct file access to the server, use this field to upload"
 " your shortcut icon."
 msgstr ""
+"Använd detta fält för att ladda upp din bokmärkesikon om du inte har direkt "
+"tillgång till filerna på servern."
 
 msgid "No modules selected."
-msgstr ""
+msgstr "Inga moduler valda."
 
 msgid "Default 403 (access denied) page"
-msgstr ""
+msgstr "Standardsida för 403 (åtkomst nekad)"
 
 msgid "Default 404 (not found) page"
-msgstr ""
+msgstr "Standardsida för 404 (hittades inte)"
 
 msgid "Select an image processing toolkit"
-msgstr ""
+msgstr "Välj ett bildhanteringsverktyg"
 
 msgid "Number of items in each feed"
-msgstr ""
+msgstr "Antal poster i varje nyhetsflöde"
 
 msgid "Default number of items to include in each feed."
-msgstr ""
+msgstr "Det förvalda antalet poster som inkluderas i varje nyhetsflöde."
 
 msgid "Feed content"
-msgstr ""
+msgstr "Innehåll i nyhetsflöde"
 
 msgid "Titles plus teaser"
-msgstr ""
+msgstr "Titlar och ingresser"
 
 msgid "Global setting for the default display of content items in each feed."
 msgstr ""
+"Global inställning för standardvisningen av inlägg i varje nyhetsflöde."
 
 msgid "Formatting"
-msgstr ""
+msgstr "Formatering"
 
 msgid "Cron ran successfully."
-msgstr ""
+msgstr "Schemalagda aktiviteter kördes utan problem."
 
 msgid "Cron run failed."
-msgstr ""
+msgstr "Körning av schemalagda aktiviteter misslyckades."
 
 msgid "No modules are available to uninstall."
-msgstr ""
+msgstr "Inga moduler är tillgängliga för avinstallation."
 
 msgid ""
 "This page shows you all available administration tasks for each module."
-msgstr ""
+msgstr "Den här sidan visar alla administrativa uppgifter för varje modul."
 
 msgid ""
 "The <em>Powered by Drupal</em> block is an optional link to the home page of"
 " the Drupal project. While there is absolutely no requirement that sites "
 "feature this link, it may be used to show support for Drupal."
 msgstr ""
+"Blocket <em>Drivs av Drupal</em> är en valfri länk till hemsidan för Drupal-"
+"projektet. Det är absolut inget krav att webbplatsen visar den här länken, "
+"men den kan användas för att visa sitt stöd för Drupal."
 
 msgid "Compact mode"
-msgstr ""
+msgstr "Komprimerat läge"
 
 msgid "Date and time"
-msgstr ""
+msgstr "Datum och tid"
 
 msgid "-1 (Unlimited)"
-msgstr ""
+msgstr "-1 (Obegränsad)"
 
 msgid ""
 "Consider increasing your PHP memory limit to %memory_minimum_limit to help "
 "prevent errors in the installation process."
 msgstr ""
+"Överväg att öka minnesgränsen för PHP (memory limit) till "
+"%memory_minimum_limit för att undvika fel i installationsprocessen."
 
 msgid ""
 "Consider increasing your PHP memory limit to %memory_minimum_limit to help "
 "prevent errors in the update process."
 msgstr ""
+"Överväg att öka minnegränsen för PHP (memory limit) till "
+"%memory_minimum_limit för att undvika fel i uppdateringsprocessen."
 
 msgid ""
 "Depending on your configuration, Drupal can run with a %memory_limit PHP "
@@ -7120,78 +7387,95 @@ msgid ""
 "recommended, especially if your site uses additional custom or contributed "
 "modules."
 msgstr ""
+"Beroende på din konfiguration kan Drupal köras med %memory_limit som "
+"minnesgräns för PHP. Dock rekommenderas en minnesgräns för PHP på minst "
+"%memory_minimum_limit eller mer, speciellt om din webbplats använder flera "
+"tilläggsmoduler."
 
 msgid ""
 "Increase the memory limit by editing the memory_limit parameter in the file "
 "%configuration-file and then restart your web server (or contact your system"
 " administrator or hosting provider for assistance)."
 msgstr ""
+"Höj minnesgränsen genom att redigera parametern memory_limit i filen "
+"%configuration-file och starta sedan om webbservern (eller be din "
+"systemadministratör eller webbleverantör om hjälp)."
 
 msgid ""
 "Contact your system administrator or hosting provider for assistance with "
 "increasing your PHP memory limit."
 msgstr ""
+"Be din systemadministratör eller webbleverantör om hjälp med att höja "
+"minnesgränsen för PHP."
 
 msgid "Not protected"
-msgstr ""
+msgstr "Ej skyddad"
 
 msgid ""
 "The file %file is not protected from modifications and poses a security "
 "risk. You must change the file's permissions to be non-writable."
 msgstr ""
+"Filen %file är inte skyddad för modifieringar och utgör en säkerhetsrisk. Du"
+" måste ändra filens behörigheter så att den inte är skrivbar."
 
 msgid "Cron has not run recently."
-msgstr ""
+msgstr "Schemalaga aktiviteter har inte körts nyligen."
 
 msgid "The directory %directory is not writable."
-msgstr ""
+msgstr "Katalogen %directory är skrivskyddad."
 
 msgid "Writable (<em>public</em> download method)"
-msgstr ""
+msgstr "Skrivbar (<em>offentlig</em> nedladdningsmetod)"
 
 msgid "Writable (<em>private</em> download method)"
-msgstr ""
+msgstr "Skrivbar (<em>privat</em> nedladdningsmetod)"
 
 msgid "Reset to alphabetical"
-msgstr ""
+msgstr "Återställ till alfabetisk"
 
 msgid "Terms are displayed in ascending order by weight."
-msgstr ""
+msgstr "Termer visas i stigande ordning baserat på vikt."
 
 msgid "Weight value must be numeric."
-msgstr ""
+msgstr "Värdet för vikt måste vara ett heltal."
 
 msgid ""
 "Are you sure you want to reset the vocabulary %title to alphabetical order?"
 msgstr ""
+"Är du säker på att du vill återställa vokabulären %title till alfabetisk "
+"ordning?"
 
 msgid ""
 "Resetting a vocabulary will discard all custom ordering and sort items "
 "alphabetically."
 msgstr ""
+"Genom att återställa en vokabulär tas alla anpassade ordningar bort och "
+"inläggen sorteras därefter alfabetiskt."
 
 msgid "Reset vocabulary %name to alphabetical order."
-msgstr ""
+msgstr "Återställ vokabulär %name till alfabetisk ordning."
 
 msgid "Translation settings"
-msgstr ""
+msgstr "Inställningar för översättning"
 
 msgid "This translation needs to be updated"
-msgstr ""
+msgstr "Översättningen behöver uppdateras"
 
 msgid "Unknown release date"
-msgstr ""
+msgstr "Okänt utgivningsdatum"
 
 msgid "Last checked: never"
-msgstr ""
+msgstr "Senast kontrollerad: aldrig"
 
 msgid "Includes: %includes"
-msgstr ""
+msgstr "Innehåller: %includes"
 
 msgid ""
 "Select how frequently you want to automatically check for new releases of "
 "your currently installed modules and themes."
 msgstr ""
+"Välj hur ofta du vill att automatiska sökningar efter nya utgåvor av dina "
+"installerade moduler och teman skall ske."
 
 msgid ""
 "Here you can find information about available updates for your installed "
@@ -7199,144 +7483,160 @@ msgid ""
 " which may or may not have the same name, and might include multiple modules"
 " or themes within it."
 msgstr ""
+"Here you can find information about available updates for your installed "
+"modules and themes. Note that each module or theme is part of a \"project\","
+" which may or may not have the same name, and might include multiple modules"
+" or themes within it."
 
 msgid ""
 "There are security updates available for one or more of your modules or "
 "themes. To ensure the security of your server, you should update "
 "immediately!"
 msgstr ""
+"Det finns säkerhetsuppdateringar tillgängliga för en eller flera av dina "
+"tilläggsmoduler eller teman. För att försäkra dig om din servers säkerhet "
+"bör du omedelbart uppdatera!"
 
 msgid ""
 "There are updates available for one or more of your modules or themes. To "
 "ensure the proper functioning of your site, you should update as soon as "
 "possible."
 msgstr ""
+"Det finns uppdateringar för en eller flera av dina moduler eller teman. För "
+"att försäkra dig om att din webbplats fungerar ordentligt bör du uppdatera "
+"så snart som möjligt."
 
 msgid "%name has been deleted."
-msgstr ""
+msgstr "%name har raderats."
 
 msgid "Image toolkit"
-msgstr ""
+msgstr "Bildhanteringsverktyg"
 
 msgid "RSS publishing"
-msgstr ""
+msgstr "RSS-publicering"
 
 msgid ""
 "Get a status report about available updates for your installed modules and "
 "themes."
 msgstr ""
+"Visa en statusrapport över tillgängliga uppdateringar för dina installerade "
+"moduler och teman."
 
 msgid "Access to update.php"
-msgstr ""
+msgstr "Åtkomst till update.php"
 
 msgid "Database updates"
-msgstr ""
+msgstr "Databasuppdateringar"
 
 msgid "Cron maintenance tasks"
-msgstr ""
+msgstr "Underhållsuppgifter för schemalagda aktiviter"
 
 msgid "PHP memory limit"
-msgstr ""
+msgstr "Minnesgräns för PHP"
 
 msgid "Caches cleared."
-msgstr ""
+msgstr "Cacheutrymmen rensade."
 
 msgid "Module and theme update status"
-msgstr ""
+msgstr "Modulers och temans uppdateringsstatus"
 
 msgid "Enables site-wide keyword searching."
-msgstr ""
+msgstr "Möjliggör nyckelordssökning på webbplatsen."
 
 msgid "Logs and records system events to syslog."
-msgstr ""
+msgstr "Loggar och registrerar systemhändelser till syslog."
 
 msgid "Handles general site configuration for administrators."
-msgstr ""
+msgstr "Hanterar allmänna inställningar för administratörer."
 
 msgid "@module (<span class=\"admin-missing\">missing</span>)"
-msgstr ""
+msgstr "@module (<span class=\"admin-missing\">saknas</span>)"
 
 msgid "Would you like to continue with uninstalling the above?"
-msgstr ""
+msgstr "Vill du fortsätta och avinstallera ovanstående?"
 
 msgid "Confirm uninstall"
-msgstr ""
+msgstr "Bekräfta avinstallation"
 
 msgid "The selected modules have been uninstalled."
-msgstr ""
+msgstr "De valda modulerna har avinstallerats."
 
 msgid "You must enter a username."
-msgstr ""
+msgstr "Du måste ange ett användarnamn."
 
 msgid "The username cannot begin with a space."
-msgstr ""
+msgstr "Användarnamnet får inte börja med ett mellanslag."
 
 msgid "The username cannot end with a space."
-msgstr ""
+msgstr "Användarnamnet får inte sluta med mellanslag."
 
 msgid "The username cannot contain multiple spaces in a row."
-msgstr ""
+msgstr "Användarnamnet får inte innehålla flera mellanslag i rad."
 
 msgid "The username contains an illegal character."
-msgstr ""
+msgstr "Användarnamnet innehåller ett otillåtet tecken."
 
 msgid "The username %name is too long: it must be %max characters or less."
 msgstr ""
+"Användarnamnet %name är för långt. Det får inte innehålla mer än %max "
+"tecken."
 
 msgid "Unblock the selected users"
-msgstr ""
+msgstr "Återaktivera de markerade användarna"
 
 msgid "Block the selected users"
-msgstr ""
+msgstr "Spärra de markerade användarna"
 
 msgid "Deleted user: %name %email."
-msgstr ""
+msgstr "Raderade användare: %name %email."
 
 msgid "Edit role"
-msgstr ""
+msgstr "Redigera roll"
 
 msgid "Language list"
-msgstr ""
+msgstr "Språklista"
 
 msgid "File extension"
-msgstr ""
+msgstr "Filändelse"
 
 msgid "wide"
-msgstr ""
+msgstr "bred"
 
 msgid ""
 "The title is used as a tool tip when the user hovers the mouse over the "
 "image."
-msgstr ""
+msgstr "Titeln syns i en ruta när användaren för musen över bilden."
 
 msgid "Progress indicator"
-msgstr ""
+msgstr "Förloppsindikator"
 
 msgid "Bar with progress meter"
-msgstr ""
+msgstr "Stapel med förloppsindikator"
 
 msgid "Throbber"
-msgstr ""
+msgstr "Laddningsindikator"
 
 msgid "Path settings"
-msgstr ""
+msgstr "Sökvägsinställningar"
 
 msgid "The file upload failed. %upload"
-msgstr ""
+msgstr "Filuppladdningen misslyckades. %upload"
 
 msgid "URL to file"
-msgstr ""
+msgstr "URL till fil"
 
 msgid ""
 "An unrecoverable error occurred. The uploaded file likely exceeded the "
 "maximum file size (@size) that this server supports."
 msgstr ""
+"Ett oåterkalleligt fel har inträffat. Den uppladdade filen överskred "
+"troligen den maximala filstorleken (@size) som denna server har stöd för."
 
 msgid "Starting upload..."
-msgstr ""
+msgstr "Påbörjar uppladdning..."
 
 msgid "Uploading... (@current of @total)"
-msgstr ""
+msgstr "Laddar upp... (@current av @total)"
 
 msgid ""
 "Your server is capable of displaying file upload progress using APC RFC1867."
@@ -7344,351 +7644,369 @@ msgid ""
 "the <a href=\"http://pecl.php.net/package/uploadprogress\">PECL "
 "uploadprogress library</a> if possible."
 msgstr ""
+"Din server kan visa filuppladdningsförlop med APC RFC1867. Observera att "
+"bara en uppladdning åt gången stöds. Det rekommenderas att använda <a "
+"href=\"http://pecl.php.net/package/uploadprogress\">PECL:s bibliotek för "
+"uppladdningsförlopp</a> om möjligt."
 
 msgid ""
 "Enabled (<a href=\"http://pecl.php.net/package/uploadprogress\">PECL "
 "uploadprogress</a>)"
 msgstr ""
+"Aktiverade (<a href=\"http://pecl.php.net/package/uploadprogress\">PECL:s "
+"uppladdningsförlopp</a>)"
 
 msgid "Preferred language"
-msgstr ""
+msgstr "Föredraget språk"
 
 msgid "Number field"
-msgstr ""
+msgstr "Nummerfält"
 
 msgid "Styles"
-msgstr ""
+msgstr "Stilmallar"
 
 msgid "Item ID"
-msgstr ""
+msgstr "Föremålets ID"
 
 msgid "Posted on"
-msgstr ""
+msgstr "Inlagd den"
 
 msgid "The size of the file in bytes."
-msgstr ""
+msgstr "Storleken på filen i byte."
 
 msgid "Interface"
-msgstr ""
+msgstr "Gränssnitt"
 
 msgid "Thresholds"
-msgstr ""
+msgstr "Tröskelvärden"
 
 msgid "@size KB"
-msgstr ""
+msgstr "@size KB"
 
 msgid "@size MB"
-msgstr ""
+msgstr "@size MB"
 
 msgid "@size GB"
-msgstr ""
+msgstr "@size GB"
 
 msgid "@size TB"
-msgstr ""
+msgstr "@size TB"
 
 msgid "@size PB"
-msgstr ""
+msgstr "@size PB"
 
 msgid "@size EB"
-msgstr ""
+msgstr "@size EB"
 
 msgid "@size ZB"
-msgstr ""
+msgstr "@size ZB"
 
 msgid "@size YB"
-msgstr ""
+msgstr "@size YB"
 
 msgid "All messages"
-msgstr ""
+msgstr "Alla meddelanden"
 
 msgid "Serialized"
-msgstr ""
+msgstr "Seriell"
 
 msgid "Discard changes"
-msgstr ""
+msgstr "Ignorera ändringar"
 
 msgid "No new posts"
-msgstr ""
+msgstr "Inga nya inlägg"
 
 msgid "Sticky topic"
-msgstr ""
+msgstr "Klistrat ämne"
 
 msgid "Emergency"
-msgstr ""
+msgstr "Nödsituation"
 
 msgid "Sort descending"
-msgstr ""
+msgstr "Sortera fallande"
 
 msgid "Sort ascending"
-msgstr ""
+msgstr "Sortera stigande"
 
 msgid "The name of the site."
-msgstr ""
+msgstr "Namnet på webbplatsen."
 
 msgid "The name of the term."
-msgstr ""
+msgstr "Namnet på termen."
 
 msgid "Optional features"
-msgstr ""
+msgstr "Valfria funktioner"
 
 msgid "Administrative title"
-msgstr ""
+msgstr "Administrativ titel"
 
 msgid "Administrative description"
-msgstr ""
+msgstr "Administrativ beskrivning"
 
 msgid "Allow settings"
-msgstr ""
+msgstr "Tillåt inställningar"
 
 msgid "Title override"
-msgstr ""
+msgstr "Åsidosättande av titel"
 
 msgid "Style settings"
-msgstr ""
+msgstr "Inställningar för stil"
 
 msgid "Views Block"
-msgstr ""
+msgstr "Block för vy"
 
 msgid "Alert"
-msgstr ""
+msgstr "Varna"
 
 msgid "Critical"
-msgstr ""
+msgstr "Kritisk"
 
 msgid "Top center"
-msgstr ""
+msgstr "Längst upp i mitten"
 
 msgid "Bottom center"
-msgstr ""
+msgstr "Nederst - centrerad"
 
 msgid "Content Translation"
-msgstr ""
+msgstr "Översättning av innehåll"
 
 msgid "Warnings"
-msgstr ""
+msgstr "Varningar"
 
 msgid "Format string"
-msgstr ""
+msgstr "Formatera sträng"
 
 msgid "Add format"
-msgstr ""
+msgstr "Lägg till format"
 
 msgid "Delete date format"
-msgstr ""
+msgstr "Radera datumformat"
 
 msgid "Content type name"
-msgstr ""
+msgstr "Namn för innehållstyp"
 
 msgid "Taxonomy Term"
-msgstr ""
+msgstr "Taxonomiterm"
 
 msgid "Slate"
-msgstr ""
+msgstr "Skiffer"
 
 msgid "Check settings"
-msgstr ""
+msgstr "Kontrollera inställningar"
 
 msgid "@field_name (Locked)"
-msgstr ""
+msgstr "@field_name (Låst)"
 
 msgid "- Select a field type -"
-msgstr ""
+msgstr "- Välj en fälttyp -"
 
 msgid "- Select an existing field -"
-msgstr ""
+msgstr "- Välj ett befintligt fält -"
 
 msgid "Add new field: you need to provide a label."
-msgstr ""
+msgstr "Lägg till nytt fält: du måste ange en etikett."
 
 msgid "The field %field is locked and cannot be edited."
-msgstr ""
+msgstr "Fältet %field är låst och kan inte redigeras."
 
 msgid "%name must be a number."
-msgstr ""
+msgstr "%name måste vara ett tal."
 
 msgid "Field formatter"
-msgstr ""
+msgstr "Fältformaterare"
 
 msgid "(first item is 0)"
-msgstr ""
+msgstr "(första alternativet är 0)"
 
 msgid "(start from last values)"
-msgstr ""
+msgstr "(börja från sista värdena)"
 
 msgid "New group"
-msgstr ""
+msgstr "Ny grupp"
 
 msgid "Content moderation"
-msgstr ""
+msgstr "Moderering av innehåll"
 
 msgid "Unsigned"
-msgstr ""
+msgstr "Ej signerad"
 
 msgid "Number of pages"
-msgstr ""
+msgstr "Antal sidor"
 
 msgid "The weight of this term in relation to other terms."
-msgstr ""
+msgstr "Vikten på den här termen i relation till andra."
 
 msgid "Help text to display for the vocabulary."
-msgstr ""
+msgstr "Hjälptext att visa för vokabulären."
 
 msgid ""
 "Whether or not related terms are enabled within the vocabulary. (0 = "
 "disabled, 1 = enabled)"
 msgstr ""
+"Huruvida relaterade termer är aktiverade i vokabulären eller ej. (0 = "
+"inaktiverad, 1 = aktiverad)"
 
 msgid ""
 "The type of hierarchy allowed within the vocabulary. (0 = disabled, 1 = "
 "single, 2 = multiple)"
 msgstr ""
+"Den typ av hierarki som är tillåten inom vokabulären. (0 = inaktiverad, 1 = "
+"singel, 2 = flera)"
 
 msgid ""
 "Whether or not multiple terms from this vocabulary may be assigned to a "
 "node. (0 = disabled, 1 = enabled)"
 msgstr ""
+"Huruvida flera termer från denna vokabulär kan tilldelas till en nod eller "
+"ej. (0 = inaktiverad, 1 = aktiverad)"
 
 msgid ""
 "Whether or not terms are required for nodes using this vocabulary. (0 = "
 "disabled, 1 = enabled)"
 msgstr ""
+"Huruvida termer krävs för noder eller ej med hjälp av denna vokabulär. (0 = "
+"inaktiverad, 1 = aktiverad)"
 
 msgid ""
 "Whether or not free tagging is enabled for the vocabulary. (0 = disabled, 1 "
 "= enabled)"
 msgstr ""
+"Huruvida fri märkning är aktiverad för vokabulären eller ej. (0 = "
+"inaktiverad, 1 = aktiverad)"
 
 msgid "The weight of the vocabulary in relation to other vocabularies."
-msgstr ""
+msgstr "Vikten av vokabulären i förhållande till andra vokabulärer."
 
 msgid "Views settings"
-msgstr ""
+msgstr "Inställningar för vyer"
 
 msgid "Rotate"
-msgstr ""
+msgstr "Rotera"
 
 msgid "Relative date"
-msgstr ""
+msgstr "Relativt datum"
 
 msgid "Remove selected"
-msgstr ""
+msgstr "Tag bort valda"
 
 msgid "Facility"
-msgstr ""
+msgstr "Resurshantering"
 
 msgid "Page bottom"
-msgstr ""
+msgstr "Nederst på sidan"
 
 msgid "Show links"
-msgstr ""
+msgstr "Visa länkar"
 
 msgid "Lock"
-msgstr ""
+msgstr "Lås"
 
 msgid "Limited"
-msgstr ""
+msgstr "Begränsad"
 
 msgid "Current revision"
-msgstr ""
+msgstr "Nuvarande version"
 
 msgid " minutes"
-msgstr ""
+msgstr " minutes"
 
 msgid "Definitions"
-msgstr ""
+msgstr "Definitioner"
 
 msgid "Drupal 6"
-msgstr ""
+msgstr "Drupal 6"
 
 msgid "Drupal 7"
-msgstr ""
+msgstr "Drupal 7"
 
 msgid "Regional settings"
-msgstr ""
+msgstr "Lokala inställningar"
 
 msgid "Your virtual face or picture."
-msgstr ""
+msgstr "Ditt virtuella ansikte eller bild."
 
 msgid "Delete content"
-msgstr ""
+msgstr "Radera innehåll"
 
 msgid "Author name"
-msgstr ""
+msgstr "Författarnamn"
 
 msgid "Text format"
-msgstr ""
+msgstr "Textformat"
 
 msgid "Last »"
-msgstr ""
+msgstr "Sista »"
 
 msgid "Who's online"
-msgstr ""
+msgstr "Vilka är inloggade"
 
 msgid "Page count"
-msgstr ""
+msgstr "Sidräkning"
 
 msgid "« First"
-msgstr ""
+msgstr "« Första"
 
 msgid "Upload progress"
-msgstr ""
+msgstr "Uppladdningsförlopp"
 
 msgid "Manages the user registration and login system."
-msgstr ""
+msgstr "Hanterar användarregistreringen och inloggningssystemet."
 
 msgid "Show description"
-msgstr ""
+msgstr "Visa beskrivning"
 
 msgid "URL of the origin of the event."
-msgstr ""
+msgstr "URL för källan till händelsen."
 
 msgid "Referer"
-msgstr ""
+msgstr "Refererare"
 
 msgid "Hostname of the user who triggered the event."
-msgstr ""
+msgstr "Värdnamn för användaren som utlöste händelsen."
 
 msgid "Database is encoded in UTF-8"
-msgstr ""
+msgstr "Databasen är kodad i UTF-8"
 
 msgid ""
 "Drupal could not determine the encoding of the database was set to UTF-8"
-msgstr ""
+msgstr "Drupal kunde inte avgöra om kodningen för databasen angavs till UTF-8"
 
 msgid "PostgreSQL has initialized itself."
-msgstr ""
+msgstr "PostgreSQL har initialiserat sig självt."
 
 msgid "Workflows"
-msgstr ""
+msgstr "Arbetsflöden"
 
 msgid "Default values"
-msgstr ""
+msgstr "Förvalda värden"
 
 msgid "Saving"
-msgstr ""
+msgstr "Sparar"
 
 msgid ""
 "Select the test(s) or test group(s) you would like to run, and click <em>Run"
 " tests</em>."
 msgstr ""
+"Välj test(er) eller testgrupp(er) som du vill köra och klicka sedan på "
+"<em>Kör tester</em>."
 
 msgid "All (@count)"
-msgstr ""
+msgstr "Alla (@count)"
 
 msgid "Pass (@count)"
-msgstr ""
+msgstr "Godkända (@count)"
 
 msgid "Fail (@count)"
-msgstr ""
+msgstr "Misslyckades @count)"
 
 msgid "Return to list"
-msgstr ""
+msgstr "Återgå till lista"
 
 msgid "Clear results after each complete test suite run"
-msgstr ""
+msgstr "Rensa resultat efter varje genomförd testkörning"
 
 msgid "Provide verbose information when running tests"
-msgstr ""
+msgstr "Tillhandahåll utförlig information vid körning av tester"
 
 msgid ""
 "The verbose data will be printed along with the standard assertions and is "
@@ -7696,124 +8014,135 @@ msgid ""
 "suite run. The verbose data output is very detailed and should only be used "
 "when debugging."
 msgstr ""
+"Den utförlig informationen kommer att skrivas ut tillsammans med "
+"standardpåståenden och är användbart för felsökning. Den utförlig "
+"informationen kommer att raderas mellan varje testkörning. Utmatningen av "
+"den utförlig informationen är mycket detaljerad och bör endast användas vid "
+"felsökning."
 
 msgid ""
 "HTTP auth settings to be used by the SimpleTest browser during testing. "
 "Useful when the site requires basic HTTP authentication."
 msgstr ""
+"HTTP-auth inställningar som skall användas av SimpleTest läsare under "
+"testning. Användbart när webbplatsen kräver grundläggande HTTP-verifiering."
 
 msgid "The test run did not successfully finish."
-msgstr ""
+msgstr "Testkörningen kunde inte köras klart."
 
 msgid ""
 "Clear results is disabled and the test results table will not be cleared."
 msgstr ""
+"Rensning av resultat är inaktiverat och tabellen för testresultat kommer "
+"inte att rensas."
 
 msgid "No leftover tables to remove."
-msgstr ""
+msgstr "Inga kvarvarande tabeller att ta bort."
 
 msgid "1 debug message"
 msgid_plural "@count debug messages"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 felsökningmeddelande"
+msgstr[1] "@count felsökningsmeddelanden"
 
 msgid "Removed 1 test result."
 msgid_plural "Removed @count test results."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Tog bort 1 testresultat."
+msgstr[1] "Tog bort @ testresultat."
 
 msgid "Removed 1 leftover table."
 msgid_plural "Removed @count leftover tables."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Tog bort 1 överbliven tabell."
+msgstr[1] "Tog bort @count överblivna tabeller."
 
 msgid "Removed 1 temporary directory."
 msgid_plural "Removed @count temporary directories."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Tog bort 1 tillfällig katalog."
+msgstr[1] "Tog bort @count tillfälliga kataloger."
 
 msgid "Test result"
-msgstr ""
+msgstr "Testresultat"
 
 msgid "Node status"
-msgstr ""
+msgstr "Nodstatus"
 
 msgid "Edit style"
-msgstr ""
+msgstr "Redigera stil"
 
 msgid "All content"
-msgstr ""
+msgstr "Allt innehåll"
 
 msgid "Maximum file size"
-msgstr ""
+msgstr "Största filstorlek"
 
 msgid "Machine name:"
-msgstr ""
+msgstr "Maskinläsbart namn:"
 
 msgid "Content statistics"
-msgstr ""
+msgstr "Statistik för innehåll"
 
 msgid "Translation files"
-msgstr ""
+msgstr "Översättningsfiler"
 
 msgid "Upgrade"
-msgstr ""
+msgstr "Uppgradera"
 
 msgid "Delete items"
-msgstr ""
+msgstr "Radera objekt"
 
 msgid "Fetcher"
-msgstr ""
+msgstr "Inhämtare"
 
 msgid "This permission is inherited from the authenticated user role."
-msgstr ""
+msgstr "Denna behörighet ärvs från rollen verifierad användare."
 
 msgid "Seven"
-msgstr ""
+msgstr "Seven"
 
 msgid "Filter format"
-msgstr ""
+msgstr "Format för filter"
 
 msgid "Pager type"
-msgstr ""
+msgstr "Typ av paginerare"
 
 msgid ""
 "Target of the link, such as _blank, _parent or an iframe's name. This field "
 "is rarely used."
 msgstr ""
+"Länkens mål, t.ex. _blank, _parent eller en iframe:s namn. Detta fält "
+"används sällan."
 
 msgid "@argument title"
-msgstr ""
+msgstr "Titel för @argument"
 
 msgid "@argument input"
-msgstr ""
+msgstr "Inmatning för @argument"
 
 msgid "Count the number 0 as empty"
-msgstr ""
+msgstr "Räkna nummer 0 som tom"
 
 msgid "Hide if empty"
-msgstr ""
+msgstr "Dölj om tomt"
 
 msgid "Starting value"
-msgstr ""
+msgstr "Startvärde"
 
 msgid "Specify the number the counter should start at."
-msgstr ""
+msgstr "Ange vilket nummer räknaren skall börja på."
 
 msgid "Does not start with"
-msgstr ""
+msgstr "Som inte börjar med"
 
 msgid "not_begins"
-msgstr ""
+msgstr "Börjar inte med"
 
 msgid "Does not end with"
-msgstr ""
+msgstr "Slutar inte med"
 
 msgid "not_ends"
-msgstr ""
+msgstr "Slutar inte med"
 
 msgid "The view %name has been saved."
-msgstr ""
+msgstr "Vyn %name har sparats."
 
 msgid ""
 "This filter can cause items that have more than one of the selected options "
@@ -7823,585 +8152,637 @@ msgid ""
 "caution. Shouldn't be set on single-value fields, as it may cause values to "
 "disappear from display, if used on an incompatible field."
 msgstr ""
+"Om det här filtret har flera val markerade i listan kan det resultera i "
+"duplicerade resultat. Den här kryssrutan kan reducera dessa dubbletter. "
+"Observera att om du har många termer markerade kan sökningen bli "
+"prestandakrävande, så använd detta val aktsamt. Kryssrutan bör inte vara "
+"ikryssad på fält med endast ett värde eftersom värdet då kan försvinna."
 
 msgid ""
 "Email of user that posted the comment. Will be empty if the author is a "
 "registered user."
 msgstr ""
+"E-postadress för användaren som lade in kommentaren. Kommer att vara tomt om"
+" författaren är en registrerad användare."
 
 msgid "The taxonomy term ID for the term."
-msgstr ""
+msgstr "Taxonomitermens ID"
 
 msgid "The taxonomy term name for the term."
-msgstr ""
+msgstr "Taxonomitermens namn"
 
 msgid "The name for the vocabulary the term belongs to."
-msgstr ""
+msgstr "Namnet för vokabuläret som termen tillhör."
 
 msgid ""
 "Choose which vocabularies you wish to relate. Remember that every term found"
 " will create a new record, so this relationship is best used on just one "
 "vocabulary that has only one term per node."
 msgstr ""
+"Välj vilka vokabulär som du vill relatera. Kom ihåg att varje term som "
+"hittas kommer att skapa en ny post, så denna relation är bäst lämpat för "
+"just ett vokabulär som enbart har en term per nod."
 
 msgid "The name of the role."
-msgstr ""
+msgstr "Namnet på rollen."
 
 msgid "Hide empty fields"
-msgstr ""
+msgstr "Dölj tomma fält"
 
 msgid "Do not display fields, labels or markup for fields that are empty."
-msgstr ""
+msgstr "Visa inte fält, etiketter eller uppmärkning för fält som är tomma."
 
 msgid "Title of the feed."
-msgstr ""
+msgstr "Titel på innehållsflödet."
 
 msgid "Language select"
-msgstr ""
+msgstr "Språkval"
 
 msgid "Site email address"
-msgstr ""
+msgstr "Webbplatsens e-postadress"
 
 msgid ""
 "The <em>From</em> address in automated emails sent during registration and "
 "new password requests, and other notifications. (Use an address ending in "
 "your site's domain to help prevent this email being flagged as spam.)"
 msgstr ""
+"Avsändaradress <em>Från</em> som används för automatisk e-post som skickas "
+"vid registrering, begäran om nytt lösenord och vid andra aviseringar. "
+"(Använd en adress som slutar med din webbplats domän för att minska risken "
+"för att e-posten flaggas som spam.)"
 
 msgid "Administer forums"
-msgstr ""
+msgstr "Administrera forum"
 
 msgid "Length is shorter than"
-msgstr ""
+msgstr "Längden är kortare än"
 
 msgid "shorter than"
-msgstr ""
+msgstr "kortare än"
 
 msgid "Length is longer than"
-msgstr ""
+msgstr "Length is longer than"
 
 msgid "longer than"
-msgstr ""
+msgstr "längre än"
 
 msgid "SQL Query"
-msgstr ""
+msgstr "SQL Query"
 
 msgid "Query will be generated and run using the Drupal database API."
 msgstr ""
+"Databasfråga kommer att genereras och köras genom att använda Drupals "
+"databas API."
 
 msgid "revision user"
-msgstr ""
+msgstr "användare för version"
 
 msgid "Exposed form"
-msgstr ""
+msgstr "Exponerat formulär"
 
 msgid "Cancel account"
-msgstr ""
+msgstr "Ta bort konto"
 
 msgid "Maximum number of characters"
-msgstr ""
+msgstr "Största antal tecken"
 
 msgid "Current Theme"
-msgstr ""
+msgstr "Nuvarande tema"
 
 msgid "Dependencies"
-msgstr ""
+msgstr "Beroenden"
 
 msgid "Administrator role"
-msgstr ""
+msgstr "Administratörsroll"
 
 msgid "Inherit pager"
-msgstr ""
+msgstr "Ärv paginering"
 
 msgid "Render pager"
-msgstr ""
+msgstr "Generera paginerare"
 
 msgid "Render"
-msgstr ""
+msgstr "Generera"
 
 msgid "Image scale"
-msgstr ""
+msgstr "Bildskala"
 
 msgid "No revision"
-msgstr ""
+msgstr "Inga versioner"
 
 msgid "Requires a title"
-msgstr ""
+msgstr "Kräver en titel"
 
 msgid "CKEditor"
-msgstr ""
+msgstr "CKEditor"
 
 msgid "Filter value"
-msgstr ""
+msgstr "Filtervärde"
 
 msgid "Entities"
-msgstr ""
+msgstr "Objekt"
 
 msgid "Private files"
-msgstr ""
+msgstr "Privata filer"
 
 msgid "Not restricted"
-msgstr ""
+msgstr "Ej begränsad"
 
 msgid "Operations links"
-msgstr ""
+msgstr "Länkar till funktioner"
 
 msgid "Choose a block"
-msgstr ""
+msgstr "Välj ett block"
 
 msgid "Toolbar buttons"
-msgstr ""
+msgstr "Knappar för verktygsrad"
 
 msgid "Book ID"
-msgstr ""
+msgstr "ID-nummer för bok"
 
 msgid "The unique ID of the comment."
-msgstr ""
+msgstr "Det unika ID-numret för kommentaren."
 
 msgid "The IP address of the computer the comment was posted from."
-msgstr ""
+msgstr "IP-adressen för datorn som kommentaren lades in ifrån."
 
 msgid "The email address left by the comment author."
-msgstr ""
+msgstr "Den e-postadress som kommentarens författare lämnade."
 
 msgid "The home page URL left by the comment author."
-msgstr ""
+msgstr "Hemside-URL som kommentarens författare angav."
 
 msgid "The formatted content of the comment itself."
-msgstr ""
+msgstr "Det formatterade innehållet för själva kommentaren."
 
 msgid "The URL of the comment."
-msgstr ""
+msgstr "URL:en för kommentaren."
 
 msgid "Base table"
-msgstr ""
+msgstr "Bastabell"
 
 msgid "Published status"
-msgstr ""
+msgstr "Status för publicering"
 
 msgid "Structure"
-msgstr ""
+msgstr "Struktur"
 
 msgid "The URL of the comment's edit page."
-msgstr ""
+msgstr "URL:en för kommentarens redigeringssida."
 
 msgid "The date the comment was posted."
-msgstr ""
+msgstr "Datumet som kommentaren lades in."
 
 msgid "The comment's parent, if comment threading is active."
-msgstr ""
+msgstr "Kommentarens ovanliggande kommentar, om trådning är aktiverat."
 
 msgid "The unique ID of the node's latest revision."
-msgstr ""
+msgstr "Det unika ID-numret för nodens senaste version."
 
 msgid "The human-readable name of the node type."
-msgstr ""
+msgstr "Det synliga namnet för nodtypen."
 
 msgid "The URL of the node."
-msgstr ""
+msgstr "URL:en för noden."
 
 msgid "The URL of the node's edit page."
-msgstr ""
+msgstr "URL:en för nodens redigeringssida."
 
 msgid "The date the node was most recently updated."
-msgstr ""
+msgstr "Datumet som noden senast uppdaterades."
 
 msgid "The number of visitors who have read the node."
-msgstr ""
+msgstr "Antalet besökare som har läst noden."
 
 msgid "The number of visitors who have read the node today."
-msgstr ""
+msgstr "Antalet besökare som har läst noden idag."
 
 msgid "Last view"
-msgstr ""
+msgstr "Senast visad"
 
 msgid "The date on which a visitor last read the node."
-msgstr ""
+msgstr "Datumet som en besökare senast läste noden."
 
 msgid "The slogan of the site."
-msgstr ""
+msgstr "Slogan för webbplatsen."
 
 msgid "The administrative email address for the site."
-msgstr ""
+msgstr "Den administrativa e-postadressen för webbplatsen."
 
 msgid "The URL of the site's front page."
-msgstr ""
+msgstr "URL:en för webbplatsens startsida."
 
 msgid "The URL of the site's login page."
-msgstr ""
+msgstr "URL:en för webbplatsens inloggningssida."
 
 msgid "The unique ID of the uploaded file."
-msgstr ""
+msgstr "Det unika ID-numret för den uppladdade filen."
 
 msgid "The name of the file on disk."
-msgstr ""
+msgstr "Namnet på filen på hårddisken."
 
 msgid "The web-accessible URL for the file."
-msgstr ""
+msgstr "Den åtkomliga URL:en för filen."
 
 msgid "The date the file was most recently changed."
-msgstr ""
+msgstr "Datumet som filen senast ändrades."
 
 msgid "The user who originally uploaded the file."
-msgstr ""
+msgstr "Användaren som ursprungligen laddade upp filen."
 
 msgid "The unique ID of the taxonomy term."
-msgstr ""
+msgstr "Det unika ID-numret för taxonomitermen."
 
 msgid "The name of the taxonomy term."
-msgstr ""
+msgstr "Namnet på taxonomintermen."
 
 msgid "The optional description of the taxonomy term."
-msgstr ""
+msgstr "Den valfria beskrivningen för taxonomitermen."
 
 msgid "The number of nodes tagged with the taxonomy term."
-msgstr ""
+msgstr "Det antal noder som märkts med taxonomitermen."
 
 msgid "The URL of the taxonomy term."
-msgstr ""
+msgstr "URL:en för taxonomitermen."
 
 msgid "The vocabulary the taxonomy term belongs to."
-msgstr ""
+msgstr "Vokabulären som taxonomitermen hör till."
 
 msgid "The parent term of the taxonomy term, if one exists."
-msgstr ""
+msgstr "Den ovanliggande termen för taxonomitermen, om det finns någon."
 
 msgid "The unique ID of the taxonomy vocabulary."
-msgstr ""
+msgstr "Det unika ID-numret för taxonomivokabulären."
 
 msgid "The name of the taxonomy vocabulary."
-msgstr ""
+msgstr "Namnet på taxonomivokabulären."
 
 msgid "The optional description of the taxonomy vocabulary."
-msgstr ""
+msgstr "Den valfria beskrivningen av taxonomins vokabulär."
 
 msgid ""
 "The number of nodes tagged with terms belonging to the taxonomy vocabulary."
 msgstr ""
+"Det antal noder som märkts med termer som hör till taxonomivokabulären."
 
 msgid "The number of terms belonging to the taxonomy vocabulary."
-msgstr ""
+msgstr "Det antal termer som hör till taxonomivokabulären."
 
 msgid "The unique ID of the user account."
-msgstr ""
+msgstr "Det unika ID-numret för användarkontot."
 
 msgid "The login name of the user account."
-msgstr ""
+msgstr "Inloggningsnamnet för användarkontot."
 
 msgid "The email address of the user account."
-msgstr ""
+msgstr "E-postadressen för användarkontot."
 
 msgid "The URL of the account profile page."
-msgstr ""
+msgstr "URL för kontots profilsida."
 
 msgid "The date the user last logged in to the site."
-msgstr ""
+msgstr "Datumet då användaren senast loggade in på webbplatsen."
 
 msgid "The date the user account was created."
-msgstr ""
+msgstr "Datumet som användarkontot skapades."
 
 msgid "Review log"
-msgstr ""
+msgstr "Granska logg"
 
 msgid "Sender name"
-msgstr ""
+msgstr "Avsändarens namn"
 
 msgid "Sender email"
-msgstr ""
+msgstr "Avsändarens e-post"
 
 msgid "Time zone settings"
-msgstr ""
+msgstr "Inställningar för tidszon"
 
 msgid "Content Moderation"
-msgstr ""
+msgstr "Moderering av innehåll"
 
 msgid "You are not allowed to access this page."
-msgstr ""
+msgstr "Du har inte behörighet att se denna sida."
 
 msgid "Authorize file system changes"
-msgstr ""
+msgstr "Godkänn ändringar i filsystemet"
 
 msgid "It appears you have reached this page in error."
-msgstr ""
+msgstr "Det verkar som om du har kommit till denna sida av misstag."
 
 msgid "authorize.php"
-msgstr ""
+msgstr "authorize.php"
 
 msgid "Cron could not run because an invalid key was used."
 msgstr ""
+"Schemalagda aktiviteter kunde inte köras eftersom en ogiltig nyckel "
+"användes."
 
 msgid "Cron could not run because the site is in maintenance mode."
 msgstr ""
+"Schemalagda aktiviteter kunde inte köras eftersom webbplatsen är i "
+"underhållsläge."
 
 msgid "Default country"
-msgstr ""
+msgstr "Förvalt land"
 
 msgid ""
 "In your %settings_file file you have configured @drupal to use a %driver "
 "server, however your PHP installation currently does not support this "
 "database type."
 msgstr ""
+"I din fil %settings_file har du ställt in att @drupal skall använda en "
+"server av typen %driver, men din installation av PHP stöder för närvarande "
+"inte denna typ av databas."
 
 msgid ""
 "We were unable to find any installation profiles. Installation profiles tell"
 " us what modules to enable and what schema to install in the database. A "
 "profile is necessary to continue with the installation process."
 msgstr ""
+"Vi kunde inte hitta några installationprofiler. Installationprofiler talar "
+"om för oss vilka moduler som skall aktiveras och vilket schema som skall "
+"installeras i databasen. En profil är nödvändig för att kunna fortsätta med "
+"installationsprocessen."
 
 msgid "Congratulations, you installed @drupal!"
-msgstr ""
+msgstr "Grattis, du har installerat @drupal!"
 
 msgid "Settings file"
-msgstr ""
+msgstr "Inställningsfil"
 
 msgid "Site maintenance account"
-msgstr ""
+msgstr "Konto för underhåll av webbplats"
 
 msgid "No pending updates."
-msgstr ""
+msgstr "Inga väntande uppdateringar."
 
 msgid "1 pending update"
 msgid_plural "@count pending updates"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 väntande uppdatering"
+msgstr[1] "@count väntande uppdateringar"
 
 msgid "Unable to continue, no available methods of file transfer"
-msgstr ""
+msgstr "Kunde inte fortsätta, inga filöverföringsmetoder tillgängliga."
 
 msgid "To continue, provide your server connection details"
-msgstr ""
+msgstr "Ange detaljerna för din servers anslutning för att fortsätta"
 
 msgid "Connection method"
-msgstr ""
+msgstr "Anslutningsmetod"
 
 msgid "Enter connection settings"
-msgstr ""
+msgstr "Ange inställningar för anslutning"
 
 msgid "@backend connection settings"
-msgstr ""
+msgstr "Anslutningsinställningar för @backend"
 
 msgid "Change connection type"
-msgstr ""
+msgstr "Ändra typ av anslutning"
 
 msgid "No active batch."
-msgstr ""
+msgstr "Ingen aktiv batch."
 
 msgid "Site under maintenance"
-msgstr ""
+msgstr "Webbplatsen underhålls"
 
 msgid "Archivers can only operate on local files: %file not supported"
-msgstr ""
+msgstr "Arkiveringsverktyg fungerar endast på lokala filer: %file stöds inte"
 
 msgid ""
 "The file %source could not be uploaded because a file by that name already "
 "exists in the destination %directory."
 msgstr ""
+"Filen %source kunde inte laddas upp eftersom en fil med samma namn redan "
+"finns i målmappen %directory."
 
 msgid ""
 "The file's name exceeds the 240 characters limit. Please rename the file and"
 " try again."
 msgstr ""
+"Filens namn är längre än gränsen på 240 tecken. Var vänlig byt namn på filen"
+" och försök igen."
 
 msgid "The file permissions could not be set on %uri."
-msgstr ""
+msgstr "Filbehörigheterna kunde inte anges för %uri."
 
 msgid "Completed @current of @total."
-msgstr ""
+msgstr "Slutförde @current av @total."
 
 msgid ""
 "Failed to run all tasks against the database server. The task %task wasn't "
 "found."
 msgstr ""
+"Misslyckades med att köra uppgifter mot servern för databasen. Uppgiften "
+"%task hittades inte."
 
 msgid "Failed to modify %settings. Verify the file permissions."
-msgstr ""
+msgstr "Kunde inte modifiera %settings. Kontrollera filbehörigheterna."
 
 msgid "Failed to open %settings. Verify the file permissions."
-msgstr ""
+msgstr "Kunde inte öppna %settings. Kontrollera filbehörigheterna."
 
 msgid "Required modules"
-msgstr ""
+msgstr "Obligatoriska moduler"
 
 msgid "Required modules not found."
-msgstr ""
+msgstr "Obligatoriska moduler hittades ej."
 
 msgid "%module module uninstalled."
-msgstr ""
+msgstr "Modulen %module avinstallerades."
 
 msgid "Saint Barthélemy"
-msgstr ""
+msgstr "Saint-Barthélemy"
 
 msgid "No strings available."
-msgstr ""
+msgstr "Inga strängar tillgängliga."
 
 msgid "JavaScript translation file %file.js was lost."
-msgstr ""
+msgstr "Översättningsfil för JavaScript %file.js förlorades."
 
 msgid "Operating in maintenance mode."
-msgstr ""
+msgstr "Webbplatsen är i underhållsläge."
 
 msgid "Unable to determine the type of the source directory."
-msgstr ""
+msgstr "Kunde inte fastställa typen för källkatalogen."
 
 msgid "Cannot determine the type of project."
-msgstr ""
+msgstr "Kan inte fastställa typ av projekt."
 
 msgid ""
 "Fatal error in update, cowardly refusing to wipe out the install directory."
 msgstr ""
+"Kritiskt fel under uppdatering. Vägrar fegt att rensa bort "
+"installationskatalogen."
 
 msgid "Unable to create %directory due to the following: %reason"
-msgstr ""
+msgstr "Kunde inte skapa %directory på grund av följande: %reason"
 
 msgid "New comment count"
-msgstr ""
+msgstr "Antal nya kommentarer"
 
 msgid "Field types"
-msgstr ""
+msgstr "Fälttyper"
 
 msgid "Path: !uri"
-msgstr ""
+msgstr "Sökväg: !uri"
 
 msgid "StatusText: !statusText"
-msgstr ""
+msgstr "Statustext: !statusText"
 
 msgid "(active tab)"
-msgstr ""
+msgstr "(aktiv flik)"
 
 msgid "HTTP Result Code: !status"
-msgstr ""
+msgstr "Resultatkod för HTTP: !status"
 
 msgid "Status message"
-msgstr ""
+msgstr "Statusmeddelande"
 
 msgid "An AJAX HTTP request terminated abnormally."
-msgstr ""
+msgstr "Ett AJAX HTTP-anrop avslutades oväntat."
 
 msgid "An AJAX HTTP error occurred."
-msgstr ""
+msgstr "Ett AJAX HTTP-fel inträffade"
 
 msgid "Debugging information follows."
-msgstr ""
+msgstr "Felsökningsinformation följer."
 
 msgid "Upload an OPML file containing a list of feeds to be imported."
 msgstr ""
+"Ladda upp en OPML-fil innehållandes en lista med nyhetsflöden som skall "
+"importeras."
 
 msgid "OPML Remote URL"
-msgstr ""
+msgstr "Extern URL till OPML"
 
 msgid ""
 "Enter the URL of an OPML file. This file will be downloaded and processed "
 "only once on submission of the form."
 msgstr ""
+"Ange URL:en för en OPML-fil. Denna fil kommer enbart att laddas ned och "
+"bearbetas en gång vid skickandet av formuläret."
 
 msgid "No new feed has been added."
-msgstr ""
+msgstr "Inget nytt nyhetsflöde har lagts till."
 
 msgid "The URL %url is invalid."
-msgstr ""
+msgstr "URL:en %url är inte giltig."
 
 msgid "A feed named %title already exists."
-msgstr ""
+msgstr "Ett nyhetsflöde med namnet %title finns redan."
 
 msgid "A feed with the URL %url already exists."
-msgstr ""
+msgstr "Ett nyhetsflöde med URL:en %url finns redan."
 
 msgid ""
 "Fetchers download data from an external source. Choose a fetcher suitable "
 "for the external source you would like to download from."
 msgstr ""
+"Inhämtare laddar ned data från en extern källa. Välj inhämtare som passar "
+"för den externa källan som du vill ladda ned från."
 
 msgid ""
 "Parsers transform downloaded data into standard structures. Choose a parser "
 "suitable for the type of feeds you would like to aggregate."
 msgstr ""
+"Tolkare omvandlar nedladdad data till standardstrukturer. Välj en tolkare "
+"som passar för den typ av flöde som du vill samla på."
 
 msgid ""
 "Processors act on parsed feed data, for example they store feed items. "
 "Choose the processors suitable for your task."
 msgstr ""
+"Bearbetare fungerar på tolkad data för nyhetsflöde, till exempel så lagrar "
+"de poster. Välj den bearbetare som passar bäst för din uppgift."
 
 msgid "For most aggregation tasks, the default settings are fine."
 msgstr ""
+"För de flesta uppgifter för innehållssamlaren så fungerar "
+"standardinställningarna."
 
 msgid "Default fetcher"
-msgstr ""
+msgstr "Förvald inhämtare"
 
 msgid "Downloads data from a URL using Drupal's HTTP request handler."
 msgstr ""
+"Laddar ned data från en URL genom att använda Drupals hanterare för HTTP-"
+"anrop."
 
 msgid "Default parser"
-msgstr ""
+msgstr "Förvald tolkare"
 
 msgid "Default processor"
-msgstr ""
+msgstr "Förvald bearbetare"
 
 msgid "Creates lightweight records from feed items."
-msgstr ""
+msgstr "Skapar lättviktiga registreringar från poster i nyhetsflöde."
 
 msgid "Default processor settings"
-msgstr ""
+msgstr "Förvalda inställningar för bearbetare"
 
 msgid "Number of items shown in listing pages"
-msgstr ""
+msgstr "Antal poster som visas på listsidor"
 
 msgid "Length of trimmed description"
-msgstr ""
+msgstr "Längd på nedkortad beskrivning"
 
 msgid ""
 "The maximum number of characters used in the trimmed version of content."
 msgstr ""
+"Det maximala antal tecken som används i en nedkortad version av innehåll."
 
 msgid "Viewing feeds"
-msgstr ""
+msgstr "Visar nyhetsflöden"
 
 msgid "Adding, editing, and deleting feeds"
-msgstr ""
+msgstr "Skapa, redigera och radera nyhetsflöden"
 
 msgid "Configuring cron"
-msgstr ""
+msgstr "Konfigurera schemalagda aktiviteter"
 
 msgid "Administer news feeds"
-msgstr ""
+msgstr "Administrera nyhetsflöden"
 
 msgid "View news feeds"
-msgstr ""
+msgstr "Visa flöden"
 
 msgid "Controlling visibility"
-msgstr ""
+msgstr "Synlighet"
 
 msgid "Creating custom blocks"
-msgstr ""
+msgstr "Spapa anpassade block"
 
 msgid "Demonstrate block regions (@theme)"
-msgstr ""
+msgstr "Visa blockregioner (@theme)"
 
 msgid "Administer blocks"
-msgstr ""
+msgstr "Administrera block"
 
 msgid "Restricted to certain pages"
-msgstr ""
+msgstr "Begränsad till vissa sidor"
 
 msgid "The block cannot be placed in this region."
-msgstr ""
+msgstr "Blocket kan inte placeras i denna region."
 
 msgid "No books available."
-msgstr ""
+msgstr "Inga böcker tillgängliga."
 
 msgid "Content types allowed in book outlines"
-msgstr ""
+msgstr "Tillåtna innehållstyper i bokdisposition"
 
 msgid "Users with the %outline-perm permission can add all content types."
 msgstr ""
+"Användare med behörigheten %outline-perm kan lägga till alla innehållstyper."
 
 msgid "Administer book outlines"
-msgstr ""
+msgstr "Administrera disposition för böcker"
 
 msgid "Adding and managing book content"
-msgstr ""
+msgstr "Lägga till och hantera bokinnehåll"
 
 msgid "Printing books"
-msgstr ""
+msgstr "Skriva ut böcker"
 
 msgid ""
 "Users with the <em>View printer-friendly books</em> permission can select "
@@ -8409,6 +8790,9 @@ msgid ""
 "page's content to generate a printer-friendly display of the page and all of"
 " its subsections."
 msgstr ""
+"Användare med behörigheten <em>visa utskriftsvänliga böcker</em> kan följa "
+"länken <em>utskriftsvänlig version</em> längst ner på boksidor, för att visa"
+" en utskriftsvänlig version av sidan och alla dess underavdelningar."
 
 msgid ""
 "The book module offers a means to organize a collection of related content "
@@ -8416,280 +8800,334 @@ msgid ""
 " displays links to adjacent book pages, providing a simple navigation system"
 " for creating and reviewing structured content."
 msgstr ""
+"Modulen Book ger möjlighet att organisera en samling besläktade "
+"innehållssidor, sammantaget kallat en bok. När de visas har detta innehåll "
+"automatiskt länkar till närliggande boksidor och ger ett enkelt "
+"navigeringssystem för att skapa och hitta strukturerat innehåll."
 
 msgid "Create new books"
-msgstr ""
+msgstr "Skapa nya böcker"
 
 msgid "View printer-friendly books"
-msgstr ""
+msgstr "Visa utskriftsvänliga böcker"
 
 msgid ""
 "View a book page and all of its sub-pages as a single document for ease of "
 "printing. Can be performance heavy."
 msgstr ""
+"Visa en boksida och alla dess underliggande sidor som ett samlat dokument "
+"för enklare utskrift. Kan vara prestandakrävande."
 
 msgid ""
 "<em>Books</em> have a built-in hierarchical navigation. Use for handbooks or"
 " tutorials."
 msgstr ""
+"<em>Böcker</em> har en inbyggd hierarkisk navigering. Använd för handböcker "
+"eller handledningar."
 
 msgid "Changing colors"
-msgstr ""
+msgstr "Ändring av färger"
 
 msgid "Select one or more comments to perform the update on."
-msgstr ""
+msgstr "Markera en eller flera kommentarer att utföra uppdateringen på."
 
 msgid "Deleted comment @cid and its replies."
-msgstr ""
+msgstr "Raderade kommentaren @cid och dess svar."
 
 msgid "Comment approved."
-msgstr ""
+msgstr "Kommentar godkänd."
 
 msgid "Tokens for comments posted on the site."
-msgstr ""
+msgstr "Ersättningstecken för kommentarer inlagda på webbplatsen."
 
 msgid "Unapproved comments (@count)"
-msgstr ""
+msgstr "Ej godkända kommentarer (@count)"
 
 msgid "Administer comments and comment settings"
-msgstr ""
+msgstr "Administrera kommentarer och kommentarinställningar"
 
 msgid "Edit own comments"
-msgstr ""
+msgstr "Redigera egna kommentarer"
 
 msgid "Threading"
-msgstr ""
+msgstr "Trådning"
 
 msgid "Show comment replies in a threaded list."
-msgstr ""
+msgstr "Visa svar på kommentarerer i en trådad visning."
 
 msgid "Allow comment title"
-msgstr ""
+msgstr "Tillåt titel för kommentar"
 
 msgid "Show reply form on the same page as comments"
-msgstr ""
+msgstr "Visa svarsformuläret på samma sida som kommentarer"
 
 msgid "Users with the \"Post comments\" permission can post comments."
-msgstr ""
+msgstr "Användare med behörigheten \"Skriva kommentarer\" kan skriva kommentarer."
 
 msgid "Users cannot post comments, but existing comments will be displayed."
 msgstr ""
+"Användare kan inte lägga in kommentarer, men existerande kommentarer kommer "
+"att visas."
 
 msgid "Comments are hidden from view."
-msgstr ""
+msgstr "Kommentarer är dolda från vyn."
 
 msgid ""
 "Your comment has been queued for review by site administrators and will be "
 "published after approval."
 msgstr ""
+"Your comment has been queued for review by site administrators and will be "
+"published after approval."
 
 msgid "Your comment has been posted."
-msgstr ""
+msgstr "Din kommentar har lagts in."
 
 msgid ""
 "The comment will be unpublished if it contains any of the phrases above. Use"
 " a case-sensitive, comma-separated list of phrases. Example: funny, bungee "
 "jumping, \"Company, Inc.\""
 msgstr ""
+"Kommentaren kommer att avpubliceras om den innehåller någon av ovanstående "
+"fraser. Använd en kommaseparerad lista med fraser. Exempel: rolig, hoppa "
+"fallskärm, \"Företag, AB\". \"."
 
 msgid ""
 "You cannot send more than %limit messages in @interval. Try again later."
 msgstr ""
+"Du kan inte skicka mer än %limit meddelanden inom @interval. Försök igen "
+"senare."
 
 msgid "Contact @username"
-msgstr ""
+msgstr "Kontakta @username"
 
 msgid "Administer contact forms and contact form settings"
-msgstr ""
+msgstr "Administrera kontaktformulär och inställningar för kontaktformulär."
 
 msgid "Use the site-wide contact form"
-msgstr ""
+msgstr "Använda webbplatsens kontaktformulär"
 
 msgid "Use users' personal contact forms"
-msgstr ""
+msgstr "Använd användarnas personliga kontaktformulär"
 
 msgid "Changing this setting will not affect existing users."
 msgstr ""
+"Ändringar i denna inställning kommer inte att påverka befintliga användare."
 
 msgid "Displaying contextual links"
-msgstr ""
+msgstr "Visar kontextuella länkar"
 
 msgid "Use contextual links"
-msgstr ""
+msgstr "Använda kontextuella länkar"
 
 msgid "Contextual links"
-msgstr ""
+msgstr "Contextual links"
 
 msgid "Database log cleared."
-msgstr ""
+msgstr "Logg för databasen rensad."
 
 msgid "Monitoring your site"
-msgstr ""
+msgstr "Bevaka din webbplats"
 
 msgid "Debugging site problems"
-msgstr ""
+msgstr "Felsöker webbplatsens problem"
 
 msgid "Allowed HTML tags in labels: @tags"
-msgstr ""
+msgstr "Tillåtna HTML-taggar i etiketter: @tags"
 
 msgid ""
 "The value of this field is being determined by the %function function and "
 "may not be changed."
 msgstr ""
+"Värdet för detta fält bestäms av funktionen %function och kan inte ändras."
 
 msgid "Allowed values list: each key must be a valid integer or decimal."
 msgstr ""
+"Lista för tillåtna värden: varje nyckel måste vara ett giltigt heltal eller "
+"decimaltal."
 
 msgid ""
 "Allowed values list: each key must be a string at most 255 characters long."
 msgstr ""
+"Lista för tillåtna värden: varje nyckel måste vara en sträng på som mest 255"
+" tecken."
 
 msgid "Allowed values list: keys must be integers."
-msgstr ""
+msgstr "Lista för tillåtna värden: nycklar måste vara heltal."
 
 msgid "Allows users to create and organize related content in an outline."
 msgstr ""
+"Låter användare skapa och organisera tillhörande innehåll i en översikt."
 
 msgid "Unapproved comments"
-msgstr ""
+msgstr "Ej godkända kommentarer"
 
 msgid "ResponseText: !responseText"
-msgstr ""
+msgstr "Svarstext: !responseText"
 
 msgid "Allows administrators to change the color scheme of compatible themes."
-msgstr ""
+msgstr "Låter administratörer ändra färgschemat för kompatibla teman."
 
 msgid ""
 "Provides contextual links to perform actions related to elements on a page."
 msgstr ""
+"Skapar kontextuella länkar för att genomföra handlingar relaterade till "
+"element på en sida."
 
 msgid "Provides discussion forums."
-msgstr ""
+msgstr "Tillhandahåller diskussionsforum."
 
 msgid "List (text)"
-msgstr ""
+msgstr "Lista (text)"
 
 msgid "ReadyState: !readyState"
-msgstr ""
+msgstr "Tillstånd: !readyState"
 
 msgid "This field stores a number in the database as an integer."
-msgstr ""
+msgstr "Detta fält lagrar ett tal i databasen som ett heltal."
 
 msgid "This field stores a number in the database in a fixed decimal format."
 msgstr ""
+"Detta fält lagrar ett tal i databasen som ett fastställt decimalformat."
 
 msgid "This field stores a number in the database in a floating point format."
-msgstr ""
+msgstr "Detta fält lagrar ett tal i databasen som ett flyttal."
 
 msgid ""
 "The minimum value that should be allowed in this field. Leave blank for no "
 "minimum."
 msgstr ""
+"Det minsta värdet som skall tillåtas i detta fält. Lämna tomt för inget "
+"minsta värde."
 
 msgid ""
 "The maximum value that should be allowed in this field. Leave blank for no "
 "maximum."
 msgstr ""
+"Det största värdet som skall tillåtas i detta fält. Lämna tomt för inget "
+"största värde."
 
 msgid ""
 "Define a string that should be prefixed to the value, like '$ ' or '&euro; "
 "'. Leave blank for none. Separate singular and plural values with a pipe "
 "('pound|pounds')."
 msgstr ""
+"Ange en sträng som skall sättas in före värdet, till exempel \"$\" eller  "
+"\"&euro;\". Utelämna för tomt värde. Separera enstaka och flerfaldiga värden"
+" med ett stående streck (\"krona|kronor\")."
 
 msgid "Summary input"
-msgstr ""
+msgstr "Inmatning av sammanfattning"
 
 msgid ""
 "This allows authors to input an explicit summary, to be displayed instead of"
 " the automatically trimmed text when using the \"Summary or trimmed\" "
 "display type."
 msgstr ""
+"Detta låter författare mata in en tydlig sammanfattning som skall visas "
+"istället för den automatiskt nedkortade texten vid användning av "
+"\"Sammanfattning eller nedkortad\" visningstyp."
 
 msgid "Summary or trimmed"
-msgstr ""
+msgstr "Sammanfattning eller nedkortad"
 
 msgid "Text area with a summary"
-msgstr ""
+msgstr "Textfält med en sammanfattning"
 
 msgid "Leave blank to use trimmed value of full text as the summary."
 msgstr ""
+"Lämna tomt för att använda nedkortat värde för fullständig text som "
+"sammanfattning."
 
 msgid "Hide summary"
-msgstr ""
+msgstr "Dölj sammanfattning"
 
 msgid "Edit summary"
-msgstr ""
+msgstr "Redigera sammanfattning"
 
 msgid "Edit field settings."
-msgstr ""
+msgstr "Inställningar för redigering av fält."
 
 msgid ""
 "These settings apply to the %field field everywhere it is used. These "
 "settings impact the way that data is stored in the database and cannot be "
 "changed once data has been created."
 msgstr ""
+"Dessa inställningar gäller för fältet %field på varje ställe som det "
+"används. Dessa inställningar påverkar hur data lagras i databasen och kan "
+"inte ändras när data väl har skapats."
 
 msgid "Updated field %label field settings."
-msgstr ""
+msgstr "Uppdaterade inställningar för fält %label."
 
 msgid "Attempt to update field %label failed: %message."
-msgstr ""
+msgstr "Försök att uppdatera fält %label misslyckades: %message."
 
 msgid "The field %field has been deleted from the %type content type."
-msgstr ""
+msgstr "Fältet %field har raderats från innehållstypen %type."
 
 msgid "There was a problem removing the %field from the %type content type."
 msgstr ""
+"Det uppstod ett problem vid borttagandet av %field från innehållstypen "
+"%type."
 
 msgid "Required field"
-msgstr ""
+msgstr "Obligatoriskt fält"
 
 msgid "The default value for this field, used when creating new content."
 msgstr ""
+"Standardvärdet för detta fält som används vid skapande av nytt innehåll."
 
 msgid "Saved %label configuration."
-msgstr ""
+msgstr "Sparade inställningar för %label."
 
 msgid "This list shows all fields currently in use for easy reference."
 msgstr ""
+"Denna lista visar alla fält som för närvarande används för enkel referens."
 
 msgid "Manage display"
-msgstr ""
+msgstr "Hantera visning"
 
 msgid "Field UI"
-msgstr ""
+msgstr "Field UI"
 
 msgid "This field stores the ID of a file as an integer value."
-msgstr ""
+msgstr "Det här fältet sparar ID för en fil som heltalsvärde."
 
 msgid "Enable <em>Display</em> field"
-msgstr ""
+msgstr "Aktivera fält <em>Visa</em>"
 
 msgid ""
 "The display option allows users to choose if a file should be shown when "
 "viewing the content."
 msgstr ""
+"Visningsalternativet tillåter en användare att välja om en fil skall visas "
+"när innehållet visas."
 
 msgid "Files displayed by default"
-msgstr ""
+msgstr "Visa filer som standard"
 
 msgid "This setting only has an effect if the display option is enabled."
 msgstr ""
+"Den här inställningen påverkar endast om visningsalternativet är aktiverat."
 
 msgid "Upload destination"
-msgstr ""
+msgstr "Destination för uppladdning"
 
 msgid ""
 "Select where the final files should be stored. Private file storage has "
 "significantly more overhead than public files, but allows restricted access "
 "to files within this field."
 msgstr ""
+"Välj var slutgiltiga filer skall lagras. Privat fillagring är avsevärt mer "
+"prestandakrävande än offentliga filer, men ger möjlighet till begränsad "
+"åtkomst till filer i detta fält."
 
 msgid ""
 "Optional subdirectory within the upload destination where files will be "
 "stored. Do not include preceding or trailing slashes."
 msgstr ""
+"Valbar underkatalog för den plats där filen kommer att lagras. Inkludera ej "
+"snedstreck i början eller slutet av katalognamnet."
 
 msgid ""
 "Enter a value like \"512\" (bytes), \"80 KB\" (kilobytes) or \"50 MB\" "
@@ -8697,89 +9135,104 @@ msgid ""
 "file sizes will be limited only by PHP's maximum post and file upload sizes "
 "(current limit <strong>%limit</strong>)."
 msgstr ""
+"Ange ett värde som \"512\" (bytes), \"80 KB\" (kilobytes) eller \"50 MB\" "
+"(megabytes) för att begränsa tillåten filstorlek. Om detta lämnas tomt "
+"kommer filstorleken endast att begränsas av PHP:s största post- och "
+"filuppladdningsstorlek (nuvarande begränsning är <strong>%limit</strong>)."
 
 msgid "Enable <em>Description</em> field"
-msgstr ""
+msgstr "Aktivera <em>Beskrivningsfält</em>"
 
 msgid ""
 "The description field allows users to enter a description about the uploaded"
 " file."
 msgstr ""
+"Fältet beskrivning ger användaren möjlighet att ange en beskrivning av den "
+"uppladdade filen."
 
 msgid ""
 "The list of allowed extensions is not valid, be sure to exclude leading dots"
 " and to separate extensions with a comma or space."
 msgstr ""
+"Listan med tillåtna filändelser är inte giltig. Se till att ta bort punkter "
+"i början av ord och separera filändelser med komma eller mellanslag."
 
 msgid "Generic file"
-msgstr ""
+msgstr "Allmän fil"
 
 msgid "Table of files"
-msgstr ""
+msgstr "Tabell av filer"
 
 msgid "Add a new file"
-msgstr ""
+msgstr "Lägg till ny fil"
 
 msgid "Include file in display"
-msgstr ""
+msgstr "Inkludera filen i visningen"
 
 msgid "The description may be used as the label of the link to the file."
-msgstr ""
+msgstr "Beskrivningen kan användas som etikett för länken till filen."
 
 msgid "All roles may use this format"
-msgstr ""
+msgstr "Alla roller får använda detta format"
 
 msgid "The text format ordering has been saved."
-msgstr ""
+msgstr "Ordningen för textformat har sparats."
 
 msgid "Add text format"
-msgstr ""
+msgstr "Lägg till textformat"
 
 msgid "All roles for this text format must be enabled and cannot be changed."
 msgstr ""
+"Alla roller för detta textformat måste vara aktiverade och kan inte ändras."
 
 msgid "Filter processing order"
-msgstr ""
+msgstr "Ordning för filterbehandling"
 
 msgid "Text format names must be unique. A format named %name already exists."
 msgstr ""
+"Namn på textformat måste vara unika. Ett format med namnet %name finns "
+"redan."
 
 msgid "Added text format %format."
-msgstr ""
+msgstr "Lade till textformat %format."
 
 msgid "The text format %format has been updated."
-msgstr ""
+msgstr "Textformatet %format har uppdaterats."
 
 msgid "Text formats"
-msgstr ""
+msgstr "Textformat"
 
 msgid "Choosing a text format"
-msgstr ""
+msgstr "Att välja ett text format"
 
 msgid ""
 "Warning: This permission may have security implications depending on how the"
 " text format is configured."
 msgstr ""
+"Varning: Denna behörighet kan ha säkerhetskonsekvenser beroende på hur "
+"textformatet är konfigurerat."
 
 msgid ""
 "Convert line breaks into HTML (i.e. <code>&lt;br&gt;</code> and "
 "<code>&lt;p&gt;</code>)"
 msgstr ""
+"Konvertera radbrytningar till HTML (t.ex. <code>&lt;br&gt;</code> och "
+"<code>&lt;p&gt;</code>)"
 
 msgid "Convert URLs into links"
-msgstr ""
+msgstr "Konvertera URL:er till länkar"
 
 msgid "Correct faulty and chopped off HTML"
-msgstr ""
+msgstr "Rätta till felaktig och avhuggen HTML"
 
 msgid "Display any HTML as plain text"
-msgstr ""
+msgstr "Visa all HTML som ren text"
 
 msgid "Display basic HTML help in long filter tips"
-msgstr ""
+msgstr "Visa grundläggande HTML-hjälp i de omfattande filtreringstipsen"
 
 msgid "Add rel=\"nofollow\" to all links"
-msgstr ""
+msgstr "Lägg till rel=\"nofollow\" på alla länkar"
 
 msgid ""
 "This site allows HTML content. While learning all of HTML may feel "
@@ -8787,21 +9240,25 @@ msgid ""
 " \"tags\" is very easy. This table provides examples for each tag that is "
 "enabled on this site."
 msgstr ""
+"Denna webbplats tillåter innehåll med HTML. Att lära sig HTML kan kännas som"
+" en övermäktig uppgift, men att lära sig de enklaste HTML-taggarna är mycket"
+" enkelt. Denna tabell ger exempel för varje tagg som är aktiverad på denna "
+"webbplats."
 
 msgid "Most unusual characters can be directly entered without any problems."
-msgstr ""
+msgstr "De flesta ovanliga tecken kan skrivas in direkt utan problem."
 
 msgid "No HTML tags allowed."
-msgstr ""
+msgstr "Inga HTML-taggar tillåtna."
 
 msgid "The number of replies a topic must have to be considered \"hot\"."
-msgstr ""
+msgstr "Antalet svar ett ämne måste ha för att anses vara \"hett\"."
 
 msgid "Starting a discussion"
-msgstr ""
+msgstr "Påbörja en diskussion"
 
 msgid "Moving forum topics"
-msgstr ""
+msgstr "Flyttar diskussionsämnen"
 
 msgid ""
 "A forum topic (and all of its comments) may be moved between forums by "
@@ -8809,9 +9266,14 @@ msgid ""
 " topic between forums, the <em>Leave shadow copy</em> option creates a link "
 "in the original forum pointing to the new location."
 msgstr ""
+"Ett diskussionsämne (och alla dess kommentarer) kan flyttas mellan forum "
+"genom att välja ett nytt forum när du redigerar ett diskussionsämne. När du "
+"flyttar ett diskussionsämne mellan forum så kommer alternativet <em>Lämna "
+"skuggkopia</em> att skapa en länk till originalforumet som pekar till den "
+"nya platsen."
 
 msgid "Locking and disabling comments"
-msgstr ""
+msgstr "Låser och inaktiverar kommentarer"
 
 msgid ""
 "Selecting <em>Closed</em> under <em>Comment settings</em> while editing a "
@@ -8819,199 +9281,240 @@ msgid ""
 "<em>Hidden</em> under <em>Comment settings</em> while editing a forum topic "
 "will hide all existing comments on the thread, and prevent new ones."
 msgstr ""
+"Genom att välja <em>Stängd</em> i <em>Inställningar för kommentarer</em> då "
+"ett diskussionsämne redigeras låser du tråden (och förhindrar att nya "
+"kommentarer postas). Genom att välja <em>Dold</em> i <em>Inställningar för "
+"kommentarer</em> då ett diskussionsämne redigeras kommer alla befintliga "
+"kommentarer i tråden att döljas och förhindra att nya postas."
 
 msgid "Forums contain forum topics. Use containers to group related forums."
 msgstr ""
+"Forum innehåller diskussionsämnen. Använd forumgrupper för att gruppera "
+"relaterade forum."
 
 msgid "Use containers to group related forums."
-msgstr ""
+msgstr "Använd forumgrupper för att gruppera relaterade forum."
 
 msgid "A forum holds related forum topics."
-msgstr ""
+msgstr "Ett forum innehåller relaterade diskussionsämnen."
 
 msgid "Add new @node_type"
-msgstr ""
+msgstr "Skapa ny @node_type"
 
 msgid ""
 "The item %forum is a forum container, not a forum. Select one of the forums "
 "below instead."
 msgstr ""
+"Alternativet %forum är en forumgrupp. Välj ett av forumen nedan istället."
 
 msgid "A <em>forum topic</em> starts a new discussion thread within a forum."
 msgstr ""
+"Ett <em>diskussionsämne</em> påbörjar en ny trådad diskussion inom ett "
+"forum."
 
 msgid "Control forum hierarchy settings."
-msgstr ""
+msgstr "Kontrollera inställningar för forumhierarkier."
 
 msgid "Forum navigation vocabulary"
-msgstr ""
+msgstr "Vokabulär för forumnavigation"
 
 msgid "Filters content in preparation for display."
-msgstr ""
+msgstr "Filtrerar innehåll inför visning."
 
 msgid "Follow these steps to set up and start using your website:"
-msgstr ""
+msgstr "Följ dessa steg för att ställa in och börja använda din webbplats:"
 
 msgid "Providing a help reference"
-msgstr ""
+msgstr "Tillhandahålla en referens för hjälp"
 
 msgid "Image style name"
-msgstr ""
+msgstr "Namn på bildstil"
 
 msgid "Select a new effect"
-msgstr ""
+msgstr "Välj en ny effekt"
 
 msgid "Select an effect to add."
-msgstr ""
+msgstr "Välj en effekt att lägga till."
 
 msgid "The image effect was successfully applied."
-msgstr ""
+msgstr "Bildeffekten lades till utan problem."
 
 msgid "Style name"
-msgstr ""
+msgstr "Namn på stil"
 
 msgid "Create new style"
-msgstr ""
+msgstr "Skapa ny stil"
 
 msgid "Style %name was created."
-msgstr ""
+msgstr "Stilen %name skapades."
 
 msgid "Replacement style"
-msgstr ""
+msgstr "Stil för ersättning"
 
 msgid "Optionally select a style before deleting %style"
-msgstr ""
+msgstr "Du kan valfritt välja en stil innan radering av %style"
 
 msgid "Edit %label effect"
-msgstr ""
+msgstr "Redigera effekt %label"
 
 msgid "Add %label effect"
-msgstr ""
+msgstr "Lägg till effekt %label"
 
 msgid "Update effect"
-msgstr ""
+msgstr "Uppdatera effekt"
 
 msgid ""
 "Are you sure you want to delete the @effect effect from the %style style?"
 msgstr ""
+"Är du säker på att du vill radera effekten @effect från stilen %style?"
 
 msgid "The image effect %name has been deleted."
-msgstr ""
+msgstr "Bildeffekten %name har raderats."
 
 msgid "Width and height can not both be blank."
-msgstr ""
+msgstr "Bredd och höjd kan inte båda vara tomma."
 
 msgid "The part of the image that will be retained during the crop."
-msgstr ""
+msgstr "Den del av bilden som kommer att bibehållas under beskärningen."
 
 msgid ""
 "The background color to use for exposed areas of the image. Use web-style "
 "hex colors (#FFFFFF for white, #000000 for black). Leave blank for "
 "transparency on image types that support it."
 msgstr ""
+"Bakgrundsfärg att använda för exponerat tomrum. Använd hexfärger för HTML "
+"(#FFFFFF för vitt, #000000 för svart). Lämna tomt för genomskinlighet på "
+"bildtyper som stöder det."
 
 msgid ""
 "There are currently no effects in this style. Add one by selecting an option"
 " below."
 msgstr ""
+"Det finns för närvarande inga effekter i denna stil. Lägg till en genom att "
+"välja ett alternativ nedan."
 
 msgid "view actual size"
-msgstr ""
+msgstr "visa verklig storlek"
 
 msgid "Sample original image"
-msgstr ""
+msgstr "Prov på ursprunglig bild"
 
 msgid "Sample modified image"
-msgstr ""
+msgstr "Prov på förändrad bild"
 
 msgid ""
 "Resizing will make images an exact set of dimensions. This may cause images "
 "to be stretched or shrunk disproportionately."
 msgstr ""
+"Ändring av storlek skapar bilder med exakta mått. Detta kan orsaka att "
+"bilder tänjs ut eller trycks ihop oproportionerligt."
 
 msgid ""
 "Scaling will maintain the aspect-ratio of the original image. If only a "
 "single dimension is specified, the other dimension will be calculated."
 msgstr ""
+"Skalning kommer att bibehålla proportionerna i den ursprungliga bilden. Om "
+"enbart ett mått anges kommer det andra måttet att räknas ut."
 
 msgid "Scale and crop"
-msgstr ""
+msgstr "Skala och beskär"
 
 msgid ""
 "Scale and crop will maintain the aspect-ratio of the original image, then "
 "crop the larger dimension. This is most useful for creating perfectly square"
 " thumbnails without stretching the image."
 msgstr ""
+"Skala och beskär kommer att bibehålla proportionerna i den ursprungliga "
+"bilden, därefter beskära det större måttet. Detta är mest användbart för att"
+" skapa perfekta kvadratiska miniatyrbilder utan att tänja ut bilden."
 
 msgid "Desaturate"
-msgstr ""
+msgstr "Färgreduktion"
 
 msgid "Desaturate converts an image to grayscale."
-msgstr ""
+msgstr "Färgreduktion konverterar en bild till gråskala."
 
 msgid ""
 "Rotating an image may cause the dimensions of an image to increase to fit "
 "the diagonal."
 msgstr ""
+"Rotering av en bild kan orsaka att måtten för en bild ökas för att passa "
+"diagonalen."
 
 msgid ""
 "Image resize failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Förändring av bildstorlek misslyckades vid användande av verktyget %toolkit "
+"på %path (%mimetype, %dimensions)"
 
 msgid ""
 "Image scale failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Skalning av bild misslyckades vid användande av verktyget %toolkit på %path "
+"(%mimetype, %dimensions)"
 
 msgid ""
 "Image crop failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Beskärning av bild misslyckades vid användande av verktyget %toolkit på "
+"%path (%mimetype, %dimensions)"
 
 msgid ""
 "Image scale and crop failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Skalning och beskärning av bild misslyckades vid användande av verktyget "
+"%toolkit på %path (%mimetype, %dimensions)"
 
 msgid ""
 "Image desaturate failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Färgreduktion i bild misslyckades vid användande av verktyget %toolkit på "
+"%path (%mimetype, %dimensions)"
 
 msgid ""
 "Image rotate failed using the %toolkit toolkit on %path (%mimetype, "
 "%dimensions)"
 msgstr ""
+"Rotering av bild misslyckades vid användande av verktyget %toolkit på %path "
+"(%mimetype, %dimensions)"
 
 msgid "This field stores the ID of an image file as an integer value."
-msgstr ""
+msgstr "Detta fält lagrar ID-numret för en bild som ett heltalsvärde."
 
 msgid "If no image is uploaded, this image will be shown on display."
-msgstr ""
+msgstr "Om ingen bild laddas upp så kommer denna att visas."
 
 msgid "Minimum image resolution"
-msgstr ""
+msgstr "Minsta bildupplösning"
 
 msgid "Enable <em>Alt</em> field"
-msgstr ""
+msgstr "Aktivera fält <em>Alt</em>"
 
 msgid "Enable <em>Title</em> field"
-msgstr ""
+msgstr "Aktivera fält <em>Title</em>"
 
 msgid ""
 "The title attribute is used as a tooltip when the mouse hovers over the "
 "image."
 msgstr ""
+"Attributet \"title\" används som verktygstips när musmarkören placeras över "
+"bilden."
 
 msgid "Preview image style"
-msgstr ""
+msgstr "Förhandsgranska bildstil"
 
 msgid "no preview"
-msgstr ""
+msgstr "ingen förhandsgranskning"
 
 msgid "The preview image will be shown while editing the content."
 msgstr ""
+"Bilden för förhandsvisning kommer att visas under tiden som du redigerar "
+"innehållet."
 
 msgid ""
 "Image styles commonly provide thumbnail sizes by scaling and cropping "
@@ -9019,84 +9522,97 @@ msgid ""
 "an image is displayed with a style, a new file is created and the original "
 "image is left unchanged."
 msgstr ""
+"Bildstilar tillhandahåller vanligtvis miniatyrstorlekar genom skalning och "
+"beskärning av bilder, men kan också vara olika effekter innan en bild visas."
+" När en bild visas med en stil så kommer en ny fil att skapas och den "
+"ursprungliga filen lämnas kvar orörd."
 
 msgid "Administer image styles"
-msgstr ""
+msgstr "Administrera bildstilar"
 
 msgid "No defined styles"
-msgstr ""
+msgstr "Inga definierade stilar"
 
 msgid "Image generation in progress. Try again shortly."
-msgstr ""
+msgstr "Bildgenerering pågår. Försök igen om en liten stund."
 
 msgid "Error generating image."
-msgstr ""
+msgstr "Fel vid generering av bild."
 
 msgid "Unable to generate the derived image located at %path."
-msgstr ""
+msgstr "Kunde inte generera den härledda bilden som finns på %path."
 
 msgid "Failed to create style directory: %directory"
-msgstr ""
+msgstr "Misslyckades med att skapa stilkatalogen: %directory"
 
 msgid ""
 "Cached image file %destination already exists. There may be an issue with "
 "your rewrite configuration."
 msgstr ""
+"Cachad bildfil %destination finns redan. Det kan finnas ett fel i din "
+"inställning för omskrivning."
 
 msgid "Edit image effect"
-msgstr ""
+msgstr "Redigera bildeffekt"
 
 msgid "Delete image effect"
-msgstr ""
+msgstr "Radera bildeffekt"
 
 msgid "Add image effect"
-msgstr ""
+msgstr "Lägg till bildeffekt"
 
 msgid "Detection method"
-msgstr ""
+msgstr "Avkänningsmetod"
 
 msgid "Part of the URL that determines language"
-msgstr ""
+msgstr "Del av URL som bestämmer språk"
 
 msgid "Request/session parameter"
-msgstr ""
+msgstr "Begäran/sessionsparameter"
 
 msgid ""
 "Name of the request/session parameter used to determine the desired "
 "language."
 msgstr ""
+"Namn på begäran/sessionsparametern som används för att bestämma det önskade "
+"språket."
 
 msgid "Date type"
-msgstr ""
+msgstr "Datumtyp"
 
 msgid ""
 "Determine the language from a request/session parameter. Example: "
 "\"http://example.com?language=de\" sets language to German based on the use "
 "of \"de\" within the \"language\" parameter."
 msgstr ""
+"Bestäm språket från en begäran/sessionsparameter. Exempel: "
+"\"http://exempel.se?language=en\" anger språket till engelska baserat på "
+"användandet av \"en\" inom \"språk\"-parametern."
 
 msgid "Administer languages"
-msgstr ""
+msgstr "Administrera språk"
 
 msgid ""
 "Order of language detection methods for content. If a version of content is "
 "available in the detected language, it will be displayed."
 msgstr ""
+"Ordning på metoder för språkidentifiering för innehåll. Om en version i det "
+"identifierade språket finns tillgänglig så kommer den att visas."
 
 msgid "Follow the user's language preference."
-msgstr ""
+msgstr "Följ användarens språkinställning."
 
 msgid "Language switcher (@type)"
-msgstr ""
+msgstr "Språkbytare (@type)"
 
 msgid "Detection and selection"
-msgstr ""
+msgstr "Avkänning och val"
 
 msgid "URL language detection configuration"
-msgstr ""
+msgstr "Inställningar för språkidentifiering via URL"
 
 msgid "Session language detection configuration"
-msgstr ""
+msgstr "Inställningar för språkidentifiering via session"
 
 msgctxt "Long month name"
 msgid "January"
@@ -9143,47 +9659,52 @@ msgid "December"
 msgstr "december"
 
 msgid "The text to be used for this link in the menu."
-msgstr ""
+msgstr "Texten som skall användas för denna länken i menyn."
 
 msgid "Menu links that are not enabled will not be listed in any menu."
-msgstr ""
+msgstr "Menylänkar som inte är aktiverade kommer inte att visas i någon meny."
 
 msgid ""
 "If selected and this menu link has children, the menu will always appear "
 "expanded."
 msgstr ""
+"Om detta väljs och det finns underliggande menylänkar kommer det alltid att "
+"vara utfällt."
 
 msgid "Parent link"
-msgstr ""
+msgstr "Ovanliggande länk"
 
 msgid "Add to shortcuts"
-msgstr ""
+msgstr "Lägg till genvägar"
 
 msgid "Add effect"
-msgstr ""
+msgstr "Lägg till effekt"
 
 msgid "Image styles"
-msgstr ""
+msgstr "Bildstilar"
 
 msgid ""
 "Configure styles that can be used for resizing or adjusting images on "
 "display."
 msgstr ""
+"Konfigurera stilar som kan användas för att ändra storlek eller anpassa "
+"bilder vid visning."
 
 msgid "Filter translatable strings"
-msgstr ""
+msgstr "Filtrera översättningsbara strängar"
 
 msgid "The menu link %title has been deleted."
-msgstr ""
+msgstr "Den anpassade menylänken %title har raderats."
 
 msgid "Are you sure you want to reset the link %item to its default values?"
 msgstr ""
+"Är du säker på att du vill återställa länken %item till dess standardvärde?"
 
 msgid "The menu link was reset to its default settings."
-msgstr ""
+msgstr "Menylänken återställdes till dess standardinställningar."
 
 msgid "Deleted custom menu %title and all its menu links."
-msgstr ""
+msgstr "Raderade anpassad meny %title och alla dess menylänkar."
 
 msgid ""
 "<strong>Warning:</strong> There is currently 1 menu link in %title. It will "
@@ -9192,122 +9713,141 @@ msgid_plural ""
 "<strong>Warning:</strong> There are currently @count menu links in %title. "
 "They will be deleted (system-defined links will be reset)."
 msgstr[0] ""
+"<strong>Varning:</strong> Det finns för närvarande en menylänk i %title. Den"
+" kommer att raderas (systemdefinierade alternativ kommer att återställas)."
 msgstr[1] ""
+"<strong>Varning:</strong> Det finns för närvarande @count menylänkar i "
+"%title. De kommer att raderas (systemdefinierade alternativ kommer att "
+"återställas)."
 
 msgid "Managing menus"
-msgstr ""
+msgstr "Hantering av menyer"
 
 msgid "Administer menus and menu items"
-msgstr ""
+msgstr "Administer menus and menu items"
 
 msgid "Provide a menu link"
-msgstr ""
+msgstr "Ange en menylänk"
 
 msgid "Available menus"
-msgstr ""
+msgstr "Tillgängliga menyer"
 
 msgid "The menus available to place links in for this content type."
-msgstr ""
+msgstr "De tillgängliga menyerna att placera länkar i för denna innehållstyp."
 
 msgid "Default parent item"
-msgstr ""
+msgstr "Förvalt ovanliggande alternativ"
 
 msgid ""
 "Choose the menu item to be the default parent for a new link in the content "
 "authoring form."
 msgstr ""
+"Välj det menyval som skall vara ovanliggande menyval som standard för en ny "
+"länk i formuläret för att skapa innehåll."
 
 msgid "Edit menu link"
-msgstr ""
+msgstr "Redigera menylänk"
 
 msgid "Reset menu link"
-msgstr ""
+msgstr "Återställ menylänk"
 
 msgid "Delete menu link"
-msgstr ""
+msgstr "Radera menylänk"
 
 msgid "Preview before submitting"
-msgstr ""
+msgstr "Förhandsgranska innan skickande"
 
 msgid ""
 "This text will be displayed at the top of the page when creating or editing "
 "content of this type."
 msgstr ""
+"Denna text kommer att visas överst på sidan vid skapande eller redigerande "
+"av innehåll av denna typ."
 
 msgid ""
 "Users with the <em>Administer content</em> permission will be able to "
 "override these options."
 msgstr ""
+"Användare med behörigheten <em>Administrera innehåll</em> kan åsidosätta "
+"dessa inställningar."
 
 msgid "Author username and publish date will be displayed."
-msgstr ""
+msgstr "Författarens användarnamn och publiceringsdatum kommer att visas."
 
 msgid "Invalid machine-readable name. Enter a name other than %invalid."
 msgstr ""
+"Det maskinläsbara namnet är ogiltigt. Ange ett annat namn än %invalid."
 
 msgid "Publish selected content"
-msgstr ""
+msgstr "Publicera valt innehåll"
 
 msgid "Unpublish selected content"
-msgstr ""
+msgstr "Avpublicera valt innehåll"
 
 msgid "Promote selected content to front page"
-msgstr ""
+msgstr "Visa valt innehåll på startsidan"
 
 msgid "Demote selected content from front page"
-msgstr ""
+msgstr "Ta bort valt innehåll från startsidan"
 
 msgid "Make selected content sticky"
-msgstr ""
+msgstr "Visa valt innehåll överst i listor"
 
 msgid "Make selected content not sticky"
-msgstr ""
+msgstr "Visa inte valt innehåll överst i listor"
 
 msgid "Are you sure you want to delete this item?"
 msgid_plural "Are you sure you want to delete these items?"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Är du säker på att du vill ta bort detta inlägg?"
+msgstr[1] "Är du säker på att du vill ta bort dessa inlägg?"
 
 msgid "<em>Edit @type</em> @title"
-msgstr ""
+msgstr "<em>Redigera @type</em> @title"
 
 msgid "Tokens related to individual content items, or \"nodes\"."
 msgstr ""
+"Ersättningstecken relaterade till individuella innehållsposter, eller "
+"\"noder\"."
 
 msgid "The unique ID of the content item, or \"node\"."
-msgstr ""
+msgstr "Det unika ID-numret för innehållsposten, eller \"noden\"."
 
 msgid "The main body text of the node."
-msgstr ""
+msgstr "Den huvudsakliga brödtexten av noden."
 
 msgid "The summary of the node's main body text."
-msgstr ""
+msgstr "Sammanfattningen för nodens huvudsakliga brödtext."
 
 msgid "Creating content"
-msgstr ""
+msgstr "Skapande av innehåll"
 
 msgid "Creating custom content types"
-msgstr ""
+msgstr "Skapande av anpassade innehållstyper"
 
 msgid "Administering content"
-msgstr ""
+msgstr "Administrerande av innehåll"
 
 msgid "Creating revisions"
-msgstr ""
+msgstr "Skapande av versioner"
 
 msgid ""
 "The Node module also enables you to create multiple versions of any content,"
 " and revert to older versions using the <em>Revision information</em> "
 "settings."
 msgstr ""
+"Modulen Node möjliggör också att du kan skapa flera versioner av ett "
+"innehåll, och återgå till en äldre version genom att använda inställningarna"
+" <em>Information om versionshantering</em>."
 
 msgid "User permissions"
-msgstr ""
+msgstr "Behörigheter för användare"
 
 msgid ""
 "Individual content types can have different fields, behaviors, and "
 "permissions assigned to them."
 msgstr ""
+"Individuella innehållstyper kan ha olika fält, funktioner och behörigheter "
+"tilldelade till dem."
 
 msgid ""
 "Content items can be displayed using different view modes: Teaser, Full "
@@ -9315,186 +9855,204 @@ msgid ""
 "typically used in lists of multiple content items. <em>Full content</em> is "
 "typically used when the content is displayed on its own page."
 msgstr ""
+"Innehållsposter kan visas genom att visa olika typer av visning: Ingress, "
+"Fullständigt innehåll, Utskrift, RSS, etcetera. <em>Förhandstitt</em> är ett"
+" kort format som vanligtvis används i listor av flera innehållsposter. "
+"<em>Fullständigt innehåll</em> används vanligtvis när innehållet visas på "
+"dess egna sida."
 
 msgid ""
 "Here, you can define which fields are shown and hidden when %type content is"
 " displayed in each view mode, and define how the fields are displayed in "
 "each view mode."
 msgstr ""
+"Här kan du definiera vilka fält som visas och döljs när innehåll av typen "
+"%type visas i varje visningsläge, och definiera hur fältet visas i varje "
+"visningsläge."
 
 msgid "Administer content types"
-msgstr ""
+msgstr "Administrera innehållstyper"
 
 msgid ""
 "Warning: Give to trusted roles only; this permission has security "
 "implications."
 msgstr ""
+"Varning: Ge enbart till betrodda användare. Denna behörighet har "
+"konsekvenser för säkerheten."
 
 msgid "View published content"
-msgstr ""
+msgstr "Visa publicerat innehåll"
 
 msgid "Bypass content access control"
-msgstr ""
+msgstr "Kringgå kontroll av åtkomst till innehåll"
 
 msgid "View own unpublished content"
-msgstr ""
+msgstr "Visa eget avpublicerat innehåll"
 
 msgid "Content is sticky at top of lists"
-msgstr ""
+msgstr "Innehåll är klistrat överst i listor"
 
 msgid "Content is promoted to the front page"
-msgstr ""
+msgstr "Innehåll visas på startsidan"
 
 msgid "No front page content has been created yet."
-msgstr ""
+msgstr "Inget innehåll för startsidan har skapats ännu."
 
 msgid "Change the author of content"
-msgstr ""
+msgstr "Ändra författare för inlägg"
 
 msgid "Unpublish content containing keyword(s)"
-msgstr ""
+msgstr "Avpublicera inlägg innehållande nyckelord(en)"
 
 msgid ""
 "The content will be unpublished if it contains any of the phrases above. Use"
 " a case-sensitive, comma-separated list of phrases. Example: funny, bungee "
 "jumping, \"Company, Inc.\""
 msgstr ""
+"Inlägget kommer att avpubliceras om det innehåller någon av ovanstående "
+"teckenserier. Skilj på gemener och versaler och använd en kommaseparerad "
+"lista med teckenserier. Exempel: rolig, hoppa fallskärm, \"Företag, AB\"."
 
 msgid "One permission in use"
 msgid_plural "@count permissions in use"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "En behörighet används"
+msgstr[1] "@count behörigheter används"
 
 msgid "Don't display post information"
-msgstr ""
+msgstr "Visa inte information om inlägg"
 
 msgid "Creating aliases"
-msgstr ""
+msgstr "Skapa alias"
 
 msgid "Managing aliases"
-msgstr ""
+msgstr "Hantera alias"
 
 msgid ""
 "An alias defines a different name for an existing URL path - for example, "
 "the alias 'about' for the URL path 'node/1'. A URL path can have multiple "
 "aliases."
 msgstr ""
+"Ett alias definierar ett annat namn för en existerande URL-sökväg, till "
+"exempel aliaset \"info\" för sökvägen \"node/1\". En sökväg kan ha flera "
+"alias."
 
 msgid "Administer URL aliases"
-msgstr ""
+msgstr "Administrera URL-alias"
 
 msgid "Create and edit URL aliases"
-msgstr ""
+msgstr "Skapa och redigera URL-alias"
 
 msgid "The alias is already in use."
-msgstr ""
+msgstr "Aliaset används redan."
 
 msgid "Searched %type for %keys."
-msgstr ""
+msgstr "Sökte genom %type efter %keys."
 
 msgid "Administer search"
-msgstr ""
+msgstr "Administrera sökfunktionen"
 
 msgid "Use search"
-msgstr ""
+msgstr "Använda sökning"
 
 msgid "Choose a set of shortcuts to use"
-msgstr ""
+msgstr "Välj en uppsättning genvägar att använda"
 
 msgid "Choose a set of shortcuts for this user"
-msgstr ""
+msgstr "Välj en uppsättning genvägar för denna användare"
 
 msgid ""
 "%user is now using a new shortcut set called %set_name. You can edit it from"
 " this page."
 msgstr ""
+"%user använder nu genvägäsgrupperingen kallad %set_name. Du kan ändra på "
+"grupperingen på denna sida."
 
 msgid "You are now using the %set_name shortcut set."
-msgstr ""
+msgstr "Du använder nu genvägsuppsättningen %set_name."
 
 msgid "%user is now using the %set_name shortcut set."
-msgstr ""
+msgstr "%user använder nu genvägsuppsättningen %set_name."
 
 msgid "Change set"
-msgstr ""
+msgstr "Ändra uppsättning"
 
 msgid "The shortcut set has been updated."
-msgstr ""
+msgstr "Genvägsuppsättningen har uppdaterats."
 
 msgid "The name of the shortcut."
-msgstr ""
+msgstr "Namnet på genvägen."
 
 msgid "The shortcut %link has been updated."
-msgstr ""
+msgstr "Genvägen %link har uppdaterats."
 
 msgid "Added a shortcut for %title."
-msgstr ""
+msgstr "Lade till en genväg för %title."
 
 msgid "The shortcut %title has been deleted."
-msgstr ""
+msgstr "Genvägen %title har raderats."
 
 msgid "Unable to add a shortcut for %title."
-msgstr ""
+msgstr "Kunde inte lägga till en genväg för %title."
 
 msgid "Adding and removing shortcuts"
-msgstr ""
+msgstr "Lägga till och ta bort genvägar"
 
 msgid "Displaying shortcuts"
-msgstr ""
+msgstr "Visar genvägar"
 
 msgid "Administer shortcuts"
-msgstr ""
+msgstr "Administrera genvägar"
 
 msgid "Revision log message"
-msgstr ""
+msgstr "Loggmeddelande för versionshantering"
 
 msgid "Make content unsticky"
-msgstr ""
+msgstr "Ta bort visning överst i listor"
 
 msgid "Promote content to front page"
-msgstr ""
+msgstr "Visa innehåll på startsidan"
 
 msgid "Save content"
-msgstr ""
+msgstr "Spara innehåll"
 
 msgid "Unpublish content"
-msgstr ""
+msgstr "Avpublicera inlägg"
 
 msgid "Find and manage content."
-msgstr ""
+msgstr "Hitta och hantera innehåll."
 
 msgid "Recent content"
-msgstr ""
+msgstr "Nyligen uppdaterat innehåll"
 
 msgid "Node Access Permissions"
-msgstr ""
+msgstr "Behörigheter för nodåtkomst"
 
 msgid "Add to %shortcut_set shortcuts"
-msgstr ""
+msgstr "Bifoga till genvägar i %shortcut_set"
 
 msgid "Use advanced search"
-msgstr ""
+msgstr "Använda avancerad sökning"
 
 msgid "Remove from %shortcut_set shortcuts"
-msgstr ""
+msgstr "Ta bort från genvägar i %shortcut_set"
 
 msgid "Remove from shortcuts"
-msgstr ""
+msgstr "Ta bort från genvägar"
 
 msgid "Add shortcut"
-msgstr ""
+msgstr "Lägg till genväg"
 
 msgid "GSS negotiate"
-msgstr ""
+msgstr "GSS-förhandla"
 
 msgid "NTLM"
-msgstr ""
+msgstr "NTLM"
 
 msgid "Any safe"
-msgstr ""
+msgstr "Vilken som helst, säker"
 
 msgid "Running tests"
-msgstr ""
+msgstr "Köra tester"
 
 msgid ""
 "After the tests run, a message will be displayed next to each test group "
@@ -9506,70 +10064,91 @@ msgid ""
 " exceptions will be indicated in red or pink rows. You can then use these "
 "results to refine your code and tests, until all tests pass."
 msgstr ""
+"Efter att testen körts kommer ett meddelande att visas bredvid varje "
+"testgrupp som visar om testet inom det godkänts, misslyckats eller hade "
+"undantag. Ett godkännande innebär att testet gav förväntade resultat medan "
+"ett misslyckande betyder att det inte gjorde det. Ett undantag indikerar "
+"vanligen ett fel utanför själva testet som till exempel en PHP-varning eller"
+" meddelande. Om testet genererade ett misslyckande eller undantag kan "
+"resultatet fällas ut att visa detaljer och test som hade misslyckanden eller"
+" undantag kommer att visas i röda eller rosa rader. Du kan använda dessa "
+"testresultat för att utveckla din kod och testa tills samtliga tester "
+"godkänns."
 
 msgid "Administer tests"
-msgstr ""
+msgstr "Administrera tester"
 
 msgid "The test run finished in @elapsed."
-msgstr ""
+msgstr "Testkörningen slutfördes inom @elapsed."
 
 msgid ""
 "Use the <em>Clean environment</em> button to clean-up temporary files and "
 "tables."
 msgstr ""
+"Använd knappen <em>rensa upp miljö</em> för att rensa upp temporära filer "
+"och tabeller."
 
 msgid "PHP open_basedir restriction"
-msgstr ""
+msgstr "Begränsning av PHP open_basedir"
 
 msgid "Displaying popular content"
-msgstr ""
+msgstr "Visar populärt innehåll"
 
 msgid "Page view counter"
-msgstr ""
+msgstr "Räkning av sidvisning"
 
 msgid "Administer statistics"
-msgstr ""
+msgstr "Administrera statistik"
 
 msgid "View content hits"
-msgstr ""
+msgstr "Visa innehållsträffar"
 
 msgid "Logging for UNIX, Linux, and Mac OS X"
-msgstr ""
+msgstr "Loggning för UNIX, Linux och Mac OS X."
 
 msgid "Logging for Microsoft Windows"
-msgstr ""
+msgstr "Loggning för Microsoft Windows"
 
 msgid ""
 "On Microsoft Windows, messages are always sent to the Event Log using the "
 "code <code>LOG_USER</code>."
 msgstr ""
+"I Microsoft Windows, skickas alltid meddelande till Händelseloggen med koden"
+" <code>LOG_USER</code>-"
 
 msgid "Syslog facility"
-msgstr ""
+msgstr "Resurshantering i Syslog"
 
 msgid ""
 "Depending on the system configuration, Syslog and other logging tools use "
 "this code to identify or filter messages from within the entire system log."
 msgstr ""
+"Beroende på systemkonfigurationen så kan Syslog och andra loggningsverktyg "
+"använda denna kod för att identifiera eller filtrera meddelanden från hela "
+"systemloggen."
 
 msgid ""
 "The image %file could not be rotated because the imagerotate() function is "
 "not available in this PHP installation."
 msgstr ""
+"Bilden %file kunde inte roteras eftersom funktionen imagerotate() inte är "
+"tillgänglig i denna installation av PHP."
 
 msgid "default theme"
-msgstr ""
+msgstr "standardtema"
 
 msgid ""
 "Choose \"Default theme\" to always use the same theme as the rest of the "
 "site."
 msgstr ""
+"Välj \"Standardtema\" för att alltid använda samma tema som resten av "
+"webbplatsen."
 
 msgid "Use the administration theme when editing or creating content"
-msgstr ""
+msgstr "Använd adminstrationstemat när du redigerar eller skapar innehåll."
 
 msgid "The %theme theme was not found."
-msgstr ""
+msgstr "Temat %theme kunde inte hittas."
 
 msgid ""
 "Please note that the administration theme is still set to the %admin_theme "
@@ -9577,758 +10156,845 @@ msgid ""
 "administrative sections of the site, however, will show the selected "
 "%selected_theme theme by default."
 msgstr ""
+"Observera att administrationstemat fortfarande är inställt på temat "
+"%admin_theme. Därför har inte temat ändrats på den här sidan. Alla "
+"ickeadministrativa delar av webbplatsen kommer dock att använda det valda "
+"temat %selected_theme som standardtema."
 
 msgid "%theme is now the default theme."
-msgstr ""
+msgstr "%theme är nu standardtemat."
 
 msgid "User verification status in comments"
-msgstr ""
+msgstr "Status för användarbekräftelse i kommentarer"
 
 msgid ""
 "These settings only exist for the themes based on the %engine theme engine."
 msgstr ""
+"Dessa inställningar finns bara för temat som baseras på temamotorn %engine."
 
 msgid "The custom logo path is invalid."
-msgstr ""
+msgstr "Sökvägen för egen logotyp är ogiltig."
 
 msgid "The custom favicon path is invalid."
-msgstr ""
+msgstr "Sökvägen för egen bokmärkesikon är ogiltig."
 
 msgid "Would you like to continue with the above?"
-msgstr ""
+msgstr "Vill du fortsätta med ovanstående?"
 
 msgid "Enter a valid IP address."
-msgstr ""
+msgstr "Ange en giltig IP-adress."
 
 msgid "The IP address %ip was deleted."
-msgstr ""
+msgstr "IP-adressen %ip raderades."
 
 msgid "How this is used depends on your site's theme."
-msgstr ""
+msgstr "Hur detta används beror på din webbplats tema."
 
 msgid ""
 "This page is displayed when the requested document is denied to the current "
 "user. Leave blank to display a generic \"access denied\" page."
 msgstr ""
+"Denna sida visas när den aktuella användaren inte har rätt att se det "
+"begärda dokumentet. Lämna tomt för att visa en allmän \"åtkomst nekad till "
+"sidan\"."
 
 msgid ""
 "This page is displayed when no other content matches the requested document."
 " Leave blank to display a generic \"page not found\" page."
 msgstr ""
+"Denna sida visas när inget innehåll matchar det begärda dokumentet. Lämna "
+"tomt för att visa en allmän \"sidan hittades inte\"."
 
 msgid "Errors and warnings"
-msgstr ""
+msgstr "Felmeddelanden och varningar"
 
 msgid "Public file system path"
-msgstr ""
+msgstr "Systemsökväg för offentliga filer"
 
 msgid "Private file system path"
-msgstr ""
+msgstr "Systemsökväg för privata filer"
 
 msgid ""
 "A local file system path where temporary files will be stored. This "
 "directory should not be accessible over the web."
 msgstr ""
+"En lokal systemsökväg där temporära filer kommer att lagras. Denna katalog "
+"bör inte vara åtkomlig via webben."
 
 msgid "Default download method"
-msgstr ""
+msgstr "Förvald nedladdningsmetod"
 
 msgid ""
 "This setting is used as the preferred download method. The use of public "
 "files is more efficient, but does not provide any access control."
 msgstr ""
+"Denna inställning används som den föredragna nedladdningsmetoden. Användande"
+" av offentliga filer är mer effektivt, men tillhandahåller ingen "
+"åtkomstkontroll."
 
 msgid "Description of your site, included in each feed."
-msgstr ""
+msgstr "Beskrivning av din webbplats, inkluderad i varje nyhetsflöde."
 
 msgid "Time zones"
-msgstr ""
+msgstr "Tidszoner"
 
 msgid "Only applied if users may set their own time zone."
-msgstr ""
+msgstr "Gäller enbart om användare får ange sina egna tidszoner."
 
 msgid "Time zone for new users"
-msgstr ""
+msgstr "Tidszon för nya användare"
 
 msgid "Put site into maintenance mode"
-msgstr ""
+msgstr "Sätt webbplatsen i underhållsläge"
 
 msgid "Displayed as %date"
-msgstr ""
+msgstr "Visas som %date"
 
 msgid "Save format"
-msgstr ""
+msgstr "Spara format"
 
 msgid "Custom date format updated."
-msgstr ""
+msgstr "Anpassat datumformat uppdaterades."
 
 msgid "Custom date format added."
-msgstr ""
+msgstr "Anpassat datumformat lades till."
 
 msgid "Available actions:"
-msgstr ""
+msgstr "Tillgängliga åtgärder:"
 
 msgid "Create an advanced action"
-msgstr ""
+msgstr "Skapa en avancerad åtgärd"
 
 msgid "Deleted %ip"
-msgstr ""
+msgstr "Raderade %ip"
 
 msgid "You must enable the @required module to install @module."
 msgid_plural "You must enable the @required modules to install @module."
 msgstr[0] ""
+"Du måste aktivera modulen @required för att kunna installera @module."
 msgstr[1] ""
+"Du måste aktivera modulerna @required för att kunna installera @module."
 
 msgid "Tokens for site-wide settings and other global information."
 msgstr ""
+"Ersättningstecken för webbplatsens inställningar och annan övergripande "
+"information."
 
 msgid "Tokens related to times and dates."
-msgstr ""
+msgstr "Ersättningstecken relaterade till tider och datum."
 
 msgid "Tokens related to uploaded files."
-msgstr ""
+msgstr "Ersättningstecken relaterade till uppladdade filer."
 
 msgid "The URL of the site's front page without the protocol."
-msgstr ""
+msgstr "URL:en för webbplatsens startsida utan protokollet."
 
 msgid "A date in 'short' format. (%date)"
-msgstr ""
+msgstr "Ett datum i \"kort\" format. (%date)"
 
 msgid "A date in 'medium' format. (%date)"
-msgstr ""
+msgstr "Ett datum i \"mellanlångt\" format. (%date)"
 
 msgid "A date in 'long' format. (%date)"
-msgstr ""
+msgstr "Ett datum i \"långt\" format. (%date)"
 
 msgid "A date in UNIX timestamp format (%date)"
-msgstr ""
+msgstr "Ett datum i formatet UNIX tidsstämpel (%date)"
 
 msgid "Managing modules"
-msgstr ""
+msgstr "Hantering av moduler"
 
 msgid "Managing themes"
-msgstr ""
+msgstr "Hantering av teman"
 
 msgid "Configuring basic site settings"
-msgstr ""
+msgstr "Konfigurering av grundläggande inställningar för webbplats"
 
 msgid "Administer modules"
-msgstr ""
+msgstr "Administrera moduler"
 
 msgid "Administer site configuration"
-msgstr ""
+msgstr "administrera konfiguration av webbplats"
 
 msgid "Administer themes"
-msgstr ""
+msgstr "Administrera teman"
 
 msgid "Administer actions"
-msgstr ""
+msgstr "Administrera åtgärder"
 
 msgid "Use the administration pages and help"
-msgstr ""
+msgstr "Använda administrationssidorna och hjälp"
 
 msgid "Use the site in maintenance mode"
-msgstr ""
+msgstr "Använd webbplatsen i underhållsläge"
 
 msgid "View site reports"
-msgstr ""
+msgstr "Visa rapporter för webbplatsen"
 
 msgid "Public files"
-msgstr ""
+msgstr "Offentliga filer"
 
 msgid "Public local files served by the webserver."
-msgstr ""
+msgstr "Lokala offentliga filer som hanteras av webbservern."
 
 msgid "Private local files served by Drupal."
-msgstr ""
+msgstr "Privata lokala filer hanterade av Drupal."
 
 msgid "Temporary files"
-msgstr ""
+msgstr "Temporära filer"
 
 msgid "Temporary local files for upload and previews."
-msgstr ""
+msgstr "Lokala temporära filer för uppladdning och förhandsgranskningar."
 
 msgid "Update modules"
-msgstr ""
+msgstr "Uppdatera moduler"
 
 msgid "Update themes"
-msgstr ""
+msgstr "Uppdatera teman"
 
 msgid "SSH"
-msgstr ""
+msgstr "SSH"
 
 msgid ""
 "Your password is not saved in the database and is only used to establish a "
 "connection."
 msgstr ""
+"Ditt lösenord sparas inte i databasen och används enbart för att upprätta en"
+" anslutning."
 
 msgid "Edit shortcuts"
-msgstr ""
+msgstr "Redigera genvägar"
 
 msgid "Clear all caches"
-msgstr ""
+msgstr "Töm all cache"
 
 msgid "Bandwidth optimization"
-msgstr ""
+msgstr "Bandbreddsoptimering"
 
 msgid "Allows users to manage customizable lists of shortcut links."
 msgstr ""
+"Låter användare hantera anpassningsbara listor av länkar till genvägar."
 
 msgid ""
 "The connection will be created between your web server and the machine "
 "hosting the web server files. In the vast majority of cases, this will be "
 "the same machine, and \"localhost\" is correct."
 msgstr ""
+"Anslutningen kommer att skapas mellan din webbserver och maskinen som är "
+"värd för webbserverns filer. För det mesta är detta samma maskin och "
+"\"localhost\" är korrekt."
 
 msgid ""
 "Select the desired local time and time zone. Dates and times throughout this"
 " site will be displayed using this time zone."
 msgstr ""
+"Välj den önskade lokala tiden och tidszonen. Datum och tid kommer att visas "
+"i denna tidszon på hela webbplatsen."
 
 msgid "The directory %directory does not exist and could not be created."
-msgstr ""
+msgstr "Katalogen %directory finns inte och kunde inte skapas."
 
 msgid ""
 "The directory %directory exists but is not writable and could not be made "
 "writable."
 msgstr ""
+"Katalogen %directory finns, men är skrivskyddad och kunde inte göras "
+"skrivbar."
 
 msgid "Delete IP address"
-msgstr ""
+msgstr "Radera IP-adress"
 
 msgid "Edit date format"
-msgstr ""
+msgstr "Redigera datumformat"
 
 msgid "%profile_name (%profile-%version)"
-msgstr ""
+msgstr "%profile_name (%profile-%version)"
 
 msgid "Tokens related to taxonomy terms."
-msgstr ""
+msgstr "Ersättningstecken relaterade till taxonomitermer."
 
 msgid "Tokens related to taxonomy vocabularies."
-msgstr ""
+msgstr "Ersättningstecken relaterade till taxonomier för vokabulärer."
 
 msgid ""
 "Taxonomy is for categorizing content. Terms are grouped into vocabularies. "
 "For example, a vocabulary called \"Fruit\" would contain the terms \"Apple\""
 " and \"Banana\"."
 msgstr ""
+"Taxonomi används för att kategorisera innehåll. Termer grupperas i "
+"vokabulärer. Till exempel kan en vokabulär kallad \"Frukter\" innehålla "
+"termerna \"Äpple\" och \"Banan\"."
 
 msgid ""
 "You can reorganize the terms in %capital_name using their drag-and-drop "
 "handles, and group terms under a parent term by sliding them under and to "
 "the right of the parent."
 msgstr ""
+"Du kan organisera om termerna i %capital_name genom att använda deras drag-"
+"och-släpphandtag och gruppera termer under en ovanliggande term genom att "
+"dra dem till höger och under den ovanliggande."
 
 msgid ""
 "%capital_name contains terms grouped under parent terms. You can reorganize "
 "the terms in %capital_name using their drag-and-drop handles."
 msgstr ""
+"%capital_name innehåller termer som är grupperade under ovanliggande termer."
+" Du kan omorganisera dem genom att använda drag-och-släpphandtagen."
 
 msgid "Administer vocabularies and terms"
-msgstr ""
+msgstr "Administer vocabularies and terms"
 
 msgid "Tracking new and updated site content"
-msgstr ""
+msgstr "Spårar nytt och uppdaterat innehåll på webbplatsen"
 
 msgid "Tracking user-specific content"
-msgstr ""
+msgstr "Spårar användarspecifikt innehåll"
 
 msgid "My recent content"
-msgstr ""
+msgstr "Mitt senaste innehåll"
 
 msgid "Translating content"
-msgstr ""
+msgstr "Översätta innehåll"
 
 msgid "Installing updates"
-msgstr ""
+msgstr "Installerar uppdateringar"
 
 msgid "Preparing to update your site"
-msgstr ""
+msgstr "Förbereder för uppdatering av din webbplats"
 
 msgid "Installing %project"
-msgstr ""
+msgstr "Installerar %project"
 
 msgid "Preparing to install"
-msgstr ""
+msgstr "Förbereder för installation"
 
 msgid "Error installing / updating"
-msgstr ""
+msgstr "Fel vid installation / uppdatering"
 
 msgid "Installed %project_name successfully"
-msgstr ""
+msgstr "Installerade %project_name"
 
 msgid ""
 "Update was completed successfully. Your site has been taken out of "
 "maintenance mode."
 msgstr ""
+"Uppdatering genomfördes utan problem. Din webbplats har tagits bort från "
+"underhållsläge."
 
 msgid "Update was completed successfully."
-msgstr ""
+msgstr "Uppdatering genomfördes utan problem."
 
 msgid "Update failed! See the log below for more information."
-msgstr ""
+msgstr "Uppdatering misslyckades! Se loggen nedan för mer information."
 
 msgid ""
 "Update failed! See the log below for more information. Your site is still in"
 " maintenance mode."
 msgstr ""
+"Uppdatering misslyckades! Se loggen nedan för mer information. Din webbplats"
+" är fortfarande i underhållsläge."
 
 msgid ""
 "Installation was completed successfully. Your site has been taken out of "
 "maintenance mode."
 msgstr ""
+"Installationen genomfördes utan problem. Din webbplats är inte längre i "
+"underhållsläge."
 
 msgid "Installation was completed successfully."
-msgstr ""
+msgstr "Installation genomfördes utan problem."
 
 msgid "Installation failed! See the log below for more information."
-msgstr ""
+msgstr "Installation misslyckades! Se loggen nedan för mer information."
 
 msgid ""
 "Installation failed! See the log below for more information. Your site is "
 "still in maintenance mode."
 msgstr ""
+"Installation misslyckades! Se loggen nedan för mer information. Din "
+"webbplats är fortfarande i underhållsläge."
 
 msgid "No available update data"
-msgstr ""
+msgstr "Ingen tillgänglig information om uppdateringar"
 
 msgid "Checking available update data"
-msgstr ""
+msgstr "Undersöker tillgänglig information om uppdateringar"
 
 msgid "Trying to check available update data ..."
-msgstr ""
+msgstr "Försöker hitta tillgänglig information om uppdateringar..."
 
 msgid "Error checking available update data."
-msgstr ""
+msgstr "Fel vid försök att hitta information om tillgängliga uppdateringar."
 
 msgid "Checking available update data ..."
-msgstr ""
+msgstr "Söker efter tillgänglig information om uppdatering ..."
 
 msgid "Checked available update data for %title."
-msgstr ""
+msgstr "Sökte efter tillgänglig information om uppdatering för %title."
 
 msgid "Failed to check available update data for %title."
 msgstr ""
+"Kunde inte undersöka tillgänglig information om uppdatering för %title."
 
 msgid "An error occurred trying to get available update data."
 msgstr ""
+"Ett fel uppstod vid försök att hitta tillgänglig information om uppdatering."
 
 msgid "Checked available update data for one project."
 msgid_plural "Checked available update data for @count projects."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Letade efter tillgängliga uppdateringar för ett projekt."
+msgstr[1] "Letade efter tillgängliga uppdateringar för @count projekt."
 
 msgid "Failed to get available update data for one project."
 msgid_plural "Failed to get available update data for @count projects."
 msgstr[0] ""
+"Kunde inte hämta tillgänglig information om uppdatering för ett projekt."
 msgstr[1] ""
+"Kunde inte hämta tillgänglig information om uppdatering för @count projekt."
 
 msgid "There was a problem getting update information. Try again later."
 msgstr ""
+"Det uppstod ett problem att få information om uppdatering. Var vänlig försök"
+" igen senare."
 
 msgid "(Theme)"
-msgstr ""
+msgstr "(Tema)"
 
 msgid "(Security update)"
-msgstr ""
+msgstr "(Säkerhetsuppdatering)"
 
 msgid "(Unsupported)"
-msgstr ""
+msgstr "(Stöds ej)"
 
 msgid "All of your projects are up to date."
-msgstr ""
+msgstr "Alla dina projekt är aktuella."
 
 msgid "Download these updates"
-msgstr ""
+msgstr "Ladda ned dessa uppdateringar"
 
 msgid "Manual updates required"
-msgstr ""
+msgstr "Manuella uppdateringar krävs"
 
 msgid "You must select at least one project to update."
-msgstr ""
+msgstr "Du måste välja åtminstone ett projekt att uppdatera."
 
 msgid "Downloading updates"
-msgstr ""
+msgstr "Laddar ned uppdateringar"
 
 msgid "Preparing to download selected updates"
-msgstr ""
+msgstr "Förbereder för att ladda ned valda uppdateringar"
 
 msgid "Downloading updates failed:"
-msgstr ""
+msgstr "Nedladdning av uppdateringar misslyckades:"
 
 msgid "Updates downloaded successfully."
-msgstr ""
+msgstr "Uppdateringarna laddades ner utan problem."
 
 msgid "Fatal error trying to download."
-msgstr ""
+msgstr "Kritiskt fel vid försök att ladda ned."
 
 msgid "Perform updates with site in maintenance mode (strongly recommended)"
 msgstr ""
+"Genomför uppdateringar med webbplatsen satt i underhållsläge (starkt "
+"rekommenderat)"
 
 msgid "Install from a URL"
-msgstr ""
+msgstr "Installera från en URL"
 
 msgid "For example: %url"
-msgstr ""
+msgstr "Till exempel: %url"
 
 msgid "Upload a module or theme archive to install"
-msgstr ""
+msgstr "Ladda upp ett arkiv med modul eller tema att installera."
 
 msgid "For example: %filename from your local computer"
-msgstr ""
+msgstr "Till exempel: %filename på din dator"
 
 msgid "You must either provide a URL or upload an archive file to install."
 msgstr ""
+"Du måste antingen tillhandahålla en URL eller ladda upp ett filarkiv för att"
+" installera."
 
 msgid "Unable to retrieve Drupal project from %url."
-msgstr ""
+msgstr "Kunde inte hämta Drupalprojekt Drupal från %url."
 
 msgid "Provided archive contains no files."
-msgstr ""
+msgstr "Tillhandahållet arkiv innehåller inga filer."
 
 msgid "Unable to determine %project name."
-msgstr ""
+msgstr "Kunde inte fastställa namnet %project."
 
 msgid "%project is already installed."
-msgstr ""
+msgstr "%project är redan installerat."
 
 msgid "Cannot extract %file, not a valid archive."
-msgstr ""
+msgstr "Kan inte packa upp %file, inte ett giltig arkiv."
 
 msgid "Downloading %project"
-msgstr ""
+msgstr "Laddar ned %project"
 
 msgid "Failed to download %project from %url"
-msgstr ""
+msgstr "Misslyckades med att ladda ned %project från %url"
 
 msgid "Includes:"
-msgstr ""
+msgstr "Innehåller:"
 
 msgid "Enabled: %includes"
-msgstr ""
+msgstr "Aktiverade: %includes"
 
 msgid "Disabled: %disabled"
-msgstr ""
+msgstr "Inaktiverade: %disabled"
 
 msgid "Checking for available updates"
-msgstr ""
+msgstr "Undersöker tillgänglig information om uppdateringar"
 
 msgid ""
 "You can automatically install your missing updates using the Update manager:"
 msgstr ""
+"Du kan automatiskt installera dina saknade uppdateringar genom "
+"uppdateringshanteraren:"
 
 msgid ""
 "The installed version of at least one of your modules or themes is no longer"
 " supported. Upgrading or disabling is strongly recommended. See the project "
 "homepage for more details."
 msgstr ""
+"Den installerade versionen av åtminstone en av dina moduler eller teman "
+"stöds inte längre. Uppgradering eller inaktivering rekommenderas starkt. Var"
+" vänlig se projektets hemsida för mer detaljer."
 
 msgid "Ready to update"
-msgstr ""
+msgstr "Klar för uppdatering"
 
 msgid "Update manager"
-msgstr ""
+msgstr "Uppdateringshanteraren"
 
 msgid ""
 "This role will be automatically assigned new permissions whenever a module "
 "is enabled. Changing this setting will not affect existing permissions."
 msgstr ""
+"Denna roll kommer automatiskt att tilldelas nya behörigheter när moduler "
+"aktiveras. Ändras denna inställning kommer inte nuvarande behörigheter att "
+"påverkas."
 
 msgid "Registration and cancellation"
-msgstr ""
+msgstr "Registrering och borttagning"
 
 msgid "Maintenance mode"
-msgstr ""
+msgstr "Underhållsläge"
 
 msgid "No people available."
-msgstr ""
+msgstr "Inga personer tillgängliga."
 
 msgid "Logging and errors"
-msgstr ""
+msgstr "Loggar och felmeddelanden"
 
 msgid "Regional and language"
-msgstr ""
+msgstr "Lokalt och språk"
 
 msgid "Search and metadata"
-msgstr ""
+msgstr "Sök- och metadata"
 
 msgid "Content authoring"
-msgstr ""
+msgstr "Författande av innehåll"
 
 msgid "more information"
-msgstr ""
+msgstr "mer information"
 
 msgid "Failed to get available update data."
-msgstr ""
+msgstr "Kunde inte hämta information om tillgängliga uppdateringar."
 
 msgid "Enables tracking of recent content for users."
-msgstr ""
+msgstr "Möjliggör spårning av senaste innehåll för användare."
 
 msgid ""
 "Checks for available updates, and can securely install or update modules and"
 " themes via a web interface."
 msgstr ""
+"Kollar efter tillgängliga uppdateringar, och kan på ett säkert sätt "
+"installera eller uppdatera moduler och teman via ett webbgränssnitt."
 
 msgid "Who can register accounts?"
-msgstr ""
+msgstr "Vem kan registrera konton?"
 
 msgid "Administrators only"
-msgstr ""
+msgstr "Enbart administratörer"
 
 msgid "Visitors, but administrator approval is required"
-msgstr ""
+msgstr "Besökare, men godkännande från administratör krävs."
 
 msgid "When cancelling a user account"
-msgstr ""
+msgstr "Vid borttagning av ett användarkonto"
 
 msgid "Select method for cancelling account"
-msgstr ""
+msgstr "Välj metod för att ta bort konto"
 
 msgid "Administer users"
-msgstr ""
+msgstr "Administrera användare"
 
 msgid "Welcome (new user created by administrator)"
-msgstr ""
+msgstr "Välkomstmeddelande (ny användare skapad av administratör)"
 
 msgid "Welcome (awaiting approval)"
-msgstr ""
+msgstr "Välkomstmeddelande (väntar på godkännande)"
 
 msgid "Welcome (no approval required)"
-msgstr ""
+msgstr "Välkomstmeddelande (inget godkännande krävs)"
 
 msgid "Password recovery"
-msgstr ""
+msgstr "Återställ lösenord"
 
 msgid "Account activation"
-msgstr ""
+msgstr "Aktivering av konto"
 
 msgid "Account cancellation confirmation"
-msgstr ""
+msgstr "Bekräftelse för borttagning av konto"
 
 msgid "Account canceled"
-msgstr ""
+msgstr "Konto borttaget"
 
 msgid "The one-time login link you clicked is invalid."
-msgstr ""
+msgstr "Engångslänken för inloggning som du klickade på är ogiltig."
 
 msgid ""
 "You have just used your one-time login link. It is no longer necessary to "
 "use this link to log in. Please change your password."
 msgstr ""
+"Du har just använt din engångslänk för inloggning. Det är inte längre "
+"nödvändigt att använda denna länk för att logga in. Var vänlig byt lösenord."
 
 msgid ""
 "<p>This is a one-time login for %user_name and will expire on "
 "%expiration_date.</p><p>Click on this button to log in to the site and "
 "change your password.</p>"
 msgstr ""
+"<p>Detta är en engångsinloggning för %user_name som upphör att gälla "
+"%expiration_date.</p><p>Klicka på denna knapp för att logga in på "
+"webbplatsen och byta lösenord.</p>"
 
 msgid ""
 "You have tried to use a one-time login link that has either been used or is "
 "no longer valid. Please request a new one using the form below."
 msgstr ""
+"Du har försökt använda en engångslänk för inloggning som antingen redan har "
+"använts eller inte längre är giltig. Var vänlig begär en ny genom att "
+"använda formuläret nedan."
 
 msgid "When cancelling your account"
-msgstr ""
+msgstr "Vid borttagning av ditt konto"
 
 msgid "When cancelling the account"
-msgstr ""
+msgstr "Vid borttagning av kontot"
 
 msgid "Are you sure you want to cancel your account?"
-msgstr ""
+msgstr "Är du säker på att du vill ta bort ditt konto?"
 
 msgid "Are you sure you want to cancel the account %name?"
-msgstr ""
+msgstr "Är du säker på att du vill ta bort kontot %name?"
 
 msgid "Select the method to cancel the account above."
-msgstr ""
+msgstr "Välj metod för att ta bort kontot ovan."
 
 msgid ""
 "Your account will be blocked and you will no longer be able to log in. All "
 "of your content will be hidden from everyone but administrators."
 msgstr ""
+"Ditt konto kommer att spärras och du kommer inte längre att kunna logga in. "
+"Allt ditt innehåll kommer att döljas för alla utom administratörer."
 
 msgid ""
 "Your account will be removed and all account information deleted. All of "
 "your content will be assigned to the %anonymous-name user."
 msgstr ""
+"Ditt konto kommer att tas bort och all information om kontot raderas. Allt "
+"ditt innehåll kommer att tilldelas användaren %anonymous-name."
 
 msgid ""
 "Your account will be removed and all account information deleted. All of "
 "your content will also be deleted."
 msgstr ""
+"Ditt konto kommer att tas bort och all information om kontot raderas. Allt "
+"ditt innehåll kommer också att tas bort."
 
 msgid ""
 "You have tried to use an account cancellation link that has expired. Please "
 "request a new one using the form below."
 msgstr ""
+"Du har försökt använda en länk för att ta bort konto som inte längre är "
+"giltig. Var vänlig begär en ny länk genom formuläret nedan."
 
 msgid "Sent account cancellation request to %name %email."
-msgstr ""
+msgstr "Skickade begäran om borttagning av konto till %name %email."
 
 msgid "Tokens related to individual user accounts."
-msgstr ""
+msgstr "Ersättningstecken relaterade till individuella användarkonton."
 
 msgid "Tokens related to the currently logged in user."
-msgstr ""
+msgstr "Ersättningstecken relaterade till den nuvarande inloggade användaren."
 
 msgid "Creating and managing users"
-msgstr ""
+msgstr "Skapande och hanterande av användare"
 
 msgid ""
 "This form lets administrators configure how fields should be displayed when "
 "rendering a user profile page."
 msgstr ""
+"Detta formulär låter administratörer konfigurera hur fält skall visas vid "
+"återgivning av en användares profilsida."
 
 msgid "Administer permissions"
-msgstr ""
+msgstr "Administrera behörigheter"
 
 msgid "Change own username"
-msgstr ""
+msgstr "Ändra eget användarnamn"
 
 msgid "Cancel own user account"
-msgstr ""
+msgstr "Ta bort eget användarkonto"
 
 msgid "Cancelling account"
-msgstr ""
+msgstr "Borttagning av konto"
 
 msgid "Cancelling user account"
-msgstr ""
+msgstr "Borttagning av användarkonto"
 
 msgid "%name has been disabled."
-msgstr ""
+msgstr "%name har inaktiverats."
 
 msgid "Cancel the selected user accounts"
-msgstr ""
+msgstr "Radera valda användarkonton"
 
 msgid "When cancelling these accounts"
-msgstr ""
+msgstr "Vid borttagning av dessa konton"
 
 msgid "Are you sure you want to cancel these user accounts?"
-msgstr ""
+msgstr "Är du säker på att du vill radera dessa användarkonton?"
 
 msgid "Cancel accounts"
-msgstr ""
+msgstr "Radera konton"
 
 msgid "Add lowercase letters"
-msgstr ""
+msgstr "Lägg till små bokstäver"
 
 msgid "Add uppercase letters"
-msgstr ""
+msgstr "Lägg till versaler"
 
 msgid "Add numbers"
-msgstr ""
+msgstr "Lägg till siffror"
 
 msgid "Add punctuation"
-msgstr ""
+msgstr "Lägg till skiljetecken"
 
 msgid "Make it different from your username"
-msgstr ""
+msgstr "Ha inte samma som ditt användarnamn"
 
 msgid "Weak"
-msgstr ""
+msgstr "Svag"
 
 msgid "Fair"
-msgstr ""
+msgstr "Tillräcklig"
 
 msgid "Blocked user: %name %email."
-msgstr ""
+msgstr "Spärrad användare: %name %email."
 
 msgid "Confirm account cancellation"
-msgstr ""
+msgstr "Bekräfta borttagning av konto"
 
 msgid "Minimal"
-msgstr ""
+msgstr "Minimal"
 
 msgid "Install with commonly used features pre-configured."
-msgstr ""
+msgstr "Installera med vanligt använda funktioner förinställda."
 
 msgid "Flood control"
-msgstr ""
+msgstr "Kontroll av översvämmelse"
 
 msgid "Exposed"
-msgstr ""
+msgstr "Exponerad"
 
 msgid "Remove this display"
-msgstr ""
+msgstr "Tag bort denna visning"
 
 msgid "Operator to use on all groups"
-msgstr ""
+msgstr "Operand att använda på alla grupper"
 
 msgid ""
 "Either \"group 0 AND group 1 AND group 2\" or \"group 0 OR group 1 OR group "
 "2\", etc"
 msgstr ""
+"Antingen \"grupp 0 AND grupp 1 AND gupp 2\" eller \"grupp 0 OR grupp 1 OR "
+"gupp 2\", etc"
 
 msgid "Remove group @group"
-msgstr ""
+msgstr "Tag bort grupp @group"
 
 msgid "Default group"
-msgstr ""
+msgstr "Förvald grupp"
 
 msgid "Group @group"
-msgstr ""
+msgstr "Grupp @group"
 
 msgid "Ungroupable filters"
-msgstr ""
+msgstr "Ej grupperingsbara filter"
 
 msgid "Basic exposed form"
-msgstr ""
+msgstr "Vanligt exponerat formulär"
 
 msgid "Input required"
-msgstr ""
+msgstr "Inmatning krävs"
 
 msgid ""
 "An exposed form that only renders a view if the form contains user input."
 msgstr ""
+"Ett exponerat formulär som enbart genererar en vy om formuläret innehåller "
+"användarinmatning."
 
 msgid "Display all items"
-msgstr ""
+msgstr "Visa alla objekt"
 
 msgid "Display a specified number of items"
-msgstr ""
+msgstr "Visa ett angivet antal objekt"
 
 msgid "Display a limited number items that this view might find."
-msgstr ""
+msgstr "Visa ett begränsat antal objekt som denna vy kan hitta."
 
 msgid "Paged output, full pager"
-msgstr ""
+msgstr "Paginerad utmatning, fullständig paginerare"
 
 msgid "Paged output, full Drupal style"
-msgstr ""
+msgstr "Paginerad utmatning, fullständig stil för Drupal"
 
 msgid "Paged output, mini pager"
-msgstr ""
+msgstr "Paginerad utmatning, minipaginerare"
 
 msgid "Name (raw)"
-msgstr ""
+msgstr "Namn (obearbetat)"
 
 msgid "Provide markup text for the area."
-msgstr ""
+msgstr "Tillhandahåll uppmärkningstext för fältet."
 
 msgid "Machine Name"
-msgstr ""
+msgstr "Maskinläsbart namn"
 
 msgid "Change the machine name of this display."
-msgstr ""
+msgstr "Ändra det maskinläsbara namnet för denna visning."
 
 msgid "Change settings for this pager type."
-msgstr ""
+msgstr "Ändra inställningar för denna typ av paginerare."
 
 msgid "Allow grouping and aggregation (calculation) of fields."
-msgstr ""
+msgstr "Tillåt gruppering och insamling (beräkning) av fält"
 
 msgid "Exposed form style"
-msgstr ""
+msgstr "Stil på exponerat formulär"
 
 msgid "Select the kind of exposed filter to use."
-msgstr ""
+msgstr "Välj vilken typ av exponerat filter att använda."
 
 msgid "Exposed form settings for this exposed form style."
-msgstr ""
+msgstr "Inställningar för denna stil på exponerat formulär."
 
 msgid "The machine name of this display"
-msgstr ""
+msgstr "Det maskinläsbara namnet på denna visning"
 
 msgid ""
 "If enabled, some fields may become unavailable. All fields that are selected"
@@ -10337,113 +11003,120 @@ msgid ""
 "them. For example, you can group nodes on title and count the number of nids"
 " in order to get a list of duplicate titles."
 msgstr ""
+"Om aktiverad, kan vissa fält bli otillgängliga. Alla fält som markerats för "
+"gruppering kommer att fällas ihop till en post per enskilt värde. Andra fält"
+" som väljs ut för hopsamling kommer att få funktionen körd på sig. Till "
+"exempel kan du gruppera noder på titel och räkna antalet NID för att få en "
+"lista med dubbletter av titlar."
 
 msgid "Exposed Form"
-msgstr ""
+msgstr "Exponerat formulär"
 
 msgid "Exposed form options"
-msgstr ""
+msgstr "Alternativ för exponerat formulär"
 
 msgid "Pager options"
-msgstr ""
+msgstr "Alternativ för paginerare"
 
 msgid "Display id should be unique."
-msgstr ""
+msgstr "ID för visning skall vara unikt."
 
 msgid "Include reset button"
-msgstr ""
+msgstr "Inkludera återställningsknapp"
 
 msgid "Reset button label"
-msgstr ""
+msgstr "Etikett för återställningsknapp"
 
 msgid "Text to display in the reset button of the exposed form."
-msgstr ""
+msgstr "Text att visa i återställningsknappen till det exponerade formuläret."
 
 msgid "Exposed sorts label"
-msgstr ""
+msgstr "Exponerad sorteringsetikett"
 
 msgid "Select any filter and click on Apply to see results"
-msgstr ""
+msgstr "Välj valfritt filter och klicka på applicera för att se resultaten."
 
 msgid "Image style"
-msgstr ""
+msgstr "Stilmall för bild"
 
 msgid "Use tags to group articles on similar topics into categories."
 msgstr ""
+"Använd etiketter för att gruppera artiklar med liknande ämnen till "
+"kategorier."
 
 msgid "An administrator created an account for you at [site:name]"
-msgstr ""
+msgstr "En administratör har skapat ett konto åt dig på [site:name]"
 
 msgid "Find and manage people interacting with your site."
-msgstr ""
+msgstr "Hitta och hantera personer som använder din webbplats."
 
 msgid "Entity ID"
-msgstr ""
+msgstr "ID-nummer för objekt"
 
 msgid "Contact forms"
-msgstr ""
+msgstr "Kontaktformulär"
 
 msgid "Text on demand"
-msgstr ""
+msgstr "Text på begäran"
 
 msgid "Exposed options"
-msgstr ""
+msgstr "Exponerade alternativ"
 
 msgid "Items per page label"
-msgstr ""
+msgstr "Etikett för inlägg per sida"
 
 msgid "Exposed items per page options"
-msgstr ""
+msgstr "Alternativ för exponerade inlägg per sida"
 
 msgid "Expose Offset"
-msgstr ""
+msgstr "Exponera motvikt"
 
 msgid "Offset label"
-msgstr ""
+msgstr "Etikett för motvikt"
 
 msgid "Mini pager, @count item, skip @skip"
 msgid_plural "Mini pager, @count items, skip @skip"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Minipaginerad, @count inlägg, hoppa över @skip"
+msgstr[1] "Minipaginerad, @count inlägg, hoppa över @skip"
 
 msgid "Mini pager, @count item"
 msgid_plural "Mini pager, @count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Minipaginerare, @count inlägg"
+msgstr[1] "Minipaginerare, @count inlägg"
 
 msgid "All items, skip @skip"
-msgstr ""
+msgstr "Alla inlägg, hoppa över @skip"
 
 msgid "All items"
-msgstr ""
+msgstr "Alla inlägg"
 
 msgid "@count item, skip @skip"
 msgid_plural "@count items, skip @skip"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count inlägg, hoppa över @skip"
+msgstr[1] "@count inlägg, hoppa över @skip"
 
 msgid "@count item"
 msgid_plural "@count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count inlägg"
+msgstr[1] "@count inlägg"
 
 msgid "Group results together"
-msgstr ""
+msgstr "Gruppera resultat tillsammans"
 
 msgid "Unlock"
-msgstr ""
+msgstr "Lås upp"
 
 msgid "Bundle ID"
-msgstr ""
+msgstr "Bundle ID"
 
 msgid "Add custom block"
-msgstr ""
+msgstr "Lägg till anpassat block"
 
 msgid "Internet"
-msgstr ""
+msgstr "Internet"
 
 msgid "Alt"
-msgstr ""
+msgstr "Alternativ"
 
 msgid ""
 "1 pending update (@number_applied to be applied, @number_incompatible "
@@ -10452,118 +11125,138 @@ msgid_plural ""
 "@count pending updates (@number_applied to be applied, @number_incompatible "
 "skipped)"
 msgstr[0] ""
+"1 förestående uppdatering (@number_applied att genomföra, "
+"@number_incompatible överhoppade)"
 msgstr[1] ""
+"@count förestående uppdateringar (@number_applied att genomföra, "
+"@number_incompatible överhoppade)"
 
 msgid "Author textfield"
-msgstr ""
+msgstr "Textfält för författare"
 
 msgid "Error messages to display"
-msgstr ""
+msgstr "Felmeddelanden att visa"
 
 msgid ""
 "It is recommended that sites running on production environments do not "
 "display any errors."
 msgstr ""
+"Det är rekommenderat att webbplatser som körs i skarpt läge inte visar några"
+" felmeddelanden."
 
 msgid "Cannot open %file_path"
-msgstr ""
+msgstr "Kan inte öppna %file_path"
 
 msgid "Current password"
-msgstr ""
+msgstr "Nuvarande lösenord"
 
 msgid ""
 "Your current password is missing or incorrect; it's required to change the "
 "%name."
 msgstr ""
+"Ditt nuvarande lösenord saknas eller är felaktigt. Det krävs för att ändra "
+"%name."
 
 msgid "Terminology"
-msgstr ""
+msgstr "Terminologi"
 
 msgid "Last login timestamp"
-msgstr ""
+msgstr "Tidsstämpel för senare inloggning"
 
 msgid "Forum settings"
-msgstr ""
+msgstr "Inställningar för forum"
 
 msgid "Maximize"
-msgstr ""
+msgstr "Maximera"
 
 msgid "Update preview"
-msgstr ""
+msgstr "Uppdatera förhandsgranskning"
 
 msgid "No media available."
-msgstr ""
+msgstr "No media available."
 
 msgid "Administer media"
-msgstr ""
+msgstr "Administer media"
 
 msgid "View media"
-msgstr ""
+msgstr "View media"
 
 msgid "Remove block"
-msgstr ""
+msgstr "Ta bort block"
 
 msgid "all languages"
-msgstr ""
+msgstr "alla språk"
 
 msgid "%module module installed."
-msgstr ""
+msgstr "Modulen %module installerades."
 
 msgid "@node_type comment"
-msgstr ""
+msgstr "Kommentar till @node_type"
 
 msgid "Administer text formats and filters"
-msgstr ""
+msgstr "Administrera textformat och filter"
 
 msgid "@type language detection"
-msgstr ""
+msgstr "Språkidentifiering för @type"
 
 msgid "Use the detected interface language."
-msgstr ""
+msgstr "Använd det upptäckta gränssnittsspråket."
 
 msgid ""
 "The new set is created by copying items from your default shortcut set."
 msgstr ""
+"Den nya uppsättningen skapas genom att kopiera alternativen från din "
+"förvalda genvägsuppsättning."
 
 msgid "The new set is created by copying items from the %default set."
 msgstr ""
+"Den nya uppsättningen skapades genom att kopiera alternativ från "
+"genvägsuppsättningen %default."
 
 msgid "You are currently using the %set-name shortcut set."
-msgstr ""
+msgstr "Du använder för närvarande genvägsuppsättningen %set-name."
 
 msgid "Create new set"
-msgstr ""
+msgstr "Skapa ny uppsättning"
 
 msgid ""
 "The %set_name shortcut set has been created. You can edit it from this page."
 msgstr ""
+"Genvägsuppsättningen %set_name har skapats. Du kan redigera den på denna "
+"sida."
 
 msgid "Updated set name to %set-name."
-msgstr ""
+msgstr "Uppdaterade namnet på uppsättning till %set-name."
 
 msgid ""
 "If you have chosen this shortcut set as the default for some or all users, "
 "they may also be affected by deleting it."
 msgstr ""
+"Om du har valt denna genvägsuppsättning som förvald för alla användare, kan "
+"de också komma att bli påverkade av borttagning av den."
 
 msgid "1 user has chosen or been assigned to this shortcut set."
 msgid_plural "@count users have chosen or been assigned to this shortcut set."
 msgstr[0] ""
+"En användare har valt eller tilldelats till denna genvägsuppsättning."
 msgstr[1] ""
+"@count användare har valt eller tilldelats till denna genvägsuppsättning."
 
 msgid "Administering shortcuts"
-msgstr ""
+msgstr "Administrera genvägar"
 
 msgid "Choosing shortcut sets"
-msgstr ""
+msgstr "Välja genvägsuppsättning"
 
 msgid ""
 "Users with permission to switch shortcut sets can choose a shortcut set to "
 "use from the Shortcuts tab of their user account page."
 msgstr ""
+"Användare med behörighet att ändra genvägsuppsättningar kan välja en "
+"genvägsuppsättning att använda i fliken Genvägar på deras användarsida."
 
 msgid "Edit current shortcut set"
-msgstr ""
+msgstr "Redigera den nuvarande genvägsuppsättningen."
 
 msgid ""
 "Editing the current shortcut set will affect other users if that set has "
@@ -10571,323 +11264,357 @@ msgid ""
 "set\" permission along with this permission will grant permission to edit "
 "any shortcut set."
 msgstr ""
+"Redigering av aktuell genvägsuppsättning kommer att påverka andra användare "
+"om den uppsättningen har tilldelats till eller valts av andra användare. "
+"Beviljande av behörigheten \"Välj genvägsuppsättning\" tillsammans med denna"
+" behörighet kommer att ge behörighet att redigera alla genvägsuppsättningar."
 
 msgid "Select any shortcut set"
-msgstr ""
+msgstr "Välj valfri genvägsuppsättning"
 
 msgid ""
 "From all shortcut sets, select one to be own active set. Without this "
 "permission, an administrator selects shortcut sets for users."
 msgstr ""
+"Från alla genvägsuppsättningar, ange en som ska bli den egna aktiva "
+"uppsättningen. Utan denna behörighet är det en administratör som anger "
+"genvägsuppsättningar för användare."
 
 msgid "Add shortcut set"
-msgstr ""
+msgstr "Lägg till genvägsuppsättning"
 
 msgid "Edit set name"
-msgstr ""
+msgstr "Redigera uppsättningsnamn"
 
 msgid "Delete shortcut set"
-msgstr ""
+msgstr "Radera genvägsuppsättning"
 
 msgid "@remote could not be saved to @path."
-msgstr ""
+msgstr "@remote kunde inte sparas till @path."
 
 msgid "Database support"
-msgstr ""
+msgstr "Stöd för databas"
 
 msgid "Cache type"
-msgstr ""
+msgstr "Typ av cache"
 
 msgid "Is not empty (NOT NULL)"
-msgstr ""
+msgstr "Är inte tom (INTE INNEHÅLLSLÖST)"
 
 msgid ""
 "Display %display has set node/% as path. This will not produce what you "
 "want. If you want to have multiple versions of the node view, use panels."
 msgstr ""
+"Visning %display har angivit node/% som sökväg. Detta kommer inte att "
+"producera vad du vill. Om du vill ha flera versioner av nodvisningen, "
+"använda modulen Panels."
 
 msgid "Use absolute link (begins with \"http://\")"
-msgstr ""
+msgstr "Använd absolut länk (börjar med \"http://\")"
 
 msgid "Output machine name"
-msgstr ""
+msgstr "Mata ut maskinläsbart namn"
 
 msgid "Change the CSS class name(s) that will be added to this display."
-msgstr ""
+msgstr "Ändra namn för CSS-klass som kommer att läggas till denna visning."
 
 msgid "CSS classes must be alphanumeric or dashes only."
-msgstr ""
+msgstr "CSS-klasser får endast bestå av alfanumeriska tecken eller streck."
 
 msgid ""
 "Set between which values the user can choose when determining the items per "
 "page. Separated by comma."
 msgstr ""
+"Ange mellan vilka värden som användaren kan välja vid fastställandet av "
+"poster per sida. Åtskilda med kommatecken."
 
 msgid "Update @name"
-msgstr ""
+msgstr "Uppdatera @name"
 
 msgid "Link field"
-msgstr ""
+msgstr "Länkfält"
 
 msgid "Attachment before"
-msgstr ""
+msgstr "Bilaga innan"
 
 msgid "Attachment after"
-msgstr ""
+msgstr "Bilaga efter"
 
 msgid "Feed icon"
-msgstr ""
+msgstr "Ikon för innehållsflöde"
 
 msgid "Cache configuration"
-msgstr ""
+msgstr "Konfiguration av cache"
 
 msgid "Editing"
-msgstr ""
+msgstr "Redigerar"
 
 msgid "The date the comment was most recently updated."
-msgstr ""
+msgstr "Datumet då kommentaren senast uppdaterades."
 
 msgid "Comment posted: %subject."
-msgstr ""
+msgstr "Kommentar inlagd: %subject"
 
 msgid ""
 "This field has been disabled because you do not have sufficient permissions "
 "to edit it."
 msgstr ""
+"Det här fältet har inaktiverats för att du inte har nödvändiga behörigheter "
+"för att redigera det."
 
 msgid ""
 "View, edit and delete all content regardless of permission restrictions."
 msgstr ""
+"Visa, redigera och radera allt innehåll oberoende av begränsning av "
+"behörighet."
 
 msgid "Syslog format"
-msgstr ""
+msgstr "Format på Syslog"
 
 msgid "A date in 'time-since' format. (%date)"
-msgstr ""
+msgstr "Ett datum i formatet \"tid sedan\". (%date)"
 
 msgid "The location of the file relative to Drupal root."
-msgstr ""
+msgstr "Filens plats relativ till Drupals rot."
 
 msgid "Your modules have been downloaded and updated."
-msgstr ""
+msgstr "Dina moduler har laddats ned och uppdaterats."
 
 msgid ""
 "The selected file %filename cannot be uploaded. Only files with the "
 "following extensions are allowed: %extensions."
 msgstr ""
+"Den valda filen %filename kan inte laddas upp. Endast filer med följande "
+"ändelser är tillåtna: %extensions."
 
 msgid "Bartik"
-msgstr ""
+msgstr "Bartik"
 
 msgid "Highlighted"
-msgstr ""
+msgstr "Framhävd"
 
 msgid "Main background"
-msgstr ""
+msgstr "Huvudbakgrund"
 
 msgid "Sidebar background"
-msgstr ""
+msgstr "Bakgrund för sidospalt"
 
 msgid "Current page"
-msgstr ""
+msgstr "Nuvarande sida"
 
 msgid "Configure user accounts."
-msgstr ""
+msgstr "Konfigurera användarkonton."
 
 msgid "Add and modify shortcut sets."
-msgstr ""
+msgstr "Lägg till och modifiera genvägsuppsättningar."
 
 msgid "Overview of fields on all entity types."
-msgstr ""
+msgstr "Fältöversikt för alla objektstyper."
 
 msgid "GD library PNG support"
-msgstr ""
+msgstr "Stöd för PNG i GD-biblioteket"
 
 msgid "Translation update status"
-msgstr ""
+msgstr "Status för uppdatering av översättningar"
 
 msgid "Filter modules"
-msgstr ""
+msgstr "Filtreringsmoduler"
 
 msgid "Field API to add fields to entities like nodes and users."
 msgstr ""
+"Field API för att lägga till fält till enheter som noder och användare."
 
 msgid "Collapse"
-msgstr ""
+msgstr "Fäll in"
 
 msgid "Sidebar borders"
-msgstr ""
+msgstr "Kant för sidospalt"
 
 msgid "Footer background"
-msgstr ""
+msgstr "Sidfotens bakgrund"
 
 msgid "Plum"
-msgstr ""
+msgstr "Plommon"
 
 msgid "Site logo"
-msgstr ""
+msgstr "Webbplatsens logotyp"
 
 msgid "Title link"
-msgstr ""
+msgstr "Länktitel"
 
 msgid ""
 "A space-separated list of HTML tags allowed in the content of feed items. "
 "Disallowed tags are stripped from the content."
 msgstr ""
+"En blankstegsseparerad lista av HTML-taggar som är tillåtna i innehållet för"
+" flöden. Ej tillåtna taggar tas bort från innehållet."
 
 msgid "%field cannot contain any markup."
-msgstr ""
+msgstr "%field får inte innehålla någon uppmärkning."
 
 msgid ""
 "These options control the display settings for the %name theme. When your "
 "site is displayed using this theme, these settings will be used."
 msgstr ""
+"De här alternativen styr visningsinställningarna för temat %name. När din "
+"webbplats visas med detta tema, kommer dessa inställningar att användas."
 
 msgid "Administer software updates"
-msgstr ""
+msgstr "Administrera uppdateringar för programvara"
 
 msgid "@required_name (Missing)"
-msgstr ""
+msgstr "@required_name (Saknas)"
 
 msgid "@required_name (Version @compatibility required)"
-msgstr ""
+msgstr "@required_name (version @compatibility krävs)"
 
 msgid "@name requires at least PHP @version."
-msgstr ""
+msgstr "@name kräver åtminstone PHP @version."
 
 msgid "Unresolved dependency"
-msgstr ""
+msgstr "Ej löst beroende"
 
 msgid "@name requires this module."
-msgstr ""
+msgstr "@name kräver denna modul."
 
 msgid ""
 "@name requires this module and version. Currently using @required_name "
 "version @version"
 msgstr ""
+"@name kräver denna modul och version. För närvarande används @required_name "
+"version @version"
 
 msgid "Previous page"
-msgstr ""
+msgstr "Föregående sida"
 
 msgid "Fetch settings"
-msgstr ""
+msgstr "Inställningar för hämtning"
 
 msgid "Site details"
-msgstr ""
+msgstr "Detaljer för webbplats"
 
 msgid "The email address %mail is not valid."
-msgstr ""
+msgstr "E-postadressen %mail är inte giltig."
 
 msgid "Add media"
-msgstr ""
+msgstr "Lägg till media"
 
 msgid "Interfaces"
-msgstr ""
+msgstr "Gränssnitt"
 
 msgid "Title and slogan"
-msgstr ""
+msgstr "Titel och slogan"
 
 msgid "Firehouse"
-msgstr ""
+msgstr "Brandstation"
 
 msgid "Ice"
-msgstr ""
+msgstr "Is"
 
 msgid ""
 "The database table prefix you have entered, %prefix, is invalid. The table "
 "prefix can only contain alphanumeric characters, periods, or underscores."
 msgstr ""
+"Prefixet till databasen som du angivit, %prefix, är ogiltigt. Tabellens "
+"prefix får endast innehålla alfanumeriska tecken, punkter eller understreck."
 
 msgid "Default settings file"
-msgstr ""
+msgstr "Filen med förvalda inställningar"
 
 msgid "The default settings file does not exist."
-msgstr ""
+msgstr "Filen med förvalda inställningar finns inte"
 
 msgid ""
 "The @drupal installer requires that the %default-file file not be modified "
 "in any way from the original download."
 msgstr ""
+"Installeraren för @drupal kräver att filen %default-file inte modifieras på "
+"något sätt utifrån den ursprungliga nedladdningen."
 
 msgid "Show row weights"
-msgstr ""
+msgstr "Visa radernas vikt"
 
 msgid "Hide row weights"
-msgstr ""
+msgstr "Dölj radernas vikt"
 
 msgid "%name: the value may be no less than %min."
-msgstr ""
+msgstr "%name: värdet får inte vara mindre än %min."
 
 msgid "%name: the value may be no greater than %max."
-msgstr ""
+msgstr "%name: värdet får inte vara större än %max."
 
 msgid "Custom display settings"
-msgstr ""
+msgstr "Inställningar för anpassad visning"
 
 msgid ""
 "Separate extensions with a space or comma and do not include the leading "
 "dot."
 msgstr ""
+"Separera filändelser med mellanslag eller kommatecken och ta ej med en "
+"inledande punkt."
 
 msgid "Node module element"
-msgstr ""
+msgstr "Element för modulen Node"
 
 msgid "not yet assigned"
-msgstr ""
+msgstr "inte tilldelad ännu"
 
 msgid "not yet created"
-msgstr ""
+msgstr "inte skapad ännu"
 
 msgid "Edit permissions"
-msgstr ""
+msgstr "Redigera behörigheter"
 
 msgid "None (original image)"
-msgstr ""
+msgstr "Ingen (ursprunglig bild)"
 
 msgid "Row class"
-msgstr ""
+msgstr "Klass för rad"
 
 msgid "Latest version"
-msgstr ""
+msgstr "Senaste version"
 
 msgid "The URL of the account edit page."
-msgstr ""
+msgstr "URL-en för kontots redigeringssidan."
 
 msgid "Edit translations"
-msgstr ""
+msgstr "Redigera översättningar"
 
 msgid "- Use default -"
-msgstr ""
+msgstr "- Använd förvalt -"
 
 msgid "Query type"
-msgstr ""
+msgstr "Typ av databasfråga"
 
 msgid "Search pages"
-msgstr ""
+msgstr "Söksidor"
 
 msgid "Add search page"
-msgstr ""
+msgstr "Lägg till söksida"
 
 msgid "Redirect path"
-msgstr ""
+msgstr "Sökväg för omdirigering"
 
 msgid "Unknown content type"
-msgstr ""
+msgstr "Okänd innehållstyp"
 
 msgid "Drupal Upgrade"
-msgstr ""
+msgstr "Uppgradera Drupal"
 
 msgid "Summary options"
-msgstr ""
+msgstr "Alternativ för sammandrag"
 
 msgid "Never (manually)"
-msgstr ""
+msgstr "Aldrig (manuell)"
 
 msgid ""
 "The data could not be saved because the destination %destination is invalid."
 " This may be caused by improper use of file_save_data() or a missing stream "
 "wrapper."
 msgstr ""
+"Datainformationen kunde inte sparas eftersom målet %destination inte är "
+"giltigt. Detta orsakas ofta av felaktigt användande av file_data() eller "
+"avsaknad av stream wrapper."
 
 msgid ""
 "Failed to connect to your database server. The server reports the following "
@@ -10896,696 +11623,802 @@ msgid ""
 " you entered the correct username and password?</li><li>Have you entered the"
 " correct database hostname?</li></ul>"
 msgstr ""
+"Kunde inte ansluta till din databasserver. Servern rapporterar följande "
+"meddelande: %error.<ul><li>Körs databasservern?</li><li>Finns databasen, och"
+" har du angett rätt namn på databasen?</li><li>Har du angett rätt "
+"användarnamn och lösenord?</li><li>Har du angett rätt värdnamn för "
+"databasen?</li></ul>"
 
 msgid "Exit block region demonstration"
-msgstr ""
+msgstr "Avsluta visning av blockregioner"
 
 msgid "Database log messages to keep"
-msgstr ""
+msgstr "Loggmeddelanden som skall sparas"
 
 msgid ""
 "Define a string that should be suffixed to the value, like ' m', ' kb/s'. "
 "Leave blank for none. Separate singular and plural values with a pipe "
 "('pound|pounds')."
 msgstr ""
+"Ange en sträng som skall sättas in efter värdet, såsom \"m\" eller \"kb/s\"."
+" Utelämna för tomt värde. Separera enstaka och flervärdiga värden med ett "
+"stående streck (\"krona|kronor\")."
 
 msgid "Thousand marker"
-msgstr ""
+msgstr "Tusentalsavgränsare"
 
 msgid "Display prefix and suffix."
-msgstr ""
+msgstr "Visa prefix och suffix."
 
 msgid "Display with prefix and suffix."
-msgstr ""
+msgstr "Visa med prefix och suffix."
 
 msgid "- Select a value -"
-msgstr ""
+msgstr "- Välj ett värde -"
 
 msgid "Trim length"
-msgstr ""
+msgstr "Korta ned längd"
 
 msgid "No field is displayed."
-msgstr ""
+msgstr "Inga fält visas."
 
 msgid "No field is hidden."
-msgstr ""
+msgstr "Inga fält är dolda."
 
 msgid "Format settings:"
-msgstr ""
+msgstr "Inställningar för format:"
 
 msgid ""
 "Text formats are presented on content editing pages in the order defined on "
 "this page. The first format available to a user will be selected by default."
 msgstr ""
+"Textformat visas på redigeringssidor i den ordning som definieras på denna "
+"sida. Det första formatet som är tillgängligt för en användare kommer att "
+"användas som standard."
 
 msgid "Link image to"
-msgstr ""
+msgstr "Länka bild till"
 
 msgid "Image style: @style"
-msgstr ""
+msgstr "Bildstil: @style"
 
 msgid "Linked to content"
-msgstr ""
+msgstr "Länkat till innehåll"
 
 msgid "Linked to file"
-msgstr ""
+msgstr "Länkat till fil"
 
 msgid "Shown when hovering over the menu link."
-msgstr ""
+msgstr "Visas när man för musmarkören över menylänken."
 
 msgid ""
 "Format: %time. The date format is YYYY-MM-DD and %timezone is the time zone "
 "offset from UTC. Leave blank to use the time of form submission."
 msgstr ""
+"Format: %time. Datumformatet är YYYY-MM-DD och %timezone är kompensationen "
+"av tidszon från UTC. Lämna tomt för att använda tiden för formulärinlägg."
 
 msgid "Syslog identity"
-msgstr ""
+msgstr "Identitet för systemlogg"
 
 msgid ""
 "A string that will be prepended to every message logged to Syslog. If you "
 "have multiple sites logging to the same Syslog log file, a unique identity "
 "per site makes it easy to tell the log entries apart."
 msgstr ""
+"En sträng som kommer att läggs till i början av varje meddelande som loggas "
+"i Syslog. Om du har flera webbplatser som loggar till samma loggfil för "
+"Syslog, gör en unik identitet per plats det lätt att hålla isär "
+"logginläggen."
 
 msgid "Error pages"
-msgstr ""
+msgstr "Sidor för felmeddelanden"
 
 msgid "Run cron every"
-msgstr ""
+msgstr "Kör schemalagda aktiviteter varje"
 
 msgid "Weight for added term"
-msgstr ""
+msgstr "Vikt för tillagd term"
 
 msgid ""
 "Minimal profile for running tests. Includes absolutely required modules "
 "only."
 msgstr ""
+"Minimal profil för att köra tester. Inkluderar enbart de moduler som krävs."
 
 msgid "Administrative name"
-msgstr ""
+msgstr "Administrativt namn"
 
 msgid "Saint Martin"
-msgstr ""
+msgstr "Saint Martin"
 
 msgid "Invalid merge query: no conditions"
-msgstr ""
+msgstr "Ogiltig sammanslagningsfråga: inga villkor"
 
 msgid "Weight for @block block"
-msgstr ""
+msgstr "Vikt för block @block"
 
 msgid "Region for @block block"
-msgstr ""
+msgstr "Region för blocket @block"
 
 msgid "Post comments"
-msgstr ""
+msgstr "Kommentera"
 
 msgid "Skip comment approval"
-msgstr ""
+msgstr "Hoppa över godkännande av kommentar"
 
 msgid "Are you sure you want to disable the text format %format?"
-msgstr ""
+msgstr "Är du säker på att du vill inaktivera textformatet %format?"
 
 msgid ""
 "Disabled text formats are completely removed from the administrative "
 "interface, and any content stored with that format will not be displayed. "
 "This action cannot be undone."
 msgstr ""
+"Inaktiverade textformat tas bort helt och hållet från gränssnittet för "
+"administration, och eventuellt innehåll lagrat med detta format kommer inte "
+"att visas. Denna åtgärd kan inte ångras."
 
 msgid "Disabled text format %format."
-msgstr ""
+msgstr "Inaktiverade textformat %format."
 
 msgid "Text Formats"
-msgstr ""
+msgstr "Textformat"
 
 msgid "Disable text format"
-msgstr ""
+msgstr "Inaktivera textformat"
 
 msgid "Comment type"
-msgstr ""
+msgstr "Typ av kommentar"
 
 msgid "Bulk update"
-msgstr ""
+msgstr "Massuppdatera"
 
 msgid "Search page"
-msgstr ""
+msgstr "Söksida"
 
 msgid "View mode"
-msgstr ""
+msgstr "Visningsläge"
 
 msgid "UUID"
-msgstr ""
+msgstr "UUID"
 
 msgid "Subscribe to @title"
-msgstr ""
+msgstr "Prenumerera på @title"
 
 msgid "Back to site"
-msgstr ""
+msgstr "Tillbaka till webbplats"
 
 msgid "Configuration files"
-msgstr ""
+msgstr "Konfigurationsfiler"
 
 msgid "@module"
-msgstr ""
+msgstr "@module"
 
 msgid "User interface for the Field API."
-msgstr ""
+msgstr "Användargränssnitt för Field API."
 
 msgid "Hot topic, new comments"
-msgstr ""
+msgstr "Hett ämne, nya kommentarer"
 
 msgid "Hot topic"
-msgstr ""
+msgstr "Hett ämne"
 
 msgid "Normal topic"
-msgstr ""
+msgstr "Vanligt ämne"
 
 msgid "Closed topic"
-msgstr ""
+msgstr "Stängt ämne"
 
 msgid "Configure @module permissions"
-msgstr ""
+msgstr "Konfigurera behörigheter för @module"
 
 msgid "Install new module or theme"
-msgstr ""
+msgstr "Installera en ny modul eller ett nytt tema"
 
 msgid "Install new theme"
-msgstr ""
+msgstr "Installera ett nytt tema"
 
 msgid "Nothing"
-msgstr ""
+msgstr "Inget"
 
 msgid "Update @title"
-msgstr ""
+msgstr "Uppdatera @title"
 
 msgid ""
 "A unique machine-readable name. Can only contain lowercase letters, numbers,"
 " and underscores."
 msgstr ""
+"Ett unikt maskinläsbart namn. Får bara innehålla små bokstäver, siffror och "
+"understreck."
 
 msgid "The machine-readable name must contain unique characters."
-msgstr ""
+msgstr "Det maskinläsbara namnet måste innehålla unika tecken."
 
 msgid ""
 "The machine-readable name must contain only lowercase letters, numbers, and "
 "hyphens."
 msgstr ""
+"Det maskinläsbara namnet får bara innehålla små bokstäver, siffror och "
+"understreck."
 
 msgid "The machine-readable name is already in use. It must be unique."
-msgstr ""
+msgstr "Det maskinläsbara namnet används redan. Det måste vara unikt."
 
 msgid "Weight for @title"
-msgstr ""
+msgstr "Vikt för @title"
 
 msgid "Weight for row @number"
-msgstr ""
+msgstr "Vikt för rad @number"
 
 msgid "Label display for @title"
-msgstr ""
+msgstr "Visningsetikett för @title"
 
 msgid "Formatter for @title"
-msgstr ""
+msgstr "Formaterare för @title"
 
 msgid "Parents for @title"
-msgstr ""
+msgstr "Ovanliggande för @title"
 
 msgid ""
 "There is data for this field in the database. The field settings can no "
 "longer be changed."
 msgstr ""
+"Det finns information för detta fält i databasen. Inställningarna för detta "
+"fält kan inte längre ändras."
 
 msgid "Weight for new file"
-msgstr ""
+msgstr "Vikt för ny fil"
 
 msgid "Choose a file"
-msgstr ""
+msgstr "Välj en fil"
 
 msgid "Weight for new effect"
-msgstr ""
+msgstr "Vikt för ny effekt"
 
 msgid "Enable @title menu link"
-msgstr ""
+msgstr "Aktivera menylänk @title"
 
 msgid ""
 "A unique name to construct the URL for the menu. It must only contain "
 "lowercase letters, numbers and hyphens."
 msgstr ""
+"Ett unikt namn för att konstruera URL:en för menyn. Det får bara innehålla "
+"små bokstäver, siffror och bindestreck."
 
 msgid "Schema version"
-msgstr ""
+msgstr "Version av databasschema"
 
 msgid "Number of servings"
-msgstr ""
+msgstr "Number of servings"
 
 msgid "Theme name"
-msgstr ""
+msgstr "Namn på tema"
 
 msgid "URL fallback"
-msgstr ""
+msgstr "URL i reserv"
 
 msgid "Use an already detected language for URLs if none is found."
-msgstr ""
+msgstr "Använd ett redan identifierat språk för URL om ingen hittats."
 
 msgid "%type_name: Create new content"
-msgstr ""
+msgstr "%type_name: Skapa nytt innehåll"
 
 msgid "%type_name: Edit own content"
-msgstr ""
+msgstr "%type_name: Redigera eget innehåll"
 
 msgid "%type_name: Edit any content"
-msgstr ""
+msgstr "%type_name: Redigera innehåll"
 
 msgid "%type_name: Delete own content"
-msgstr ""
+msgstr "%type_name: Radera eget innehåll"
 
 msgid "%type_name: Delete any content"
-msgstr ""
+msgstr "%type_name: Radera innehåll"
 
 msgid "New object was not saved, no error provided"
-msgstr ""
+msgstr "Nya objekt sparades inte, inga felmeddelande tillhandahölls"
 
 msgid "The published status of a comment. (0 = Published, 1 = Not Published)"
 msgstr ""
+"Den publicerade statusen för en kommentar. (0 = Publicerad, 1 = Ej "
+"publicerad)"
 
 msgid "The comment author's name."
-msgstr ""
+msgstr "Namnet på kommentarens författare."
 
 msgid "Next steps"
-msgstr ""
+msgstr "Nästa steg"
 
 msgid "@driver_name settings"
-msgstr ""
+msgstr "Inställningar för @driver_name"
 
 msgid "SQLite"
-msgstr ""
+msgstr "SQLite"
 
 msgid "Database file"
-msgstr ""
+msgstr "Databasfil"
 
 msgid ""
 "The absolute path to the file where @drupal data will be stored. This must "
 "be writable by the web server and should exist outside of the web root."
 msgstr ""
+"Den absoluta sökvägen till filen där data för @drupal kommer att lagras. Den"
+" måste vara skrivbar av webbservern och bör finnas utanför webbplatsens rot."
 
 msgid "No fields are present yet."
-msgstr ""
+msgstr "Inga fält finns ännu."
 
 msgctxt "Font weight"
 msgid "Strong"
-msgstr ""
+msgstr "Fet"
 
 msgid "Enable newly added modules"
-msgstr ""
+msgstr "Aktivera nyligen tillagda moduler"
 
 msgid "View the administration theme"
-msgstr ""
+msgstr "Visa administrationstemat"
 
 msgid "Indexed %count content items for tracking."
-msgstr ""
+msgstr "Indexerade %count innehållsinlägg för spårning."
 
 msgid "Release notes for @project_title"
-msgstr ""
+msgstr "Anteckningar om utgåvan för @project_title"
 
 msgid "The role settings have been updated."
-msgstr ""
+msgstr "Inställningarna för rollen har uppdaterats."
 
 msgid "Disable the account and keep its content."
-msgstr ""
+msgstr "Inaktivera kontot och behåll dess innehåll."
 
 msgid "Disable the account and unpublish its content."
-msgstr ""
+msgstr "Inaktivera kontot och avpublicera dess innehåll."
 
 msgid ""
 "Delete the account and make its content belong to the %anonymous-name user."
 msgstr ""
+"Radera kontot och tilldela dess innehåll till användaren %anonymous-name."
 
 msgid "Delete the account and its content."
-msgstr ""
+msgstr "Radera kontot och dess innehåll."
 
 msgid "Drupal system listing compatible test"
-msgstr ""
+msgstr "Kompatibelt test av Drupals systemvisning"
 
 msgid "Support module for testing the drupal_system_listing function."
-msgstr ""
+msgstr "Stödmodul för testning av funktionen drupal_system_listing."
 
 msgid "Fixed value"
-msgstr ""
+msgstr "Låst värde"
 
 msgid "String settings"
-msgstr ""
+msgstr "Inställningar för sträng"
 
 msgid "Use field label instead of the \"On value\" as label"
-msgstr ""
+msgstr "Använd fältetikett istället för \"Värde för på\" som etikett"
 
 msgid "List (integer)"
-msgstr ""
+msgstr "Lista (heltal)"
 
 msgid ""
 "This field stores integer values from a list of allowed 'value => label' "
 "pairs, i.e. 'Lifetime in days': 1 => 1 day, 7 => 1 week, 31 => 1 month."
 msgstr ""
+"Detta fält lagrar heltalsvärden från en lista av tillåtna par som \"värde =>"
+" etikett\". Till exempel \"Giltighetstid i dagar\": 1 => 1 dag, 7 => 1 "
+"vecka, 31 => 1 månad."
 
 msgid "List (float)"
-msgstr ""
+msgstr "Lista (flyttal)"
 
 msgid ""
 "This field stores float values from a list of allowed 'value => label' "
 "pairs, i.e. 'Fraction': 0 => 0, .25 => 1/4, .75 => 3/4, 1 => 1."
 msgstr ""
+"Detta fält lagrar flyttalsvärden från en lista av tillåtna par som  \"värde "
+"=> etikett\". Till exempel \"Bråkdel: 0 => 0, .25 => 1/4, .75 => 3/4, 1 => "
+"1."
 
 msgid ""
 "This field stores text values from a list of allowed 'value => label' pairs,"
 " i.e. 'US States': IL => Illinois, IA => Iowa, IN => Indiana."
 msgstr ""
+"Detta fält lagrar textvärden från en lista av tillåtna par som \"värde => "
+"etikett\". Till exempel \"Stater i USA\": IL => Illinois, IA => Iowa, IN => "
+"Indiana."
 
 msgid ""
 "The possible values this field can contain. Enter one value per line, in the"
 " format key|label."
 msgstr ""
+"De möjliga värden detta fält kan innehålla. Ange ett värde per rad med "
+"formatet nyckel|etikett."
 
 msgid ""
 "The key is the stored value, and must be numeric. The label will be used in "
 "displayed values and edit forms."
 msgstr ""
+"Nyckeln är det lagrade värdet och måste vara numeriskt. Etiketten kommer att"
+" användas för visade värden och på redigeringsformulär."
 
 msgid ""
 "The label is optional: if a line contains a single number, it will be used "
 "as key and label."
 msgstr ""
+"Etiketten är valfri. Om en rad innehåller ett ensamt tal kommer det att "
+"användas både som nyckel och etikett."
 
 msgid ""
 "Lists of labels are also accepted (one label per line), only if the field "
 "does not hold any values yet. Numeric keys will be automatically generated "
 "from the positions in the list."
 msgstr ""
+"Listor av etiketter godtas också (en etikett per rad), men bara om fältet "
+"inte innehåller några värden ännu. Numeriska nycklar kommer automatiskt att "
+"genereras från positionerna i listan."
 
 msgid ""
 "The key is the stored value. The label will be used in displayed values and "
 "edit forms."
 msgstr ""
+"Nyckeln är det lagrade värdet. Etiketten kommer att användas i visade värden"
+" och i redigeringsformulär."
 
 msgid ""
 "The label is optional: if a line contains a single string, it will be used "
 "as key and label."
 msgstr ""
+"Etiketten är valfri. Om en rad innehåller en ensam textsträng kommer den att"
+" användas både som nyckel och etikett."
 
 msgid "Allowed values list: invalid input."
-msgstr ""
+msgstr "Lista på tillåtna värden: ogiltig inmatning."
 
 msgid ""
 "Allowed values list: some values are being removed while currently in use."
 msgstr ""
+"Lista på tillåtna värden: några värden kommer att tas bort medan de "
+"fortfarande används."
 
 msgid "The entity type."
-msgstr ""
+msgstr "Objektstypen."
 
 msgid "Center left"
-msgstr ""
+msgstr "Vänster - centrerad"
 
 msgid "Center right"
-msgstr ""
+msgstr "Höger - centrerad"
 
 msgid "Unable to parse info file: %info_file."
-msgstr ""
+msgstr "Kunde inte tolka informationsfil: %info_file."
 
 msgid "Custom blocks"
-msgstr ""
+msgstr "Anpassade block"
 
 msgid "HTML element"
-msgstr ""
+msgstr "HTML-element"
 
 msgid "Label HTML element"
-msgstr ""
+msgstr "Etikett för HTML-element"
 
 msgid "Place a colon after the label"
-msgstr ""
+msgstr "Sätt ett kolon efter etiketten"
 
 msgid "Wrapper HTML element"
-msgstr ""
+msgstr "Omslutande HTML-element"
 
 msgid "Wrapper class"
-msgstr ""
+msgstr "Omslutande klass"
 
 msgid "Add default classes"
-msgstr ""
+msgstr "Lägg till förvalda klasser"
 
 msgid ""
 "Use default Views classes to identify the field, field label and field "
 "content."
 msgstr ""
+"Använd förvalda klasser för Views för att identifiera fältet, fältetiketten "
+"och fältinnehåll."
 
 msgid "Use absolute path"
-msgstr ""
+msgstr "Använd absolut sökväg"
 
 msgid "Rel Text"
-msgstr ""
+msgstr "Text för relaterat attribut"
 
 msgid ""
 "Include Rel attribute for use in lightbox2 or other javascript utility."
 msgstr ""
+"Innefatta relaterat attribut för användning i Lightbox2 eller andra "
+"JavaScriptverktyg."
 
 msgid "Preserve certain tags"
-msgstr ""
+msgstr "Bevara vissa taggar"
 
 msgid "Specify validation criteria"
-msgstr ""
+msgstr "Ange kriterier för validering"
 
 msgid "Representative sort order"
-msgstr ""
+msgstr "Representativ sorteringsordning"
 
 msgid "Hash"
-msgstr ""
+msgstr "Hash"
 
 msgid "Administer settings."
-msgstr ""
+msgstr "Administrera inställningar."
 
 msgid "Changed date"
-msgstr ""
+msgstr "Datum för ändring"
 
 msgid "Asc"
-msgstr ""
+msgstr "Stigande"
 
 msgid "View reports, updates, and errors."
-msgstr ""
+msgstr "Visa rapporter, uppdateringar och felmeddelanden."
 
 msgid "Reference for usage, configuration, and modules."
-msgstr ""
+msgstr "Referens för användande, inställningar och moduler."
 
 msgid "Database system version"
-msgstr ""
+msgstr "Version av databassystem"
 
 msgid "Database system"
-msgstr ""
+msgstr "Databassystem"
 
 msgid "Install new module"
-msgstr ""
+msgstr "Installera en ny modul"
 
 msgid "Uninstall @module module"
-msgstr ""
+msgstr "Avinstallera modul @module"
 
 msgid ""
 "List the tags that need to be preserved during the stripping process. "
 "example &quot;&lt;p&gt; &lt;br&gt;&quot; which will preserve all p and br "
 "elements"
 msgstr ""
+"Lista taggarna som behöver bevaras under avkortningsprocessen. Exempel: "
+"&quot;&lt;p&gt; &lt;br&gt;&quot; vilket kommer att bevara alla p- och br-"
+"element"
 
 msgid "Format plural"
-msgstr ""
+msgstr "Pluralsformat"
 
 msgid "If checked, special handling will be used for plurality."
-msgstr ""
+msgstr "Om markerad kommer särskild hantering användas för pluralsform."
 
 msgid "Singular form"
-msgstr ""
+msgstr "Singularform"
 
 msgid "Plural form"
-msgstr ""
+msgstr "Pluralform"
 
 msgid ""
 "Text to use for the plural form, @count will be replaced with the value."
-msgstr ""
+msgstr "Text som används för pluralformen, @count kommer ersättas med värdet."
 
 msgid ""
 "A unique machine-readable name for this View. It must only contain lowercase"
 " letters, numbers, and underscores."
 msgstr ""
+"Ett unikt maskinläsbart namn för denna vy. Det får bara innehålla små "
+"bokstäver, siffror och understreck."
 
 msgid "Weight for @display"
-msgstr ""
+msgstr "Vikt för @display"
 
 msgid ""
 "This title will be displayed on the views edit page instead of the default "
 "one. This might be useful if you have the same item twice."
 msgstr ""
+"Den här titel kommer att visas på visningens redigeringssida istället för "
+"den förvalda. Det här kan vara användbart om du har samma alternativ flera "
+"gånger."
 
 msgid "The unique ID of the aggregator item."
-msgstr ""
+msgstr "Det unika ID-numret för innehållsflödets post."
 
 msgid "The guid of the original imported item."
-msgstr ""
+msgstr "GUID för den ursprungliga importerade posten."
 
 msgid "Date and time of when the comment was created."
-msgstr ""
+msgstr "Datum och tid då kommentaren skapades."
 
 msgid "Date and time of when the comment was last updated."
-msgstr ""
+msgstr "Datum och tid då kommentaren senast uppdaterades."
 
 msgid "Whether the comment is approved (or still in the moderation queue)."
 msgstr ""
+"Huruvida kommentaren är godkänd (eller fortfarande är i modereringskön)."
 
 msgid "Last comment CID"
-msgstr ""
+msgstr "CID för senaste kommentar"
 
 msgid "Last Comment"
-msgstr ""
+msgstr "Senaste kommentar"
 
 msgid ""
 "Some roles lack permission to access content, but display %display has no "
 "access control."
 msgstr ""
+"Några roller saknar behörighet för att komma åt innehåll, men visning "
+"%display har ingen åtkomstkontroll."
 
 msgid "The extension of the file."
-msgstr ""
+msgstr "Filändelse för filen."
 
 msgid "File Usage"
-msgstr ""
+msgstr "Filanvändning"
 
 msgid ""
 "A file that is associated with this node, usually because it is in a field "
 "on the node."
 msgstr ""
+"En fil som är associerad med denna nod, vanligtvis eftersom den är i ett "
+"fält på noden."
 
 msgid ""
 "A user that is associated with this file, usually because this file is in a "
 "field on the user."
 msgstr ""
+"En användare som är associerad med denna fil, vanligtvis eftersom denna fil "
+"är i ett fält på användaren."
 
 msgid ""
 "A file that is associated with this user, usually because it is in a field "
 "on the user."
 msgstr ""
+"En fil som är associerad med denna användare, vanligtvis eftersom den är i "
+"ett fält på användaren."
 
 msgid ""
 "A comment that is associated with this file, usually because this file is in"
 " a field on the comment."
 msgstr ""
+"En kommentar som är associerad med denna fil, vanligtvis eftersom denna fil "
+"är i ett fält på kommentaren."
 
 msgid ""
 "A file that is associated with this comment, usually because it is in a "
 "field on the comment."
 msgstr ""
+"En fil som är associerad med denna kommentar, vanligtvis eftersom den är i "
+"ett fält på kommentaren."
 
 msgid ""
 "A taxonomy term that is associated with this file, usually because this file"
 " is in a field on the taxonomy term."
 msgstr ""
+"En taxonomiterm som är associerad med denna fil, vanligtvis eftersom denna "
+"fil är i ett fält på taxonomitermen."
 
 msgid ""
 "A file that is associated with this taxonomy term, usually because it is in "
 "a field on the taxonomy term."
 msgstr ""
+"En fil som är associerad med denna taxonomiterm, vanligtvis eftersom den är "
+"i ett fält på taxonomitermen."
 
 msgid "The module managing this file relationship."
-msgstr ""
+msgstr "Modulen som hanterar den här filens relation."
 
 msgid "The type of entity that is related to the file."
-msgstr ""
+msgstr "Typen av objekt som är relaterad till filen."
 
 msgid "The number of times the file is used by this entity."
-msgstr ""
+msgstr "Antalet gånger filen används av det här objektet."
 
 msgid ""
 "Used by Style: Table to determine the actual column to click sort the field "
 "on. The default is usually fine."
 msgstr ""
+"Används av stil: Tabell för att bestämma den aktuella kolumnen att klickvis "
+"sortera fältet på. Det förvalda fungerar oftast bra."
 
 msgid "Group column"
-msgstr ""
+msgstr "Grupperingskolumn"
 
 msgid ""
 "Select the column of this field to apply the grouping function selected "
 "above."
 msgstr ""
+"Markera kolumnen för detta fält att tillämpa den grupperande funktionen som "
+"valts ovan."
 
 msgid "Group columns (additional)"
-msgstr ""
+msgstr "Gruppkolumner (ytterligare)"
 
 msgid ""
 "Select any additional columns of this field to include in the query and to "
 "group on."
 msgstr ""
+"Välj ytterligare kolumner för detta fält att inkludera i databasfrågan och "
+"för att gruppera på."
 
 msgid "Display download path instead of file storage URI"
-msgstr ""
+msgstr "Visa nedladdningssökväg istället för URI för fillagring"
 
 msgid "The machine name for the vocabulary the term belongs to."
-msgstr ""
+msgstr "Det maskinläsbara namnet för vokabulären som termen hör till."
 
 msgid "Display error message"
-msgstr ""
+msgstr "Visa felmeddelande"
 
 msgid "Comment or document this display."
-msgstr ""
+msgstr "Kommentera eller dokumentera denna visning."
 
 msgid "Query settings"
-msgstr ""
+msgstr "Inställningar för databasfråga"
 
 msgid "Allow to set some advanced settings for the query plugin"
 msgstr ""
+"Tillåt att ställa in några utökade inställningar för insticksprogrammet att "
+"köra databasfråga"
 
 msgid "The name and the description of this display"
-msgstr ""
+msgstr "Namnet och beskrivningen för denna visning"
 
 msgid "Query options"
-msgstr ""
+msgstr "Alternativ för databasfråga"
 
 msgid "Display name must be letters, numbers, or underscores only."
 msgstr ""
+"Namn för visning får enbart bestå av bokstäver, siffror eller understreck."
 
 msgid ""
 "Should this display inherit its paging values from the parent display to "
 "which it is attached?"
 msgstr ""
+"Skall denna visning ärva sina paginerade värden från den ovanliggande "
+"visningen som den är bifogad till?"
 
 msgid ""
 "Should this display render the pager values? This is only meaningful if "
 "inheriting a pager."
 msgstr ""
+"Skall denna visning generera de paginerade värdena? Detta är enbart "
+"meningsfullt om en paginerare ärvs."
 
 msgid ""
 "This will appear as the name of this block in administer >> structure >> "
 "blocks."
 msgstr ""
+"Detta kommer att synas som namnet för detta block under administrera >> "
+"uppbyggnad >> block."
 
 msgid ""
 "Text to display instead of results until the user selects and applies an "
 "exposed filter."
 msgstr ""
+"Text att visa istället för resultat tills användaren väljer och tillämpar "
+"ett exponerat filter."
 
 msgid "Include all items option"
-msgstr ""
+msgstr "Inkludera alla valalternativ"
 
 msgid "All items label"
-msgstr ""
+msgstr "Etikett för alla poster"
 
 msgid "Disable SQL rewriting"
-msgstr ""
+msgstr "Inaktivera omskrivning av SQL"
 
 msgid "The class to provide on each row."
-msgstr ""
+msgstr "Klassen att tillhandahålla på varje rad."
 
 msgid ""
 "You may use field tokens from as per the \"Replacement patterns\" used in "
 "\"Rewrite the output of this field\" for all fields."
 msgstr ""
+"Du kan använda ersättningstecken för fält enligt \"Ersättningsmönster\" som "
+"används i \"Skriv om utmatningen för detta fält\" för alla fält."
 
 msgid "The class to provide on the wrapper, outside the list."
-msgstr ""
+msgstr "Klassen att tillhandahålla för omsvepningen, utanför listan."
 
 msgid "List class"
-msgstr ""
+msgstr "Klass för lista"
 
 msgid "The class to provide on the list element itself."
-msgstr ""
+msgstr "Klassen att tillhandahålla för själva listelementet."
 
 msgid ""
 "Define the base path for links in this summary\n"
@@ -11594,595 +12427,676 @@ msgid ""
 "        is empty, views will use the first path found as the base path,\n"
 "        in page displays, or / if no path could be found."
 msgstr ""
+"Ange bassökvägen för länkar i denna sammanfattande vy, till exempel "
+"http://exempel.se/<strong>sökväg_till_din_vy/arkiv</strong>. Ta inte med "
+"inledande och avslutande snedstreck. Om detta värde är tomt kommer Views att"
+" använda den första funna sökvägen som grundsökväg i sidvisningar, eller / "
+"om ingen sökväg kan hittas."
 
 msgid "Content access"
-msgstr ""
+msgstr "Åtkomst till innehåll"
 
 msgctxt "ampm"
 msgid "am"
-msgstr ""
+msgstr "förmiddag"
 
 msgctxt "ampm"
 msgid "pm"
-msgstr ""
+msgstr "eftermiddag"
 
 msgid "Sticky status"
-msgstr ""
+msgstr "Status för klistrad"
 
 msgid "RSS category"
-msgstr ""
+msgstr "Kategori för RSS"
 
 msgid "RSS enclosure"
-msgstr ""
+msgstr "Kapsling för RSS"
 
 msgid "Paste your configuration here"
-msgstr ""
+msgstr "Klistra in din konfiguration här"
 
 msgid "Import configuration"
-msgstr ""
+msgstr "Konfiguration på importering"
 
 msgid "5 minute"
-msgstr ""
+msgstr "5 minuter"
 
 msgid "15 minute"
-msgstr ""
+msgstr "15 minuter"
 
 msgid "URL to image"
-msgstr ""
+msgstr "URL till bild"
 
 msgid "Content revisions"
-msgstr ""
+msgstr "Versioner av innehåll"
 
 msgid "%time hence"
-msgstr ""
+msgstr "%time från nu"
 
 msgid "Language selection"
-msgstr ""
+msgstr "Språkval"
 
 msgid "Delete all translations"
-msgstr ""
+msgstr "Radera alla översättningar"
 
 msgid "No Access"
-msgstr ""
+msgstr "Ingen åtkomst"
 
 msgid "Search page path"
-msgstr ""
+msgstr "Sökväg till söksida"
 
 msgid "Many to one"
-msgstr ""
+msgstr "Många till en"
 
 msgid "All Day"
-msgstr ""
+msgstr "Hela dagen"
 
 msgid "Upscale"
-msgstr ""
+msgstr "Skala upp"
 
 msgid "Logo settings"
-msgstr ""
+msgstr "Inställningar för logotyp"
 
 msgid "Delete field."
-msgstr ""
+msgstr "Radera fält."
 
 msgid "No results behavior"
-msgstr ""
+msgstr "Beteende vid inget resultat"
 
 msgid "Edit @section"
-msgstr ""
+msgstr "Redigera @section"
 
 msgid "View to insert"
-msgstr ""
+msgstr "Vy att infoga"
 
 msgid "The view to insert into this area."
-msgstr ""
+msgstr "Vyn att infoga i detta område."
 
 msgid "Inherit contextual filters"
-msgstr ""
+msgstr "Ärv kontextuella filter"
 
 msgid ""
 "If checked, this view will receive the same contextual filters as its "
 "parent."
 msgstr ""
+"Om detta väljs kommer denna vy att ärva samma kontextuella filter som dess "
+"ovanliggande ."
 
 msgid "Recursion detected in view @view display @display."
-msgstr ""
+msgstr "Rekursion upptäckt i vy @view @display."
 
 msgid "When the filter value is <em>NOT</em> in the URL"
-msgstr ""
+msgstr "När filtervärdet <em>INTE FINNS</em> i URL:en"
 
 msgid "Exception value"
-msgstr ""
+msgstr "Undantagsvärde"
 
 msgid "If this value is received, the filter will be ignored; i.e, \"all values\""
 msgstr ""
+"Om detta värde tas emot, kommer filtret att ignoreras. Det vill säga \"alla "
+"värden\""
 
 msgid "When the filter value <em>IS</em> in the URL or a default is provided"
 msgstr ""
+"När filtervärdet <em>FINNS</em> i URL:en eller en förvald tillhandahålls"
 
 msgid "Provide title"
-msgstr ""
+msgstr "Tillhandahåll titel"
 
 msgid "Custom block"
-msgstr ""
+msgstr "Anpassat block"
 
 msgid "Action to take if filter value does not validate"
-msgstr ""
+msgstr "Åtgärd att vidta om filtervärde inte validerar"
 
 msgid "Display all results for the specified field"
-msgstr ""
+msgstr "Visa alla resultat för det angivna fältet"
 
 msgid "Provide default value"
-msgstr ""
+msgstr "Tillhandahåll förvalt värde"
 
 msgid "Show \"Page not found\""
-msgstr ""
+msgstr "Visa \"Sida hittades inte\""
 
 msgid "Display a summary"
-msgstr ""
+msgstr "Visa en sammanfattning"
 
 msgid "Display contents of \"No results found\""
-msgstr ""
+msgstr "Visa innehåll för \"Inget resultat hittades\""
 
 msgid "Skip default argument for view URL"
-msgstr ""
+msgstr "Hoppa över förvalt argument för vyns URL"
 
 msgid ""
 "Select whether to include this default argument when constructing the URL "
 "for this view. Skipping default arguments is useful e.g. in the case of "
 "feeds."
 msgstr ""
+"Välj huruvida att inkludera detta förvalda argument eller ej vid uppbyggnad "
+"av URL:en för denna vy. Att hoppa över förvalt argument är användbart till "
+"exempel när det gäller innehållsflöden."
 
 msgid "Number of records"
-msgstr ""
+msgstr "Antal poster"
 
 msgctxt "Sort order"
 msgid "Default sort"
-msgstr ""
+msgstr "Förvald sortering"
 
 msgctxt "Sort order"
 msgid "Date"
-msgstr ""
+msgstr "Datum"
 
 msgctxt "Sort order"
 msgid "Numerical"
-msgstr ""
+msgstr "Numerisk"
 
 msgid ""
 "If selected, users can enter multiple values in the form of 1+2+3 (for OR) "
 "or 1,2,3 (for AND)."
 msgstr ""
+"Om vald, kan användare ange flera värden på formen 1+2+3 (för OR) eller "
+"1,2,3 (för AND)."
 
 msgid ""
 "If selected, multiple instances of this filter can work together, as though "
 "multiple values were supplied to the same filter. This setting is not "
 "compatible with the \"Reduce duplicates\" setting."
 msgstr ""
+"Om vald, kan flera instanser av det här filtret fungera tillsammans, som om "
+"flera värden har levererats till samma filter. Denna inställning är inte "
+"förenlig med inställningen \"Minska dubbletter\"."
 
 msgid ""
 "If selected, the numbers entered for the filter will be excluded rather than"
 " limiting the view."
 msgstr ""
+"Om vald, kommer de inmatade siffrorna för filtret att uteslutas stället för "
+"att begränsa vyn."
 
 msgid ""
 "Glossary mode applies a limit to the number of characters used in the filter"
 " value, which allows the summary view to act as a glossary."
 msgstr ""
+"Ordlisteläge tillfogar en begränsning för hur många tecken som används i "
+"filtervärdet, vilket gör att vyn för sammanfattningen fungerar som en "
+"ordlista."
 
 msgid ""
 "How many characters of the filter value to filter against. If set to 1, all "
 "fields starting with the first letter in the filter value would be matched."
 msgstr ""
+"Hur många tecken på filtervärdet att filtrera mot. Om satt till 1, kommer "
+"alla fält som börjar med första bokstaven i filtervärdet att matchas."
 
 msgid ""
 "When printing the title and summary, how to transform the case of the filter"
 " value."
 msgstr ""
+"Hur omvandling av det gällande filtervärdet skall ske, vid utskrift av "
+"titeln och sammanfattningen."
 
 msgctxt "Sort order"
 msgid "Alphabetical"
-msgstr ""
+msgstr "Alfabetisk"
 
 msgid "Create a label"
-msgstr ""
+msgstr "Skapa en etikett"
 
 msgid ""
 "Enable to load this field as hidden. Often used to group fields, or to use "
 "as token in another field."
 msgstr ""
+"Aktivera för att ladda detta fält som dolt. Används ofta för att gruppera "
+"fält, eller för att använda som ersättningstecken i ett annat fält."
 
 msgid "Choose the HTML element to wrap around this field, e.g. H1, H2, etc."
 msgstr ""
+"Välj HTML-elementet att bädda in runt detta fält. Till exempel: H1, H2, etc."
 
 msgid "Create a CSS class"
-msgstr ""
+msgstr "Skapa en CSS-klass"
 
 msgid "Choose the HTML element to wrap around this label, e.g. H1, H2, etc."
 msgstr ""
+"Välj HTML-element att bädda in runt denna etikett. Till exempel H1, H2, etc."
 
 msgid "Rewrite results"
-msgstr ""
+msgstr "Skriv om resultat"
 
 msgid "Replace spaces with dashes"
-msgstr ""
+msgstr "Ersätt mellanslag med streck"
 
 msgid "External server URL"
-msgstr ""
+msgstr "URL för extern server"
 
 msgid ""
 "Links to an external server using a full URL: e.g. 'http://www.example.com' "
 "or 'www.example.com'."
 msgstr ""
+"Länkar till en extern server genom att använda en fullständig URL. Till "
+"exempel: \"http://www.exempel.se\" eller \"www.exempel.se\"."
 
 msgid "Convert newlines to HTML &lt;br&gt; tags"
-msgstr ""
+msgstr "Konvertera radbrytningstecken till HTML-taggar av typ &lt;br&gt;"
 
 msgid "No results text"
-msgstr ""
+msgstr "Text vid inget resultat"
 
 msgid ""
 "Enable to display the \"no results text\" if the field contains the number "
 "0."
 msgstr ""
+"Aktivera för att visa \"text vid inget resultat\" om detta fält innehåller "
+"siffran 0."
 
 msgid "Time hence"
-msgstr ""
+msgstr "Tid från nu"
 
 msgid "Time hence (with \"hence\" appended)"
-msgstr ""
+msgstr "Tid från nu (med \"från nu\" tillagt efter)"
 
 msgid "Time span (future dates have \"-\" prepended)"
-msgstr ""
+msgstr "Tidsintervall (framtida datum har \"-\" tillagt före)"
 
 msgid "Time span (past dates have \"-\" prepended)"
-msgstr ""
+msgstr "Tidsintervall (tidigare datum har \"-\" tillagt före)"
 
 msgid ""
 "How should the serialized data be displayed. You can choose a custom "
 "array/object key or a print_r on the full output."
 msgstr ""
+"Hur skall den seriella datainformationen visas. Du kan välja en anpassad "
+"nyckel för array/object eller en print_r på den fullständiga utmatningen."
 
 msgid "Full data (unserialized)"
-msgstr ""
+msgstr "Full data (unserialized)"
 
 msgid "A certain key"
-msgstr ""
+msgstr "En viss nyckel"
 
 msgid "Which key should be displayed"
-msgstr ""
+msgstr "Vilken nyckel skall visas"
 
 msgid "You have to enter a key if you want to display a key of the data."
 msgstr ""
+"Du måste ange en nyckel om du vill visa en nyckel från datainformationen."
 
 msgid "How many different units to display in the string."
-msgstr ""
+msgstr "Hur många olika enheter som skall visas i strängen."
 
 msgid "This filter is not exposed. Expose it to allow the users to change it."
-msgstr ""
+msgstr "Detta filter visas inte. Visa det för att låta användare ändra det."
 
 msgid "Expose filter"
-msgstr ""
+msgstr "Visa filter"
 
 msgid ""
 "This filter is exposed. If you hide it, users will not be able to change it."
-msgstr ""
+msgstr "Detta filter visas"
 
 msgid "Hide filter"
-msgstr ""
+msgstr "Dölj filter"
 
 msgid "Expose operator"
-msgstr ""
+msgstr "Visa operand"
 
 msgid "Allow the user to choose the operator."
-msgstr ""
+msgstr "Tillåt användare att välja operanden."
 
 msgid "Allow multiple selections"
-msgstr ""
+msgstr "Tillåt flerval"
 
 msgid "Enable to allow users to select multiple items."
-msgstr ""
+msgstr "Aktivera för att låta användare välja flera alternativ."
 
 msgid "Remember the last selection"
-msgstr ""
+msgstr "Kom ihåg det senaste valet"
 
 msgid "Enable to remember the last selection made by the user."
 msgstr ""
+"Aktivera för att komma ihåg det senaste valet som gjordes av användaren."
 
 msgid "You must select a value unless this is an non-required exposed filter."
 msgstr ""
+"Du måste välja ett värde såvida detta inte är ett valfritt visat filter."
 
 msgid "Enable to hide items that do not contain this relationship"
-msgstr ""
+msgstr "Aktivera för att dölja poster som inte innehåller denna relation"
 
 msgid "This sort is not exposed. Expose it to allow the users to change it."
 msgstr ""
+"Denna sortering visas inte. Visa den för att låta användare kunna ändra det."
 
 msgid "Expose sort"
-msgstr ""
+msgstr "Visa sortering"
 
 msgid ""
 "This sort is exposed. If you hide it, users will not be able to change it."
 msgstr ""
+"Denna sortering visas. Om du döljer den kommer inte användare kunna ändra "
+"det."
 
 msgid "Hide sort"
-msgstr ""
+msgstr "Dölj sortering"
 
 msgid "Provide description"
-msgstr ""
+msgstr "Tillhandahåll beskrivning"
 
 msgid "Update \"@title\" choice"
-msgstr ""
+msgstr "Uppdatera alternativ \"@title\""
 
 msgid "Update \"@title\" choice (@number)"
-msgstr ""
+msgstr "Uppdatera alternativ (@number) \"@title\""
 
 msgid "Auto preview"
-msgstr ""
+msgstr "Automatiskt förhandsgranskning"
 
 msgid "Preview with contextual filters:"
-msgstr ""
+msgstr "Förhandsgranska med kontextuella filter:"
 
 msgid "Separate contextual filter values with a \"/\". For example, %example."
 msgstr ""
+"Separera sammanhängande filtervärden med ett \"/\". Till exempel: %example."
 
 msgid ":"
-msgstr ""
+msgstr ":"
 
 msgid "Apply and continue"
-msgstr ""
+msgstr "Lägg till och fortsätt"
 
 msgid "@current of @total"
-msgstr ""
+msgstr "@current av @total"
 
 msgid "All displays (except overridden)"
-msgstr ""
+msgstr "Alla visningar (förutom åsidosatta)"
 
 msgid "All displays"
-msgstr ""
+msgstr "Alla visningar"
 
 msgid "This @display_type (override)"
-msgstr ""
+msgstr "Denna @display_type (åsidosatt)"
 
 msgid "Create new filter group"
-msgstr ""
+msgstr "Skapa ny filtergrupp"
 
 msgid "No filters have been added."
-msgstr ""
+msgstr "Inga filter har lagts till."
 
 msgid "Drag to add filters."
-msgstr ""
+msgstr "Drag-och-släpp för att lägga till filter."
 
 msgid "Add and configure @types"
-msgstr ""
+msgstr "Lägg till och konfigurera @types"
 
 msgid "Configure @type: @item"
-msgstr ""
+msgstr "Konfigurera @type: @item"
 
 msgid "Always show advanced display settings"
-msgstr ""
+msgstr "Visa alltid inställningar för utökad visning"
 
 msgid "Label for \"Any\" value on non-required single-select exposed filters"
 msgstr ""
+"Etikett för värdet \"Alla\" på synliga filter med valfria "
+"enkelvalsalternativ"
 
 msgid "Live preview settings"
-msgstr ""
+msgstr "Inställningar för direkt förhandsgranskning"
 
 msgid "Automatically update preview on changes"
-msgstr ""
+msgstr "Uppdatera förhandsgranskning automatiskt vid ändringar"
 
 msgid "Show information and statistics about the view during live preview"
-msgstr ""
+msgstr "Visa information och statistik om vyn under direkt förhandsgranskning"
 
 msgid "Above the preview"
-msgstr ""
+msgstr "Ovanför förhandstitten"
 
 msgid "Below the preview"
-msgstr ""
+msgstr "Nedanför förhandstitten"
 
 msgid "Show the SQL query"
-msgstr ""
+msgstr "Visa databasfrågan för SQL"
 
 msgid "Show performance statistics"
-msgstr ""
+msgstr "Visa statistik för prestanda"
 
 msgid "Display"
 msgid_plural "Displays"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Visning"
+msgstr[1] "Visningar"
 
 msgid "Unformatted list"
-msgstr ""
+msgstr "Oformaterad lista"
 
 msgid "Contextual filters"
-msgstr ""
+msgstr "Kontextuella filter"
 
 msgid "contextual filters"
-msgstr ""
+msgstr "kontextuella filter"
 
 msgid "Contextual filter"
-msgstr ""
+msgstr "Kontextuellt filter"
 
 msgid "contextual filter"
-msgstr ""
+msgstr "kontextuellt filter"
 
 msgid "filter criteria"
-msgstr ""
+msgstr "filterkriterier"
 
 msgid "Filter criterion"
-msgstr ""
+msgstr "Filterkriterium"
 
 msgid "filter criterion"
-msgstr ""
+msgstr "filterkriterium"
 
 msgid "no results behavior"
-msgstr ""
+msgstr "beteende vid inget resultat"
 
 msgid "The node ID."
-msgstr ""
+msgstr "ID för noden."
 
 msgid "The content title."
-msgstr ""
+msgstr "Innehållets titel."
 
 msgid "The date the content was posted."
-msgstr ""
+msgstr "Datumet som innehållet lades in."
 
 msgid "Filters out unpublished content if the current user cannot view it."
 msgstr ""
+"Filtrerar ut ej publicerat innehåll om den aktuella användaren inte kan visa"
+" det."
 
 msgid "Whether or not the content is sticky."
-msgstr ""
+msgstr "Huruvida innehållet är klistrat eller ej."
 
 msgid ""
 "Whether or not the content is sticky. To list sticky content first, set this"
 " to descending."
 msgstr ""
+"Huruvida innehållet är klistrat eller ej. För att lista klistrat innehåll "
+"först, sätt detta till ökande."
 
 msgid "Relate content to the user who created it."
-msgstr ""
+msgstr "Relatera innehåll till användaren som skapade det."
 
 msgid "User has a revision"
-msgstr ""
+msgstr "Användare har en version"
 
 msgid "All nodes where a certain user has a revision"
-msgstr ""
+msgstr "Alla noder där en viss användare har en version"
 
 msgid "Content revision is a history of changes to content."
-msgstr ""
+msgstr "Version av innehåll är en historik av ändringar till innehåll."
 
 msgid "Relate a content revision to the user who created the revision."
 msgstr ""
+"Relatera en version av innehåll till användaren som skapade versionen."
 
 msgid "Get the actual content from a content revision."
-msgstr ""
+msgstr "Erhåll det nuvarande innehållet från en versions innehåll."
 
 msgid "Provide a simple link to delete the content revision."
-msgstr ""
+msgstr "Tillhandahåll en enkel länk för att radera versionens innehåll."
 
 msgid ""
 "Filter for content by view access. <strong>Not necessary if you are using "
 "node as your base table.</strong>"
 msgstr ""
+"Filter för innehåll genom vyåtkomst. <strong>Ej nödvändigt om du använder "
+"nod som din bastabell.</strong>"
 
 msgid "Show a marker if the content is new or updated."
-msgstr ""
+msgstr "Visa en markering om innehållet är nytt eller uppdaterat."
 
 msgid "Show only content that is new or updated."
-msgstr ""
+msgstr "Visa enbart innehåll som är nytt eller uppdaterat."
 
 msgid "Display the content with standard node view."
-msgstr ""
+msgstr "Visa innehållet med förvald nodvy."
 
 msgid "Content ID from URL"
-msgstr ""
+msgstr "ID för innehåll från URL"
 
 msgid ""
 "Content that is associated with this file, usually because this file is in a"
 " field on the content."
 msgstr ""
+"Innehåll som är associerat med denna fil, vanligtvis eftersom denna fil är "
+"ett fält på ett innehåll."
 
 msgid ""
 "Allows the \"depth\" for Taxonomy: Term ID (with depth) to be modified via "
 "an additional contextual filter value."
 msgstr ""
+"Ger möjlighet att ändra \"djupet\" för Taxonomi: ID för Term (med djup) med "
+"ett ytterligare sammanhängande filtervärde."
 
 msgid "Content authored"
-msgstr ""
+msgstr "Författade innehåll"
 
 msgid ""
 "Relate content to the user who created it. This relationship will create one"
 " record for each content item created by the user."
 msgstr ""
+"Relatera innehåll till användaren som skapade det. Denna relation kommer att"
+" skapa en lagring för varje innehållspost skapad av användaren."
 
 msgid ""
 "Allow a contextual filter value to be ignored. The query will not be altered"
 " by this contextual filter value. Can be used when contextual filter values "
 "come from the URL, and a part of the URL needs to be ignored."
 msgstr ""
+"Ger möjlighet att ignorera ett sammanhängande filtervärde. Databasfrågan "
+"kommer då inte att påverkas av detta sammanhängande filtervärde. Detta kan "
+"användas när sammanhängande filtervärden hämtas från URL:en och en del av "
+"den måste ignoreras."
 
 msgid "View area"
-msgstr ""
+msgstr "Vyområde"
 
 msgid "Insert a view inside an area."
-msgstr ""
+msgstr "Infoga en vy inuti ett område"
 
 msgid "Enable to override this field's links."
-msgstr ""
+msgstr "Aktivera för att åsidosätta detta fälts länkar."
 
 msgid "Use field template"
-msgstr ""
+msgstr "Använd fältmall"
 
 msgid ""
 "Checking this option will cause the group Display Type and Separator values "
 "to be ignored."
 msgstr ""
+"Markeras det här alternativet kommer det att orsaka att värden för gruppen "
+"Visningstyp och Avskiljare ignoreras."
 
 msgid "Multiple field settings"
-msgstr ""
+msgstr "Inställningar för flera fält"
 
 msgid "Display all values in the same row"
-msgstr ""
+msgstr "Visa alla värden på samma rad"
 
 msgid "Display @count value(s)"
-msgstr ""
+msgstr "Visar @count värde(n)"
 
 msgid "Raw @column"
-msgstr ""
+msgstr "Obearbetad @column"
 
 msgid "Link this field to the original piece of content"
-msgstr ""
+msgstr "Länka detta fält till den ursprungliga delen av innehållet"
 
 msgid ""
 "Enable this option to output an absolute link. Required if you want to use "
 "the path as a link destination (as in \"output this field as a link\" "
 "above)."
 msgstr ""
+"Aktivera detta alternativ för att mata ut en absolut länk. Obligatoriskt om "
+"du vill använda sökvägen som en mållänk (som i \"mata ut detta fält som en "
+"länk\" ovan)."
 
 msgid "Access operation to check"
-msgstr ""
+msgstr "Åtkomstfunktion att kontrollera"
 
 msgid ""
 "If selected, users can enter multiple values in the form of 1+2+3. Due to "
 "the number of JOINs it would require, AND will be treated as OR with this "
 "filter."
 msgstr ""
+"Om vald, kan användare ange flera värden på formen 1+2+3. På grund av det "
+"antal JOINS det skulle kräva, kommer AND att behandlas som OR med detta "
+"filter."
 
 msgid "Load default filter from term page"
-msgstr ""
+msgstr "Ladda förvalt filter från termsida"
 
 msgid "Transform dashes in URL to spaces in term name filter values"
 msgstr ""
+"Förvandla tankestreck i URL till mellanslag i filtreringsvärden för namn på "
+"term"
 
 msgid ""
 "Note: you do not have permission to modify this. If you change the default "
 "filter type, this setting will be lost and you will NOT be able to get it "
 "back."
 msgstr ""
+"Observera: du inte har behörighet att ändra detta. Om du ändrar den förvalda"
+" filtertypen, kommer denna inställning att gå förlorade och du kommer INTE "
+"kunna få tillbaka den."
 
 msgid "Change the way content is formatted."
-msgstr ""
+msgstr "Ändra hur innehåll är formaterat."
 
 msgid "Change settings for this format"
-msgstr ""
+msgstr "Ändra inställningar för detta format"
 
 msgid "Change the way each row in the view is styled."
-msgstr ""
+msgstr "Ändra hur varje rad i vyn är formaterad."
 
 msgid "Hide attachments in summary"
-msgstr ""
+msgstr "Dölj bilagor i sammanfattning"
 
 msgid ""
 "Change whether or not to display attachments when displaying a contextual "
 "filter summary."
 msgstr ""
+"Ändra huruvida bilagor skall visas eller inte vid visning av en "
+"sammanhängande filtrerad sammanfattning."
 
 msgid "Hide attachments when displaying a contextual filter summary"
 msgstr ""
+"Dölj bilagor vid visning av en sammanhängande filtrerad sammanfattning"
 
 msgid "Attachment position"
-msgstr ""
+msgstr "Position av bilaga"
 
 msgid ""
 "Should this display inherit its contextual filter values from the parent "
 "display to which it is attached?"
 msgstr ""
+"Skall denna visning ärva dess sammanhängande filtreringsvärden från dess "
+"ovanliggande visning som den är bifogad till?"
 
 msgid ""
 "This view will be displayed by visiting this path on your site. It is "
@@ -12190,180 +13104,195 @@ msgid ""
 "\"path/%/%/rss.xml\", putting one % in the path for each contextual filter "
 "you have defined in the view."
 msgstr ""
+"Denna vy kommer att visas när den här sökvägen besöks på din webbplats. "
+"Sökvägen bör vara något i stil med \"sökväg/%/%/feed\" eller "
+"\"sökväg/%/%/rss.xml\" där varje kontextuellt filter som du angivit i vyn "
+"motsvaras av %."
 
 msgid ""
 "Display @display is set to use a menu but the menu link text is not set."
 msgstr ""
+"Visning @display är inställd på att använda en meny, men texten till "
+"menylänken är inte inställd."
 
 msgid ""
 "Display @display is set to use a parent menu but the parent menu link text "
 "is not set."
 msgstr ""
+"Visning @display är inställd på att använda en ovanliggande meny, men texten"
+" till den ovanliggande menylänken är inte inställd."
 
 msgid "@count item, skip @skip"
 msgid_plural "Paged, @count items, skip @skip"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count post, hoppa över @skip"
+msgstr[1] "Paginerad, @count poster, hoppa över @skip"
 
 msgid "@count item"
 msgid_plural "Paged, @count items"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count post"
+msgstr[1] "Paginerad, @count poster"
 
 msgid "Create a page"
-msgstr ""
+msgstr "Skapa en sida"
 
 msgid "Create a menu link"
-msgstr ""
+msgstr "Skapa en menylänk"
 
 msgid "Include an RSS feed"
-msgstr ""
+msgstr "Inkludera ett RSS-flöde"
 
 msgid "Feed path"
-msgstr ""
+msgstr "Sökväg för innehållsflöde"
 
 msgid "Feed row style"
-msgstr ""
+msgstr "Radstil för innehållsflöde"
 
 msgid "Create a block"
-msgstr ""
+msgstr "Skapa ett block"
 
 msgid "of fields"
-msgstr ""
+msgstr "av fält"
 
 msgid "of type"
-msgstr ""
+msgstr "av typ"
 
 msgid "tagged with"
-msgstr ""
+msgstr "märkta med"
 
 msgid "teasers"
-msgstr ""
+msgstr "ingresser"
 
 msgid "full posts"
-msgstr ""
+msgstr "fullständiga inlägg"
 
 msgid "titles"
-msgstr ""
+msgstr "titlar"
 
 msgid "titles (linked)"
-msgstr ""
+msgstr "titlar (länkade)"
 
 msgid "Sorts"
-msgstr ""
+msgstr "Sorteringar"
 
 msgid "Hide view"
-msgstr ""
+msgstr "Dölj vy"
 
 msgid "@group (historical data)"
-msgstr ""
+msgstr "@group (historisk data)"
 
 msgid "Use path alias"
-msgstr ""
+msgstr "Använd sökvägsalias"
 
 msgid "Field mappings"
-msgstr ""
+msgstr "Fältmappningar"
 
 msgid "Cooking time"
-msgstr ""
+msgstr "Cooking time"
 
 msgid "View any unpublished content"
-msgstr ""
+msgstr "Visa ej publicerat innehåll"
 
 msgid "Relative default value"
-msgstr ""
+msgstr "Relativt förvalt värde"
 
 msgid "The comment UUID."
-msgstr ""
+msgstr "UUID för kommentaren."
 
 msgid "The file UUID."
-msgstr ""
+msgstr "UUID för filen."
 
 msgid "The term UUID."
-msgstr ""
+msgstr "UUID för termen."
 
 msgid "The user UUID."
-msgstr ""
+msgstr "UUID för användaren."
 
 msgid "Field item"
-msgstr ""
+msgstr "Fältobjekt"
 
 msgid "Edit shortcut set"
-msgstr ""
+msgstr "Redigera uppsättning av genväg"
 
 msgid "Appearance settings"
-msgstr ""
+msgstr "Inställningar för utseende"
 
 msgid "Delete translation"
-msgstr ""
+msgstr "Radera översättning"
 
 msgid "Unsorted"
-msgstr ""
+msgstr "Ej sorterad"
 
 msgid "Changes to the style have been saved."
-msgstr ""
+msgstr "Ändringar till stilen har sparats."
 
 msgid "Media query"
-msgstr ""
+msgstr "Databasfråga för media"
 
 msgid "Aggregation type"
-msgstr ""
+msgstr "Typ av hopsamling"
 
 msgid "Mapping type"
-msgstr ""
+msgstr "Typ av mappning"
 
 msgid "Create media"
-msgstr ""
+msgstr "Create media"
 
 msgid "Use replacement tokens from the first row"
-msgstr ""
+msgstr "Använd ersättningstecken från den första raden"
 
 msgid "Allow multiple filter values to work together"
-msgstr ""
+msgstr "Tillåt flera filtervärden att fungera tillsammans"
 
 msgid "Customize field HTML"
-msgstr ""
+msgstr "Anpassa HTML-fält"
 
 msgid ""
 "You may use token substitutions from the rewriting section in this class."
 msgstr ""
+"Du kan använda teckenersättningar från utmatningssektionen i den här "
+"klassen."
 
 msgid "Customize label HTML"
-msgstr ""
+msgstr "Anpassa HTML-etikett"
 
 msgid "Customize field and label wrapper HTML"
-msgstr ""
+msgstr "Anpassa omslutande HTML för fält och etikett"
 
 msgid ""
 "Choose the HTML element to wrap around this field and label, e.g. H1, H2, "
 "etc. This may not be used if the field and label are not rendered together, "
 "such as with a table."
 msgstr ""
+"Välj HTML-elementet som skall omsluta detta fält och etikett, till exempel "
+"H1, H2, etcetera. Detta kan inte användas om fältet och etiketten inte "
+"genereras tillsammans, såsom med en tabell."
 
 msgid "Remove whitespace"
-msgstr ""
+msgstr "Tag bort blanksteg"
 
 msgid "Hide rewriting if empty"
-msgstr ""
+msgstr "Dölj utmatning om tomt"
 
 msgid "Do not display rewritten content if this field is empty."
-msgstr ""
+msgstr "Visa inte omskrivet innehåll om detta fält är tomt."
 
 msgid "Thousands marker"
-msgstr ""
+msgstr "Tusentalsmarkör"
 
 msgid "Expose this filter to visitors, to allow them to change it"
-msgstr ""
+msgstr "Visa detta filter för besökare för att låta dem ändra det"
 
 msgid "Subquery namespace"
-msgstr ""
+msgstr "Namnutrymme för inbäddad databasfråga"
 
 msgid ""
 "Advanced. Enter a namespace for the subquery used by this relationship."
 msgstr ""
+"Utökat. Ange ett namnutrymme för den inbäddade databasfrågan som används av "
+"denna relation."
 
 msgid "Representative view"
-msgstr ""
+msgstr "Representativ vy"
 
 msgid ""
 "Advanced. Use another view to generate the relationship subquery. This "
@@ -12371,407 +13300,460 @@ msgid ""
 " the sort options above are ignored. Your view must have the ID of its base "
 "as its only field, and should have some kind of sorting."
 msgstr ""
+"Utökat. Använd en annan vy för att generera den relaterade inbäddade "
+"databasfrågan. Detta låter dig använda filtrering och mer än en sortering. "
+"Om du väljer en vy här kommer sorteringsalternativen ovan att ignoreras. Din"
+" vy måste ha ID-numret för sin huvudvy som dess enda fält, och bör ha någon "
+"slags sortering."
 
 msgid ""
 "Will re-generate the subquery for this relationship every time the view is "
 "run, instead of only when these options are saved. Use for testing if you "
 "are making changes elsewhere. WARNING: seriously impairs performance."
 msgstr ""
+"Kommer att generera den inbäddade databasfrågan igen för denna relation "
+"varje gång som vyn körs istället för enbart när dessa alternativ sparas. "
+"Använd detta för testning om du gör ändringar någon annanstans. VARNING: "
+"påverkar prestandan väldigt mycket."
 
 msgid "Expose this sort to visitors, to allow them to change it"
-msgstr ""
+msgstr "Visa denna sortering för besökare för att låta dem ändra det"
 
 msgid "This display is disabled."
-msgstr ""
+msgstr "Denna visning är inaktiverad."
 
 msgid ""
 "Error: Display @display refers to a plugin named '@plugin', but that plugin "
 "is not available."
 msgstr ""
+"Felmeddelande: Visning @display hänvisar till ett insticksprogram som kallas"
+" \"@plugin\", men det finns inte tillgängligt."
 
 msgid "Aggregation settings"
-msgstr ""
+msgstr "Inställningar för hopsamling"
 
 msgid "Display extenders"
-msgstr ""
+msgstr "Visningsändelser"
 
 msgid "Select extensions of the views interface."
-msgstr ""
+msgstr "Välj ändelser för vyns gränssnitt."
 
 msgid ""
 "You have configured display %display with a path which is an path alias as "
 "well. This might lead to unwanted effects so better use an internal path."
 msgstr ""
+"Du har konfigurerat visning %display med en sökväg som också är ett "
+"sökvägsalias. Detta kan leda till oönskade effekter så det är bättre att "
+"använda en intern sökväg."
 
 msgid "Configure aggregation settings for @type %item"
-msgstr ""
+msgstr "Konfigurera inställningar för hopsamling för @type %item"
 
 msgid "Select the aggregation function to use on this field."
-msgstr ""
+msgstr "Välj funktionen för hopsamling att använda på detta fält."
 
 msgid "Empty display extender"
-msgstr ""
+msgstr "Tom visningsändelse"
 
 msgid "Raw value from URL"
-msgstr ""
+msgstr "Obehandlat värde från URL"
 
 msgid "Apply (all displays)"
-msgstr ""
+msgstr "Tillämpa (alla visningar)"
 
 msgid "Apply (this display)"
-msgstr ""
+msgstr "Tillämpa (denna visning)"
 
 msgid "The date of the most recent new content on the feed."
-msgstr ""
+msgstr "Datumet för det senaste nya innehållet på flödet."
 
 msgid "This is an alias of @group: @field."
-msgstr ""
+msgstr "Detta är ett alias för @group: @field."
 
 msgid "@label:delta"
-msgstr ""
+msgstr "@label:delta"
 
 msgid "Delta - Appears in: @bundles."
-msgstr ""
+msgstr "Delta - Förekommer i: @bundles."
 
 msgid "User who uploaded"
-msgstr ""
+msgstr "Användare som laddade upp"
 
 msgid "Taxonomy term chosen from autocomplete or select widget."
 msgstr ""
+"Taxonomitermen vald från gränssnittskomponent för automatisk komplettering "
+"eller val."
 
 msgid "Representative node"
-msgstr ""
+msgstr "Representativ nod"
 
 msgid ""
 "Obtains a single representative node for each term, according to a chosen "
 "sort criterion."
 msgstr ""
+"Erhåller en enstaka representativ nod för varje term, enligt ett valt "
+"sorteringskriterium."
 
 msgid "Content with term"
-msgstr ""
+msgstr "Innehåll med term"
 
 msgid "Relate all content tagged with a term."
-msgstr ""
+msgstr "Relatera allt innehåll märkt med en term."
 
 msgid "Has taxonomy term ID"
-msgstr ""
+msgstr "Har ID-nummer för taxonomiterm"
 
 msgid "Display content if it has the selected taxonomy terms."
-msgstr ""
+msgstr "Visa innehåll om det har de valda taxonomitermerna."
 
 msgid "Has taxonomy term"
-msgstr ""
+msgstr "Har taxonomiterm"
 
 msgid "Taxonomy terms on node"
-msgstr ""
+msgstr "Taxonomitermer på nod"
 
 msgid "All taxonomy terms"
-msgstr ""
+msgstr "Alla taxonomitermer"
 
 msgid ""
 "Display content if it has the selected taxonomy terms, or children of the "
 "selected terms. Due to additional complexity, this has fewer options than "
 "the versions without depth."
 msgstr ""
+"Visa innehåll om det har de valda taxonomitermerna, eller underliggande av "
+"de valda termerna. På grund av ytterligare komplexitet har detta färre "
+"alternativ än versionerna utan djup."
 
 msgid "Has taxonomy term ID (with depth)"
-msgstr ""
+msgstr "Har ID-nummer för taxonomiterm (med djup)"
 
 msgid "Has taxonomy terms (with depth)"
-msgstr ""
+msgstr "Har taxonomitermer (med djup)"
 
 msgid "Has taxonomy term ID depth modifier"
-msgstr ""
+msgstr "Har modifierare för djup av ID-nummer för taxonomiterm"
 
 msgid "@entity using @field"
-msgstr ""
+msgstr "@entity som använder @field"
 
 msgid "Taxonomy term ID from URL"
-msgstr ""
+msgstr "ID-nummer för taxonomiterm från URL"
 
 msgid ""
 "Obtains a single representative node for each user, according to a chosen "
 "sort criterion."
 msgstr ""
+"Obtains a single representative node for each user, according to a chosen "
+"sort criterion."
 
 msgid ""
 "Display an icon representing the file type, instead of the MIME text (such "
 "as \"image/jpeg\")"
 msgstr ""
+"Visa en ikon som representerar filtypen, istället för MIME-texten (såsom "
+"\"image/jpeg\")."
 
 msgid ""
 "Load default filter from node page, that's good for related taxonomy blocks"
 msgstr ""
+"Ladda förvalt filter från nodsida, detta duger för relaterade taxonomiblock"
 
 msgid "Path component"
-msgstr ""
+msgstr "Sökvägskomponent"
 
 msgid ""
 "The numbering starts from 1, e.g. on the page admin/structure/types, the 3rd"
 " path component is \"types\"."
 msgstr ""
+"Numreringen startar från 1, till exempel på sidan admin/structure/types, är "
+"den tredje sökvägskomponenten \"types\"."
 
 msgid "Use aggregation"
-msgstr ""
+msgstr "Använd gruppering"
 
 msgid "Display title may not be empty."
-msgstr ""
+msgstr "Visningstitel får inte vara tomt."
 
 msgid "When the filter value is <em>NOT</em> available"
-msgstr ""
+msgstr "När filtreringsvärdet <em>INTE</em> finns tillgängligt"
 
 msgid "When the filter value <em>IS</em> available or a default is provided"
 msgstr ""
+"När filtreringsvärdet <em>FINNS</em> tillgängligt eller ett förvalt "
+"tillhandahålls"
 
 msgid ""
 "This display does not have a source for contextual filters, so no contextual"
 " filter value will be available unless you select 'Provide default'."
 msgstr ""
+"Denna visning har ingen källa för kontextuella filter, så inget filtervärde "
+"kommer att finnas tillgängligt om du inte väljer \"Tillhandahåll förvalt\"."
 
 msgid "Query Comment"
-msgstr ""
+msgstr "Kommentar för databasfråga"
 
 msgid ""
 "If set, this comment will be embedded in the query and passed to the SQL "
 "server. This can be helpful for logging or debugging."
 msgstr ""
+"Om satt, kommer denna kommentar att bäddas in i databasfrågan och skickas "
+"med till SQL-servern. Detta kan vara hjälpsamt för loggning och felsökning."
 
 msgid "Count DISTINCT"
-msgstr ""
+msgstr "Räkna ÅTSKILDA"
 
 msgid "Provide default field wrapper elements"
-msgstr ""
+msgstr "Tillhandahåll förvalt element för fältinbäddning"
 
 msgid ""
 "Inline fields will be displayed next to each other rather than one after "
 "another. Note that some fields will ignore this if they are block elements, "
 "particularly body fields and other formatted HTML."
 msgstr ""
+"Radvisa fält kommer att visas bredvid varandra istället för en i taget. "
+"Observera att några fält kommer att ignorera detta om de är blockelement, "
+"särskilt blockfält och annan formaterad HTML."
 
 msgid "Show the empty text in the table"
-msgstr ""
+msgstr "Visa den tomma texten i tabellen"
 
 msgid "The block could not be saved."
-msgstr ""
+msgstr "Blocket kunde inte sparas."
 
 msgid "Datetime"
-msgstr ""
+msgstr "Tidsdatum"
 
 msgid "Language (fr, en, ...)"
-msgstr ""
+msgstr "Språk (fr, en, ...)"
 
 msgid "Link attributes"
-msgstr ""
+msgstr "Länkattribut"
 
 msgid "Max age"
-msgstr ""
+msgstr "Äldsta ålder"
 
 msgid "Last Cron Run"
-msgstr ""
+msgstr "Senaste körningen av schemalagda aktiviteter"
 
 msgid "The user ID."
-msgstr ""
+msgstr "ID-numret för användaren."
 
 msgid "Latest revision"
-msgstr ""
+msgstr "Senaste version"
 
 msgid "Responsive image"
-msgstr ""
+msgstr "Responsiv bild"
 
 msgid "The field that is going to be used as the RSS item title for each row."
-msgstr ""
+msgstr "Fältet som kommer användas som RSS-objektstitel för varje rad."
 
 msgid ""
 "The field that is going to be used as the RSS item link for each row. This "
 "must be a drupal relative path."
 msgstr ""
+"Fältet som kommer användas som RSS-objektslänk för varje rad. Detta måste "
+"vara en relativ sökväg inom Drupal."
 
 msgid ""
 "The field that is going to be used as the RSS item description for each row."
-msgstr ""
+msgstr "Fältet som kommer användas som RSS-objektsbeskrivning för varje rad."
 
 msgid "Creator field"
-msgstr ""
+msgstr "Fält för skapare"
 
 msgid ""
 "The field that is going to be used as the RSS item creator for each row."
-msgstr ""
+msgstr "Fältet som kommer användas som RSS-objektsskapare för varje rad."
 
 msgid "Publication date field"
-msgstr ""
+msgstr "Datumfält för publicering"
 
 msgid ""
 "Row style plugin requires specifying which views fields to use for RSS item."
 msgstr ""
+"Insticksprogram för radstil kräver att du specificerar vilka vyfält som "
+"skall användas för RSS-objekt."
 
 msgid "Unique watchdog event ID."
-msgstr ""
+msgstr "Unikt ID-nummer för övervakningshändelse."
 
 msgid ""
 "The severity level of the event; ranges from 0 (Emergency) to 7 (Debug)."
 msgstr ""
+"Säkerhetsnivån för händelsen. Sträcker sig från 0 (Nödläge) till 7 (Felsök)."
 
 msgid "Logo image"
-msgstr ""
+msgstr "Bild för logga"
 
 msgid "Curaçao"
-msgstr ""
+msgstr "Curaçao"
 
 msgid "Réunion"
-msgstr ""
+msgstr "Réunion"
 
 msgid "Sint Maarten"
-msgstr ""
+msgstr "Sint Maarten"
 
 msgid "Manage view modes"
-msgstr ""
+msgstr "Hantera vylägen"
 
 msgid "JavaScript settings"
-msgstr ""
+msgstr "Inställningar för JavaScript"
 
 msgid "Entity Reference"
-msgstr ""
+msgstr "Objektsreferens"
 
 msgid "An autocomplete text field."
-msgstr ""
+msgstr "Ett automatiskt kompletterande textfält."
 
 msgid "Display the label of the referenced entities."
-msgstr ""
+msgstr "Visa etiketten för de refererade objekten."
 
 msgid "Rendered entity"
-msgstr ""
+msgstr "Genererat objekt"
 
 msgid "Display the referenced entities rendered by entity_view()."
-msgstr ""
+msgstr "Visa de refererade objekten som genererats av entity_view()."
 
 msgid "Link label to the referenced entity"
-msgstr ""
+msgstr "Länketikett till det refererade objektet"
 
 msgid "Link to the referenced entity"
-msgstr ""
+msgstr "Länk för det refererade objektet"
 
 msgid "Rendered as @mode"
-msgstr ""
+msgstr "Genererad som @mode"
 
 msgid "Language types"
-msgstr ""
+msgstr "Typ av språk"
 
 msgid "Add view mode"
-msgstr ""
+msgstr "Lägg till vyläge"
 
 msgid "@group: @field"
-msgstr ""
+msgstr "@group: @field"
 
 msgid "@group (historical data): @field"
-msgstr ""
+msgstr "@group (historisk data): @field"
 
 msgid "Edit view mode"
-msgstr ""
+msgstr "Redigera visningsläge"
 
 msgid "Default date"
-msgstr ""
+msgstr "Förvalt datum"
 
 msgid "Default end date"
-msgstr ""
+msgstr "Förvalt slutdatum"
 
 msgid "Time increments"
-msgstr ""
+msgstr "Tidssteg"
 
 msgid "10 minute"
-msgstr ""
+msgstr "10 minuter"
 
 msgid "30 minute"
-msgstr ""
+msgstr "30 minuter"
 
 msgid "Text of the auto-reply message."
-msgstr ""
+msgstr "Text för automatiskt svarsmeddelande"
 
 msgid "Entity reference"
-msgstr ""
+msgstr "Objektsreferens"
 
 msgid "@name field is required."
-msgstr ""
+msgstr "Fält @name är obligatoriskt."
 
 msgid "Fields pending deletion"
-msgstr ""
+msgstr "Fält som väntar på radering"
 
 msgid "No translatable fields"
-msgstr ""
+msgstr "Inga översättningsbara fält"
 
 msgid "Translations of %label"
-msgstr ""
+msgstr "Översättningar av %label"
 
 msgid "This translation is published"
-msgstr ""
+msgstr "Denna översättning är publicerad"
 
 msgid "Are you sure you want to delete the @language translation of %label?"
 msgstr ""
+"Är du säker på att du vill radera den @language översättningen för %label?"
 
 msgid "Shown"
-msgstr ""
+msgstr "Visade"
 
 msgid "Translate any entity"
-msgstr ""
+msgstr "Översätta ett objekt"
 
 msgid "Hide empty columns"
-msgstr ""
+msgstr "Dölj tomma kolumner"
 
 msgid ""
 "The node ID of the node a user created or commented on. You must use an "
 "argument or filter on UID or you will get misleading results using this "
 "field."
 msgstr ""
+"Nodens ID-nummer för noden en användare skapat eller kommenterat. Du måste "
+"använda ett argument eller filtrera på UID annars kommer du få missvisande "
+"resultat med hjälp av detta fält."
 
 msgid ""
 "The user ID of a user who touched the node (either created or commented on "
 "it)."
 msgstr ""
+"Användarens ID-nummer för en användare som rörde noden (antingen skapade "
+"eller kommenterade den)."
 
 msgid ""
 "The date the node was last updated or commented on. You must use an argument"
 " or filter on UID or you will get misleading results using this field."
 msgstr ""
+"Datumet noden senast uppdaterades eller kommenterades. Du måste använda ett "
+"argument eller filtrera på UID annars kommer du få missvisande resultat om "
+"du använder det här fältet."
 
 msgid "Entity types"
-msgstr ""
+msgstr "Entity types"
 
 msgid "Change handler"
-msgstr ""
+msgstr "Byt hanterare"
 
 msgid "Autocomplete (Tags style)"
-msgstr ""
+msgstr "Automatisk komplettering (etiketter)"
 
 msgid "Mail system"
-msgstr ""
+msgstr "E-postsystem"
 
 msgid "Hide empty column"
-msgstr ""
+msgstr "Dölj tom kolumn"
 
 msgid "Restrict images to this site"
-msgstr ""
+msgstr "Begränsa bilder till denna webbplats"
 
 msgid ""
 "Disallows usage of &lt;img&gt; tag sources that are not hosted on this site "
 "by replacing them with a placeholder image."
 msgstr ""
+"Tillåter inte användning av taggarna &lt;img&gt; som inte hanteras på denna "
+"webbplats genom att ersätta dem med en platshållarbild."
 
 msgid "Maximum dimensions"
-msgstr ""
+msgstr "Största mått"
 
 msgid "Fallback image style"
-msgstr ""
+msgstr "Bildstil i reserv"
 
 msgid "Wide"
-msgstr ""
+msgstr "Bred"
 
 msgid "The operator is invalid on filter: @filter."
-msgstr ""
+msgstr "Operanden är ogiltig på filter: @filter."
 
 msgid "No valid values found on filter: @filter."
-msgstr ""
+msgstr "Inga giltiga värden funna på filter: @filter."
 
 msgid "The value @value is not an array for @operator on filter: @filter"
-msgstr ""
+msgstr "Värdet @value är inte en array för @operator på filter: @filter"
 
 msgid ""
 "If not checked, fields that are not configured to customize their HTML "
@@ -12780,177 +13762,205 @@ msgid ""
 "view provides by default, at the cost of making it more difficult to apply "
 "CSS."
 msgstr ""
+"Om ej markerat kommer fält som inte är konfigurerade för att anpassa sina "
+"HTML-element inte att få några inbäddningar över huvud taget för sitt fält, "
+"etikett och fält + etikett. Du kan använda detta för att snabbt minska "
+"mängden uppmärkning som vyn tillhandahåller som standard, på bekostnad av "
+"att det blir svårare att tillämpa CSS."
 
 msgid "@label (@column)"
-msgstr ""
+msgstr "@label (@column)"
 
 msgid "banned IP addresses"
-msgstr ""
+msgstr "spärrade IP-adresser"
 
 msgid "The IP address %ip has been banned."
-msgstr ""
+msgstr "IP-adrresen %ip har spärrats."
 
 msgid "CKEditor settings"
-msgstr ""
+msgstr "Inställningar för CKEditor"
 
 msgid "The field name."
-msgstr ""
+msgstr "The field name."
 
 msgid "Validate options"
-msgstr ""
+msgstr "Alternativ för validering"
 
 msgid "Whether the user is active or blocked."
-msgstr ""
+msgstr "Huruvida användaren är aktiv eller spärrad."
 
 msgid "Views query"
-msgstr ""
+msgstr "Databasfråga för vy"
 
 msgid ""
 "The throbber display does not show the status of uploads but takes up less "
 "space. The progress bar is helpful for monitoring progress on large uploads."
 msgstr ""
+"Laddningsindikatorn visar inte statusen för uppladdningen men tar upp mindre"
+" plats. Förloppsindikatorn är till hjälp för att se hur långt man kommit med"
+" stora uppladdningar."
 
 msgid "Leave this blank to delete both the existing username and password."
 msgstr ""
+"Lämna detta tomt för att radera både det nuvarande användarnamnet och "
+"lösenordet."
 
 msgid "To change the password, enter the new password here."
-msgstr ""
+msgstr "Ange det nya lösenordet här för att ändra lösenordet."
 
 msgid ""
 "HTTP authentication credentials must include a username in addition to a "
 "password."
 msgstr ""
+"Verifieringsinformation för HTTP måste innehålla ett användarnamn förutom "
+"ett lösenord."
 
 msgid ""
 "Cron takes care of running periodic tasks like checking for updates and "
 "indexing content for search."
 msgstr ""
+"Schemalagda aktiviteter tar hand om att köra återkommande uppgifter som att "
+"söka efter uppdateringar och indexering av innehåll för sökningen."
 
 msgid "User name and password"
-msgstr ""
+msgstr "Användarnamn och lösenord"
 
 msgid "User module account form elements."
-msgstr ""
+msgstr "Användarmodulens formulärelement för kontofält"
 
 msgid "Manage form display"
-msgstr ""
+msgstr "Hantera formulärsvisning"
 
 msgid ""
 "A Drupal path or external URL the more link will point to. Note that this "
 "will override the link display setting above."
 msgstr ""
+"En sökväg i Drupal eller extern URL som länken \"mer\" kommer att peka mot. "
+"Observera att detta kommer åsidosätta inställningen för visningslänk ovan."
 
 msgid "<em>Alt</em> field required"
-msgstr ""
+msgstr "Fält <em>Alt</em> är obligatoriskt"
 
 msgid "<em>Title</em> field required"
-msgstr ""
+msgstr "Fält <em>Titel</em> är obligatoriskt"
 
 msgid "Link to entity"
-msgstr ""
+msgstr "Länk för objekt"
 
 msgid "Bypass access checks"
-msgstr ""
+msgstr "Kringgå åtkomstkontroller"
 
 msgid "Media type"
-msgstr ""
+msgstr "Media type"
 
 msgid "@view : @display"
-msgstr ""
+msgstr "@view : @display"
 
 msgid "View: @view - Display: @display"
-msgstr ""
+msgstr "Vy: @view - Visning: @display"
 
 msgid "Transform the case"
-msgstr ""
+msgstr "Omvandla värdet"
 
 msgid ""
 "If \"Custom\", see <a href=\"http://us.php.net/manual/en/function.date.php\""
 " target=\"_blank\">the PHP docs</a> for date formats. Otherwise, enter the "
 "number of different time units to display, which defaults to 2."
 msgstr ""
+"Om \"Anpassad\", se <a "
+"href=\"http://us.php.net/manual/en/function.date.php\" "
+"target=\"_blank\">PHP:s dokumentation</a> för datumformat. Annars skriver du"
+" in det antal olika tidsenheter att visa, vilket som förvalt är två."
 
 msgid "Representative sort criteria"
-msgstr ""
+msgstr "Representativt sorteringskriterium"
 
 msgid ""
 "The sort criteria is applied to the data brought in by the relationship to "
 "determine how a representative item is obtained for each row. For example, "
 "to show the most recent node for each user, pick 'Content: Updated date'."
 msgstr ""
+"Sorteringskriteriet läggs till på datan som förts in genom relationen för "
+"att avgöra hur ett ett representativt objekt erhålls för varje rad. Till "
+"exempel, för att visa den senaste noden för varje användare, välj "
+"\"Innehåll: Uppdaterad datum\"."
 
 msgid "The ordering to use for the sort criteria selected above."
-msgstr ""
+msgstr "Ordningen att använda för sorteringskriteriet valt ovan."
 
 msgid "Revert to default"
-msgstr ""
+msgstr "Återgår till förvalt"
 
 msgid "No fields have been used in views yet."
-msgstr ""
+msgstr "Inga fält har används i vyer ännu."
 
 msgid "Provide a simple link to approve the comment."
-msgstr ""
+msgstr "Tillhandahåll en enkel länk för att godkänna kommentaren."
 
 msgid "Author uid"
-msgstr ""
+msgstr "UID för författare"
 
 msgid "Relate each @entity with a @field set to the file."
-msgstr ""
+msgstr "Relatera varje @entity med ett @field satt till filen."
 
 msgid "Relate each @entity with a @field set to the image."
-msgstr ""
+msgstr "Relatera varje @entity med ett @field satt till bilden."
 
 msgid "The tid of a taxonomy term."
-msgstr ""
+msgstr "TID för en taxonomiterm."
 
 msgid "The user permissions."
-msgstr ""
+msgstr "Behörigheterna för användare."
 
 msgid "First and last only"
-msgstr ""
+msgstr "Enbart första och sista"
 
 msgid "Multiple-value handling"
-msgstr ""
+msgstr "Hantering av flera värden"
 
 msgid "Filter to items that share all terms"
-msgstr ""
+msgstr "Filter till objekt som delar alla termer"
 
 msgid "Filter to items that share any term"
-msgstr ""
+msgstr "Filter till objekt som delar en term"
 
 msgid "Use a pager"
-msgstr ""
+msgstr "Använd en paginerare"
 
 msgid "Logo path"
-msgstr ""
+msgstr "Sökväg till logotyp"
 
 msgid ""
 "@module (<span class=\"admin-missing\">incompatible with</span> this version"
 " of Drupal core)"
 msgstr ""
+"@module (<span class=\"admin-missing\">ej kompatibel</span> med den här "
+"versionen av Drupals kärna)"
 
 msgid "Responsive"
-msgstr ""
+msgstr "Följsam"
 
 msgid "Tokens related to views."
-msgstr ""
+msgstr "Ersättningstecken relaterade till vyer."
 
 msgid "The description of the view."
-msgstr ""
+msgstr "Beskrivningen för vyn."
 
 msgid "The title of current display of the view."
-msgstr ""
+msgstr "Titeln för den aktuella visningen av vyn."
 
 msgid "The URL of the view."
-msgstr ""
+msgstr "URL:en för vyn."
 
 msgid "-Select-"
-msgstr ""
+msgstr "-Välj-"
 
 msgid ""
 "Text to place as \"title\" text which most browsers display as a tooltip "
 "when hovering over the link."
 msgstr ""
+"Text att sätta in som \"titel\" som de flesta webbläsare visar som en "
+"hjälptext när man för musmarkören över länken."
 
 msgid ""
 "Enable to hide this field if it is empty. Note that the field label or "
@@ -12958,914 +13968,1025 @@ msgid ""
 "row style settings for empty fields. To hide rewritten content, check the "
 "\"Hide rewriting if empty\" checkbox."
 msgstr ""
+"Aktivera för att dölja detta fält om det är tomt. Observera att "
+"fältetikettet eller omskriven utmatning fortfarande kan visas. Kontrollera "
+"inställningarna för stil eller radstil för att dölja etiketter för tomma "
+"fält. Kryssa för Dölj utmatning om tomt för att dölja omskrivet innehåll."
 
 msgid "Apostrophe"
-msgstr ""
+msgstr "Apostrof"
 
 msgid "Date in the form of CCYYMMDD."
-msgstr ""
+msgstr "Datum på formen ÅÅÅÅMMDD."
 
 msgid "Date in the form of YYYYMM."
-msgstr ""
+msgstr "Datum på formen ÅÅÅÅMM."
 
 msgid "Date in the form of YYYY."
-msgstr ""
+msgstr "Datum på formen ÅÅÅÅ."
 
 msgid "Date in the form of MM (01 - 12)."
-msgstr ""
+msgstr "Datum på formen MM (01-12)."
 
 msgid "Date value"
-msgstr ""
+msgstr "Datumvärde"
 
 msgid "Full HTML"
-msgstr ""
+msgstr "Fullständig HTML"
 
 msgid "View modes"
-msgstr ""
+msgstr "Visningsläge"
 
 msgid "Date in the form of DD (01 - 31)."
-msgstr ""
+msgstr "Datum på formen DD (01-31)."
 
 msgid "Date in the form of WW (01 - 53)."
-msgstr ""
+msgstr "Datum på formen WW (01-53)."
 
 msgid ""
 "If you need more fields than the uid add the comment: author relationship"
 msgstr ""
+"Om du behöver fler fält än UID, lägg till kommentar: relation till "
+"författare"
 
 msgid "Last comment uid"
-msgstr ""
+msgstr "UID för senaste kommentar"
 
 msgid ""
 "The user authoring the content. If you need more fields than the uid add the"
 " content: author relationship"
 msgstr ""
+"Användaren som författar innehållet. Om du behöver fler fält än UID, lägg "
+"till innehåll: relation till författare"
 
 msgid "Convert spaces in term names to hyphens"
-msgstr ""
+msgstr "Konvertera mellanslag i termnamn till bindestreck"
 
 msgid "Use rendered output to group rows"
-msgstr ""
+msgstr "Används genererad utmatning för att gruppera rader"
 
 msgid ""
 "If enabled the rendered output of the grouping field is used to group the "
 "rows."
 msgstr ""
+"Om aktiverad, kommer den genererade utmatningen för grupperingsfältet "
+"användas för att gruppera rader."
 
 msgid "Block count"
-msgstr ""
+msgstr "Antal block"
 
 msgid "Limit to vocabulary"
-msgstr ""
+msgstr "Begränsa till vokabulär"
 
 msgid ""
 "You may use HTML code in this field. The following tokens are supported:"
 msgstr ""
+"Du kan använda HTML-kod i detta fält. Följande ersättningstecken stöds:"
 
 msgid "Result summary"
-msgstr ""
+msgstr "Sammanfattning av resultat"
 
 msgid "Shows result summary, for example the items per page."
-msgstr ""
+msgstr "Visar sammanfattning av resultat, till exempel artiklar per sida."
 
 msgid "Use site default RSS settings"
-msgstr ""
+msgstr "Använd webbplatsens förvalda RSS-inställningar"
 
 msgid "Display list value as human readable"
-msgstr ""
+msgstr "Visa listvärde läsvänligt"
 
 msgid "Displays the link in contextual links"
-msgstr ""
+msgstr "Visar länken i sammanhängande länkar"
 
 msgid "Grouping field Nr.@number"
-msgstr ""
+msgstr "Grupperande fält nummer @number"
 
 msgid "Response status code"
-msgstr ""
+msgstr "Svarskod"
 
 msgid "Callback function"
-msgstr ""
+msgstr "Funktion för återanrop"
 
 msgid ""
 "Your search used too many AND/OR expressions. Only the first @count terms "
 "were included in this search."
 msgstr ""
+"Din sökning använde för många AND/OR-uttryck. Endast de första @count "
+"termerna togs med i denna sökning."
 
 msgid "Other…"
-msgstr ""
+msgstr "Annat..."
 
 msgid "The selected selection handler is broken."
-msgstr ""
+msgstr "Den valda urvalshanteraren är trasig."
 
 msgid "Performance settings"
-msgstr ""
+msgstr "Inställningar för prestanda"
 
 msgid "Display field as machine name."
-msgstr ""
+msgstr "Visa fält som maskinläsbart namn."
 
 msgid "Provide a display which can be embedded using the views api."
 msgstr ""
+"Tillhandahåll en visning som kan bäddas in genom att använda Views API."
 
 msgid "Only has the 'authenticated user' role"
-msgstr ""
+msgstr "Enbart har rollen \"verifierad användare\""
 
 msgid "Has roles in addition to 'authenticated user'"
-msgstr ""
+msgstr "Har roller utöver \"verifierad användare\""
 
 msgid "Remove tags from rendered output"
-msgstr ""
+msgstr "Tag bort taggar från genererad utmatning"
 
 msgid "Fields to be included as contextual links."
-msgstr ""
+msgstr "Fält som skall inkluderas som sammanhängande länkar."
 
 msgid "Include destination"
-msgstr ""
+msgstr "Inkludera mål"
 
 msgid ""
 "Include a \"destination\" parameter in the link to return the user to the "
 "original view upon completing the contextual action."
 msgstr ""
+"Inkludera en \"mål\"-parameter i länken för att vidarebefordra användaren "
+"till den ursprungliga vyn efter att den sammanhängande åtgärden genomförts."
 
 msgid "Contextual Links"
-msgstr ""
+msgstr "Sammanhängande länkar"
 
 msgid "Display fields in a contextual links menu."
-msgstr ""
+msgstr "Visa fält i en sammanhängande länkmeny."
 
 msgid "Upload directory"
-msgstr ""
+msgstr "Uppladdningskatalog"
 
 msgid "The file %file could not be saved because the upload did not complete."
-msgstr ""
+msgstr "Filen %file kunde inte sparas eftersom uppladdningen inte slutfördes."
 
 msgid "Authentication provider"
-msgstr ""
+msgstr "Autentiseringsleverantör"
 
 msgid "Allowed values function"
-msgstr ""
+msgstr "Funktion för tillåtna värden"
 
 msgid "Select media"
-msgstr ""
+msgstr "Select media"
 
 msgid "Third party settings"
-msgstr ""
+msgstr "Tredjepartsinställningar"
 
 msgid "Date/time format"
-msgstr ""
+msgstr "Datum-/tidsformat"
 
 msgid "Enable translation"
-msgstr ""
+msgstr "Aktivera översättning"
 
 msgid "Drupal Version"
-msgstr ""
+msgstr "Version av Drupal"
 
 msgid "This field supports tokens."
-msgstr ""
+msgstr "Detta fält stöder ersättningstecken."
 
 msgid "Twig"
-msgstr ""
+msgstr "Twig"
 
 msgid "Search score"
-msgstr ""
+msgstr "Sökpoäng"
 
 msgid "Add transition"
-msgstr ""
+msgstr "Add transition"
 
 msgid "There was a problem creating field %label: @message"
-msgstr ""
+msgstr "Det gick inte att skapa fält %label: @message"
 
 msgid "No content selected."
-msgstr ""
+msgstr "Inget innehåll valt."
 
 msgid ""
 "A list field (@field_name) with existing data cannot have its keys changed."
 msgstr ""
+"Ett listfält (@field_name) med befintlig data kan inte ha dess nycklar "
+"ändrade."
 
 msgid ""
 "A unique machine-readable name containing letters, numbers, and underscores."
 msgstr ""
+"Ett unikt maskinläsbart namn som innehåller bokstäver, siffror och "
+"understreck."
 
 msgid ""
 "If no image is uploaded, this image will be shown on display and will "
 "override the field's default image."
 msgstr ""
+"Om ingen bild laddas upp, kommer denna att visas och åsidosätta fältets "
+"förvalda bild."
 
 msgid "The menu name. Primary key."
-msgstr ""
+msgstr "The menu name. Primary key."
 
 msgid "The human-readable name of the menu."
-msgstr ""
+msgstr "The human-readable name of the menu."
 
 msgid "A description of the menu"
-msgstr ""
+msgstr "A description of the menu"
 
 msgid ""
 "The menu name. All links with the same menu name (such as 'navigation') are "
 "part of the same menu."
 msgstr ""
+"The menu name. All links with the same menu name (such as 'navigation') are "
+"part of the same menu."
 
 msgid "The menu link ID (mlid) is the integer primary key."
-msgstr ""
+msgstr "The menu link ID (mlid) is the integer primary key."
 
 msgid "The name of the module that generated this link."
-msgstr ""
+msgstr "The name of the module that generated this link."
 
 msgid "Bulk operation"
-msgstr ""
+msgstr "Hopsamlad funktion"
 
 msgid "View used to select the entities"
-msgstr ""
+msgstr "Vy som används för att välja objekten"
 
 msgid ""
 "Choose the view and display that select the entities that can be "
 "referenced.<br />Only views with a display of type \"Entity Reference\" are "
 "eligible."
 msgstr ""
+"Välj vyn och visning som väljer de objekt som kan refereras.<br />Endast "
+"vyer med en visning av typ \"Objektsreferens\" kan väljas."
 
 msgid "Views: Filter by an entity reference view"
-msgstr ""
+msgstr "Vyer: Filtrera på en vy av objektsreferens"
 
 msgid "Entity Reference Source"
-msgstr ""
+msgstr "Källa för Objektsreferens"
 
 msgid "Entity Reference list"
-msgstr ""
+msgstr "Lista för Objektsreferens"
 
 msgid ""
 "Display \"@display\" needs a selected search fields to work properly. See "
 "the settings for the Entity Reference list format."
 msgstr ""
+"Visning \"@display\" behöver ett valt sökfält som fungerar på rätt sätt. Se "
+"inställningarna för listformatet Objektsreferens."
 
 msgid ""
 "Display \"@display\" uses field %field as search field, but the field is no "
 "longer present. See the settings for the Entity Reference list format."
 msgstr ""
+"Visning \"@display\" använder fält %field som sökfält men fältet finns inte "
+"längre. Se inställningarna för listformatet Objektsreferens."
 
 msgid ""
 "<strong>Note:</strong> In 'Entity Reference' displays, all fields will be "
 "displayed inline unless an explicit selection of inline fields is made here."
 msgstr ""
+"<strong>Observera:</strong> I visningar för \"Objektsreferens\" kommer alla "
+"fält visas på samma rad såvida inte ett uttryckligt val av radfält görs här."
 
 msgid ""
 "Select the field(s) that will be searched when using the autocomplete "
 "widget."
 msgstr ""
+"Välj fältet/fälten som skall sökas igenom vid användning av den automatiskt "
+"kompletterande gränssnittskomponenten."
 
 msgid "Public files directory"
-msgstr ""
+msgstr "Offentlig filkatalog"
 
 msgid "Temporary files directory"
-msgstr ""
+msgstr "Temporär filkatalog"
 
 msgid "Private files directory"
-msgstr ""
+msgstr "Privat filkatalog"
 
 msgid "Comment Statistics"
-msgstr ""
+msgstr "Statistik för kommentarer"
 
 msgid "You have unsaved changes"
-msgstr ""
+msgstr "Du har ändringar som inte sparats"
 
 msgid "Loading…"
-msgstr ""
+msgstr "Laddar..."
 
 msgid "Use site name"
-msgstr ""
+msgstr "Använd webbplatsens namn"
 
 msgid "Use site slogan"
-msgstr ""
+msgstr "Använd webbplatsens slogan"
 
 msgid "File status"
-msgstr ""
+msgstr "Filstatus"
 
 msgid "Reduce"
-msgstr ""
+msgstr "Reducera"
 
 msgid "Easy"
-msgstr ""
+msgstr "Easy"
 
 msgid "Breakpoint"
-msgstr ""
+msgstr "Brytpunkt"
 
 msgid "Needs to be updated"
-msgstr ""
+msgstr "Behöver uppdateras"
 
 msgid "Does not need to be updated"
-msgstr ""
+msgstr "Behöver inte uppdateras"
 
 msgid "Edit comment @subject"
-msgstr ""
+msgstr "Redigera kommentar @subject"
 
 msgid ""
 "Only this translation is published. You must publish at least one more "
 "translation to unpublish this one."
 msgstr ""
+"Enbart denna översättning är publicerad. Du måste publicera minst en till "
+"översättning för att avpublicera denna."
 
 msgid "Time interval"
-msgstr ""
+msgstr "Tidsintervall"
 
 msgid "Used in views"
-msgstr ""
+msgstr "Används i vyer"
 
 msgid "Display \"Access Denied\""
-msgstr ""
+msgstr "Visa \"Åtkomst nekad\""
 
 msgid "Timezone to be used for date output."
-msgstr ""
+msgstr "Tidszon som skall användas för utskrift av datum."
 
 msgid "- Default site/user timezone -"
-msgstr ""
+msgstr "- Förvald tidszon för webbplats/användare -"
 
 msgid ""
 "Grouped filters allow a choice between predefined operator|value pairs."
 msgstr ""
+"Grupperade filter tillåter ett val mellan fördefinierad par av "
+"operand|värde."
 
 msgid "Filter type to expose"
-msgstr ""
+msgstr "Filtertyp att exponera"
 
 msgid "Single filter"
-msgstr ""
+msgstr "Enstaka filter"
 
 msgid "Grouped filters"
-msgstr ""
+msgstr "Grupperade filter"
 
 msgid "Language type"
-msgstr ""
+msgstr "Språktyp"
 
 msgid "No book content available."
-msgstr ""
+msgstr "Inget bokinnehåll tillgängligt."
 
 msgid "Default translation"
-msgstr ""
+msgstr "Förvald översättning"
 
 msgid "Views plugins"
-msgstr ""
+msgstr "Insticksprogram i Views"
 
 msgid "Translation for @language"
-msgstr ""
+msgstr "Översättning för @language"
 
 msgid "Last page"
-msgstr ""
+msgstr "Sista sidan"
 
 msgid "Export options"
-msgstr ""
+msgstr "Alternativ för export"
 
 msgid "Hide description"
-msgstr ""
+msgstr "Dölj beskrivning"
 
 msgid ""
 "Remember exposed selection only for the selected user role(s). If you select"
 " no roles, the exposed data will never be stored."
 msgstr ""
+"Kom ihåg exponerat urval endast för den valda användarrollen/rollerna. Om du"
+" inte väljer någon roll kommer exponerad data aldrig lagras."
 
 msgid ""
 "Select which kind of widget will be used to render the group of filters"
 msgstr ""
+"Välj vilken typ av gränssnittskomponent som kommer att användas för att "
+"generera gruppen av filter"
 
 msgid "grouped"
-msgstr ""
+msgstr "grupperad"
 
 msgid "Choose fields to combine for filtering"
-msgstr ""
+msgstr "Välj fält att kombinera för filtrering"
 
 msgid "This filter doesn't work for very special field handlers."
-msgstr ""
+msgstr "Detta filter fungerar inte för mycket speciella fälthanterare."
 
 msgid "You have to add some fields to be able to use this filter."
-msgstr ""
+msgstr "Du måste lägga till några fält för att kunna använda det här filtret."
 
 msgid "@entity types"
-msgstr ""
+msgstr "Typer för @entity"
 
 msgid "There is no lock on view %name to break."
-msgstr ""
+msgstr "Det finns inget lås på vy %name att låsa upp."
 
 msgid "&lt;Any&gt;"
-msgstr ""
+msgstr "&lt;Vilken som helst&gt;"
 
 msgid "There are no enabled views."
-msgstr ""
+msgstr "Det finns inga aktiverade vyer."
 
 msgid "Display fields as RSS items."
-msgstr ""
+msgstr "Visa fält som RSS-objekt."
 
 msgid "- No value -"
-msgstr ""
+msgstr "- Inget värde -"
 
 msgid "Provide a simple link to the revision."
-msgstr ""
+msgstr "Tillhandahåll en enkel länk till versionen."
 
 msgid "The ID of the entity that is related to the file."
-msgstr ""
+msgstr "ID-numret för objektet som är relaterat till filen."
 
 msgid "The raw numeric user ID."
-msgstr ""
+msgstr "Det obearbetade numeriska ID-numret för användare."
 
 msgid "Unfiltered text"
-msgstr ""
+msgstr "Ofiltrerad text"
 
 msgid ""
 "Add unrestricted, custom text or markup. This is similar to the custom text "
 "field."
 msgstr ""
+"Lägg till obegränsad valfri text eller uppmärkning. Det här är liknande det "
+"anpassade textfältet."
 
 msgid "Combine fields filter"
-msgstr ""
+msgstr "Kombinera filterfält"
 
 msgid "Column used for click sorting"
-msgstr ""
+msgstr "Kolumn som används för klickbar sortering"
 
 msgid "Use path alias instead of internal path."
-msgstr ""
+msgstr "Använd sökvägsalias istället för intern sökväg."
 
 msgid "Length of time in seconds raw query results should be cached."
-msgstr ""
+msgstr "Tidslängd i sekunder obearbetade databasfrågeresultat skall cachas."
 
 msgid "Length of time in seconds rendered HTML output should be cached."
-msgstr ""
+msgstr "Tidslängd i sekunder genererad HTML-utmatning skall cachas."
 
 msgid "Custom time values must be numeric."
-msgstr ""
+msgstr "Anpassade tidsvärden måste vara numeriska."
 
 msgid "Change whether or not to display contextual links for this view."
 msgstr ""
+"Ändra huruvida sammanhängande länkar skall visas eller ej för den här vyn."
 
 msgid "Display 'more' link only if there is more content"
-msgstr ""
+msgstr "Visa länk \"mer\" enbart om det finns mer innehåll"
 
 msgid ""
 "Exposed filters in block displays require \"Use AJAX\" to be set to work "
 "correctly."
 msgstr ""
+"Synliga filter i blockvisningar kräver \"Använd AJAX\" att vara inställt för"
+" att fungera på rätt sätt."
 
 msgid "Number of pager links visible"
-msgstr ""
+msgstr "Antal synliga pagineringslänkar"
 
 msgid "Specify the number of links to pages to display in the pager."
-msgstr ""
+msgstr "Ange antalet länkar att visa i pagineraren."
 
 msgid "Query Tags"
-msgstr ""
+msgstr "Taggar för databasfråga"
 
 msgid ""
 "If set, these tags will be appended to the query and can be used to identify"
 " the query in a module. This can be helpful for altering queries."
 msgstr ""
+"Om inställt kommer dessa taggar läggas till databasfrågan och kan användas "
+"för att identifiera frågan i en modul. Detta kan vara användbart för byte "
+"mellan frågor."
 
 msgid ""
 "The query tags may only contain lower-case alphabetical characters and "
 "underscores."
 msgstr ""
+"Etiketterna för databasfrågorna får bara innehålla gemena bokstäver och "
+"understreck."
 
 msgid ""
 "The field that is going to be used as the RSS item pubDate for each row. It "
 "needs to be in RFC 2822 format."
 msgstr ""
+"Fältet som kommer användas som RSS-objektet pubDate för varje rad. Det måste"
+" vara i formatet RFC 2822."
 
 msgid "GUID settings"
-msgstr ""
+msgstr "Inställningar för GUID"
 
 msgid "GUID field"
-msgstr ""
+msgstr "Fält för GUID"
 
 msgid "The globally unique identifier of the RSS item."
-msgstr ""
+msgstr "Den globalt unika identifieraren för RSS-objektet"
 
 msgid "GUID is permalink"
-msgstr ""
+msgstr "GUID är permanent länk"
 
 msgid "The RSS item GUID is a permalink."
-msgstr ""
+msgstr "RSS-objektet GUID är en permanent länk."
 
 msgid "Add views row classes"
-msgstr ""
+msgstr "Lägg till radklasser för vyer"
 
 msgid "Force using fields"
-msgstr ""
+msgstr "Tvinga användning av fält"
 
 msgid ""
 "If neither the row nor the style plugin supports fields, this field allows "
 "to enable them, so you can for example use groupby."
 msgstr ""
+"Om varken insticksprogrammet för rad eller stil stöder fält tillåter detta "
+"fält att du aktiverar dem, så att du till exempel kan använda gruppera på."
 
 msgid "File storage"
-msgstr ""
+msgstr "Fillagring"
 
 msgid ""
 "A flexible, recolorable theme with many regions and a responsive, mobile-"
 "first layout."
 msgstr ""
+"Ett flexibelt, färgbart tema med många regioner och en responsiv layout "
+"avsedd för mobiler."
 
 msgid "Enter 0 for no limit."
-msgstr ""
+msgstr "Ange 0 för ingen begränsning."
 
 msgid "Entity label"
-msgstr ""
+msgstr "Etikett för objekt"
 
 msgid "The @type %title has been deleted."
-msgstr ""
+msgstr "@type %title har raderats."
 
 msgid "The URL %url is not valid."
-msgstr ""
+msgstr "URL:en %url är inte giltig."
 
 msgid "All messages, with backtrace information"
-msgstr ""
+msgstr "All messages, with backtrace information"
 
 msgid "The views entity selection mode requires a view."
-msgstr ""
+msgstr "Vyns objektsväljarläge kräver en vy."
 
 msgid "The connection protocol %backend does not exist."
-msgstr ""
+msgstr "Anslutningsprotokollet %backend finns inte."
 
 msgid "Unknown (@langcode)"
-msgstr ""
+msgstr "Okänd (@langcode)"
 
 msgid ""
 "The file %file could not be saved because it exceeds %maxsize, the maximum "
 "allowed size for uploads."
 msgstr ""
+"Filen %file kunde inte sparas eftersom den överskrider %maxsize vilket är "
+"den största tillåtna storleken för uppladdningar."
 
 msgid ""
 "The file could not be uploaded because the destination %destination is "
 "invalid."
 msgstr ""
+"Filen kunde inte laddas upp på grund av att målet %destination är ogiltig."
 
 msgid "The file %path was not deleted because it does not exist."
-msgstr ""
+msgstr "Filen %path raderades inte eftersom den inte finns."
 
 msgid "%name field is not in the right format."
-msgstr ""
+msgstr "Fält %name är inte i rätt format."
 
 msgid "%name is not a valid number."
-msgstr ""
+msgstr "%name är inte ett giltigt nummer."
 
 msgid "%name must be a valid color."
-msgstr ""
+msgstr "%name måste vara en giltig färg."
 
 msgid "Theme hook %hook not found."
-msgstr ""
+msgstr "Temahook %hook hittades inte."
 
 msgid "…"
-msgstr ""
+msgstr "..."
 
 msgid "Table @name already exists."
-msgstr ""
+msgstr "Tabell @name finns redan."
 
 msgid "Cannot rename @table to @table_new: table @table doesn't exist."
-msgstr ""
+msgstr "Kan inte döpa om @table till @table_new: tabell @table finns inte."
 
 msgid "Cannot rename @table to @table_new: table @table_new already exists."
 msgstr ""
+"Kan inte döpa om @table till @table_new: tabell @table_new finns redan."
 
 msgid "Cannot add field @table.@field: table doesn't exist."
-msgstr ""
+msgstr "Kan inte lägga till fält @table.@field: tabell finns inte."
 
 msgid "Cannot add field @table.@field: field already exists."
-msgstr ""
+msgstr "Kan inte lägga till fält @table.@field: fält finns redan."
 
 msgid "Cannot set default value of field @table.@field: field doesn't exist."
 msgstr ""
+"Kan inte ange standardvärde för fältet @table.@field: fältet finns inte."
 
 msgid ""
 "Cannot remove default value of field @table.@field: field doesn't exist."
 msgstr ""
+"Kan inte ta bort standardvärde för fältet @table.@field: fältet finns inte."
 
 msgid "Cannot add primary key to table @table: table doesn't exist."
 msgstr ""
+"Kan inte lägga till primärnyckel till tabellen @table: tabellen finns inte."
 
 msgid "Cannot add primary key to table @table: primary key already exists."
 msgstr ""
+"Kan inte lägga till primärnyckel till tabellen @table: primärnyckeln finns "
+"redan."
 
 msgid "Cannot add unique key @name to table @table: table doesn't exist."
 msgstr ""
+"Kan inte lägga till den unika nyckeln @name till tabellen @table: tabellen "
+"finns inte."
 
 msgid ""
 "Cannot add unique key @name to table @table: unique key already exists."
 msgstr ""
+"Kan inte lägga till den unika nyckeln @name till tabellen @table: den unika "
+"nyckeln finns redan."
 
 msgid "Cannot add index @name to table @table: table doesn't exist."
 msgstr ""
+"Kan inte lägga till index @name till tabellen @table: tabellen finns inte."
 
 msgid "Cannot add index @name to table @table: index already exists."
 msgstr ""
+"Kan inte lägga till index @name till tabellen @table: index finns redan."
 
 msgid ""
 "Cannot change the definition of field @table.@name: field doesn't exist."
-msgstr ""
+msgstr "Kan inte ändra definitionen av fält @table.@name: fält finns inte."
 
 msgid ""
 "Cannot rename field @table.@name to @name_new: target field already exists."
 msgstr ""
+"Kan inte byta namn på fält @table.@name till @name_new: målfält finns redan."
 
 msgid "Boolean value"
-msgstr ""
+msgstr "Booleskt värde"
 
 msgid "The referenced entity"
-msgstr ""
+msgstr "Det refererade objektet"
 
 msgid "Integer value"
-msgstr ""
+msgstr "Värde för heltal"
 
 msgid "Language object"
-msgstr ""
+msgstr "Språkobjekt"
 
 msgid "Text value"
-msgstr ""
+msgstr "Textvärde"
 
 msgid ""
 "A unique label for this advanced action. This label will be displayed in the"
 " interface of modules that integrate with actions."
 msgstr ""
+"En unik etikett för denna avancerade åtgärd. Denna etikett kommer att visas "
+"i gränssnittet av moduler som kan integreras med åtgärder."
 
 msgid "Aggregator refresh"
-msgstr ""
+msgstr "Uppdatera nyhetssamlare"
 
 msgid "The feed from %site seems to be broken because of error \"%error\"."
-msgstr ""
+msgstr "Flödet från %site verkar inte fungera på grund av felet \"%error\"."
 
 msgid "This IP address is already banned."
-msgstr ""
+msgstr "Denna IP-adress är redan spärrad."
 
 msgid "You may not ban your own IP address."
-msgstr ""
+msgstr "Du kan inte spärra din egen IP-adress."
 
 msgid "Banning IP addresses"
-msgstr ""
+msgstr "Spärrar IP-adresser"
 
 msgid ""
 "IP addresses listed here are banned from your site. Banned addresses are "
 "completely forbidden from accessing the site and instead see a brief message"
 " explaining the situation."
 msgstr ""
+"IP-adresser som visas här är spärrade från din webbplats. Spärrade adresser "
+"är helt förbjudna från att komma åt webbplatsen och kommer istället se ett "
+"kort meddelande som förklarar situationen."
 
 msgid "Ban IP addresses"
-msgstr ""
+msgstr "Spärra IP-adresser"
 
 msgid "IP address bans"
-msgstr ""
+msgstr "Spärr av IP-adresser"
 
 msgid "Perform tasks on specific events triggered within the system."
-msgstr ""
+msgstr "Perform tasks on specific events triggered within the system."
 
 msgid "List additional actions"
-msgstr ""
+msgstr "Visa fler åtgärder"
 
 msgid "Enables banning of IP addresses."
-msgstr ""
+msgstr "Enables banning of IP addresses."
 
 msgid "You must enter a valid hexadecimal color value for %name."
-msgstr ""
+msgstr "Du måste ange ett giltigt hexadecimalt färgvärde för %name."
 
 msgid "Database Logging"
-msgstr ""
+msgstr "Loggning av databas"
 
 msgid "Trim link text length"
-msgstr ""
+msgstr "Korta ned längd på länktext"
 
 msgid "Leave blank to allow unlimited link text lengths."
-msgstr ""
+msgstr "Lämna tomt för att tillåta oändliga längder på länktext."
 
 msgid "URL only"
-msgstr ""
+msgstr "Enbart URL"
 
 msgid "Show URL as plain text"
-msgstr ""
+msgstr "Visa URL som ren text"
 
 msgid "Add rel=\"nofollow\" to links"
-msgstr ""
+msgstr "Lägg till rel=\"nofollow\" till länkar"
 
 msgid "Link text trimmed to @limit characters"
-msgstr ""
+msgstr "Link text trimmed to @limit characters"
 
 msgid "Link text not trimmed"
-msgstr ""
+msgstr "Link text not trimmed"
 
 msgid "Show URL only as plain-text"
-msgstr ""
+msgstr "Visa enbart URL som ren text"
 
 msgid "Show URL only"
-msgstr ""
+msgstr "Visa enbart URL"
 
 msgid "Add rel=\"@rel\""
-msgstr ""
+msgstr "Lägg till rel=\"@rel\""
 
 msgid "Thin space"
-msgstr ""
+msgstr "Tunt utrymme"
 
 msgid "Processed text"
-msgstr ""
+msgstr "Behandlad text"
 
 msgid "Re-use existing field: you need to provide a label."
-msgstr ""
+msgstr "Återanvänd befintligt fält: du måste tillhandahålla en etikett."
 
 msgid ""
 "The specified file %file could not be copied because the destination is "
 "invalid. More information is available in the system log."
 msgstr ""
+"The specified file %file could not be copied because the destination is "
+"invalid. More information is available in the system log."
 
 msgid ""
 "The specified file %file could not be moved because the destination is "
 "invalid. More information is available in the system log."
 msgstr ""
+"The specified file %file could not be moved because the destination is "
+"invalid. More information is available in the system log."
 
 msgid ""
 "The data could not be saved because the destination is invalid. More "
 "information is available in the system log."
 msgstr ""
+"Data kunde inte sparas eftersom destinationen är felaktig. Mer information "
+"finns i systemloggen."
 
 msgid ""
 "File %file (%realpath) could not be copied because the destination "
 "%destination is invalid. This is often caused by improper use of file_copy()"
 " or a missing stream wrapper."
 msgstr ""
+"Fil %file (%realpath) kunde inte kopieras eftersom målet  %destination är "
+"ogiltigt. Detta orsakas ofta av felaktig användning av file_copy() eller "
+"avsaknad av stream wrapper."
 
 msgid ""
 "File %file could not be copied because the destination %destination is "
 "invalid. This is often caused by improper use of file_copy() or a missing "
 "stream wrapper."
 msgstr ""
+"Fil %file kunde inte kopieras eftersom målet  %destination är ogiltigt. "
+"Detta orsakas ofta av felaktig användning av file_copy() eller avsaknad av "
+"stream wrapper."
 
 msgid ""
 "File %file (%realpath) could not be moved because the destination "
 "%destination is invalid. This may be caused by improper use of file_move() "
 "or a missing stream wrapper."
 msgstr ""
+"Fil %file (%realpath) kunde inte flyttas eftersom målet  %destination är "
+"ogiltigt. Detta orsakas ofta av felaktig användning av file_move() eller "
+"avsaknad av stream wrapper."
 
 msgid ""
 "File %file could not be moved because the destination %destination is "
 "invalid. This may be caused by improper use of file_move() or a missing "
 "stream wrapper."
 msgstr ""
+"Fil %file kunde inte flyttas eftersom målet  %destination är ogiltigt. Detta"
+" orsakas ofta av felaktig användning av file_move() eller avsaknad av stream"
+" wrapper."
 
 msgid ""
 "Did not delete temporary file \"%path\" during garbage collection because it"
 " is in use by the following modules: %modules."
 msgstr ""
+"Did not delete temporary file \"%path\" during garbage collection because it"
+" is in use by the following modules: %modules."
 
 msgid "Are you sure you want to delete the forum %label?"
-msgstr ""
+msgstr "Är du säker på att du vill radera forumet %label?"
 
 msgid "Edit style %name"
-msgstr ""
+msgstr "Redigera stil %name"
 
 msgid "Error generating image, missing source file."
-msgstr ""
+msgstr "Error generating image, missing source file."
 
 msgid "Set @title as default"
-msgstr ""
+msgstr "Ställ in @title som förvalt"
 
 msgid "Custom language..."
-msgstr ""
+msgstr "Custom language..."
 
 msgid ""
 "Fill in the language details and save the language with <em>Add custom "
 "language</em>."
 msgstr ""
+"Fill in the language details and save the language with <em>Add custom "
+"language</em>."
 
 msgid "The language %language (%langcode) already exists."
-msgstr ""
+msgstr "Språket %language (%langcode) finns redan."
 
 msgid "Use the <em>Add language</em> button to save a predefined language."
-msgstr ""
+msgstr "Use the <em>Add language</em> button to save a predefined language."
 
 msgid "The language %language has been created and can now be used."
-msgstr ""
+msgstr "The language %language has been created and can now be used."
 
 msgid "The %language (%langcode) language has been removed."
-msgstr ""
+msgstr "Språket %language (%langcode) har tagits bort."
 
 msgid "Path prefix configuration"
-msgstr ""
+msgstr "Path prefix configuration"
 
 msgid "Domain configuration"
-msgstr ""
+msgstr "Konfiguration av domän"
 
 msgid "%language (%langcode) path prefix (Default language)"
-msgstr ""
+msgstr "Sökvägsprefix för %language (%langcode) (förvalt språk)"
 
 msgid "%language (%langcode) path prefix"
-msgstr ""
+msgstr "Sökvägsprefix för %language (%langcode)"
 
 msgid "%language (%langcode) domain"
-msgstr ""
+msgstr "Domän för %language (%langcode)"
 
 msgid "The prefix may not contain a slash."
-msgstr ""
+msgstr "The prefix may not contain a slash."
 
 msgid "The prefix for %language, %value, is not unique."
-msgstr ""
+msgstr "The prefix for %language, %value, is not unique."
 
 msgid "The domain for %language, %value, is not unique."
-msgstr ""
+msgstr "The domain for %language, %value, is not unique."
 
 msgid "Existing languages"
-msgstr ""
+msgstr "Befintliga språk"
 
 msgid "Add a new mapping"
-msgstr ""
+msgstr "Lägg till en ny mappning"
 
 msgid "Browser language code"
-msgstr ""
+msgstr "Språkkod för webbläsare"
 
 msgid "Browser language codes must be unique."
-msgstr ""
+msgstr "Språkkoder för webbläsare måste vara unika."
 
 msgid ""
 "Browser language codes can only contain lowercase letters and a hyphen(-)."
 msgstr ""
+"Språkkoder för webbläsare kan endast innehålla små bokstäver och ett "
+"bindestreck (-)."
 
 msgid "Are you sure you want to delete %browser_langcode?"
-msgstr ""
+msgstr "Är du säker på att du vill radera  %browser_langcode?"
 
 msgid ""
 "Add a language to be supported by your site. If your desired language is not"
 " available, pick <em>Custom language...</em> at the end and provide a "
 "language code and other details manually."
 msgstr ""
+"Lägg till ett språk som stöds av din webbplats. Om ditt önskade språk inte "
+"är tillgängligt välj då <em>Anpassat språk...</em> i slutet och mata in en "
+"språkkod och andra detaljer manuellt."
 
 msgid "- @name -"
-msgstr ""
+msgstr "- @name -"
 
 msgid "Language from the URL (Path prefix or domain)."
-msgstr ""
+msgstr "Language from the URL (Path prefix or domain)."
 
 msgid "Language from a request/session parameter."
-msgstr ""
+msgstr "Language from a request/session parameter."
 
 msgid "Language from the browser's language settings."
-msgstr ""
+msgstr "Language from the browser's language settings."
 
 msgid "Account administration pages"
-msgstr ""
+msgstr "Administrationssidor för konto"
 
 msgid "Account administration pages language setting."
-msgstr ""
+msgstr "Språkinställning för administrationssidor för konto."
 
 msgid "The %language (%langcode) language has been created."
-msgstr ""
+msgstr "Språket %language (%langcode) har skapats."
 
 msgid "The %language (%langcode) language has been updated."
-msgstr ""
+msgstr "Språket %language (%langcode) har uppdaterats."
 
 msgid "Browser language detection configuration"
-msgstr ""
+msgstr "Konfiguration av språkidentifiering för webbläsare"
 
 msgid "A Gettext Portable Object file."
-msgstr ""
+msgstr "En fil av typ Gettext Portable Object."
 
 msgid "Treat imported strings as custom translations"
-msgstr ""
+msgstr "Behandla importerade strängar som anpassade översättningar"
 
 msgid "Overwrite non-customized translations"
-msgstr ""
+msgstr "Skriv över ej anpassade översättningar"
 
 msgid "Overwrite existing customized translations"
-msgstr ""
+msgstr "Skriv över existerande anpassade översättningar"
 
 msgid "No language available. The export will only contain source strings."
 msgstr ""
+"Inget språk tillgängligt. Exporten kommer endast innehålla källsträngar."
 
 msgid "@count disallowed HTML string(s) in files: @files."
-msgstr ""
+msgstr "@count otillåtna HTML-sträng(ar) i filer: @files."
 
 msgid "In Context"
-msgstr ""
+msgstr "I sammanhang"
 
 msgid "First plural form"
 msgid_plural "@count. plural form"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "First plural form"
+msgstr[1] "@count. plural form"
 
 msgid "Interface translation"
-msgstr ""
+msgstr "Översättning av gränssnitt"
 
 msgid "@translated/@total (@ratio%)"
-msgstr ""
+msgstr "@translated/@total (@ratio%)"
 
 msgid "not applicable"
-msgstr ""
+msgstr "not applicable"
 
 msgid "Enable interface translation to English"
-msgstr ""
+msgstr "Aktivera översättning av gränssnitt till engelska"
 
 msgid "Interface translations directory"
-msgstr ""
+msgstr "Katalog för översättning av gränssnitt"
 
 msgid ""
 "Removed JavaScript translation file for the language %language because no "
 "translations currently exist for that language."
 msgstr ""
+"Removed JavaScript translation file for the language %language because no "
+"translations currently exist for that language."
 
 msgid ""
 "Import of string \"%string\" was skipped because of disallowed or malformed "
 "HTML."
 msgstr ""
+"Import av sträng \"%string\" hoppades över på grund av otillåten eller "
+"felaktig HTML."
 
 msgid "logged in users only"
-msgstr ""
+msgstr "logged in users only"
 
 msgid "Author's preferred language"
-msgstr ""
+msgstr "Författares förvalda språk"
 
 msgid ""
 "%type is used by 1 piece of content on your site. You can not remove this "
@@ -13874,66 +14995,78 @@ msgid_plural ""
 "%type is used by @count pieces of content on your site. You may not remove "
 "%type until you have removed all of the %type content."
 msgstr[0] ""
+"%type används av 1 del av innehåll på din webbplats. Du kan inte ta bort "
+"%type förrän du har tagit bort allt innehåll av typ %type."
 msgstr[1] ""
+"%type används av @count delar av innehåll på din webbplats. Du får inte ta "
+"bort %type förrän du har tagit bort allt innehåll av typ %type."
 
 msgid "The language code of the language the node is written in."
-msgstr ""
+msgstr "The language code of the language the node is written in."
 
 msgid ""
 "Query tagged for node access but there is no node table, specify the "
 "base_table using meta data."
 msgstr ""
+"Query tagged for node access but there is no node table, specify the "
+"base_table using meta data."
 
 msgid "Briefly describe the changes you have made."
-msgstr ""
+msgstr "Beskriv kortfattat de ändringar du har gjort."
 
 msgid "@name format: @date"
-msgstr ""
+msgstr "@name format: @date"
 
 msgid "Non-customized translation"
-msgstr ""
+msgstr "Non-customized translation"
 
 msgid "Customized translation"
-msgstr ""
+msgstr "Customized translation"
 
 msgid "Translation type"
-msgstr ""
+msgstr "Typ av översättning"
 
 msgid "Include non-customized translations"
-msgstr ""
+msgstr "Inkludera ej anpassade översättningar"
 
 msgid "Include customized translations"
-msgstr ""
+msgstr "Inkludera anpassade översättningar"
 
 msgid "Include untranslated text"
-msgstr ""
+msgstr "Inkludera ej översatt text"
 
 msgid "The strings have been saved."
-msgstr ""
+msgstr "Strängarna har sparats."
 
 msgid ""
 "A path alias set for a specific language will always be used when displaying"
 " this page in that language, and takes precedence over path aliases set as "
 "<em>- None -</em>."
 msgstr ""
+"Ett sökvägsalias för ett givet språk kommer alltid användas vid visning av "
+"denna sida i det språket och har företräde framför sökvägsalias inställda "
+"som <em>- Ingen -</em>."
 
 msgid "Use the default shortcut icon supplied by the theme"
-msgstr ""
+msgstr "Använd den förvalda genvägsikonen från temat"
 
 msgid ""
 "Examples: <code>@implicit-public-file</code> (for a file in the public "
 "filesystem), <code>@explicit-file</code>, or <code>@local-file</code>."
 msgstr ""
+"Examples: <code>@implicit-public-file</code> (for a file in the public "
+"filesystem), <code>@explicit-file</code>, or <code>@local-file</code>."
 
 msgid "Message to display when in maintenance mode"
-msgstr ""
+msgstr "Meddelande att visa vid underhållsläge"
 
 msgid "This theme requires the base theme @base_theme to operate correctly."
-msgstr ""
+msgstr "This theme requires the base theme @base_theme to operate correctly."
 
 msgid ""
 "This theme requires the theme engine @theme_engine to operate correctly."
 msgstr ""
+"This theme requires the theme engine @theme_engine to operate correctly."
 
 msgid ""
 "Use maintenance mode when making major updates, particularly if the updates "
@@ -13941,184 +15074,219 @@ msgid ""
 "importing or exporting content, modifying a theme, modifying content types, "
 "and making backups."
 msgstr ""
+"Use maintenance mode when making major updates, particularly if the updates "
+"could disrupt visitors or the update process. Examples include upgrading, "
+"importing or exporting content, modifying a theme, modifying content types, "
+"and making backups."
 
 msgid "A language object."
-msgstr ""
+msgstr "Ett språkobjekt."
 
 msgid "All kind of entities, e.g. nodes, comments or users."
 msgstr ""
+"Alla typer av objekt, till exempel noder, kommentarer eller användare."
 
 msgid "An entity field containing a boolean value."
-msgstr ""
+msgstr "Ett objektsfält som innehåller ett booleskt värde."
 
 msgid "An entity field referencing a language."
-msgstr ""
+msgstr "Ett objektsfält som refererar ett språk."
 
 msgid "An entity field containing an entity reference."
-msgstr ""
+msgstr "Ett fältobjekt som innehåller en objektsreferens."
 
 msgid ""
 "The directory %file is not protected from modifications and poses a security"
 " risk. You must change the directory's permissions to be non-writable."
 msgstr ""
+"The directory %file is not protected from modifications and poses a security"
+" risk. You must change the directory's permissions to be non-writable."
 
 msgid "Configuration directories"
-msgstr ""
+msgstr "Konfiguration av kataloger"
 
 msgid "Apply pending updates"
-msgstr ""
+msgstr "Tillämpa väntande uppdateringar"
 
 msgid ""
 "Translation is not supported if language is always one of: @locked_languages"
-msgstr ""
+msgstr "Översättning stöds inte om språk alltid är en av: @locked_languages"
 
 msgid "HTTP request to @url failed with error: @error."
-msgstr ""
+msgstr "HTTP request to @url failed with error: @error."
 
 msgid "Update Manager"
-msgstr ""
+msgstr "Update Manager"
 
 msgid ""
 "The name for this role. Example: \"Moderator\", \"Editorial board\", \"Site "
 "architect\"."
-msgstr ""
+msgstr "Namnet för denna roll. Exempel: \"Moderator\", \"Redaktion\", \"Webbarkitekt\"."
 
 msgid "User module 'member for' view element."
-msgstr ""
+msgstr "Visningselement \"medlem i\" för användarmodul."
 
 msgid ""
 "This is also assumed to be the primary language of this account's profile "
 "information."
 msgstr ""
+"Det här förutsätt också vara det primära språket för detta kontots "
+"profilinformation."
 
 msgid "Administration pages language"
-msgstr ""
+msgstr "Administrering av språksidor"
 
 msgid ""
 "Build a custom site without pre-configured functionality. Suitable for "
 "advanced users."
 msgstr ""
+"Bygg en anpassad webbplats utan förkonfigurerad funktionalitet. Passar "
+"avancerade användare."
 
 msgid "Header background top"
-msgstr ""
+msgstr "Överst i bakgrund på sidhuvud"
 
 msgid "Header background bottom"
-msgstr ""
+msgstr "Underst i bakgrund på sidhuvud"
 
 msgid "Site's default language (@lang_name)"
-msgstr ""
+msgstr "Webbplatsens förvalda språk (@lang_name)"
 
 msgid "Installation profile"
-msgstr ""
+msgstr "Installationsprofil"
 
 msgid "Selected language"
-msgstr ""
+msgstr "Valt språk"
 
 msgid "Expose sort order"
-msgstr ""
+msgstr "Expose sort order"
 
 msgid "Use a custom %field_name"
-msgstr ""
+msgstr "Använd ett anpassat %field_name"
 
 msgid "Validation settings"
-msgstr ""
+msgstr "Validation settings"
 
 msgid "Language Code"
-msgstr ""
+msgstr "Language Code"
 
 msgid "@dir can not be opened"
-msgstr ""
+msgstr "@dir kan inte öppnas"
 
 msgid ""
 "Breakpoints can be organized into groups. Modules and themes should use "
 "groups to separate out breakpoints that are meant to be used for different "
 "purposes, such as breakpoints for layouts or breakpoints for image sizing."
 msgstr ""
+"Breakpoints can be organized into groups. Modules and themes should use "
+"groups to separate out breakpoints that are meant to be used for different "
+"purposes, such as breakpoints for layouts or breakpoints for image sizing."
 
 msgid "Parent permalink"
-msgstr ""
+msgstr "Ovanliggande permanent länk"
 
 msgid "Save and manage fields"
-msgstr ""
+msgstr "Spara och hantera fält"
 
 msgid "Image removed."
-msgstr ""
+msgstr "Bild borttagen."
 
 msgid ""
 "This image has been removed. For security reasons, only images from the "
 "local domain are allowed."
 msgstr ""
+"This image has been removed. For security reasons, only images from the "
+"local domain are allowed."
 
 msgid "Only images hosted on this site may be used in &lt;img&gt; tags."
 msgstr ""
+"Enbart filer som finns på den här webbplatsen får användas i taggar av typ "
+"&lt;img&gt;."
 
 msgid ""
 "An error occurred trying to check available interface translation updates."
 msgstr ""
+"Ett fel inträffade vid försök att kontrollera tillgängliga uppdateringar för"
+" gränssnittsöversättning."
 
 msgid "Checked available interface translation updates for one project."
 msgid_plural ""
 "Checked available interface translation updates for @count projects."
 msgstr[0] ""
+"Kontrollerade tillgängliga uppdateringar för gränssnittsöversättning för ett"
+" projekt."
 msgstr[1] ""
+"Kontrollerade tillgängliga uppdateringar för gränssnittsöversättning för "
+"@count projekt."
 
 msgid ""
 "Optionally, specify a relative URL to display as the front page. Leave blank"
 " to display the default front page."
 msgstr ""
+"Optionally, specify a relative URL to display as the front page. Leave blank"
+" to display the default front page."
 
 msgid "Vocabulary language"
-msgstr ""
+msgstr "Språk för term"
 
 msgid "The role machine-name of the role."
-msgstr ""
+msgstr "Det maskinläsbara rollnamnet"
 
 msgid "The base table used for this view."
-msgstr ""
+msgstr "Bastabellen som används för den här vyn."
 
 msgid "The base field used for this view."
-msgstr ""
+msgstr "Basfältet som används för den här vyn."
 
 msgid ""
 "The total amount of results returned from the view. The current display will"
 " be used."
 msgstr ""
+"Det totala antalet resultat som återges från vyn. Den aktuella visningen "
+"kommer användas."
 
 msgid "The number of items per page."
-msgstr ""
+msgstr "Antal poster per sida."
 
 msgid "The current page of results the view is on."
-msgstr ""
+msgstr "Den aktuella resultatsidan som vyn är på."
 
 msgid "The total page count."
-msgstr ""
+msgstr "Det totala antalet sidräkningar."
 
 msgid ""
 "Override the default view title for this view. This is useful to display an "
 "alternative title when a view is empty."
 msgstr ""
+"Åsidosätt den förvalda vytiteln för den här vyn. Det här är användbart för "
+"att visa en alternativ titel när en vy är tom."
 
 msgid "Overridden title"
-msgstr ""
+msgstr "Åsidosatt titel"
 
 msgid "Tracker - User"
-msgstr ""
+msgstr "Spårare - Användare"
 
 msgid ""
 "Whether or not the node is published. You must use an argument or filter on "
 "UID or you will get misleading results using this field."
 msgstr ""
+"Huruvida noden är publicerad eller ej. Du måste använda ett argument eller "
+"filtrera på UID annars kommer du få missvisande resultat med hjälp av detta "
+"fält."
 
 msgid "The translation authoring username %name does not exist."
-msgstr ""
+msgstr "The translation authoring username %name does not exist."
 
 msgid "You have to specify a valid translation authoring date."
-msgstr ""
+msgstr "You have to specify a valid translation authoring date."
 
 msgid ""
 "Database %database not found. The server reports the following message when "
 "attempting to create the database: %error."
 msgstr ""
+"Databas %database hittades inte. Servern rapporterar följande meddelande vid"
+" försök att skapa databasen: %error."
 
 msgid ""
 "Failed to connect to your database server. The server reports the following "
@@ -14128,80 +15296,89 @@ msgid ""
 "name?</li><li>Have you entered the correct username and "
 "password?</li><li>Have you entered the correct database hostname?</li></ul>"
 msgstr ""
+"Det gick inte att ansluta till databasservern. Servern rapporterar följande "
+"meddelande: %error.<ul><li>Körs databasservern?</li><li>Finns databasen "
+"eller har användaren för databasen tillräckliga behörigheter för att skapa "
+"databasen?</li><li>Har du angivit rätt databasnamn?</li><li>Har du angivit "
+"rätt användarnamn och lösenord?</li><li>Har du angivit rätt värdnamn för "
+"databasen?</li></ul>"
 
 msgid "Install another module"
-msgstr ""
+msgstr "Installera en annan modul"
 
 msgid "Are you sure you want to unblock %ip?"
-msgstr ""
+msgstr "Är du säker på att du vill ta bort spärr av %ip?"
 
 msgid "Import all"
-msgstr ""
+msgstr "Importera alla"
 
 msgid "Another request may be synchronizing configuration already."
-msgstr ""
+msgstr "En annan begäran kanske synkroniserar konfiguration redan."
 
 msgid "The configuration was imported successfully."
-msgstr ""
+msgstr "Konfigurationen importerades utan problem."
 
 msgid "@count new"
 msgid_plural "@count new"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count nytt"
+msgstr[1] "@count nya"
 
 msgid "@count changed"
 msgid_plural "@count changed"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count ändrad"
+msgstr[1] "@count ändrade"
 
 msgid "@count removed"
 msgid_plural "@count removed"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count borttaget"
+msgstr[1] "@count borttagna"
 
 msgid "Synchronize configuration"
-msgstr ""
+msgstr "Synkronisera konfiguration"
 
 msgid "Flag other translations as outdated"
-msgstr ""
+msgstr "Märk andra översättningar som föråldrade"
 
 msgid "Do not flag other translations as outdated"
-msgstr ""
+msgstr "Märk inte andra översättningar som föråldrade"
 
 msgid "Example: 'Hero image' or 'Author image'."
-msgstr ""
+msgstr "Exempel: \"Hjältebild\" eller \"Författarbild\"."
 
 msgid "Breakpoint group"
-msgstr ""
+msgstr "Brytpunktsgrupp"
 
 msgid "Select an image style for this breakpoint."
-msgstr ""
+msgstr "Välj en bildstil för denna brytpunkt."
 
 msgid "Base field"
-msgstr ""
+msgstr "Basfält"
 
 msgid "Manage customized lists of content."
-msgstr ""
+msgstr "Hantera anpassade listor av innehåll."
 
 msgid "Add and enable modules to extend site functionality."
 msgstr ""
+"Lägg till och aktivera moduler för att utöka webbplatsens funktionalitet."
 
 msgid "User account actions"
-msgstr ""
+msgstr "Åtgärder för användarkonto"
 
 msgid "View profile"
-msgstr ""
+msgstr "Visa profil"
 
 msgid ""
 "Provides an image formatter and breakpoint mappings to output responsive "
 "images using the HTML5 picture tag."
 msgstr ""
+"Provides an image formatter and breakpoint mappings to output responsive "
+"images using the HTML5 picture tag."
 
 msgid "Administrative interface for Views."
-msgstr ""
+msgstr "Administrativt gränssnitt för Views."
 
 msgid "Access @method on %label resource"
-msgstr ""
+msgstr "Åtkomst till @method på resurs %label"
 
 msgid ""
 "By default SimpleTest will clear the results after they have been viewed on "
@@ -14212,18 +15389,25 @@ msgid ""
 "the results the first time. Additionally, some modules may provide more "
 "analysis or features that require this setting to be disabled."
 msgstr ""
+"By default SimpleTest will clear the results after they have been viewed on "
+"the results page, but in some cases it may be useful to leave the results in"
+" the database. The results can then be viewed at "
+"<em>admin/config/development/testing/results/[test_id]</em>. The test ID can"
+" be found in the database, simpletest table, or kept track of when viewing "
+"the results the first time. Additionally, some modules may provide more "
+"analysis or features that require this setting to be disabled."
 
 msgid "Displayed as %date_format"
-msgstr ""
+msgstr "Visad som %date_format"
 
 msgid "Enabling translation"
-msgstr ""
+msgstr "Aktiverar översättning"
 
 msgid "Create %language translation of %title"
-msgstr ""
+msgstr "Skapa %language översättning för %title"
 
 msgid "Source language: @language"
-msgstr ""
+msgstr "Källspråk: @language"
 
 msgid ""
 "If you made a significant change, which means the other translations should "
@@ -14231,304 +15415,321 @@ msgid ""
 "will not change any other property of them, like whether they are published "
 "or not."
 msgstr ""
+"If you made a significant change, which means the other translations should "
+"be updated, you can flag all translations of this content as outdated. This "
+"will not change any other property of them, like whether they are published "
+"or not."
 
 msgid ""
 "When this option is checked, this translation needs to be updated. Uncheck "
 "when the translation is up to date again."
 msgstr ""
+"When this option is checked, this translation needs to be updated. Uncheck "
+"when the translation is up to date again."
 
 msgid "Source language set to: %language"
-msgstr ""
+msgstr "Källspråk satt till: %language"
 
 msgid "This will delete all the translations of %label."
-msgstr ""
+msgstr "Detta kommer radera alla översättningarna för %label."
 
 msgid "No path is set"
-msgstr ""
+msgstr "Ingen sökväg är inställd"
 
 msgid "@type: @field"
-msgstr ""
+msgstr "@type: @field"
 
 msgid "View differences"
-msgstr ""
+msgstr "Visa skillnader"
 
 msgid "Menu language"
-msgstr ""
+msgstr "Språk för meny"
 
 msgid "Block types"
-msgstr ""
+msgstr "Blocktyper"
 
 msgid "@field_name"
-msgstr ""
+msgstr "@field_name"
 
 msgid "Access in-place editing"
-msgstr ""
+msgstr "Åtkomst till redigering direkt"
 
 msgid "Updated the %field-name field through in-place editing."
-msgstr ""
+msgstr "Uppdaterade fältet %field-name genom redigering på plats."
 
 msgid "No item selected."
-msgstr ""
+msgstr "Inga post vald."
 
 msgid "Modified timestamp"
-msgstr ""
+msgstr "Modified timestamp"
 
 msgid "Are you sure you want to delete the @entity-type %label?"
-msgstr ""
+msgstr "Är du säker på att du vill radera @entity-type %label?"
 
 msgid "The @entity-type %label has been deleted."
-msgstr ""
+msgstr "@entity-type %label har tagits bort."
 
 msgid "Edit %label"
-msgstr ""
+msgstr "Redigera %label"
 
 msgid "Add @bundle"
-msgstr ""
+msgstr "Lägg till @bundle"
 
 msgid "Reference type"
-msgstr ""
+msgstr "Typ av referens"
 
 msgid "Delete state"
-msgstr ""
+msgstr "Delete state"
 
 msgid "South Sudan"
-msgstr ""
+msgstr "Sydsudan"
 
 msgid "Custom output for TRUE"
-msgstr ""
+msgstr "Anpassad utmatning för SANT"
 
 msgid "Custom output for FALSE"
-msgstr ""
+msgstr "Anpassad utmatning för FALSKT"
 
 msgid ""
 "Thank you for applying for an account. Your account is currently pending "
 "approval by the site administrator.<br />In the meantime, a welcome message "
 "with further instructions has been sent to your email address."
 msgstr ""
+"Tack för din ansökan om ett konto. Ditt konto väntar för närvarande på "
+"godkännande av webbplatsens administratör.<br />Under tiden har ett "
+"välkomstmeddelande med vidare instruktioner skickats till din e-postadress."
 
 msgid ""
 "An unrecoverable error has occurred. You can find the error message below. "
 "It is advised to copy it to the clipboard for reference."
 msgstr ""
+"An unrecoverable error has occurred. You can find the error message below. "
+"It is advised to copy it to the clipboard for reference."
 
 msgid "Place block"
-msgstr ""
+msgstr "Placera block"
 
 msgid "Port number"
-msgstr ""
+msgstr "Portnummer"
 
 msgid "Revision timestamp"
-msgstr ""
+msgstr "Revision timestamp"
 
 msgid "Administer account settings"
-msgstr ""
+msgstr "Administrera kontoinställningar"
 
 msgid "Entity language"
-msgstr ""
+msgstr "Entity language"
 
 msgid "Hide empty"
-msgstr ""
+msgstr "Dölj tomma"
 
 msgid "Quick Edit"
-msgstr ""
+msgstr "Quick Edit"
 
 msgid "Revision Log message"
-msgstr ""
+msgstr "Revision Log message"
 
 msgid "The translation set id for this node"
-msgstr ""
+msgstr "The translation set id for this node"
 
 msgid "Registered timestamp"
-msgstr ""
+msgstr "Registered timestamp"
 
 msgid "Signature format"
-msgstr ""
+msgstr "Format på signatur"
 
 msgid "Init"
-msgstr ""
+msgstr "Initialisera"
 
 msgid "Update form"
-msgstr ""
+msgstr "Uppdatera formulär"
 
 msgid "HTTP Basic Authentication"
-msgstr ""
+msgstr "HTTP Basic Authentication"
 
 msgid "Storage settings"
-msgstr ""
+msgstr "Inställningar för lagring"
 
 msgid "File added"
-msgstr ""
+msgstr "Fil tillagd"
 
 msgid "File removed"
-msgstr ""
+msgstr "Fil borttagen"
 
 msgid "Translate configuration"
-msgstr ""
+msgstr "Konfiguration av översättning"
 
 msgid "Translations directory"
-msgstr ""
+msgstr "Översättningskatalog"
 
 msgid "The translations directory does not exist."
-msgstr ""
+msgstr "Översättningskatalogen finns inte."
 
 msgid "The translations directory is not readable."
-msgstr ""
+msgstr "Översättningskatalogen är inte läsbar."
 
 msgid "The translations directory is not writable."
-msgstr ""
+msgstr "Översättningskatalogen är inte skrivbar."
 
 msgid "The translations directory is writable."
-msgstr ""
+msgstr "Översättningskatalogen är skrivbar."
 
 msgid "The translation server is offline."
-msgstr ""
+msgstr "Översättningsservern är nedkopplad."
 
 msgid "The translation server is online."
-msgstr ""
+msgstr "Översättningsservern är tillgänglig."
 
 msgid "The %language translation is not available."
-msgstr ""
+msgstr "Översättning för %language är inte tillgänglig."
 
 msgid "The %language translation is available."
-msgstr ""
+msgstr "Översättning för %language är tillgänglig."
 
 msgid "The %language translation could not be downloaded."
-msgstr ""
+msgstr "Översättningen för %language kunde inte laddas ned."
 
 msgid "Not blank"
-msgstr ""
+msgstr "Inte tom"
 
 msgid "You have unsaved changes."
-msgstr ""
+msgstr "Du har ändringar som inte sparats."
 
 msgid "Allows users to apply an action to one or more items."
 msgstr ""
+"Gör det möjligt för användare att tillämpa en åtgärd för ett eller flera "
+"objekt."
 
 msgid ""
 "A unique name for this action. It must only contain lowercase letters, "
 "numbers and underscores."
 msgstr ""
+"Ett unikt namn för denna åtgärd. Det får endast innehålla små bokstäver, "
+"siffror och understreck."
 
 msgid "All actions, except selected"
-msgstr ""
+msgstr "Alla åtgärder förutom valda"
 
 msgid "Only selected actions"
-msgstr ""
+msgstr "Enbart valda åtgärder"
 
 msgid "Selected actions"
-msgstr ""
+msgstr "Valda åtgärder"
 
 msgid "%action was applied to @count item."
 msgid_plural "%action was applied to @count items."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%action genomfördes på @count post."
+msgstr[1] "%action genomfördes på @count poster."
 
 msgid "The feed language code."
-msgstr ""
+msgstr "Språkkod för flödet."
 
 msgid "Time when this feed was queued for refresh, 0 if not queued."
-msgstr ""
+msgstr "Tid när detta flöde köades för uppdatering. 0 om ej köad."
 
 msgid "The link of the feed."
-msgstr ""
+msgstr "Länken för flödet."
 
 msgid "Calculated hash of the feed data, used for validating cache."
-msgstr ""
+msgstr "Beräknat hashvärde av flödesdata, som används för att bekräfta cache."
 
 msgid "Etag"
-msgstr ""
+msgstr "Etagg"
 
 msgid "The ID of the aggregator feed."
-msgstr ""
+msgstr "ID-numret för nyhetssamlarens flöde."
 
 msgid "The title of the feed item."
-msgstr ""
+msgstr "Titeln för posten på flödet."
 
 msgid "The feed item language code."
-msgstr ""
+msgstr "Språkkoden för posten på flödet."
 
 msgid "The link of the feed item."
-msgstr ""
+msgstr "Länken till posten på flödet."
 
 msgid "The author of the feed item."
-msgstr ""
+msgstr "Författaren till posten på flödet."
 
 msgid "The body of the feed item."
-msgstr ""
+msgstr "Brödtexten till posten på flödet."
 
 msgid "Posted date of the feed item, as a Unix timestamp."
-msgstr ""
+msgstr "Datum för inlägg för posten på flödet. Som en UNIX-tidsstämpel."
 
 msgid "Failed to download OPML file due to \"%error\"."
-msgstr ""
+msgstr "Misslyckades med att ladda ned OPML-fil på grund av \"%error\"."
 
 msgid "Edit custom block %label"
-msgstr ""
+msgstr "Redigera anpassat block %label"
 
 msgid "Custom block types"
-msgstr ""
+msgstr "Anpassade blocktyper"
 
 msgid "Add custom block type"
-msgstr ""
+msgstr "Lägg till anpassad blocktyp"
 
 msgid "@type %info has been created."
-msgstr ""
+msgstr "@type %info har skapats."
 
 msgid "@type %info has been updated."
-msgstr ""
+msgstr "@type %info har uppdaterats."
 
 msgid "@type: added %info."
-msgstr ""
+msgstr "@type: lades till %info."
 
 msgid "@type: updated %info."
-msgstr ""
+msgstr "@type: uppdaterades %info."
 
 msgid "The custom block ID."
-msgstr ""
+msgstr "ID-numret för anpassat block"
 
 msgid "The custom block UUID."
-msgstr ""
+msgstr "UUID för anpassat block."
 
 msgid "The comment language code."
-msgstr ""
+msgstr "Språkkod för kommentaren"
 
 msgid "The block type."
-msgstr ""
+msgstr "Blocktypen."
 
 msgid ""
 "Provide a label for this block type to help identify it in the "
 "administration pages."
 msgstr ""
+"Tillhandahåll en etikett för denna blocktyp för att lättare identifiera den "
+"på administrationssidorna."
 
 msgid "Enter a description for this block type."
-msgstr ""
+msgstr "Ange en beskrivning för denna blocktyp."
 
 msgid "Create a new revision by default for this block type."
-msgstr ""
+msgstr "Skapa en ny version som förvalt för denna blocktyp."
 
 msgid "Custom block type %label has been updated."
-msgstr ""
+msgstr "Anpassad blocktyp %label har uppdaterats."
 
 msgid "Delete forum"
-msgstr ""
+msgstr "Radera forum"
 
 msgid "User-defined shortcuts"
-msgstr ""
+msgstr "User-defined shortcuts"
 
 msgid "Vertical orientation"
-msgstr ""
+msgstr "Vertikal orientering"
 
 msgid "Tray orientation changed to @orientation."
-msgstr ""
+msgstr "Fackorienteringen ändrad till @orientation."
 
 msgid "opened"
-msgstr ""
+msgstr "opened"
 
 msgid "Custom block type %label has been added."
-msgstr ""
+msgstr "Anpassad blocktyp %label har lagts till."
 
 msgid "Add %type custom block"
-msgstr ""
+msgstr "Lägg till anpassat block %type"
 
 msgid ""
 "%label is used by 1 custom block on your site. You can not remove this block"
@@ -14537,333 +15738,371 @@ msgid_plural ""
 "%label is used by @count custom blocks on your site. You may not remove "
 "%label until you have removed all of the %label custom blocks."
 msgstr[0] ""
+"%label används av ett anpassat block på din webbplats. Du kan inte ta bort "
+"denna blocktyp förrän du har tagit bort alla block av typ %label."
 msgstr[1] ""
+"%label används av @count anpassade block på din webbplats. Du kan inte ta "
+"bort denna blocktyp förrän du har tagit bort alla block av typ %label."
 
 msgid "Output the block in this view mode."
-msgstr ""
+msgstr "Mata ut block i detta visningsläge."
 
 msgid "Select the region where this block should be displayed."
-msgstr ""
+msgstr "Välj regionen där detta block skall visas."
 
 msgid "- Create a new book -"
-msgstr ""
+msgstr "- Skapa en ny bok -"
 
 msgid "Edit order and titles"
-msgstr ""
+msgstr "Redigera ordning och titlar"
 
 msgid "Toolbar configuration"
-msgstr ""
+msgstr "Verktygskonfiguration"
 
 msgid "Available buttons"
-msgstr ""
+msgstr "Tillgängliga knappar"
 
 msgid "Active toolbar"
-msgstr ""
+msgstr "Aktiv verktygsrad"
 
 msgid "No styles configured"
-msgstr ""
+msgstr "Inga stilar konfigurerade"
 
 msgid "@count styles configured"
-msgstr ""
+msgstr "@count stilar konfigurerade"
 
 msgid "Button separator"
-msgstr ""
+msgstr "Avskiljare för knapp"
 
 msgid "The provided list of styles is syntactically incorrect."
-msgstr ""
+msgstr "Den tillhandahållna listan av stilar är syntaktiskt felaktig."
 
 msgid "You must configure the selected text editor."
-msgstr ""
+msgstr "Du måste konfigurera den valda textredigeraren."
 
 msgid "Approved status"
-msgstr ""
+msgstr "Status för godkänd"
 
 msgid "Approved comment status"
-msgstr ""
+msgstr "Status för godkänd kommentar"
 
 msgid "Link to approve comment"
-msgstr ""
+msgstr "Länk för att godkänna kommentar"
 
 msgid "Link to reply-to comment"
-msgstr ""
+msgstr "Länk för att svara på kommentar"
 
 msgid "The parent comment ID if this is a reply to a comment."
-msgstr ""
+msgstr "Ovanliggande ID för kommentar om detta är ett svar till en kommentar."
 
 msgid "The user ID of the comment author."
-msgstr ""
+msgstr "Författarens användar-ID för kommentaren."
 
 msgid "The comment author's home page address."
-msgstr ""
+msgstr "Författarens hemsidesadress för kommentaren."
 
 msgid "The comment author's hostname."
-msgstr ""
+msgstr "Författarens värdnamn för kommentaren."
 
 msgid "The time that the comment was created."
-msgstr ""
+msgstr "Tidpunkten som kommentaren skapades."
 
 msgid "The time that the comment was last edited."
-msgstr ""
+msgstr "Tidpunkten då kommentaren senast redigerades."
 
 msgid "Thread place"
-msgstr ""
+msgstr "Placering av tråd"
 
 msgid ""
 "The alphadecimal representation of the comment's place in a thread, "
 "consisting of a base 36 string prefixed by an integer indicating its length."
 msgstr ""
+"The alphadecimal representation of the comment's place in a thread, "
+"consisting of a base 36 string prefixed by an integer indicating its length."
 
 msgid "View changes of @config_file"
-msgstr ""
+msgstr "Visa ändringar för @config_file"
 
 msgid "Send copy to sender"
-msgstr ""
+msgstr "Skicka kopia till avsändare"
 
 msgid "Contact module form element."
-msgstr ""
+msgstr "Formulärselement för kontaktmodul."
 
 msgid "Selected user"
-msgstr ""
+msgstr "Vald användare"
 
 msgid "The name of the person that is sending the contact message."
-msgstr ""
+msgstr "The name of the person that is sending the contact message."
 
 msgid "Whether to send a copy of the message to the sender."
-msgstr ""
+msgstr "Whether to send a copy of the message to the sender."
 
 msgid "The ID of the recipient user for personal contact messages."
-msgstr ""
+msgstr "The ID of the recipient user for personal contact messages."
 
 msgid "@action @title configuration options"
-msgstr ""
+msgstr "Konfigureringsalternativ @action @title"
 
 msgid "Tabbing is no longer constrained by the Contextual module."
-msgstr ""
+msgstr "Tabbing is no longer constrained by the Contextual module."
 
 msgid ""
 "Tabbing is constrained to a set of @contextualsCount and the edit mode "
 "toggle."
 msgstr ""
+"Tabbing is constrained to a set of @contextualsCount and the edit mode "
+"toggle."
 
 msgid "Press the esc key to exit."
-msgstr ""
+msgstr "Tryck på tangenten Esc för att avsluta."
 
 msgid "@count contextual link"
 msgid_plural "@count contextual links"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count sammanhängande länk"
+msgstr[1] "@count sammanhängande länkar"
 
 msgid "No contextual ids specified."
-msgstr ""
+msgstr "No contextual ids specified."
 
 msgid "Create and store date values."
-msgstr ""
+msgstr "Skapa och lagra datavärden."
 
 msgid "Choose the type of date to create."
-msgstr ""
+msgstr "Välj typ av datum att skapa."
 
 msgid "Date only"
-msgstr ""
+msgstr "Enbart datum"
 
 msgid "Set a default value for this date."
-msgstr ""
+msgstr "Ställ in ett förvalt värde för detta datum."
 
 msgid ""
 "The %field date is required. Please enter a date in the format %format."
 msgstr ""
+"Datumet %field är obligatoriskt. Var vänlig ange ett datum på format "
+"%format."
 
 msgid "The %field date is invalid. Please enter a date in the format %format."
 msgstr ""
+"Datumet %field är ogiltigt. Var vänlig ange ett datum på formatet %format."
 
 msgid "AM/PM"
-msgstr ""
+msgstr "f.m/e.m"
 
 msgid "The %field date is required."
-msgstr ""
+msgstr "Datumet %field är obligatoriskt."
 
 msgid "The %field date is invalid."
-msgstr ""
+msgstr "Datumet %field är ogiltigt."
 
 msgid "Format: %format. Leave blank to use the time of form submission."
 msgstr ""
+"Format: %format. Lämna tomt för att använda tiden när formuläret skickades "
+"in."
 
 msgid ""
 "Choose a format for displaying the date. Be sure to set a format appropriate"
 " for the field, i.e. omitting time for a field that only has a date."
 msgstr ""
+"Välj ett format för visning av datumet. Se till att ställa in ett lämpligt "
+"format för fältet. Det vill säga utelämna tid för ett fält som bara har ett "
+"datum."
 
 msgid "Format: @display"
-msgstr ""
+msgstr "Format: @display"
 
 msgid "Date part order"
-msgstr ""
+msgstr "Date part order"
 
 msgid "Month/Day/Year"
-msgstr ""
+msgstr "månad/dag/år"
 
 msgid "Day/Month/Year"
-msgstr ""
+msgstr "dag/månad/år"
 
 msgid "Year/Month/Day"
-msgstr ""
+msgstr "år/månad/dag"
 
 msgid "Time type"
-msgstr ""
+msgstr "Typ av tid"
 
 msgid "24 hour time"
-msgstr ""
+msgstr "24-timmarstid"
 
 msgid "12 hour time"
-msgstr ""
+msgstr "12-timmarstid"
 
 msgid "Text editor"
-msgstr ""
+msgstr "Textredigerare"
 
 msgid ""
 "This option is disabled because no modules that provide a text editor are "
 "currently enabled."
 msgstr ""
+"This option is disabled because no modules that provide a text editor are "
+"currently enabled."
 
 msgid ""
 "Text that will be shown inside the field until a value is entered. This hint"
 " is usually a sample value or a brief description of the expected format."
 msgstr ""
+"Text som visas inuti fältet tills ett värde anges. Detta tips är oftast ett "
+"exempelvärde eller en kort beskrivning av det förväntade formatet."
 
 msgid "Type of item to reference"
-msgstr ""
+msgstr "Typ av objekt att referera"
 
 msgid "Reference method"
-msgstr ""
+msgstr "Metod för referens"
 
 msgid "@entity_type selection"
-msgstr ""
+msgstr "Urval för @entity_type"
 
 msgid "There are no entities matching \"%value\"."
-msgstr ""
+msgstr "Det finns inga objekt som stämmer överens med \"%value\"."
 
 msgid ""
 "Many entities are called %value. Specify the one you want by appending the "
 "id in parentheses, like \"@value (@id)\"."
 msgstr ""
+"Många objekt kallas %value. Ange det du vill använda genom att lägga till "
+"ID-numret i parentes såsom \"@value (@id)\"."
 
 msgid ""
 "Multiple entities match this reference; \"%multiple\". Specify the one you "
 "want by appending the id in parentheses, like \"@value (@id)\"."
 msgstr ""
+"Flera objekt matchade denna referens; \"%multiple\". Ange den du vill ha "
+"genom att lägga till id-numret inom parenteserna, liknande \"@value (@id)\"."
 
 msgid ""
 "Select the method used to collect autocomplete suggestions. Note that "
 "<em>Contains</em> can cause performance issues on sites with thousands of "
 "entities."
 msgstr ""
+"Välj den metod som används för att samla in automatiskt kompletterande "
+"förslag. Observera att <em>Innehåller</em> kan orsaka prestandaproblem på "
+"webbplatser med tusentals objekt."
 
 msgid ""
 "If checked, field api classes will be added by field templates. This is not "
 "recommended unless your CSS depends upon these classes. If not checked, "
 "template will not be used."
 msgstr ""
+"If checked, field api classes will be added by field templates. This is not "
+"recommended unless your CSS depends upon these classes. If not checked, "
+"template will not be used."
 
 msgid "%entity_label: Administer fields"
-msgstr ""
+msgstr "%entity_label: Administrera fält"
 
 msgid "%entity_label: Administer display"
-msgstr ""
+msgstr "%entity_label: Administrera visning"
 
 msgid "Allowed number of values"
-msgstr ""
+msgstr "Tillåtna antal värden"
 
 msgid "Number of values is required."
-msgstr ""
+msgstr "Antal värden är obligatoriskt."
 
 msgid ""
 "Field %field can only hold @max values but there were @count uploaded. The "
 "following files have been omitted as a result: %list."
 msgstr ""
+"Field %field can only hold @max values but there were @count uploaded. The "
+"following files have been omitted as a result: %list."
 
 msgid "Unlimited number of files can be uploaded to this field."
-msgstr ""
+msgstr "Oändligt antal filer kan laddas upp till detta fält."
 
 msgid "The file ID."
-msgstr ""
+msgstr "The file ID."
 
 msgid "The file language code."
-msgstr ""
+msgstr "The file language code."
 
 msgid "The user ID of the file."
-msgstr ""
+msgstr "Användar-ID till filen."
 
 msgid "Name of the file with no path components."
-msgstr ""
+msgstr "Name of the file with no path components."
 
 msgid "The URI to access the file (either local or remote)."
 msgstr ""
+"URI för att få åtkomst till filen (antingen lokalt eller fjärranslutet)."
 
 msgid "The time that the node was created."
-msgstr ""
+msgstr "The time that the node was created."
 
 msgid "Detect if tar is part of the extension"
-msgstr ""
+msgstr "Detect if tar is part of the extension"
 
 msgid "This format is shown when no other formats are available"
-msgstr ""
+msgstr "This format is shown when no other formats are available"
 
 msgid ""
 "Based on the text editor configuration, these tags have automatically been "
 "added: <strong>@tag-list</strong>."
 msgstr ""
+"Based on the text editor configuration, these tags have automatically been "
+"added: <strong>@tag-list</strong>."
 
 msgid "Forum content"
-msgstr ""
+msgstr "Innehåll i forum"
 
 msgid "The content ID of the forum index entry."
-msgstr ""
+msgstr "The content ID of the forum index entry."
 
 msgid "1 new post<span class=\"visually-hidden\"> in forum %title</span>"
 msgid_plural ""
 "@count new posts<span class=\"visually-hidden\"> in forum %title</span>"
-msgstr[0] ""
+msgstr[0] "1 nytt inlägg<span class=\"visually-hidden\"> i forum %title</span>"
 msgstr[1] ""
+"@count nya inlägg<span class=\"visually-hidden\"> i forum %title</span>"
 
 msgid "The user ID of the author of the current revision."
-msgstr ""
+msgstr "Användar-ID till författaren av den aktuella versionen."
 
 msgid "Displaying link text"
-msgstr ""
+msgstr "Visar länktext"
 
 msgid "1 new post<span class=\"visually-hidden\"> in topic %title</span>"
 msgid_plural ""
 "@count new posts<span class=\"visually-hidden\"> in topic %title</span>"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 nytt inlägg<span class=\"visually-hidden\"> i tråd %title</span>"
+msgstr[1] "@count nya inlägg<span class=\"visually-hidden\"> i tråd %title</span>"
 
 msgid "The forum %label and all sub-forums have been deleted."
-msgstr ""
+msgstr "The forum %label and all sub-forums have been deleted."
 
 msgid "forum: deleted %label and all its sub-forums."
-msgstr ""
+msgstr "forum: raderade %label och alla dess underliggande forum."
 
 msgid ""
 "Source image at %source_image_path not found while trying to generate "
 "derivative image at %derivative_path."
 msgstr ""
+"Källbild på %source_image_path hittades inte vid försök att generera härledd"
+" bild på %derivative_path."
 
 msgid "Alternative image text, for the image's 'alt' attribute."
-msgstr ""
+msgstr "Alternativ bildtext för bildens attribut \"alt\"."
 
 msgid "Image title text, for the image's 'title' attribute."
-msgstr ""
+msgstr "Image title text, for the image's 'title' attribute."
 
 msgid "The width of the image in pixels."
-msgstr ""
+msgstr "Bredden på bilden i pixlar."
 
 msgid "The height of the image in pixels."
-msgstr ""
+msgstr "The height of the image in pixels."
 
 msgid "Custom language settings"
-msgstr ""
+msgstr "Custom language settings"
 
 msgid "Settings successfully updated."
-msgstr ""
+msgstr "Inställningar uppdaterades utan problem."
 
 msgid ""
 "Change language settings for <em>content types</em>, <em>taxonomy "
@@ -14871,73 +16110,87 @@ msgid ""
 " your site. By default, language settings hide the language selector and the"
 " language is the site's default language."
 msgstr ""
+"Change language settings for <em>content types</em>, <em>taxonomy "
+"vocabularies</em>, <em>user profiles</em>, or any other supported element on"
+" your site. By default, language settings hide the language selector and the"
+" language is the site's default language."
 
 msgid "Show language selector on create and edit pages"
-msgstr ""
+msgstr "Show language selector on create and edit pages"
 
 msgid ""
 "Select languages to enforce. If none are selected, all languages will be "
 "allowed."
 msgstr ""
+"Välj språk att upprätthålla. Om ingen väljs kommer alla språk att tillåtas."
 
 msgid "The language is not @languages."
-msgstr ""
+msgstr "The language is not @languages."
 
 msgid "The language is @languages."
-msgstr ""
+msgstr "The language is @languages."
 
 msgid ""
 "Stores a URL string, optional varchar link text, and optional blob of "
 "attributes to assemble a link."
 msgstr ""
+"Stores a URL string, optional varchar link text, and optional blob of "
+"attributes to assemble a link."
 
 msgid "Allow link text"
-msgstr ""
+msgstr "Tillåt länktext"
 
 msgid "Placeholder for URL"
-msgstr ""
+msgstr "Placeholder for URL"
 
 msgid "Placeholder for link text"
-msgstr ""
+msgstr "Placeholder for link text"
 
 msgid "Nothing to check."
-msgstr ""
+msgstr "Inget att kontrollera."
 
 msgid "Importing translation for %project."
-msgstr ""
+msgstr "Importerar översättning för %project."
 
 msgid "Translation file not found: @uri."
-msgstr ""
+msgstr "Översättningsfil hittades inte: @uri."
 
 msgid "Unable to download translation file @uri."
-msgstr ""
+msgstr "Kunde inte ladda ned översättningsfil @uri."
 
 msgid "One translation files could not be checked. See the log for details."
 msgid_plural ""
 "@count translation files could not be checked. See the log for details."
 msgstr[0] ""
+"En översättningsfil kunde inte kontrolleras. Se loggen för mer information."
 msgstr[1] ""
+"@count översättningsfiler kunde inte kontrolleras. Se loggen för mer "
+"information."
 
 msgid "Updating configuration translations"
-msgstr ""
+msgstr "Uppdaterar översättningar för konfiguration"
 
 msgid "Error updating configuration translations"
-msgstr ""
+msgstr "Fel vid uppdatering av översättningar för konfiguration"
 
 msgid "No configuration objects have been updated."
-msgstr ""
+msgstr "Inga konfigurationsobjekt har uppdaterats."
 
 msgid "Unable to import translations file: @file"
-msgstr ""
+msgstr "Kunde inte importera översättningsfil: @file"
 
 msgid ""
 "Translations imported: %number added, %update updated, %delete removed."
 msgstr ""
+"Översättningar importerade: %number lades till, %update uppdaterades, "
+"%delete togs bort."
 
 msgid ""
 "The configuration was successfully updated. %number configuration objects "
 "updated."
 msgstr ""
+"Konfigurationen uppdaterades utan problem. %number konfigurationsobjekt "
+"uppdaterades."
 
 msgid ""
 "One translation string was skipped because of disallowed or malformed HTML. "
@@ -14946,245 +16199,264 @@ msgid_plural ""
 "@count translation strings were skipped because of disallowed or malformed "
 "HTML. See the log for details."
 msgstr[0] ""
+"En översättningssträng hoppades över på grund av ej tillåten eller felaktig "
+"HTML. Se loggen för mer information."
 msgstr[1] ""
+"@count översättningssträngar hoppades över på grund av ej tillåten eller "
+"felaktig HTML. Se loggen för mer information."
 
 msgid "Checking translations"
-msgstr ""
+msgstr "Kontrollerar översättningar"
 
 msgid "Error checking translation updates."
-msgstr ""
+msgstr "Fel vid kontroll av uppdateringar för översättning."
 
 msgid "Updating translations"
-msgstr ""
+msgstr "Uppdaterar översättningar"
 
 msgid "Error importing translation files"
-msgstr ""
+msgstr "Fel vid import av översättningsfiler"
 
 msgid "Updating translations."
-msgstr ""
+msgstr "Uppdaterar översättningar."
 
 msgid "All translations up to date."
-msgstr ""
+msgstr "Alla översättningar uppdaterade."
 
 msgid "Select a language to update."
-msgstr ""
+msgstr "Välj ett språk att uppdatera."
 
 msgid "File not found at %remote_path nor at %local_path"
-msgstr ""
+msgstr "Fil hittades inte på %remote_path och inte heller på %local_path"
 
 msgid "File not found at %local_path"
-msgstr ""
+msgstr "Fil hittades inte på %local_path"
 
 msgid "Translation file location could not be determined."
-msgstr ""
+msgstr "Plats för översättningsfil kunde inte fastställas."
 
 msgid "Missing translations for:"
-msgstr ""
+msgstr "Saknar översättningar för:"
 
 msgid "Missing translations for one project"
 msgid_plural "Missing translations for @count projects"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Saknar översättningar för ett projekt"
+msgstr[1] "Saknar översättningar för @count projekt"
 
 msgid ""
 "A local file system path where interface translation files will be stored."
 msgstr ""
+"En lokal filsystemsökväg där filer för gränssnittsöversättning kommer "
+"lagras."
 
 msgid "Updates available"
-msgstr ""
+msgstr "Uppdateringar tillgängliga"
 
 msgid "Missing translations"
-msgstr ""
+msgstr "Saknar översättningar"
 
 msgid "Translation source"
-msgstr ""
+msgstr "Källa för översättning"
 
 msgid "Drupal translation server and local files"
-msgstr ""
+msgstr "Drupals översättningsserver och lokala filer"
 
 msgid "Local files only"
-msgstr ""
+msgstr "Enbart lokala filer"
 
 msgid "The source of translation files for automatic interface translation."
 msgstr ""
+"Källan av översättningsfiler för automatisk översättning av gränssnitt."
 
 msgid "Don't overwrite existing translations."
-msgstr ""
+msgstr "Skriv inte över befintliga översättningar."
 
 msgid ""
 "Only overwrite imported translations, customized translations are kept."
 msgstr ""
+"Skriv endast över importerade översättningar. Anpassade översättningar "
+"behålls."
 
 msgid "Overwrite existing translations."
-msgstr ""
+msgstr "Skriv över befintliga översättningar."
 
 msgid ""
 "How to treat existing translations when automatically updating the interface"
 " translations."
 msgstr ""
+"Hur befintliga översättningar skall behandlas vid automatisk uppdatering av "
+"gränssnittsöversättningar."
 
 msgid "Edit menu %label"
-msgstr ""
+msgstr "Redigera meny %label"
 
 msgid "Add menu link"
-msgstr ""
+msgstr "Add menu link"
 
 msgid "Administrative summary"
-msgstr ""
+msgstr "Administrativ sammanfattning"
 
 msgid "Menu %label has been updated."
-msgstr ""
+msgstr "Meny %label har uppdaterats."
 
 msgid "Menu %label has been added."
-msgstr ""
+msgstr "Meny %label har lagts till."
 
 msgid "The menu link has been saved."
-msgstr ""
+msgstr "Menylänken har sparats."
 
 msgid "Published status or admin user"
-msgstr ""
+msgstr "Publicerad status eller administratörsanvändare"
 
 msgid "Promoted to front page status"
-msgstr ""
+msgstr "Status för visas på startsidan"
 
 msgid "Node operations bulk form"
-msgstr ""
+msgstr "Node operations bulk form"
 
 msgid "Add a form element that lets you run operations on multiple nodes."
 msgstr ""
+"Lägg till ett formulärselement som låter dig köra funktioner på flera noder."
 
 msgid "Empty Node Frontpage behavior"
-msgstr ""
+msgstr "Beteende för tom nod på startsida"
 
 msgid "Provides a link to the node add overview page."
-msgstr ""
+msgstr "Provides a link to the node add overview page."
 
 msgid "Link to revision"
-msgstr ""
+msgstr "Länk till version"
 
 msgid "Link to revert revision"
-msgstr ""
+msgstr "Länk för att återställa version"
 
 msgid "Link to delete revision"
-msgstr ""
+msgstr "Länk för att radera version"
 
 msgid "Access the Content overview page"
-msgstr ""
+msgstr "Åtkomst till översiktssidan för innehåll"
 
 msgid "View all revisions"
-msgstr ""
+msgstr "Visa alla versioner"
 
 msgid "Revert all revisions"
-msgstr ""
+msgstr "Återställ alla versioner"
 
 msgid "%type_name: View revisions"
-msgstr ""
+msgstr "%type_name: Visa versioner"
 
 msgid "%type_name: Revert revisions"
-msgstr ""
+msgstr "%type_name: Återställ versioner"
 
 msgid "%type_name: Delete revisions"
-msgstr ""
+msgstr "%type_name: Radera versioner"
 
 msgid "Promotion options"
-msgstr ""
+msgstr "Alternativ för lansering"
 
 msgid "Read more<span class=\"visually-hidden\"> about @title</span>"
-msgstr ""
+msgstr "Läs mer<span class=\"visually-hidden\"> om @title</span>"
 
 msgid "The node revision ID."
-msgstr ""
+msgstr "ID-numret för nodens version."
 
 msgid "The time that the node was last edited."
-msgstr ""
+msgstr "The time that the node was last edited."
 
 msgid "The time that the current revision was created."
-msgstr ""
+msgstr "Tidpunkten då den aktuella versionen skapades."
 
 msgid "Checked translation for %project."
-msgstr ""
+msgstr "Kontrollerade översättning för %project."
 
 msgid "Downloaded translation for %project."
-msgstr ""
+msgstr "Laddade ned översättning för %project."
 
 msgid "Imported translation for %project."
-msgstr ""
+msgstr "Importerade översättning för %project."
 
 msgid "Importing translation file: %filename (@percent%)."
-msgstr ""
+msgstr "Importerar översättningsfil: %filename (@percent%)."
 
 msgid "Translations imported."
-msgstr ""
+msgstr "Översättning importerad"
 
 msgid ""
 "The configuration was successfully updated. There are %number configuration "
 "objects updated."
 msgstr ""
+"Konfigurationen uppdaterades utan problem. Det finns %number uppdaterade "
+"konfigurationsobjekt."
 
 msgid "Source string (@language)"
-msgstr ""
+msgstr "Källsträng (@language)"
 
 msgid "Built-in English"
-msgstr ""
+msgstr "Inbyggd engelsk"
 
 msgid "Translated string (@language)"
-msgstr ""
+msgstr "Översatt sträng (@language)"
 
 msgid "The node bundle is @bundles or @last"
-msgstr ""
+msgstr "The node bundle is @bundles or @last"
 
 msgid "The node bundle is @bundle"
-msgstr ""
+msgstr "The node bundle is @bundle"
 
 msgid "Float value"
-msgstr ""
+msgstr "Flyttalsvärde"
 
 msgid "An entity field containing a path alias and related data."
-msgstr ""
+msgstr "Ett objektsfält som innehåller ett sökvägsalias och relaterad data."
 
 msgid "Path id"
-msgstr ""
+msgstr "ID-nummer för sökväg"
 
 msgid "Log entry with ID @id was not found"
-msgstr ""
+msgstr "Logginlägg med ID @id hittades inte"
 
 msgid "Created entity %type with ID %id."
-msgstr ""
+msgstr "Skapade objekt %type med ID %id."
 
 msgid "Updated entity %type with ID %id."
-msgstr ""
+msgstr "Uppdaterade objekt %type med ID %id."
 
 msgid "Deleted entity %type with ID %id."
-msgstr ""
+msgstr "Raderade objekt %type med ID %id."
 
 msgid "Raw output"
-msgstr ""
+msgstr "Raw output"
 
 msgid "You have no fields. Add some to your view."
-msgstr ""
+msgstr "You have no fields. Add some to your view."
 
 msgid ""
 "The machine-readable name must contain only letters, numbers, dashes and "
 "underscores."
 msgstr ""
+"The machine-readable name must contain only letters, numbers, dashes and "
+"underscores."
 
 msgid "Accepted request formats"
-msgstr ""
+msgstr "Godkända format för begäran"
 
 msgid ""
 "Request formats that will be allowed in responses. If none are selected all "
 "formats will be allowed."
 msgstr ""
+"Request formats that will be allowed in responses. If none are selected all "
+"formats will be allowed."
 
 msgid "The new set label is required."
-msgstr ""
+msgstr "The new set label is required."
 
 msgid "Enter test name…"
-msgstr ""
+msgstr "Ange testnamn..."
 
 msgid ""
 "Enter at least 3 characters of the test name or description to filter by."
 msgstr ""
+"Ange åtminstone 3 tecken av testnamnet eller beskrivningen att filtrera på."
 
 msgid ""
 "On UNIX, Linux, and Mac OS X, you will find the configuration in the file "
@@ -15196,303 +16468,344 @@ msgid ""
 "or <em>rsyslog.conf</em>, see the <em>syslog.conf</em> or "
 "<em>rsyslog.conf</em> manual page on your command line."
 msgstr ""
+"On UNIX, Linux, and Mac OS X, you will find the configuration in the file "
+"<em>/etc/syslog.conf</em>, or in <em>/etc/rsyslog.conf</em> or in the "
+"directory <em>/etc/rsyslog.d</em>. These files define the routing "
+"configuration. Messages can be flagged with the codes "
+"<code>LOG_LOCAL0</code> through <code>LOG_LOCAL7</code>. For information on "
+"Syslog facilities, severity levels, and how to set up <em>syslog.conf</em> "
+"or <em>rsyslog.conf</em>, see the <em>syslog.conf</em> or "
+"<em>rsyslog.conf</em> manual page on your command line."
 
 msgid "Any data"
-msgstr ""
+msgstr "All data"
 
 msgid "An entity field containing a UUID."
-msgstr ""
+msgstr "Ett objektsfält som innehåller en UUID."
 
 msgid "@zone"
-msgstr ""
+msgstr "@zone"
 
 msgid "Failed to fetch file due to error \"%error\""
-msgstr ""
+msgstr "Failed to fetch file due to error \"%error\""
 
 msgid ""
 "The update.php script is accessible to everyone without authentication "
 "check, which is a security risk. You must change the @settings_name value in"
 " your settings.php back to FALSE."
 msgstr ""
+"The update.php script is accessible to everyone without authentication "
+"check, which is a security risk. You must change the @settings_name value in"
+" your settings.php back to FALSE."
 
 msgid "Name of the date format"
-msgstr ""
+msgstr "Name of the date format"
 
 msgid "@toolkit settings"
-msgstr ""
+msgstr "Inställningar för @toolkit"
 
 msgid "Update this item"
-msgstr ""
+msgstr "Uppdatera detta objekt"
 
 msgid "This value should not be null."
-msgstr ""
+msgstr "Detta värde skall inte vara innehållslöst."
 
 msgid "This value should be %limit or more."
-msgstr ""
+msgstr "Detta värde skall vara %limit eller mer."
 
 msgid "The term ID."
-msgstr ""
+msgstr "ID-numret för termen."
 
 msgid "The term language code."
-msgstr ""
+msgstr "Språkkoden för termen."
 
 msgid "Term Parents"
-msgstr ""
+msgstr "Överliggande termer"
 
 msgid "The parents of this term."
-msgstr ""
+msgstr "Ovanliggande termer för termen."
 
 msgid "Create referenced entities if they don't already exist"
-msgstr ""
+msgstr "Skapa refererade objekt om de inte redan finns"
 
 msgid "Telephone number"
-msgstr ""
+msgstr "Telefonnummer"
 
 msgid "This field stores a telephone number in the database."
-msgstr ""
+msgstr "Detta fält lagrar ett telefonnummer i databasen."
 
 msgid "Link using text: @title"
-msgstr ""
+msgstr "Länk som använder text: @title"
 
 msgid "Link using provided telephone number."
-msgstr ""
+msgstr "Länk som använder tillhandahållet telefonnummer."
 
 msgid "Translatable elements"
-msgstr ""
+msgstr "Översättningsbara element"
 
 msgid ""
 "At least one field needs to be translatable to enable %bundle for "
 "translation."
 msgstr ""
+"Åtminstone ett fält måste vara översättningsbart för att aktivera %bundle "
+"för översättning."
 
 msgid "<strong>@language_name (Original language)</strong>"
-msgstr ""
+msgstr "<strong>@language_name (Ursprungligt språk)</strong>"
 
 msgid "Administer translation settings"
-msgstr ""
+msgstr "Administrera översättningsinställningar"
 
 msgid "Create translations"
-msgstr ""
+msgstr "Skapa översättningar"
 
 msgid "Delete translations"
-msgstr ""
+msgstr "Radera översättningar"
 
 msgid "Translate %bundle_label @entity_label"
-msgstr ""
+msgstr "Översätt %bundle_label @entity_label"
 
 msgid "Translate @entity_label"
-msgstr ""
+msgstr "Översätt @entity_label"
 
 msgid ""
 "\"Show language selector\" is not compatible with translating content that "
 "has default language: %choice. Either do not hide the language selector or "
 "pick a specific language."
 msgstr ""
+"\"Visa språkval\" är inte kompatibel med att översätta innehåll som har "
+"standardspråk: %choice. Antingen får du inte dölja språkvalet eller välja "
+"ett specifikt språk."
 
 msgid ""
 "An unpublished translation will not be visible without translation "
 "permissions."
 msgstr ""
+"En ej publicerad översättning kommer inte att vara synlig utan behörigheter "
+"för översättning."
 
 msgid "%archive_file does not contain any .info.yml files."
-msgstr ""
+msgstr "%archive_file innehåller inga filer av typ .info.yml."
 
 msgid ""
 "<p>This is a one-time login for %user_name.</p><p>Click on this button to "
 "log in to the site and change your password.</p>"
 msgstr ""
+"<p>Detta är en engångsinloggning för %user_name.</p><p>Klicka på denna knapp"
+" för att logga in på webbplatsen och byta lösenord.</p>"
 
 msgid "Provides access to the user data service."
-msgstr ""
+msgstr "Tillhandahåll åtkomst till tjänsten för användardata."
 
 msgid "Add a form element that lets you run operations on multiple users."
 msgstr ""
+"Lägg till ett formulärselement som låter dig köra funktioner på flera "
+"användare."
 
 msgid "User module form element."
-msgstr ""
+msgstr "User module form element."
 
 msgid "System module form element."
-msgstr ""
+msgstr "Formulärselement för systemmodul."
 
 msgid "Login attempt failed from %ip."
-msgstr ""
+msgstr "Inloggningsförsök misslyckades från %ip."
 
 msgid "Cancel user"
-msgstr ""
+msgstr "Cancel user"
 
 msgid "Enable password strength indicator"
-msgstr ""
+msgstr "Aktivera indikator på lösenordsstyrka"
 
 msgid "Admin (user awaiting approval)"
-msgstr ""
+msgstr "Administratör (användare väntar på godkännande)"
 
 msgid "Role %label has been updated."
-msgstr ""
+msgstr "Roll %label har uppdaterats."
 
 msgid "Role %label has been added."
-msgstr ""
+msgstr "Roll %label har lagts till."
 
 msgid "The user language code."
-msgstr ""
+msgstr "Språkkod för användaren."
 
 msgid "The time that the user last accessed the site."
-msgstr ""
+msgstr "Tidpunkten som användaren senast använde webbplatsen."
 
 msgid "The time that the user last logged in."
-msgstr ""
+msgstr "Tidpunkten som användaren senast loggade in."
 
 msgid "The email address used for initial account creation."
-msgstr ""
+msgstr "E-postadressen som användes för att skapa konto."
 
 msgid "The roles the user has."
-msgstr ""
+msgstr "Rollerna som användaren innehar."
 
 msgid "Update the user %name"
-msgstr ""
+msgstr "Uppdatera användaren %name"
 
 msgid "The module which sets this user data."
-msgstr ""
+msgstr "Modulen som ställer in denna användardata."
 
 msgid "The name of the data key."
-msgstr ""
+msgstr "Namnet på datanyckeln."
 
 msgid "The label of the view."
-msgstr ""
+msgstr "Etiketten för vyn."
 
 msgid "The machine-readable ID of the view."
-msgstr ""
+msgstr "Det maskinläsbara ID-numret för vyn."
 
 msgid "Dropbutton"
-msgstr ""
+msgstr "Snabbvalsknapp"
 
 msgid "Display fields in a dropbutton."
-msgstr ""
+msgstr "Visa fält i en snabbvalsknapp."
 
 msgid "Rendered entity - @label"
-msgstr ""
+msgstr "Genererat objekt - @label"
 
 msgid "Displays a rendered @label entity in an area."
-msgstr ""
+msgstr "Visar ett genererat objekt @label i ett område."
 
 msgid "Display the @label"
-msgstr ""
+msgstr "Visa @label"
 
 msgid "Available global token replacements"
-msgstr ""
+msgstr "Tillgängliga globala ersättningstecken"
 
 msgid ""
 "Override the title of this view when it is empty. The available global "
 "tokens below can be used here."
 msgstr ""
+"Åsidosätt titeln på denna vy när den är tom. De tillgängliga globala "
+"ersättningstecknen nedan kan användas här."
 
 msgid "Administrative comment"
-msgstr ""
+msgstr "Administrativ kommentar"
 
 msgid "Machine name of the display"
-msgstr ""
+msgstr "Maskinläsbart namn för visningen"
 
 msgid ""
 "This description will only be seen within the administrative interface and "
 "can be used to document this display."
 msgstr ""
+"Denna beskrivning kommer endast ses i det administrativa gränssnittet och "
+"kan användas för att dokumentera denna visning."
 
 msgid "CSS class name(s)"
-msgstr ""
+msgstr "CSS-klassnamn"
 
 msgid "Show contextual links on this view."
-msgstr ""
+msgstr "Visa sammanhängande länkar på den här vyn."
 
 msgid "Show contextual links"
-msgstr ""
+msgstr "Visa sammanhängande länkar"
 
 msgid ""
 "In the menu, the heavier links will sink and the lighter links will be "
 "positioned nearer the top."
 msgstr ""
+"I menyn kommer de tyngre länkarna sjunka och de lättare kommer att placeras "
+"närmare toppen."
 
 msgid ""
 "If the parent menu item is a tab, enter the weight of the tab. Heavier tabs "
 "will sink and the lighter tabs will be positioned nearer to the first menu "
 "item."
 msgstr ""
+"Om det ovanliggande menyvalet är en flik, ange vikten på fliken. Tyngre "
+"flikar kommer att sjunka och de lättare kommer positioneras närmare det "
+"första menyvalet."
 
 msgid "Allow people to choose the sort order"
-msgstr ""
+msgstr "Tillåt personer att välja sorteringsordning"
 
 msgid ""
 "If sort order is not exposed, the sort criteria settings for each sort will "
 "determine its order."
 msgstr ""
+"Om sorteringsordningen inte visas kommer inställningarna för "
+"sorteringskriteriet åt varje sort avgöra dess ordning."
 
 msgid "Label for ascending sort"
-msgstr ""
+msgstr "Etikett för ökande sortering"
 
 msgid "Label for descending sort"
-msgstr ""
+msgstr "Etikett för fallande sortering"
 
 msgid "Toolbar items"
-msgstr ""
+msgstr "Objekt på verktygsrad"
 
 msgid "Edit user account"
-msgstr ""
+msgstr "Redigera användarkonto"
 
 msgid "End tour"
-msgstr ""
+msgstr "Avsluta rundtur"
 
 msgid "Override the output of this field with custom text"
-msgstr ""
+msgstr "Åsidosätt utmatningen för det här fältet med anpassad text"
 
 msgid "Output this field as a custom link"
-msgstr ""
+msgstr "Mata ut det här fältet som en anpassad länk"
 
 msgid "Trim this field to a maximum number of characters"
-msgstr ""
+msgstr "Korta ned detta fält till ett största antal tecken"
 
 msgid "More link label"
-msgstr ""
+msgstr "Etikett för länk \"Mer\""
 
 msgid "You may use the \"Replacement patterns\" above."
-msgstr ""
+msgstr "Du kan använda \"Ersättningsmönstren\" ovan."
 
 msgid ""
 "An HTML corrector will be run to ensure HTML tags are properly closed after "
 "trimming."
 msgstr ""
+"En HTML-korrigerare kommer köras för att se till att HTML-taggar är stängda "
+"på rätt sätt efter nedkortning."
 
 msgid "Fields to be included as links."
-msgstr ""
+msgstr "Fält som skall inkluderas som länkar."
 
 msgid ""
 "Include a \"destination\" parameter in the link to return the user to the "
 "original view upon completing the link action."
 msgstr ""
+"Inkludera en \"mål\"-parameter i länken för att vidarebefordra användaren "
+"till den ursprungliga vyn efter att länkåtgärden genomförts."
 
 msgid "First page link text"
-msgstr ""
+msgstr "Länktext till startsida"
 
 msgid "Last page link text"
-msgstr ""
+msgstr "Länktext till senaste sida"
 
 msgid "Offset (number of items to skip)"
-msgstr ""
+msgstr "Kompensation (antal poster att hoppa över)"
 
 msgid ""
 "For example, set this to 3 and the first 3 items will not be displayed."
 msgstr ""
+"Till exempel, ställ in detta till 3 och de 3 första posterna kommer inte att"
+" visas."
 
 msgid "Pager link labels"
-msgstr ""
+msgstr "Etikett för pagineringslänkar"
 
 msgid "Previous page link text"
-msgstr ""
+msgstr "Textlänk för föregående sida"
 
 msgid "Next page link text"
-msgstr ""
+msgstr "Textlänk för nästa sida"
 
 msgid ""
 "Insert a list of integer numeric values separated by commas: e.g: 10, 20, "
 "50, 100"
 msgstr ""
+"Sätt in en lista med numeriska heltalsvärden separerade med kommatecken. "
+"Till exempel: 10, 20, 50, 100"
 
 msgid ""
 "WARNING: Disabling SQL rewriting means that node access security is "
@@ -15500,375 +16813,390 @@ msgid ""
 " your view is misconfigured. Use this option only if you understand and "
 "accept this security risk."
 msgstr ""
+"WARNING: Disabling SQL rewriting means that node access security is "
+"disabled. This may allow users to see data they should not be able to see if"
+" your view is misconfigured. Use this option only if you understand and "
+"accept this security risk."
 
 msgid "No view mode selected"
-msgstr ""
+msgstr "Inget vyläge valt"
 
 msgid "Caption for the table"
-msgstr ""
+msgstr "Överskrift för tabellen"
 
 msgid "Table details"
-msgstr ""
+msgstr "Detaljer för tabell"
 
 msgid "Summary title"
-msgstr ""
+msgstr "Titel för sammanfattning"
 
 msgid "Table description"
-msgstr ""
+msgstr "Beskrivning av tabell"
 
 msgid "Provide additional details about the table to increase accessibility."
 msgstr ""
+"Tillhandahåll ytterligare detaljer om tabellen för att öka tillgängligheten."
 
 msgid "Enable @display_title"
-msgstr ""
+msgstr "Aktivera @display_title"
 
 msgid "Delete @display_title"
-msgstr ""
+msgstr "Radera @display_title"
 
 msgid "Undo delete of @display_title"
-msgstr ""
+msgstr "Ångra radering av @display_title"
 
 msgid "Disable @display_title"
-msgstr ""
+msgstr "Inaktivera @display_title"
 
 msgid "Edit view name/description"
-msgstr ""
+msgstr "Redigera vynamn/beskrivning"
 
 msgid "Analyze view"
-msgstr ""
+msgstr "Analysera vy"
 
 msgid "Reorder displays"
-msgstr ""
+msgstr "Omorganisera visningar"
 
 msgid "Revert view"
-msgstr ""
+msgstr "Återställ vy"
 
 msgid "Add <span class=\"visually-hidden\">@type</span>"
-msgstr ""
+msgstr "Lägg till <span class=\"visually-hidden\">@type</span>"
 
 msgid "And/Or Rearrange <span class=\"visually-hidden\">filter criteria</span>"
-msgstr ""
+msgstr "Och/eller ändra om <span class=\"visually-hidden\">filterkriterium</span>"
 
 msgid "Rearrange <span class=\"visually-hidden\">@type</span>"
-msgstr ""
+msgstr "Ändra om <span class=\"visually-hidden\">@type</span>"
 
 msgid "This display has one or more validation errors."
-msgstr ""
+msgstr "Denna visning har ett eller flera valideringsfel."
 
 msgid "There are no disabled views."
-msgstr ""
+msgstr "Det finns inga inaktiverade vyer."
 
 msgid "[@time ms] @query"
-msgstr ""
+msgstr "[@time ms] @query"
 
 msgid "Do you want to break the lock on view %name?"
-msgstr ""
+msgstr "Vill du bryta upp låset på vy %name?"
 
 msgid "View language"
-msgstr ""
+msgstr "Språk för vy"
 
 msgid "Language of labels and other textual elements in this view."
-msgstr ""
+msgstr "Språk på etiketter och andra textelement i denna vy."
 
 msgid "No displays available."
-msgstr ""
+msgstr "Inga visningar tillgängliga."
 
 msgid "Last saved"
-msgstr ""
+msgstr "Senast sparad"
 
 msgid "Not saved yet"
-msgstr ""
+msgstr "Inte sparad ännu"
 
 msgid "Hard"
-msgstr ""
+msgstr "Hard"
 
 msgid "Book Page"
-msgstr ""
+msgstr "Boksida"
 
 msgid "Aggregator feed item"
-msgstr ""
+msgstr "Post på nyhetssamlares flöde."
 
 msgid "Default parser for RSS, Atom and RDF feeds."
-msgstr ""
+msgstr "Förvald tolkare för RSS-, Atom- och RDF-flöden."
 
 msgid "Custom Block"
-msgstr ""
+msgstr "Anpassat block"
 
 msgid "CKEditor core"
-msgstr ""
+msgstr "CKEditor kärna"
 
 msgid "Styles dropdown"
-msgstr ""
+msgstr "Nedfällbara stilar"
 
 msgid "Comment selection"
-msgstr ""
+msgstr "Urval för kommentar"
 
 msgid "My Editor"
-msgstr ""
+msgstr "My Editor"
 
 msgid "Entity display"
-msgstr ""
+msgstr "Visning av objekt"
 
 msgid "Display the ID of the referenced entities."
-msgstr ""
+msgstr "Visa ID-numren för de refererade objekten."
 
 msgid "Selects referenceable entities for an entity reference field."
-msgstr ""
+msgstr "Väljer refererbara objekt för ett fältobjektsreferens."
 
 msgid "Entity Reference inline fields"
-msgstr ""
+msgstr "Radvisa fält för objektsreferens"
 
 msgid "Returns results as a PHP array of labels and rendered rows."
-msgstr ""
+msgstr "Returns results as a PHP array of labels and rendered rows."
 
 msgid "File selection"
-msgstr ""
+msgstr "File selection"
 
 msgid "Separate link text and URL"
-msgstr ""
+msgstr "Avskilj länktext och URL"
 
 msgid "Node Bundle"
-msgstr ""
+msgstr "Node Bundle"
 
 msgid "Node selection"
-msgstr ""
+msgstr "Node selection"
 
 msgid "Watchdog database log"
-msgstr ""
+msgstr "Watchdog database log"
 
 msgid "REST export"
-msgstr ""
+msgstr "REST export"
 
 msgid "Create a REST export resource."
-msgstr ""
+msgstr "Create a REST export resource."
 
 msgid "Use entities as row data."
-msgstr ""
+msgstr "Use entities as row data."
 
 msgid "Use fields as row data."
-msgstr ""
+msgstr "Use fields as row data."
 
 msgid "Serializer"
-msgstr ""
+msgstr "Serializer"
 
 msgid "Serializes views row data using the Serializer component."
-msgstr ""
+msgstr "Serializes views row data using the Serializer component."
 
 msgid "Tar"
-msgstr ""
+msgstr "Tar"
 
 msgid "Handles .tar files."
-msgstr ""
+msgstr "Hanterar .tar-filer."
 
 msgid "Handles zip files."
-msgstr ""
+msgstr "Hanterar .zip-filer."
 
 msgid "Taxonomy Term selection"
-msgstr ""
+msgstr "Taxonomy Term selection"
 
 msgid "Display reference to taxonomy term in RSS."
-msgstr ""
+msgstr "Visa referens till taxonomiterm i RSS."
 
 msgid "Telephone link"
-msgstr ""
+msgstr "Telefonlänk"
 
 msgid "User selection"
-msgstr ""
+msgstr "Urval av användare"
 
 msgid "Views Exposed Filter Block"
-msgstr ""
+msgstr "Views synliga blockfilter"
 
 msgid " - Basic validation - "
-msgstr ""
+msgstr " - Grundläggande validering - "
 
 msgid "A simple pager containing previous and next links."
-msgstr ""
+msgstr "En enkel paginerare som innehåller länkar för föregående och nästa."
 
 msgid "Display all items that this view might find."
-msgstr ""
+msgstr "Visa alla poster som denna vy kan hitta."
 
 msgid "Displays rows as HTML list."
-msgstr ""
+msgstr "Visar rader som HTML-lista."
 
 msgid "Language detection and selection"
-msgstr ""
+msgstr "Language detection and selection"
 
 msgid "Toolkit"
-msgstr ""
+msgstr "Toolkit"
 
 msgid "Configuration Translation"
-msgstr ""
+msgstr "Configuration Translation"
 
 msgid "- empty image -"
-msgstr ""
+msgstr "- empty image -"
 
 msgid "Field formatters"
-msgstr ""
+msgstr "Fältformaterare"
 
 msgid ""
 "If enabled, access permissions for rendering the entity are not checked."
 msgstr ""
+"Om aktiverad kommer inte åtkomstbehörigheter för generering av objekt "
+"kontrolleras."
 
 msgid "The directory %translations_directory exists."
-msgstr ""
+msgstr "Katalogen %translations_directory finns redan."
 
 msgid "MySQL, MariaDB, Percona Server, or equivalent"
-msgstr ""
+msgstr "MySQL, MariaDB, Percona Server, eller likvärdig"
 
 msgid "The referenced language"
-msgstr ""
+msgstr "Det refererade språket"
 
 msgid "Language reference"
-msgstr ""
+msgstr "Referens till språk"
 
 msgid "URI value"
-msgstr ""
+msgstr "Värde för URI"
 
 msgid "An entity field containing a URI."
-msgstr ""
+msgstr "Ett objektsfält som innehåller en URI."
 
 msgid "Caribbean Netherlands"
-msgstr ""
+msgstr "Karibiska Nederländerna"
 
 msgid "Cocos [Keeling] Islands"
-msgstr ""
+msgstr "Kokosöarna (Keelingöarna)"
 
 msgid "Congo - Kinshasa"
-msgstr ""
+msgstr "Kongo - Kinshasa"
 
 msgid "Congo - Brazzaville"
-msgstr ""
+msgstr "Kongo - Brazzaville"
 
 msgid "Côte d’Ivoire"
-msgstr ""
+msgstr "Elfenbenskusten"
 
 msgid "Clipperton Island"
-msgstr ""
+msgstr "Clippertonön"
 
 msgid "Ceuta and Melilla"
-msgstr ""
+msgstr "Ceuta och Melilla"
 
 msgid "Hong Kong SAR China"
-msgstr ""
+msgstr "Hongkong, särskild administrativ region i Kina"
 
 msgid "Canary Islands"
-msgstr ""
+msgstr "Kanarieöarna"
 
 msgid "Myanmar [Burma]"
-msgstr ""
+msgstr "Burma (Myanmar)"
 
 msgid "Macau SAR China"
-msgstr ""
+msgstr "Macao, särskild administrativ region i Kina"
 
 msgid "Palestinian Territories"
-msgstr ""
+msgstr "Palestinska Territorierna"
 
 msgid "Outlying Oceania"
-msgstr ""
+msgstr "Mindre öar i Oceanien"
 
 msgid "São Tomé and Príncipe"
-msgstr ""
+msgstr "São Tomé och Príncipe"
 
 msgid "U.S. Outlying Islands"
-msgstr ""
+msgstr "Tristan da Cunha"
 
 msgid "Time span in seconds"
-msgstr ""
+msgstr "Tidsintervall i sekunder"
 
 msgid "Using simple actions"
-msgstr ""
+msgstr "Användande av enkla åtgärder"
 
 msgid "Shortcut set"
-msgstr ""
+msgstr "Genväg inställd"
 
 msgid "Entity form display"
-msgstr ""
+msgstr "Formulärsvisning av objekt"
 
 msgid "WYSIWYG editing for rich text fields using CKEditor."
-msgstr ""
+msgstr "WYSIWYG editing for rich text fields using CKEditor."
 
 msgid "Creating and configuring advanced actions"
-msgstr ""
+msgstr "Skapande och och konfigurerande av utökade åtgärder"
 
 msgid ""
 "A unique name for this block instance. Must be alpha-numeric and underscore "
 "separated."
 msgstr ""
+"Ett unikt namn för denna blockinstans. Måste vara alfanumeriskt och "
+"åtskiljas av understreck."
 
 msgid "Filter by block name"
-msgstr ""
+msgstr "Filtrera på blocknamn"
 
 msgid "Allow settings in the block configuration"
-msgstr ""
+msgstr "Tillåt inställningar i blockkonfigurationen"
 
 msgid "Items per block"
-msgstr ""
+msgstr "Poster per block"
 
 msgid "@count (default setting)"
-msgstr ""
+msgstr "@count (förvald inställning)"
 
 msgid "Enabling CKEditor for individual text formats"
-msgstr ""
+msgstr "Aktiverar CKEditor för individuella textformat"
 
 msgid "Configuring the toolbar"
-msgstr ""
+msgstr "Konfigurerar verktygsraden"
 
 msgid "Formatting content"
-msgstr ""
+msgstr "Formaterar innehåll"
 
 msgid "Toggling between formatted text and HTML source"
-msgstr ""
+msgstr "Växlar mellan formaterad text och HTML-källa"
 
 msgid "Uploads disabled"
-msgstr ""
+msgstr "Uppladdningar inaktiverad"
 
 msgid "Uploads enabled, max size: @size @dimensions"
-msgstr ""
+msgstr "Uppladdningar aktiverad, största storlek: @size @dimensions"
 
 msgid "Edit Image"
-msgstr ""
+msgstr "Redigera bild"
 
 msgid "Drupal link"
-msgstr ""
+msgstr "Länk för Drupal"
 
 msgid "CKEditor plugin settings"
-msgstr ""
+msgstr "Inställningar för insticksprogram CKEditor"
 
 msgid ""
 "Could not extract the contents of the tar file. The error message is "
 "<em>@message</em>"
 msgstr ""
+"Could not extract the contents of the tar file. The error message is "
+"<em>@message</em>"
 
 msgid "Discard changes?"
-msgstr ""
+msgstr "Ignorera ändringar?"
 
 msgid "Enable image uploads"
-msgstr ""
+msgstr "Aktivera bilduppladdningar"
 
 msgid "Storage: @name"
-msgstr ""
+msgstr "Lager: @name"
 
 msgid ""
 "A directory relative to Drupal's files directory where uploaded images will "
 "be stored."
 msgstr ""
+"En katalog i förhållande till Drupals filkatalog där uppladdade bilder "
+"kommer lagras."
 
 msgid ""
 "If this is left empty, then the file size will be limited by the PHP maximum"
 " upload size of @size."
 msgstr ""
+"If this is left empty, then the file size will be limited by the PHP maximum"
+" upload size of @size."
 
 msgid "Images larger than these dimensions will be scaled down."
-msgstr ""
+msgstr "Images larger than these dimensions will be scaled down."
 
 msgid "Installing text editors"
-msgstr ""
+msgstr "Installerar textredigerare"
 
 msgid "Enabling a text editor for a text format"
-msgstr ""
+msgstr "Aktiverar en textredigerare för textformat"
 
 msgid "Configuring a text editor"
-msgstr ""
+msgstr "Konfigurerar en textredigerare"
 
 msgid ""
 "Once a text editor is associated with a text format, you can configure it by"
@@ -15878,69 +17206,75 @@ msgid ""
 "and they often insert HTML tags into the field source. For details, see the "
 "help page of the specific text editor."
 msgstr ""
+"Once a text editor is associated with a text format, you can configure it by"
+" clicking on the <em>Configure</em> link for this format. Depending on the "
+"specific text editor, you can configure it for example by adding buttons to "
+"its toolbar. Typically these buttons provide formatting or editing tools, "
+"and they often insert HTML tags into the field source. For details, see the "
+"help page of the specific text editor."
 
 msgid "Using different text editors and formats"
-msgstr ""
+msgstr "Using different text editors and formats"
 
 msgid "Placeholder: @placeholder"
-msgstr ""
+msgstr "Platshållare: @placeholder"
 
 msgid "No placeholder"
-msgstr ""
+msgstr "Ingen platshållare"
 
 msgid "Add, edit, and delete custom display modes."
-msgstr ""
+msgstr "Lägg till, redigera och radera anpassade visningslägen."
 
 msgid "Add form mode"
-msgstr ""
+msgstr "Lägg till formulärsläge"
 
 msgid "Edit form mode"
-msgstr ""
+msgstr "Redigera formulärsläge"
 
 msgid "Choose view mode entity type"
-msgstr ""
+msgstr "Välj objektsläge för vyläge"
 
 msgid "Choose form mode entity type"
-msgstr ""
+msgstr "Välj objektstyp för formulärsläge"
 
 msgid "Saved the %label @entity-type."
-msgstr ""
+msgstr "Sparade @entity-type %label."
 
 msgid "Autocomplete matching: @match_operator"
-msgstr ""
+msgstr "Automatisk komplettering överensstämmer: @match_operator"
 
 msgid "The referenced entity (%type: %id) does not exist."
-msgstr ""
+msgstr "Det refererade objektet (%type: %id) finns inte."
 
 msgctxt "Sort order"
 msgid "Order"
-msgstr ""
+msgstr "Ordning"
 
 msgid "%entity_label: Administer form display"
-msgstr ""
+msgstr "%entity_label: Administrera formulärvisning"
 
 msgid "Plugin for @title"
-msgstr ""
+msgstr "Insticksprogram för @title"
 
 msgid "@type (module: @module)"
-msgstr ""
+msgstr "@type (modul: @module)"
 
 msgid "Widget settings:"
-msgstr ""
+msgstr "Widget settings:"
 
 msgid "The label of the entity that is related to the file."
-msgstr ""
+msgstr "The label of the entity that is related to the file."
 
 msgid "Access the Files overview page"
-msgstr ""
+msgstr "Åtkomst till sidan för filöversikt"
 
 msgid "Progress indicator: @progress_indicator"
-msgstr ""
+msgstr "Förloppsindikator: @progress_indicator"
 
 msgid ""
 "The %filter filter is missing, and will be removed once this format is "
 "saved."
-msgstr ""
+msgstr "Filtret %filter saknas och kommer att tas bort när formatet sparas."
 
 msgid ""
 "Lines and paragraphs are automatically recognized. The &lt;br /&gt; line "
@@ -15948,42 +17282,48 @@ msgid ""
 "automatically. If paragraphs are not recognized simply add a couple of blank"
 " lines."
 msgstr ""
+"Rader och stycken hanteras automatiskt. Radbrytningar (&lt;br /&gt;) och "
+"taggar för stycken (&lt;p&gt; och &lt;/p&gt;) sätts in automatiskt. Om "
+"stycken inte fungerar är det bara att lägga till ett par tomrader."
 
 msgid "Missing filter. All text is removed"
-msgstr ""
+msgstr "Saknar filter. All text är borttagen"
 
 msgid "Missing filter plugin: %filter."
-msgstr ""
+msgstr "Saknar insticksprogram för filter: %filter."
 
 msgid "Provides a fallback for missing filters. Do not use."
-msgstr ""
+msgstr "Tillhandahåller en reserv för saknat filter. Använd inte."
 
 msgid "Updated @type %term."
-msgstr ""
+msgstr "Uppdaterade @type %term."
 
 msgid "Add image style"
-msgstr ""
+msgstr "Add image style"
 
 msgid "Preview image style: @style"
-msgstr ""
+msgstr "Förhandsgranska bildstil: @style"
 
 msgid ""
 "Deleting a language will remove all interface translations associated with "
 "it, and content in this language will be set to be language neutral. This "
 "action cannot be undone."
 msgstr ""
+"Deleting a language will remove all interface translations associated with "
+"it, and content in this language will be set to be language neutral. This "
+"action cannot be undone."
 
 msgid "No placeholders"
-msgstr ""
+msgstr "Inga platshållare"
 
 msgid "Title placeholder: @placeholder_title"
-msgstr ""
+msgstr "Platshållare för titel: @placeholder_title"
 
 msgid "URL placeholder: @placeholder_url"
-msgstr ""
+msgstr "URL placeholder: @placeholder_url"
 
 msgid "Note that importing large .po files may take several minutes."
-msgstr ""
+msgstr "Note that importing large .po files may take several minutes."
 
 msgid ""
 "Content items can be edited using different form modes. Here, you can define"
@@ -15991,25 +17331,33 @@ msgid ""
 " mode, and define how the field form widgets are displayed in each form "
 "mode."
 msgstr ""
+"Content items can be edited using different form modes. Here, you can define"
+" which fields are shown and hidden when %type content is edited in each form"
+" mode, and define how the field form widgets are displayed in each form "
+"mode."
 
 msgid "Edit %label content type"
-msgstr ""
+msgstr "Redigera innehållstyp %label"
 
 msgid ""
 "The content has either been modified by another user, or you have already "
 "submitted modifications. As a result, your changes cannot be saved."
 msgstr ""
+"Innehållet har antingen ändrats av en annan användare, eller så har du redan"
+" skickat in ändringar. Därför kan inte dina ändringarna sparas."
 
 msgid "Use field label: @display_label"
-msgstr ""
+msgstr "Använd fältetikett: @display_label"
 
 msgid "Provides a row plugin to display search results."
-msgstr ""
+msgstr "Provides a row plugin to display search results."
 
 msgid ""
 "More information about setting up scheduled tasks can be found by <a "
 "href=\"@url\">reading the cron tutorial on drupal.org</a>."
 msgstr ""
+"Mer information om inställning av schemalagda aktiviteter kan hittas genom "
+"att <a href=\"@url\">läsa guiden om cron på drupal.org</a>."
 
 msgid ""
 "A local file system path where public files will be stored. This directory "
@@ -16017,64 +17365,77 @@ msgid ""
 " Drupal installation directory and be accessible over the web. This must be "
 "changed in settings.php"
 msgstr ""
+"En lokal systemsökväg där publika filer kommer lagras. Denna katalog måste "
+"existera och vara skrivbar av Drupal. Denna katalog måste vara relativ till "
+"Drupals installationskatalog och vara åtkomlig via webben. Detta måste "
+"ändras i settings.php"
 
 msgid "%name: the telephone number may not be longer than @max characters."
-msgstr ""
+msgstr "%name: telefonnumret får inte vara längre än @max tecken."
 
 msgid "%name: the text may not be longer than @max characters."
-msgstr ""
+msgstr "%name: texten får inte vara längre än @max tecken."
 
 msgid "Summary rows"
-msgstr ""
+msgstr "Rader för sammanfattning"
 
 msgid ""
 "This form lets administrators add and edit fields for storing user data."
 msgstr ""
+"This form lets administrators add and edit fields for storing user data."
 
 msgid ""
 "This form lets administrators configure how form fields should be displayed "
 "when editing a user profile."
 msgstr ""
+"This form lets administrators configure how form fields should be displayed "
+"when editing a user profile."
 
 msgid ""
 "Alter the HTTP response status code used by this view, mostly helpful for "
 "empty results."
 msgstr ""
+"Ändra svarskoden för HTTP som används av denna vy. Mest användbart för tomma"
+" resultat."
 
 msgid "HTTP status code"
-msgstr ""
+msgstr "Statuskod för HTTP"
 
 msgid "Always display the more link"
-msgstr ""
+msgstr "Visa alltid länken för mer"
 
 msgid ""
 "Check this to display the more link even if there are no more items to "
 "display."
 msgstr ""
+"Kryssa för här för att visa länken \"mer\" även om det inte finns fler "
+"objekt att visa."
 
 msgid "Make entity label a link to entity page."
-msgstr ""
+msgstr "Gör etikettsobjekt till en länk till sidobjekt."
 
 msgid "Configure language support for content."
-msgstr ""
+msgstr "Konfigurera språkstöd för innehåll."
 
 msgid "Managing and displaying link fields"
-msgstr ""
+msgstr "Hantering och visning av länkfält"
 
 msgid "Adding link text"
-msgstr ""
+msgstr "Lägger till länktext"
 
 msgid "Display modes"
-msgstr ""
+msgstr "Visningslägen"
 
 msgid "Manage custom view modes."
-msgstr ""
+msgstr "Hantera anpassade vylägen."
 
 msgid "Configure what displays are available for your content and forms."
 msgstr ""
+"Konfigurera vilka visningar som finns tillgängliga för ditt innehåll och "
+"formulär."
 
 msgid "Allows the creation of custom blocks through the user interface."
-msgstr ""
+msgstr "Allows the creation of custom blocks through the user interface."
 
 msgid ""
 "You must add some additional fields to this display before using this field."
@@ -16082,36 +17443,49 @@ msgid ""
 "Note that due to rendering order, you cannot use fields that come after this"
 " field; if you need a field not listed here, rearrange your fields."
 msgstr ""
+"Du måste lägga till några ytterligare fält till denna visning innan du kan "
+"använda fältet. Dessa fält kan markeras som <em>Undanta från visning</em> om"
+" du föredrar det. Observera att på grund av ordningen för genereringen kan "
+"du inte använda fält som ligger efter detta fält. Om du behöver ett fält som"
+" inte visas här kan du ordna om dina fält."
 
 msgid "Automatic width"
-msgstr ""
+msgstr "Automatisk bredd"
 
 msgid "Default column classes"
-msgstr ""
+msgstr "Förvalda kolumnklasser"
 
 msgid "Custom column class"
-msgstr ""
+msgstr "Anpassad kolumnklass"
 
 msgid "Additional classes to provide on each column. Separated by a space."
 msgstr ""
+"Ytterligare klasser att tillhandahålla på varje kolumn. Avskilda med ett "
+"mellanslag."
 
 msgid "Default row classes"
-msgstr ""
+msgstr "Förvalda radklasser"
 
 msgid ""
 "Adds the default views row classes like views-row, row-1 and clearfix to the"
 " output. You can use this to quickly reduce the amount of markup the view "
 "provides by default, at the cost of making it more difficult to apply CSS."
 msgstr ""
+"Lägger till de förvalda radklasserna för visningar som views-row, row-1 och "
+"clearfix till utmatningen. Du kan använda detta för att snabbt minska "
+"mängden uppmärkning som vyn ger som standard, på bekostnad av att det blir "
+"svårare att tillämpa CSS."
 
 msgid "Custom row class"
-msgstr ""
+msgstr "Anpassad radklass"
 
 msgid "Additional classes to provide on each row. Separated by a space."
 msgstr ""
+"Ytterligare klasser att tillhandahålla på varje rad. Avskilda med ett "
+"mellanslag."
 
 msgid "Default wizard"
-msgstr ""
+msgstr "Förvald guide"
 
 msgid ""
 "All Views-generated queries will include the name of the views and display "
@@ -16119,701 +17493,731 @@ msgid ""
 "makes identifying Views queries in database server logs simpler, but should "
 "only be used when troubleshooting."
 msgstr ""
+"Alla Viewsgenererade databasfrågor kommer innehålla namnet på vyn och visa: "
+"'vynamn:visningsnamn' som en sträng i slutet av SELECT-satsen. Detta gör det"
+" enklare att identifiera databasfrågor från Views i loggar för "
+"databasservern, men bör endast användas vid felsökning."
 
 msgid "Selected:"
-msgstr ""
+msgstr "Vald:"
 
 msgctxt "Validation"
 msgid "Allowed values"
-msgstr ""
+msgstr "Tillåtna värden"
 
 msgid "You must select at least %limit choice."
 msgid_plural "You must select at least %limit choices."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Du måste välja minst %limit värde."
+msgstr[1] "Du måste välja minst %limit värden."
 
 msgid "You must select at most %limit choice."
 msgid_plural "You must select at most %limit choices."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Du måste välja som mest %limit värde."
+msgstr[1] "Du måste välja som mest %limit värden."
 
 msgctxt "Validation"
 msgid "Bundle"
-msgstr ""
+msgstr "Hopsamling"
 
 msgid "The entity must be of bundle %bundle."
-msgstr ""
+msgstr "Objektet måste vara av hopsamling %bundle."
 
 msgctxt "Validation"
 msgid "Complex data"
-msgstr ""
+msgstr "Komplex data"
 
 msgctxt "Validation"
 msgid "Count"
-msgstr ""
+msgstr "Summa"
 
 msgid "This collection should contain %limit element or more."
 msgid_plural "This collection should contain %limit elements or more."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Denna samling skall innehåll %limit element eller fler."
+msgstr[1] "Denna samling skall innehåll %limit element eller fler."
 
 msgid "This collection should contain %limit element or less."
 msgid_plural "This collection should contain %limit elements or less."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Denna samling skall innehåll %limit element eller mindre."
+msgstr[1] "Denna samling skall innehåll %limit element eller mindre."
 
 msgid "This collection should contain exactly %limit element."
 msgid_plural "This collection should contain exactly %limit elements."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Denna samling skall innehåll exakt %limit element."
+msgstr[1] "Denna samling skall innehåll exakt %limit element."
 
 msgctxt "Validation"
 msgid "Entity type"
-msgstr ""
+msgstr "Typ av objekt"
 
 msgid "The entity must be of type %type."
-msgstr ""
+msgstr "Objektet måste vara av typ %type."
 
 msgctxt "Validation"
 msgid "Length"
-msgstr ""
+msgstr "Längd"
 
 msgid "This value is too long. It should have %limit character or less."
 msgid_plural ""
 "This value is too long. It should have %limit characters or less."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Detta värde är för långt. Det skall ha %limit tecken eller mindre."
+msgstr[1] "Detta värde är för långt. Det skall ha %limit tecken eller mindre."
 
 msgid "This value is too short. It should have %limit character or more."
 msgid_plural ""
 "This value is too short. It should have %limit characters or more."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Detta värde är för kort. Det skall ha %limit tecken eller mer."
+msgstr[1] "Detta värde är för kort. Det skall ha %limit tecken eller mer."
 
 msgid "This value should have exactly %limit character."
 msgid_plural "This value should have exactly %limit characters."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Detta värde skall ha exakt %limit tecken."
+msgstr[1] "Detta värde skall ha exakt %limit tecken."
 
 msgctxt "Validation"
 msgid "Primitive type"
-msgstr ""
+msgstr "Primitiv typ"
 
 msgid "This value should be of the correct primitive type."
-msgstr ""
+msgstr "Detta värde bör vara av den korrekta primitiva typen."
 
 msgctxt "Validation"
 msgid "Range"
-msgstr ""
+msgstr "Serie"
 
 msgid "This value should be %limit or less."
-msgstr ""
+msgstr "Detta värde skall vara %limit eller mindre."
 
 msgctxt "Validation"
 msgid "Entity Reference valid reference"
-msgstr ""
+msgstr "Giltig referens för objektsreferens"
 
 msgctxt "Validation"
 msgid "User name"
-msgstr ""
+msgstr "Användarnamn"
 
 msgctxt "Validation"
 msgid "User name unique"
-msgstr ""
+msgstr "Unikt användarnamn"
 
 msgid "%name must be higher than or equal to %min."
-msgstr ""
+msgstr "%name måste vara högre än eller lika med %min."
 
 msgid "%name must be lower than or equal to %max."
-msgstr ""
+msgstr "%name måste vara lägre än eller lika med %max."
 
 msgctxt "Validation"
 msgid "Entity changed"
-msgstr ""
+msgstr "Ändrat objekt"
 
 msgid "Select the feed that should be displayed"
-msgstr ""
+msgstr "Välj det flöde som skall visas."
 
 msgid "Creating and managing custom block types"
-msgstr ""
+msgstr "Skapande och hanterande av anpassade blocktyper"
 
 msgid "The custom block language code."
-msgstr ""
+msgstr "Språkkoden för anpassat block."
 
 msgid "The time that the custom block was last edited."
-msgstr ""
+msgstr "Tidpunkten då det anpassade blocket senast redigerades."
 
 msgid "Block category"
-msgstr ""
+msgstr "Blockkategori"
 
 msgid "Hide block if the view output is empty"
-msgstr ""
+msgstr "Dölj block om vyutmatningen är tom"
 
 msgid "Block empty settings"
-msgstr ""
+msgstr "Inställningar för tomt block"
 
 msgid "Hide block if no result/empty text"
-msgstr ""
+msgstr "Dölj block om inget resultat/tom text"
 
 msgid ""
 "Hide the block if there is no result and no empty text and no header/footer "
 "which is shown on empty result"
 msgstr ""
+"Dölj blocket om det inte finns något resultat och ingen tom text och inget "
+"sidhuvud/sidfot som visas vid tomt resultat"
 
 msgid "Enter caption here"
-msgstr ""
+msgstr "Ange här en bildtext"
 
 msgid "Drupal image caption widget"
-msgstr ""
+msgstr "Gränssnittskomponenten för bildtext i Drupal"
 
 msgid "The number of comments posted on an entity."
-msgstr ""
+msgstr "Antalet kommentarer som lagts in på ett objekt."
 
 msgid ""
 "The number of comments posted on an entity since the reader last viewed it."
 msgstr ""
+"Antalet kommentarer som lagts in på ett objekt sedan läsaren senast visade "
+"det."
 
 msgid "The entity the comment was posted to."
-msgstr ""
+msgstr "The entity the comment was posted to."
 
 msgid "The @entity_type to which the comment is a reply to."
-msgstr ""
+msgstr "@entity_type som kommentaren är ett svar på."
 
 msgid "The number of comments an entity has."
-msgstr ""
+msgstr "Antalet kommentarer ett objekt har."
 
 msgid "Display the last comment of an entity"
-msgstr ""
+msgstr "Visa den sista kommentaren för ett objekt"
 
 msgid "The last comment of an entity."
-msgstr ""
+msgstr "Den sista kommentaren för ett objekt."
 
 msgid "The entity type to which the comment is a reply to."
-msgstr ""
+msgstr "Objektstypen till vilken kommentaren är ett svar till."
 
 msgid ""
 "Display nodes only if a user posted the @entity_type or commented on the "
 "@entity_type."
 msgstr ""
+"Display nodes only if a user posted the @entity_type or commented on the "
+"@entity_type."
 
 msgid "Comments of the @entity_type using field: @field_name"
-msgstr ""
+msgstr "Kommentarer för @entity_type som använder fält: @field_name"
 
 msgid "Edit comment %title"
-msgstr ""
+msgstr "Redigera kommentar %title"
 
 msgid "The ID of the entity of which this comment is a reply."
-msgstr ""
+msgstr "The ID of the entity of which this comment is a reply."
 
 msgid "The entity type to which this comment is attached."
-msgstr ""
+msgstr "The entity type to which this comment is attached."
 
 msgid "Comment field name"
-msgstr ""
+msgstr "Namn på kommentarsfält"
 
 msgid "The field name through which this comment was added."
-msgstr ""
+msgstr "The field name through which this comment was added."
 
 msgid "The time that the last comment was created."
-msgstr ""
+msgstr "The time that the last comment was created."
 
 msgid "The name of the user posting the last comment."
-msgstr ""
+msgstr "The name of the user posting the last comment."
 
 msgid "The number of comments."
-msgstr ""
+msgstr "The number of comments."
 
 msgid ""
 "This field manages configuration and presentation of comments on an entity."
 msgstr ""
+"This field manages configuration and presentation of comments on an entity."
 
 msgid "Comment list"
-msgstr ""
+msgstr "Kommentarslista"
 
 msgid "Select source language"
-msgstr ""
+msgstr "Välj källspråk"
 
 msgid "Computed date"
-msgstr ""
+msgstr "Uträknat datum"
 
 msgid "The computed DateTime object."
-msgstr ""
+msgstr "The computed DateTime object."
 
 msgid "Log entries"
-msgstr ""
+msgstr "Logga inlägg"
 
 msgid "Contains a list of log entries."
-msgstr ""
+msgstr "Innehåller en lista av logginlägg."
 
 msgid "The user on which the log entry as written."
-msgstr ""
+msgstr "Användaren för vilken logginlägget skrevs för."
 
 msgid "The actual message of the log entry."
-msgstr ""
+msgstr "Det faktiska meddelandet för logginlägget."
 
 msgid "The variables of the log entry in a serialized format."
-msgstr ""
+msgstr "The variables of the log entry in a serialized format."
 
 msgid "Operation links for the event."
-msgstr ""
+msgstr "Funktionslänkar för händelsen."
 
 msgid "URL of the previous page."
-msgstr ""
+msgstr "URL of the previous page."
 
 msgid "Date when the event occurred."
-msgstr ""
+msgstr "Datum då händelsen inträffade."
 
 msgid "Replace variables"
-msgstr ""
+msgstr "Replace variables"
 
 msgid "One file only."
 msgid_plural "Maximum @count files."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Enbart en fil."
+msgstr[1] "Som mest @count filer."
 
 msgid "Last comment ID"
-msgstr ""
+msgstr "ID-nummer för senaste kommentar"
 
 msgid "WID"
-msgstr ""
+msgstr "WID"
 
 msgid "Block layout"
-msgstr ""
+msgstr "Blocklayout"
 
 msgid "Content language and translation"
-msgstr ""
+msgstr "Content language and translation"
 
 msgid "Configure language and translation support for content."
-msgstr ""
+msgstr "Konfigurera språk- och översättningsstöd för innehåll."
 
 msgid "Adding attributes to links"
-msgstr ""
+msgstr "Lägger til attribut till länkar"
 
 msgid "Validating URLs"
-msgstr ""
+msgstr "Validating URLs"
 
 msgid "Number (decimal)"
-msgstr ""
+msgstr "Nummer (decimal)"
 
 msgid "Number (float)"
-msgstr ""
+msgstr "Nummer (flyttal)"
 
 msgid "Number (integer)"
-msgstr ""
+msgstr "Nummer (heltal)"
 
 msgid "Alias for @id"
-msgstr ""
+msgstr "Alias för @id"
 
 msgid "Raw output for @id"
-msgstr ""
+msgstr "Obearbetad utmatning för @id"
 
 msgid "The date the term was last updated."
-msgstr ""
+msgstr "Datumet då termen senast uppdaterades."
 
 msgid "The time that the term was last edited."
-msgstr ""
+msgstr "Tiden då termen senast redigerades."
 
 msgid "Managing and displaying telephone fields"
-msgstr ""
+msgstr "Hantering och visning av telefonfält"
 
 msgid "Displaying telephone numbers as links"
-msgstr ""
+msgstr "Visar telefonnummer som länkar"
 
 msgid "The user account %name cannot be canceled."
-msgstr ""
+msgstr "Användarkontot %name kan inte tas bort."
 
 msgid "Default actions"
-msgstr ""
+msgstr "Förvald åtgärd"
 
 msgid "Grouping @id"
-msgstr ""
+msgstr "Grupperande @id"
 
 msgid "Columns for @field"
-msgstr ""
+msgstr "Kolumner för @field"
 
 msgid "Sortable for @field"
-msgstr ""
+msgstr "Sorteringsbar för @field"
 
 msgid "Default sort order for @field"
-msgstr ""
+msgstr "Förvald sorteringsordning för @field"
 
 msgid "Default sort for @field"
-msgstr ""
+msgstr "Förvald sortering för @field"
 
 msgid "Alignment for @field"
-msgstr ""
+msgstr "Justering för @field"
 
 msgid "Separator for @field"
-msgstr ""
+msgstr "Avskiljare för @field"
 
 msgid "Hide empty column for @field"
-msgstr ""
+msgstr "Dölj dolda kolumner för @field"
 
 msgid "Responsive setting for @field"
-msgstr ""
+msgstr "Följsam inställning för @field"
 
 msgid "No default sort"
-msgstr ""
+msgstr "Ingen förvald sortering"
 
 msgid "Page display settings"
-msgstr ""
+msgstr "Inställningar för sidvisning"
 
 msgid "Block display settings"
-msgstr ""
+msgstr "Inställningar för blockvisning"
 
 msgid "Always show the master (default) display"
-msgstr ""
+msgstr "Visa alltid huvudvisningen (förvalt)"
 
 msgid "Allow embedded displays"
-msgstr ""
+msgstr "Tillåt inbäddade visningar"
 
 msgid "Embedded displays can be used in code via views_embed_view()."
-msgstr ""
+msgstr "Inbäddade visningar kan användas i kod via views_embed_view()."
 
 msgid "Show SQL query"
-msgstr ""
+msgstr "Visa SQL-fråga"
 
 msgid "Remove @title"
-msgstr ""
+msgstr "Tag bort @title"
 
 msgid "Weight for @id"
-msgstr ""
+msgstr "Vikt för @id"
 
 msgid "Group for @id"
-msgstr ""
+msgstr "Grupp för @id"
 
 msgid "Remove @id"
-msgstr ""
+msgstr "Tag bort @id"
 
 msgid "PHP date format"
-msgstr ""
+msgstr "Datumformat för PHP"
 
 msgid "@group: @title"
-msgstr ""
+msgstr "@group: @title"
 
 msgid "Media types"
-msgstr ""
+msgstr "Media types"
 
 msgid "Not fully protected"
-msgstr ""
+msgstr "Inte helt skyddad"
 
 msgid ""
 "Could not load the form for <q>@field-label</q>, either due to a website "
 "problem or a network connection problem.<br>Please try again."
 msgstr ""
+"Could not load the form for <q>@field-label</q>, either due to a website "
+"problem or a network connection problem.<br>Please try again."
 
 msgid "Reset your password"
-msgstr ""
+msgstr "Återställ ditt lösenord"
 
 msgid "Number of new comments"
-msgstr ""
+msgstr "Number of new comments"
 
 msgid "Button divider"
-msgstr ""
+msgstr "Button divider"
 
 msgid "CKEditor toolbar and button configuration."
-msgstr ""
+msgstr "CKEditor toolbar and button configuration."
 
 msgid "Hide group names"
-msgstr ""
+msgstr "Dölj gruppnamn"
 
 msgid "Show group names"
-msgstr ""
+msgstr "Visa gruppnamn"
 
 msgid "Press the down arrow key to create a new row."
-msgstr ""
+msgstr "Tryck på pil ned för att skapa en ny rad."
 
 msgid "@name @type."
-msgstr ""
+msgstr "@name @type."
 
 msgid "Press the down arrow key to activate."
-msgstr ""
+msgstr "Tryck på pil ned för att aktivera."
 
 msgid "This is the last group. Move the button forward to create a new group."
 msgstr ""
+"Detta är den sista gruppen. Flytta knappen framåt för att skapa en ny grupp."
 
 msgid "The \"@name\" button is currently enabled."
-msgstr ""
+msgstr "Knappen \"@name\" är aktiverad."
 
 msgid "Use the keyboard arrow keys to change the position of this button."
 msgstr ""
+"Använd tangentbordets piltangenter för att ändra placeringen av denna knapp."
 
 msgid "Press the up arrow key on the top row to disable the button."
-msgstr ""
+msgstr "Tryck på pil upp på den översta raden för att inaktivera knappen."
 
 msgid "The \"@name\" button is currently disabled."
-msgstr ""
+msgstr "Knappen \"@name\" är för närvarande inaktiverad."
 
 msgid "Use the down arrow key to move this button into the active toolbar."
 msgstr ""
+"Använd pil ned för att flytta den här knappen till det aktiva "
+"verktygsfältet."
 
 msgid "This @name is currently enabled."
-msgstr ""
+msgstr "Denna @name är för närvarande aktiverad."
 
 msgid "Use the keyboard arrow keys to change the position of this separator."
 msgstr ""
+"Använd tangentbordets piltangenter för att ändra placeringen av denna "
+"avskiljare."
 
 msgid "Separators are used to visually split individual buttons."
-msgstr ""
+msgstr "Avskiljare används för att visuellt skilja individuella knappar."
 
 msgid "This @name is currently disabled."
-msgstr ""
+msgstr "Denna @name är för närvarande inaktiverad."
 
 msgid "Use the down arrow key to move this separator into the active toolbar."
 msgstr ""
+"Använd pil ned för att flytta denna avskiljare till det aktiva "
+"verktygsfältet."
 
 msgid "You may add multiple separators to each button group."
-msgstr ""
+msgstr "Du kan lägga till flera avskiljare till varje knappgrupp."
 
 msgid "Please provide a name for the button group."
-msgstr ""
+msgstr "Var vänlig ange ett namn på gruppknappen."
 
 msgid "Button group name"
-msgstr ""
+msgstr "Namn på knappgrupp"
 
 msgid "Place a button to create a new button group."
-msgstr ""
+msgstr "Placera en knapp för att skapa en ny knappgrupp."
 
 msgid "Add a CKEditor button group to the end of this row."
-msgstr ""
+msgstr "Lägg till en knappgrupp i CKEditor i slutet av denna rad."
 
 msgid "Simple configuration"
-msgstr ""
+msgstr "Simple configuration"
 
 msgid "Configuration type"
-msgstr ""
+msgstr "Typ av konfiguration"
 
 msgid "Here is your configuration:"
-msgstr ""
+msgstr "Here is your configuration:"
 
 msgid "Are you sure you want to update the %name @type?"
-msgstr ""
+msgstr "Är du säker på att du vill uppdatera %name av typ @type?"
 
 msgid "Enter block, theme or category"
-msgstr ""
+msgstr "Ange block, tema eller kategori"
 
 msgid "Enter a part of the block, theme or category to filter by."
-msgstr ""
+msgstr "Ange en del av blocket, tema eller katagori att filtrera på."
 
 msgid "Translations for %label"
-msgstr ""
+msgstr "Översättningar för %label"
 
 msgid "@language (original)"
-msgstr ""
+msgstr "@language (ursprungligt)"
 
 msgid "Enter label"
-msgstr ""
+msgstr "Ange etikett"
 
 msgid "Enter a part of the label or description to filter by."
-msgstr ""
+msgstr "Ange en del av etiketten eller beskrivning att filtrera på."
 
 msgid "Enter field or @bundle"
-msgstr ""
+msgstr "Ange fält eller @bundle"
 
 msgid "Successfully saved @language translation."
-msgstr ""
+msgstr "Successfully saved @language translation."
 
 msgid "Successfully updated @language translation."
-msgstr ""
+msgstr "Successfully updated @language translation."
 
 msgid "(Empty)"
-msgstr ""
+msgstr "(Tom)"
 
 msgid "Feed channel"
-msgstr ""
+msgstr "Feed channel"
 
 msgid "About text formats"
-msgstr ""
+msgstr "Om textformat"
 
 msgid "The image style %name has been flushed."
-msgstr ""
+msgstr "The image style %name has been flushed."
 
 msgid "Image to be shown if no image is uploaded."
-msgstr ""
+msgstr "Bild som skall visas om ingen bild är uppladdad."
 
 msgid "Action title"
-msgstr ""
+msgstr "Titel för åtgärd"
 
 msgid "- Restricted access -"
-msgstr ""
+msgstr "- Begränsad åtkomst -"
 
 msgid "Workflow type"
-msgstr ""
+msgstr "Workflow type"
 
 msgid "Display block title"
-msgstr ""
+msgstr "Display block title"
 
 msgid "List of items"
-msgstr ""
+msgstr "Lista av objekt"
 
 msgid "The ID of the feed item."
-msgstr ""
+msgstr "The ID of the feed item."
 
 msgid "Placing and moving blocks"
-msgstr ""
+msgstr "Placering och flyttning av block"
 
 msgid "Demonstrating block regions for a theme"
-msgstr ""
+msgstr "Demonstrating block regions for a theme"
 
 msgid "Toggling between different themes"
-msgstr ""
+msgstr "Växlar mellan olika teman"
 
 msgid "Configuring block settings"
-msgstr ""
+msgstr "Konfigurerar blockinställningar"
 
 msgid ""
 "You can control the visibility of a block by restricting it to specific "
 "pages, content types, and/or roles by setting the appropriate options under "
 "<em>Visibility settings</em> of the block configuration."
 msgstr ""
+"You can control the visibility of a block by restricting it to specific "
+"pages, content types, and/or roles by setting the appropriate options under "
+"<em>Visibility settings</em> of the block configuration."
 
 msgid "Adding custom blocks"
-msgstr ""
+msgstr "Lägger till anpassat block"
 
 msgid "Pager ID: @id"
-msgstr ""
+msgstr "Pager ID: @id"
 
 msgid "The email of the person that is sending the contact message."
-msgstr ""
+msgstr "The email of the person that is sending the contact message."
 
 msgid "Managing and displaying file fields"
-msgstr ""
+msgstr "Managing and displaying file fields"
 
 msgid "Allowing file extensions"
-msgstr ""
+msgstr "Tillåter filändelser"
 
 msgid "Restricting the maximum file size"
-msgstr ""
+msgstr "Restricting the maximum file size"
 
 msgid "Displaying files and descriptions"
-msgstr ""
+msgstr "Visar filer och beskrivningar"
 
 msgid "The log entry explaining the changes in this revision."
-msgstr ""
+msgstr "The log entry explaining the changes in this revision."
 
 msgid "At least one authentication provider must be defined for resource @id"
-msgstr ""
+msgstr "At least one authentication provider must be defined for resource @id"
 
 msgid "Custom block ID"
-msgstr ""
+msgstr "Custom block ID"
 
 msgid "File usage"
-msgstr ""
+msgstr "Filanvändning"
 
 msgid "Configuration translation"
-msgstr ""
+msgstr "Översättning på konfiguration"
 
 msgid "Translate the configuration."
-msgstr ""
+msgstr "Översätta konfigurationen."
 
 msgid "@label fields"
-msgstr ""
+msgstr "Fält @label"
 
 msgid "The uninstall process removes all data related to a module."
 msgstr ""
+"Processen som körs för avinstallation tar bort all data relaterad till en "
+"modul."
 
 msgid "At least one format must be defined for resource @id"
-msgstr ""
+msgstr "Åtminstone ett format måste vara definierat för källa @id"
 
 msgid "The ID of the shortcut."
-msgstr ""
+msgstr "The ID of the shortcut."
 
 msgid "The UUID of the shortcut."
-msgstr ""
+msgstr "UUID för genvägen."
 
 msgid "The bundle of the shortcut."
-msgstr ""
+msgstr "The bundle of the shortcut."
 
 msgid "Route name"
-msgstr ""
+msgstr "Namn på rutt"
 
 msgid "The language code of the shortcut."
-msgstr ""
+msgstr "The language code of the shortcut."
 
 msgid "Rebuild access"
-msgstr ""
+msgstr "Rebuild access"
 
 msgid "Taxonomy term ID"
-msgstr ""
+msgstr "ID-nummer för taxonomiterm"
 
 msgid "Taxonomy term name"
-msgstr ""
+msgstr "Namn på taxonomiterm"
 
 msgid "The name of this user."
-msgstr ""
+msgstr "Namnet för den här användaren."
 
 msgid "The email of this user."
-msgstr ""
+msgstr "E-postadressen för den här användaren."
 
 msgid "The timezone of this user."
-msgstr ""
+msgstr "Tidszonen för den här användaren."
 
 msgid "The time that the user was created."
-msgstr ""
+msgstr "Tiden då denna användare skapades."
 
 msgid "Adding functionality to administrative pages"
-msgstr ""
+msgstr "Lägger till funktionalitet till administrativa sidor"
 
 msgid "Validate @label"
-msgstr ""
+msgstr "Validera @label"
 
 msgid "Validate user has access to the %name"
-msgstr ""
+msgstr "Bekräfta att användare har åtkomst till %name"
 
 msgid "Multiple arguments"
-msgstr ""
+msgstr "Flera argument"
 
 msgid "Single ID"
-msgstr ""
+msgstr "Enstaka ID"
 
 msgid "One or more IDs separated by , or +"
-msgstr ""
+msgstr "Ett eller flera ID-nummer separerade med , eller +"
 
 msgid "Tag based"
-msgstr ""
+msgstr "Taggbaserad"
 
 msgid ""
 "Tag based caching of data. Caches will persist until any related cache tags "
 "are invalidated."
 msgstr ""
+"Taggbaserad cachning av data. Cachar kommer finnas kvar tills relaterade "
+"cachetaggar ogiltigförklaras."
 
 msgid "Name and description"
-msgstr ""
+msgstr "Namn och beskrivning"
 
 msgid "Administrative tags"
-msgstr ""
+msgstr "Administrativa etiketter"
 
 msgid "Enter a comma-separated list of words to describe your view."
-msgstr ""
+msgstr "Ange en kommaseparerad lista av ord för att beskriva din vy."
 
 msgid "The aggregator feed UUID."
-msgstr ""
+msgstr "The aggregator feed UUID."
 
 msgid "simple configuration"
-msgstr ""
+msgstr "simple configuration"
 
 msgid "The date the file created."
-msgstr ""
+msgstr "The date the file created."
 
 msgid "The timestamp that the file was created."
-msgstr ""
+msgstr "The timestamp that the file was created."
 
 msgid "The timestamp that the file was last changed."
-msgstr ""
+msgstr "The timestamp that the file was last changed."
 
 msgid "Language based on a selected language."
-msgstr ""
+msgstr "Language based on a selected language."
 
 msgid ""
 "Menu links with lower weights are displayed before links with higher "
 "weights."
 msgstr ""
+"Menu links with lower weights are displayed before links with higher "
+"weights."
 
 msgid "The name of the user role."
-msgstr ""
+msgstr "The name of the user role."
 
 msgid "Influence"
-msgstr ""
+msgstr "Inflytande"
 
 msgid ""
 "Influence is a numeric multiplier used in ordering search results. A higher "
@@ -16821,81 +18225,86 @@ msgid ""
 "zero means the factor is ignored. Changing these numbers does not require "
 "the search index to be rebuilt. Changes take effect immediately."
 msgstr ""
+"Inflytande är en numerisk multiplikator som används vid sortering av "
+"sökresultat. Ett högre värde innebär att motsvarande faktor har mer "
+"inflytande över sökresultat. Noll betyder att faktorn ignoreras. Att ändra "
+"dessa siffror kräver inte att sökindex skall byggas om. Ändringarna börjar "
+"gälla omedelbart."
 
 msgid "Search page type"
-msgstr ""
+msgstr "Typ av söksida"
 
 msgid "- Choose page type -"
-msgstr ""
+msgstr "- Välj sidtyp -"
 
 msgid "No search pages have been configured."
-msgstr ""
+msgstr "No search pages have been configured."
 
 msgid "You must select the new search page type."
-msgstr ""
+msgstr "You must select the new search page type."
 
 msgid "Edit %label search page"
-msgstr ""
+msgstr "Redigera söksida för %label"
 
 msgid "The %label search page has been enabled."
-msgstr ""
+msgstr "The %label search page has been enabled."
 
 msgid "The %label search page has been disabled."
-msgstr ""
+msgstr "The %label search page has been disabled."
 
 msgid "The %label search page has been added."
-msgstr ""
+msgstr "The %label search page has been added."
 
 msgid "Save search page"
-msgstr ""
+msgstr "Spara söksida"
 
 msgid "The %label search page has been updated."
-msgstr ""
+msgstr "The %label search page has been updated."
 
 msgid "The label for this search page."
-msgstr ""
+msgstr "The label for this search page."
 
 msgid "The search page path must be unique."
-msgstr ""
+msgstr "The search page path must be unique."
 
 msgid "Managing and displaying text fields"
-msgstr ""
+msgstr "Hantering och visning av textfält"
 
 msgid "Creating short text fields"
-msgstr ""
+msgstr "Skapande av korta textfält"
 
 msgid "Creating long text fields"
-msgstr ""
+msgstr "Creating long text fields"
 
 msgid "Trimming the text length"
-msgstr ""
+msgstr "Kortar ned textlängden"
 
 msgid "Displaying summaries instead of trimmed text"
-msgstr ""
+msgstr "Visar sammanfattningar istället för nedkortad text"
 
 msgid "Using text formats and editors"
-msgstr ""
+msgstr "Using text formats and editors"
 
 msgctxt "Text alignment"
 msgid "Left"
-msgstr ""
+msgstr "Vänsterjustera"
 
 msgctxt "Text alignment"
 msgid "Center"
-msgstr ""
+msgstr "Centrera"
 
 msgctxt "Text alignment"
 msgid "Right"
-msgstr ""
+msgstr "Högerjustera"
 
 msgid "%name: may not be longer than @max characters."
-msgstr ""
+msgstr "%name: får inte vara längre än @max tecken."
 
 msgid "<abbr title=\"Outline Processor Markup Language\">OPML</abbr> integration"
-msgstr ""
+msgstr "<abbr title=\"Outline Processor Markup Language\">OPML</abbr> integration"
 
 msgid "Resolution multiplier"
-msgstr ""
+msgstr "Resolution multiplier"
 
 msgid ""
 "Resolution multipliers are a measure of the viewport's device resolution, "
@@ -16905,42 +18314,56 @@ msgid ""
 "multipliers of 1, 1.5, and 2; when defining breakpoints, modules and themes "
 "can define which multipliers apply to each breakpoint."
 msgstr ""
+"Resolution multipliers are a measure of the viewport's device resolution, "
+"defined to be the ratio between the physical pixel size of the active device"
+" and the <a href=\"http://en.wikipedia.org/wiki/Device_independent_pixel"
+"\">device-independent pixel</a> size. The Breakpoint module defines "
+"multipliers of 1, 1.5, and 2; when defining breakpoints, modules and themes "
+"can define which multipliers apply to each breakpoint."
 
 msgid "Defining breakpoints and breakpoint groups"
-msgstr ""
+msgstr "Defining breakpoints and breakpoint groups"
 
 msgid ""
 "Modules and themes can use the API provided by the Breakpoint module to "
 "define breakpoints and breakpoint groups, and to assign resolution "
 "multipliers to breakpoints."
 msgstr ""
+"Modules and themes can use the API provided by the Breakpoint module to "
+"define breakpoints and breakpoint groups, and to assign resolution "
+"multipliers to breakpoints."
 
 msgctxt "Validation"
 msgid "Comment author name"
-msgstr ""
+msgstr "Comment author name"
 
 msgid ""
 "Changing the text format to %text_format will permanently remove content "
 "that is not allowed in that text format.<br><br>Save your changes before "
 "switching the text format to avoid losing data."
 msgstr ""
+"Changing the text format to %text_format will permanently remove content "
+"that is not allowed in that text format.<br><br>Save your changes before "
+"switching the text format to avoid losing data."
 
 msgid "Change text format?"
-msgstr ""
+msgstr "Change text format?"
 
 msgid "Managing and displaying entity reference fields"
-msgstr ""
+msgstr "Managing and displaying entity reference fields"
 
 msgid "Selecting reference type"
-msgstr ""
+msgstr "Selecting reference type"
 
 msgid ""
 "In the field settings you can select which entity type you want to create a "
 "reference to."
 msgstr ""
+"In the field settings you can select which entity type you want to create a "
+"reference to."
 
 msgid "Filtering and sorting reference fields"
-msgstr ""
+msgstr "Filtering and sorting reference fields"
 
 msgid ""
 "Depending on the chosen entity type, additional filtering and sorting "
@@ -16948,1277 +18371,1310 @@ msgid ""
 "the field settings. For example, the list of users can be filtered by role "
 "and sorted by name or ID."
 msgstr ""
+"Depending on the chosen entity type, additional filtering and sorting "
+"options are available for the list of entities that can be referred to, in "
+"the field settings. For example, the list of users can be filtered by role "
+"and sorted by name or ID."
 
 msgid "Displaying a reference"
-msgstr ""
+msgstr "Displaying a reference"
 
 msgid "Managing text formats"
-msgstr ""
+msgstr "Managing text formats"
 
 msgid "Assigning roles to text formats"
-msgstr ""
+msgstr "Assigning roles to text formats"
 
 msgid "Selecting filters"
-msgstr ""
+msgstr "Selecting filters"
 
 msgid "The keywords to search for."
-msgstr ""
+msgstr "The keywords to search for."
 
 msgid "Choosing list field type"
-msgstr ""
+msgstr "Choosing list field type"
 
 msgid "Simpletest site directory"
-msgstr ""
+msgstr "Simpletest site directory"
 
 msgid "The vocabulary to which the term is assigned."
-msgstr ""
+msgstr "Vokabulären till vilken termen är tilldelad."
 
 msgid "Promo image"
-msgstr ""
+msgstr "Promo image"
 
 msgid "Missing profile parameter."
-msgstr ""
+msgstr "Saknad profilparameter"
 
 msgid "Timestamp value"
-msgstr ""
+msgstr "Värde för tidsstämpel"
 
 msgid "An entity field containing a UNIX timestamp value."
-msgstr ""
+msgstr "Ett objektsfält som innehåller ett värde av typ UNIX-tidsstämpel."
 
 msgid "Default PHP mailer"
-msgstr ""
+msgstr "Default PHP mailer"
 
 msgid "Sends the message as plain text, using PHP's native mail() function."
-msgstr ""
+msgstr "Sends the message as plain text, using PHP's native mail() function."
 
 msgid "Mail collector"
-msgstr ""
+msgstr "Mail collector"
 
 msgid ""
 "Does not send the message, but stores it in Drupal within the state system. "
 "Used for testing."
 msgstr ""
+"Skickar inte meddelandet men lagrar det i Drupal inom systemet. Används för "
+"testning."
 
 msgid "Synchronizing configuration"
-msgstr ""
+msgstr "Synchronizing configuration"
 
 msgid "Starting configuration synchronization."
-msgstr ""
+msgstr "Starting configuration synchronization."
 
 msgid "Configuration synchronization has encountered an error."
-msgstr ""
+msgstr "Configuration synchronization has encountered an error."
 
 msgid "Nothing to export."
-msgstr ""
+msgstr "Nothing to export."
 
 msgid "Administer responsive images"
-msgstr ""
+msgstr "Administer responsive images"
 
 msgid "Return to site content"
-msgstr ""
+msgstr "Återgå till webbplatsens innehåll"
 
 msgid "Entity view display"
-msgstr ""
+msgstr "Visning av vyobjekt"
 
 msgid "Defines a field type for telephone numbers."
-msgstr ""
+msgstr "Anger en fälttyp för telefonnummer."
 
 msgid ""
 "Defined on the Appearance or Theme Settings page. You do not have the "
 "appropriate permissions to change the site logo."
 msgstr ""
+"Defined on the Appearance or Theme Settings page. You do not have the "
+"appropriate permissions to change the site logo."
 
 msgid ""
 "Defined on the Site Information page. You do not have the appropriate "
 "permissions to change the site logo."
 msgstr ""
+"Defined on the Site Information page. You do not have the appropriate "
+"permissions to change the site logo."
 
 msgid "Toggle branding elements"
-msgstr ""
+msgstr "Toggle branding elements"
 
 msgid ""
 "Choose which branding elements you want to show in this block instance."
 msgstr ""
+"Choose which branding elements you want to show in this block instance."
 
 msgid "Rendering language"
-msgstr ""
+msgstr "Rendering language"
 
 msgid ""
 "Form build-id mismatch detected while attempting to store a form in the "
 "cache."
 msgstr ""
+"Build-id för formulär stämmer inte överens vid försök att lagra ett formulär"
+" i cachen."
 
 msgid "Deleted and replaced configuration \"@name\""
-msgstr ""
+msgstr "Raderade och ersatte konfiguration \"@name\""
 
 msgid "Update target \"@name\" is missing."
-msgstr ""
+msgstr "Mål för uppdatering \"@name\" saknas."
 
 msgid "%name: The integer must be larger or equal to %min."
-msgstr ""
+msgstr "%name: Heltalet måste vara större än eller lika med %min."
 
 msgid "Size of URI field"
-msgstr ""
+msgstr "Storlek på URI-fält"
 
 msgid "URI field"
-msgstr ""
+msgstr "URI-fält"
 
 msgid "Are you sure you want to delete all items from the feed %feed?"
-msgstr ""
+msgstr "Are you sure you want to delete all items from the feed %feed?"
 
 msgid "The news items from %site have been deleted."
-msgstr ""
+msgstr "The news items from %site have been deleted."
 
 msgid "A brief description of your block."
-msgstr ""
+msgstr "En kort beskrivning av ditt block."
 
 msgid "Completed @current step of @total."
-msgstr ""
+msgstr "Slutfört steg @current av @total."
 
 msgid "The configuration synchronization failed validation."
-msgstr ""
+msgstr "Kontrollen av konfigurationssynkroniseringen misslyckades."
 
 msgid "Allowed link type"
-msgstr ""
+msgstr "Allowed link type"
 
 msgid "Internal links only"
-msgstr ""
+msgstr "Internal links only"
 
 msgid "Both internal and external links"
-msgstr ""
+msgstr "Both internal and external links"
 
 msgid "Translating individual strings"
-msgstr ""
+msgstr "Translating individual strings"
 
 msgid "Format ID."
-msgstr ""
+msgstr "Format ID."
 
 msgid "(this translation)"
-msgstr ""
+msgstr "(this translation)"
 
 msgid "(all translations)"
-msgstr ""
+msgstr "(all translations)"
 
 msgid "Search is currently disabled"
-msgstr ""
+msgstr "Search is currently disabled"
 
 msgid "No screenshot"
-msgstr ""
+msgstr "No screenshot"
 
 msgid "Configuration deletions"
-msgstr ""
+msgstr "Configuration deletions"
 
 msgid "The listed configuration will be deleted."
-msgstr ""
+msgstr "Den listade konfigurationen kommer raderas."
 
 msgid "User's roles"
-msgstr ""
+msgstr "Användarens roller"
 
 msgid "One or more names separated by , or +"
-msgstr ""
+msgstr "One or more names separated by , or +"
 
 msgid "If none are selected, all are allowed."
-msgstr ""
+msgstr "Om ingen är vald tillåts alla."
 
 msgid "Missing row plugin"
-msgstr ""
+msgstr "Saknar insticksprogram för rad"
 
 msgid "Tab options"
-msgstr ""
+msgstr "Alternativ för flikar"
 
 msgid "Enable menu link"
-msgstr ""
+msgstr "Aktivera menylänk"
 
 msgid "Allowed HTML"
-msgstr ""
+msgstr "Tillåten HTML"
 
 msgid "Providing module"
-msgstr ""
+msgstr "Providing module"
 
 msgid "@label entities"
-msgstr ""
+msgstr "@label objekt"
 
 msgid "Synchronizing configuration: @op @name in @collection."
-msgstr ""
+msgstr "Synkroniserar konfiguration: @op @name i @collection."
 
 msgctxt "Entity type group"
 msgid "Content"
-msgstr ""
+msgstr "Innehåll"
 
 msgctxt "Entity type group"
 msgid "Other"
-msgstr ""
+msgstr "Annat"
 
 msgctxt "Entity type group"
 msgid "Configuration"
-msgstr ""
+msgstr "Konfiguration"
 
 msgid "Action ID"
-msgstr ""
+msgstr "Action ID"
 
 msgid "Action configuration"
-msgstr ""
+msgstr "Konfiguration av åtgärd"
 
 msgid "Action description"
-msgstr ""
+msgstr "Action description"
 
 msgid "The feed ID."
-msgstr ""
+msgstr "The feed ID."
 
 msgid "Refresh frequency in seconds."
-msgstr ""
+msgstr "Refresh frequency in seconds."
 
 msgid "Last-checked unix timestamp."
-msgstr ""
+msgstr "Last-checked unix timestamp."
 
 msgid "When the feed was last modified."
-msgstr ""
+msgstr "When the feed was last modified."
 
 msgid "The block numeric identifier."
-msgstr ""
+msgstr "The block numeric identifier."
 
 msgid "The module providing the block."
-msgstr ""
+msgstr "The module providing the block."
 
 msgid "The block's delta."
-msgstr ""
+msgstr "The block's delta."
 
 msgid "Pages list."
-msgstr ""
+msgstr "Pages list."
 
 msgid "Cache rule."
-msgstr ""
+msgstr "Cache rule."
 
 msgid "Admin title of the block/box."
-msgstr ""
+msgstr "Admin title of the block/box."
 
 msgid "The comment title."
-msgstr ""
+msgstr "The comment title."
 
 msgid "The {node}.type to which this comment is a reply."
-msgstr ""
+msgstr "The {node}.type to which this comment is a reply."
 
 msgid "The node type"
-msgstr ""
+msgstr "The node type"
 
 msgid "Primary Key: Unique category ID."
-msgstr ""
+msgstr "Primary Key: Unique category ID."
 
 msgid "Category name."
-msgstr ""
+msgstr "Category name."
 
 msgid "The category's weight."
-msgstr ""
+msgstr "The category's weight."
 
 msgid "Type (text, integer, ....)"
-msgstr ""
+msgstr "Type (text, integer, ....)"
 
 msgid "Global settings. Shared with every field instance."
-msgstr ""
+msgstr "Global settings. Shared with every field instance."
 
 msgid "DB storage"
-msgstr ""
+msgstr "DB storage"
 
 msgid "DB Columns"
-msgstr ""
+msgstr "DB Columns"
 
 msgid "The machine name of field."
-msgstr ""
+msgstr "The machine name of field."
 
 msgid "Weight."
-msgstr ""
+msgstr "Weight."
 
 msgid "A name to show."
-msgstr ""
+msgstr "A name to show."
 
 msgid "Widget type."
-msgstr ""
+msgstr "Widget type."
 
 msgid "A description of field."
-msgstr ""
+msgstr "A description of field."
 
 msgid "Module that implements widget."
-msgstr ""
+msgstr "Module that implements widget."
 
 msgid "Status of widget"
-msgstr ""
+msgstr "Status of widget"
 
 msgid "The module that provides the field."
-msgstr ""
+msgstr "The module that provides the field."
 
 msgid "Content type where this field is used."
-msgstr ""
+msgstr "Content type where this field is used."
 
 msgid "The published status of a file."
-msgstr ""
+msgstr "The published status of a file."
 
 msgid "The time that the file was added."
-msgstr ""
+msgstr "The time that the file was added."
 
 msgid "The Drupal files path."
-msgstr ""
+msgstr "The Drupal files path."
 
 msgid "TRUE if the files directory is public otherwise FALSE."
-msgstr ""
+msgstr "TRUE if the files directory is public otherwise FALSE."
 
 msgid "Machine name of the node type."
-msgstr ""
+msgstr "Machine name of the node type."
 
 msgid "Human name of the node type."
-msgstr ""
+msgstr "Human name of the node type."
 
 msgid "The module providing the node type."
-msgstr ""
+msgstr "The module providing the node type."
 
 msgid "Description of the node type."
-msgstr ""
+msgstr "Description of the node type."
 
 msgid "Help text for the node type."
-msgstr ""
+msgstr "Hjälptext för nodtypen."
 
 msgid "Title label."
-msgstr ""
+msgstr "Etikett för titel."
 
 msgid "Body label."
-msgstr ""
+msgstr "Body label."
 
 msgid "Flag."
-msgstr ""
+msgstr "Flag."
 
 msgid "The original type."
-msgstr ""
+msgstr "The original type."
 
 msgid "Primary Key: Unique profile field ID."
-msgstr ""
+msgstr "Primary Key: Unique profile field ID."
 
 msgid "Title of the field shown to the end user."
-msgstr ""
+msgstr "Titel på fältet som visas för slutanvändaren ."
 
 msgid "Explanation of the field to end users."
-msgstr ""
+msgstr "Explanation of the field to end users."
 
 msgid "Type of form field."
-msgstr ""
+msgstr "Type of form field."
 
 msgid "The numeric identifier of the path alias."
-msgstr ""
+msgstr "The numeric identifier of the path alias."
 
 msgid "The name of the vocabulary."
-msgstr ""
+msgstr "The name of the vocabulary."
 
 msgid "The description of the vocabulary."
-msgstr ""
+msgstr "The description of the vocabulary."
 
 msgid "Menu selection requires the activation of Menu UI module."
-msgstr ""
+msgstr "Menu selection requires the activation of Menu UI module."
 
 msgid ""
 "Numeric placeholders may not be used. Please use plain placeholders (%)."
 msgstr ""
+"Numeric placeholders may not be used. Please use plain placeholders (%)."
 
 msgid "Route Name"
-msgstr ""
+msgstr "Ruttnamn"
 
 msgid "Route Params"
-msgstr ""
+msgstr "Ruttparametrar"
 
 msgid "Param"
-msgstr ""
+msgstr "Parameter"
 
 msgid "Configuration dependencies"
-msgstr ""
+msgstr "Konfigurationsberoenden"
 
 msgid "Theme dependencies"
-msgstr ""
+msgstr "Temaberoenden"
 
 msgid "Extension settings"
-msgstr ""
+msgstr "Inställningar för tillägg"
 
 msgid "Action settings"
-msgstr ""
+msgstr "Action settings"
 
 msgid "Recursion limit for actions"
-msgstr ""
+msgstr "Recursion limit for actions"
 
 msgid "Redirect to URL configuration"
-msgstr ""
+msgstr "Omdirigera till URL-konfiguration"
 
 msgid "Display a message to the user configuration"
-msgstr ""
+msgstr "Visa ett meddelande på användarkonfigurationen"
 
 msgid "Bulk form"
-msgstr ""
+msgstr "Bulk form"
 
 msgid "Admin info"
-msgstr ""
+msgstr "Administratörsinfo"
 
 msgid "Block display options"
-msgstr ""
+msgstr "Alternativ för blockvisning"
 
 msgid "Book settings"
-msgstr ""
+msgstr "Book settings"
 
 msgid "Button groups"
-msgstr ""
+msgstr "Button groups"
 
 msgid "Button group"
-msgstr ""
+msgstr "Button group"
 
 msgid "List of styles"
-msgstr ""
+msgstr "List of styles"
 
 msgid "Color theme settings"
-msgstr ""
+msgstr "Color theme settings"
 
 msgid "Palette settings"
-msgstr ""
+msgstr "Palette settings"
 
 msgid "Last comment date"
-msgstr ""
+msgstr "Last comment date"
 
 msgid "no caching"
-msgstr ""
+msgstr "ingen cachning"
 
 msgid "Entity options"
-msgstr ""
+msgstr "Alternativ för objekt"
 
 msgid "Translate @type_name"
-msgstr ""
+msgstr "Translate @type_name"
 
 msgid "Personal contact form enabled by default"
-msgstr ""
+msgstr "Personal contact form enabled by default"
 
 msgid "Content translation link"
-msgstr ""
+msgstr "Content translation link"
 
 msgid "Contextual link"
-msgstr ""
+msgstr "Contextual link"
 
 msgid "Delete form mode"
-msgstr ""
+msgstr "Delete form mode"
 
 msgid "Entity view mode settings"
-msgstr ""
+msgstr "Inställningar för visningsläge åt objekt"
 
 msgid "Target entity type"
-msgstr ""
+msgstr "Mål för objektstyp"
 
 msgid "Entity form mode settings"
-msgstr ""
+msgstr "Inställningar för objektsformulärsläge"
 
 msgid "View or form mode machine name"
-msgstr ""
+msgstr "Maskinläsbart namn för vy eller formulärsläge"
 
 msgid "Field display setting"
-msgstr ""
+msgstr "Inställning för visning av fält"
 
 msgid "Text field display format settings"
-msgstr ""
+msgstr "Formatinställningar för visning av textfält"
 
 msgid "Sort settings"
-msgstr ""
+msgstr "Inställningar för sortering"
 
 msgid "Entity reference rendered entity display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt genererad objektsreferens"
 
 msgid "Entity reference entity ID display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat på ID-nummer för objektsreferens"
 
 msgid "Entity reference label display format settings"
 msgstr ""
+"Inställningar för visningsformat åt visning av etikett på objektsreferens"
 
 msgid "Entity reference autocomplete (Tags style) display format settings"
 msgstr ""
+"Inställningar av visningsformat för automatisk komplettering av "
+"objektsreferens (etiketter)"
 
 msgid "Entity reference autocomplete display format settings"
 msgstr ""
+"Inställningar för visningsformat åt automatiskt kompletterande "
+"objektsreferens"
 
 msgid "Search field"
-msgstr ""
+msgstr "Sökfält"
 
 msgid "- Hidden - format settings"
-msgstr ""
+msgstr "- Dold - inställningar för formatering"
 
 msgid "Integer settings"
-msgstr ""
+msgstr "Inställningar för heltal"
 
 msgid "Decimal settings"
-msgstr ""
+msgstr "Inställning för decimal"
 
 msgid "Float settings"
-msgstr ""
+msgstr "Inställning för flyttal"
 
 msgid "Number decimal display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt antal decimaler"
 
 msgid "Number unformatted display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt oformaterat nummer"
 
 msgid "Number default display format settings"
-msgstr ""
+msgstr "Inställningar för visning av numeriskt standardvärde"
 
 msgid "Reverse entity reference"
-msgstr ""
+msgstr "Reverse entity reference"
 
 msgid "Field UI settings"
-msgstr ""
+msgstr "Field UI settings"
 
 msgid "Enable Description field"
-msgstr ""
+msgstr "Enable Description field"
 
 msgid "HAL"
-msgstr ""
+msgstr "HAL"
 
 msgid "Delete language"
-msgstr ""
+msgstr "Delete language"
 
 msgid "All language types"
-msgstr ""
+msgstr "All language types"
 
 msgid "Language detection methods"
-msgstr ""
+msgstr "Language detection methods"
 
 msgid "Interface Translation"
-msgstr ""
+msgstr "Interface Translation"
 
 msgid "Translate interface settings"
-msgstr ""
+msgstr "Translate interface settings"
 
 msgid "Cache strings"
-msgstr ""
+msgstr "Cache strings"
 
 msgid "Overwrite non customized translations"
-msgstr ""
+msgstr "Overwrite non customized translations"
 
 msgid "Menu UI"
-msgstr ""
+msgstr "Menu UI"
 
 msgid "Per-content type menu settings"
-msgstr ""
+msgstr "Per-content type menu settings"
 
 msgid "Menu machine name"
-msgstr ""
+msgstr "Menu machine name"
 
 msgid "Change the author of content configuration"
-msgstr ""
+msgstr "Change the author of content configuration"
 
 msgid "Save content configuration"
-msgstr ""
+msgstr "Save content configuration"
 
 msgid "Delete content configuration"
-msgstr ""
+msgstr "Delete content configuration"
 
 msgid "Node user ID"
-msgstr ""
+msgstr "Node user ID"
 
 msgid "Node path"
-msgstr ""
+msgstr "Node path"
 
 msgid "Link to a node revision"
-msgstr ""
+msgstr "Link to a node revision"
 
 msgid "List (integer) settings"
-msgstr ""
+msgstr "List (integer) settings"
 
 msgid "List (float) settings"
-msgstr ""
+msgstr "List (float) settings"
 
 msgid "List (text) settings"
-msgstr ""
+msgstr "List (text) settings"
 
 msgid "Options list default display settings"
-msgstr ""
+msgstr "Options list default display settings"
 
 msgid "Key format settings"
-msgstr ""
+msgstr "Key format settings"
 
 msgid "Single on/off checkbox format settings"
-msgstr ""
+msgstr "Inställningar för kryssformat på ensam kryssruta för av/på"
 
 msgid "Select list format settings"
-msgstr ""
+msgstr "Select list format settings"
 
 msgid "Responsive Image"
-msgstr ""
+msgstr "Responsive Image"
 
 msgid "RESTful Web Services"
-msgstr ""
+msgstr "RESTful Web Services"
 
 msgid "REST settings"
-msgstr ""
+msgstr "REST settings"
 
 msgid "GET method settings"
-msgstr ""
+msgstr "GET method settings"
 
 msgid "POST method settings"
-msgstr ""
+msgstr "POST method settings"
 
 msgid "PATCH method settings"
-msgstr ""
+msgstr "PATCH method settings"
 
 msgid "DELETE method settings"
-msgstr ""
+msgstr "DELETE method settings"
 
 msgid "Supported format"
-msgstr ""
+msgstr "Supported format"
 
 msgid "Supported authentication"
-msgstr ""
+msgstr "Supported authentication"
 
 msgid "REST display options"
-msgstr ""
+msgstr "REST display options"
 
 msgid "Field row"
-msgstr ""
+msgstr "Field row"
 
 msgid "Alias for ID"
-msgstr ""
+msgstr "Alias for ID"
 
 msgid "Raw output for ID"
-msgstr ""
+msgstr "Raw output for ID"
 
 msgid "Serialized output format"
-msgstr ""
+msgstr "Serialized output format"
 
 msgid "Configure search pages and search indexing options."
-msgstr ""
+msgstr "Konfigurera alternativ för söksidor och sökindex."
 
 msgid "Add new search page"
-msgstr ""
+msgstr "Add new search page"
 
 msgid "AND/OR combination limit"
-msgstr ""
+msgstr "AND/OR combination limit"
 
 msgid "Default search page"
-msgstr ""
+msgstr "Default search page"
 
 msgid "HTML tags weight"
-msgstr ""
+msgstr "HTML tags weight"
 
 msgid "Tag h1 weight"
-msgstr ""
+msgstr "Tag h1 weight"
 
 msgid "Tag h2 weight"
-msgstr ""
+msgstr "Tag h2 weight"
 
 msgid "Tag h3 weight"
-msgstr ""
+msgstr "Tag h3 weight"
 
 msgid "Tag h4 weight"
-msgstr ""
+msgstr "Tag h4 weight"
 
 msgid "Tag h5 weight"
-msgstr ""
+msgstr "Tag h5 weight"
 
 msgid "Tag h6 weight"
-msgstr ""
+msgstr "Tag h6 weight"
 
 msgid "Tag u weight"
-msgstr ""
+msgstr "Tag u weight"
 
 msgid "Tag b weight"
-msgstr ""
+msgstr "Tag b weight"
 
 msgid "Tag i weight"
-msgstr ""
+msgstr "Tag i weight"
 
 msgid "Tag strong weight"
-msgstr ""
+msgstr "Tag strong weight"
 
 msgid "Tag em weight"
-msgstr ""
+msgstr "Tag em weight"
 
 msgid "Tag a weight"
-msgstr ""
+msgstr "Tag a weight"
 
 msgid "Query key"
-msgstr ""
+msgstr "Query key"
 
 msgid "Source link"
-msgstr ""
+msgstr "Source link"
 
 msgid "Serialization"
-msgstr ""
+msgstr "Serialization"
 
 msgid "Shortcut settings"
-msgstr ""
+msgstr "Shortcut settings"
 
 msgid "Statistics settings"
-msgstr ""
+msgstr "Statistics settings"
 
 msgid "Syslog settings"
-msgstr ""
+msgstr "Syslog settings"
 
 msgid "Set as default theme"
-msgstr ""
+msgstr "Set as default theme"
 
 msgid "Site UUID"
-msgstr ""
+msgstr "Site UUID"
 
 msgid "Authorize settings"
-msgstr ""
+msgstr "Authorize settings"
 
 msgid "Default file transfer protocol"
-msgstr ""
+msgstr "Default file transfer protocol"
 
 msgid "Remind users at login if their time zone is not set"
-msgstr ""
+msgstr "Remind users at login if their time zone is not set"
 
 msgid "Logging settings"
-msgstr ""
+msgstr "Logging settings"
 
 msgid "CSS performance settings"
-msgstr ""
+msgstr "CSS performance settings"
 
 msgid "Compress CSS files"
-msgstr ""
+msgstr "Compress CSS files"
 
 msgid "Fast 404 settings"
-msgstr ""
+msgstr "Fast 404 settings"
 
 msgid "Fast 404 enabled"
-msgstr ""
+msgstr "Fast 404 enabled"
 
 msgid "Fast 404 page html"
-msgstr ""
+msgstr "Fast 404 page html"
 
 msgid "Theme global settings"
-msgstr ""
+msgstr "Theme global settings"
 
 msgid "Maintain index table"
-msgstr ""
+msgstr "Maintain index table"
 
 msgid "Override selector"
-msgstr ""
+msgstr "Override selector"
 
 msgid "Number of terms per page"
-msgstr ""
+msgstr "Number of terms per page"
 
 msgid "Taxonomy format settings"
-msgstr ""
+msgstr "Taxonomy format settings"
 
 msgid "Use taxonomy term path"
-msgstr ""
+msgstr "Use taxonomy term path"
 
 msgid "Taxonomy depth modifier"
-msgstr ""
+msgstr "Taxonomy depth modifier"
 
 msgid "Taxonomy language"
-msgstr ""
+msgstr "Taxonomy language"
 
 msgid "Taxonomy term ID with depth"
-msgstr ""
+msgstr "Taxonomy term ID with depth"
 
 msgid "Telephone link format settings"
-msgstr ""
+msgstr "Telephone link format settings"
 
 msgid "Telephone default format settings"
-msgstr ""
+msgstr "Telephone default format settings"
 
 msgid "Default summary length"
-msgstr ""
+msgstr "Default summary length"
 
 msgid "Text area (multiple rows) display format settings"
-msgstr ""
+msgstr "Text area (multiple rows) display format settings"
 
 msgid "Number of summary rows"
-msgstr ""
+msgstr "Antal rader för sammanfattning"
 
 msgid "Route settings"
-msgstr ""
+msgstr "Route settings"
 
 msgid "Tracker settings"
-msgstr ""
+msgstr "Tracker settings"
 
 msgid "Cron index limit"
-msgstr ""
+msgstr "Cron index limit"
 
 msgid "User window"
-msgstr ""
+msgstr "User window"
 
 msgid "Default area"
-msgstr ""
+msgstr "Default area"
 
 msgid "The shown text of the area"
-msgstr ""
+msgstr "The shown text of the area"
 
 msgid "Provides guided tours."
-msgstr ""
+msgstr "Provides guided tours."
 
 msgid "Translates the built-in user interface."
-msgstr ""
+msgstr "Translates the built-in user interface."
 
 msgctxt "With components"
 msgid "Extend"
-msgstr ""
+msgstr "Utöka"
 
 msgid "Text custom"
-msgstr ""
+msgstr "Text custom"
 
 msgid "The shown text of the result summary area"
-msgstr ""
+msgstr "The shown text of the result summary area"
 
 msgid "The title which will be overridden for the page"
-msgstr ""
+msgstr "The title which will be overridden for the page"
 
 msgid "Node Creation Time"
-msgstr ""
+msgstr "Node Creation Time"
 
 msgid "Node Update Time"
-msgstr ""
+msgstr "Node Update Time"
 
 msgid "Day Date"
-msgstr ""
+msgstr "Day Date"
 
 msgid "Formula"
-msgstr ""
+msgstr "Formula"
 
 msgid "Place Holder"
-msgstr ""
+msgstr "Place Holder"
 
 msgid "Formula Used"
-msgstr ""
+msgstr "Formula Used"
 
 msgid "Full Date"
-msgstr ""
+msgstr "Full Date"
 
 msgid "Group by Numeric"
-msgstr ""
+msgstr "Group by Numeric"
 
 msgid "Month Date"
-msgstr ""
+msgstr "Month Date"
 
 msgid "Week Date"
-msgstr ""
+msgstr "Week Date"
 
 msgid "Year Date"
-msgstr ""
+msgstr "Year Date"
 
 msgid "YearMonthDate"
-msgstr ""
+msgstr "YearMonthDate"
 
 msgid "Date Year month"
-msgstr ""
+msgstr "Date Year month"
 
 msgid "Basic validation"
-msgstr ""
+msgstr "Basic validation"
 
 msgid "Tag based caching"
-msgstr ""
+msgstr "Taggbaserad cachning"
 
 msgid "Time based caching"
-msgstr ""
+msgstr "Tidsbaserad cachning"
 
 msgid "Exposed form type"
-msgstr ""
+msgstr "Exposed form type"
 
 msgid "Row type"
-msgstr ""
+msgstr "Row type"
 
 msgid "Filter groups"
-msgstr ""
+msgstr "Filter groups"
 
 msgid "Display comment"
-msgstr ""
+msgstr "Display comment"
 
 msgid "Plugin ID"
-msgstr ""
+msgstr "Plugin ID"
 
 msgid "A unique ID per handler type"
-msgstr ""
+msgstr "A unique ID per handler type"
 
 msgid "A sql aggregation type"
-msgstr ""
+msgstr "A sql aggregation type"
 
 msgid "When the filter value is NOT available"
-msgstr ""
+msgstr "When the filter value is NOT available"
 
 msgid "Default argument options"
-msgstr ""
+msgstr "Default argument options"
 
 msgid "Convert newlines to HTML <br> tags"
-msgstr ""
+msgstr "Convert newlines to HTML <br> tags"
 
 msgid "SQL pager"
-msgstr ""
+msgstr "SQL-paginerare"
 
 msgid "Grouping field number %i"
-msgstr ""
+msgstr "Grupperande fältnummer %i"
 
 msgid "Group items"
-msgstr ""
+msgstr "Gruppobjekt"
 
 msgid "Group item"
-msgstr ""
+msgstr "Gruppobjekt"
 
 msgid "Query comment"
-msgstr ""
+msgstr "Query comment"
 
 msgid "Default display options"
-msgstr ""
+msgstr "Alternativ för förvald visning"
 
 msgid "Page display options"
-msgstr ""
+msgstr "Alternativ för sidvisning"
 
 msgid "Attachment display options"
-msgstr ""
+msgstr "Alternativ för visning av bilaga"
 
 msgid "Text on demand format"
-msgstr ""
+msgstr "Text on demand format"
 
 msgid "Default field"
-msgstr ""
+msgstr "Förvalt fält"
 
 msgid "Drop button"
-msgstr ""
+msgstr "Drop button"
 
 msgid "Default filter"
-msgstr ""
+msgstr "Default filter"
 
 msgid "Boolean string"
-msgstr ""
+msgstr "Boolesk sträng"
 
 msgid "Group by numeric"
-msgstr ""
+msgstr "Group by numeric"
 
 msgid "IN operator"
-msgstr ""
+msgstr "IN operator"
 
 msgid "Reduce duplicate"
-msgstr ""
+msgstr "Reduce duplicate"
 
 msgid "Default pager"
-msgstr ""
+msgstr "Default pager"
 
 msgid "Groupwise max"
-msgstr ""
+msgstr "Groupwise max"
 
 msgid "Generate subquery each time view is run"
-msgstr ""
+msgstr "Generate subquery each time view is run"
 
 msgid "RSS field options"
-msgstr ""
+msgstr "Alternativ för RSS-fält"
 
 msgid "Guid settings"
-msgstr ""
+msgstr "Inställningar för Guid"
 
 msgid "Display extender"
-msgstr ""
+msgstr "Utökning av visning"
 
 msgid "Field rewrite elements"
-msgstr ""
+msgstr "Element för omskrivning av fält"
 
 msgid "Display plugin"
-msgstr ""
+msgstr "Insticksprogram för visning"
 
 msgid "Boolean sort"
-msgstr ""
+msgstr "Boolesk sortering"
 
 msgid "Date sort"
-msgstr ""
+msgstr "Sortering på datum"
 
 msgid "Date sort expose settings"
-msgstr ""
+msgstr "Exponerade inställningar för datumsortering"
 
 msgid "Custom row classes"
-msgstr ""
+msgstr "Anpassade radklasser"
 
 msgid "Default views row classes"
-msgstr ""
+msgstr "Förvalda radklasser för vyer"
 
 msgid "Custom column classes"
-msgstr ""
+msgstr "Anpassade kolumnklasser"
 
 msgid "Columns name"
-msgstr ""
+msgstr "Namn på kolumn"
 
 msgid "Columns info"
-msgstr ""
+msgstr "Information om kolumner"
 
 msgid "Column info"
-msgstr ""
+msgstr "Information om kolumn"
 
 msgid "Preview view"
-msgstr ""
+msgstr "Förhandsgranska vy"
 
 msgid "Bartik settings"
-msgstr ""
+msgstr "Inställningar för Bartik"
 
 msgid "Seven settings"
-msgstr ""
+msgstr "Inställningar för Seven"
 
 msgid "Stark settings"
-msgstr ""
+msgstr "Inställningar för Stark"
 
 msgid "Visibility Conditions"
-msgstr ""
+msgstr "Visibility Conditions"
 
 msgid "Visibility Condition"
-msgstr ""
+msgstr "Visibility Condition"
 
 msgid "Context assignments"
-msgstr ""
+msgstr "Tilldelning av sammanhang"
 
 msgid "Display variant"
-msgstr ""
+msgstr "Visa variant"
 
 msgid "Requirements review"
-msgstr ""
+msgstr "Kravgranskning"
 
 msgid ""
 "Unable to send email. Contact the site administrator if the problem "
 "persists."
 msgstr ""
+"Kunde inte att skicka e-post. Kontakta webbplatsen administratör om "
+"problemet kvarstår."
 
 msgid "Error sending email (from %from to %to with reply-to %reply)."
 msgstr ""
+"Fel vid skickande av e-post (från %from till %to med svar-till %reply)."
 
 msgid "The label for this display variant."
-msgstr ""
+msgstr "Etiketten för denna visningsvariant."
 
 msgid "%name: the email address can not be longer than @max characters."
-msgstr ""
+msgstr "%name: e-postadressen kan inte vara längre än @max tecken."
 
 msgid "An entity field containing an email value."
-msgstr ""
+msgstr "Ett objektsfält som innehåller ett e-postvärde."
 
 msgid ""
 "Automated emails, such as registration information, will be sent from this "
 "address. Use an address ending in your site's domain to help prevent these "
 "emails from being flagged as spam."
 msgstr ""
+"Automatiska e-postmeddelanden såsom registreringsinformation kommer att "
+"skickas från denna adress. Använd en adress som använder din webbplats domän"
+" för att förhindra att dessa e-postmeddelanden blir flaggade som spam."
 
 msgid "Receive email notifications"
-msgstr ""
+msgstr "Ta emot meddelanden via e-post"
 
 msgid "Send email configuration"
-msgstr ""
+msgstr "Skicka e-postkonfiguration"
 
 msgid "<em>Either</em> upload a file or enter a URL."
-msgstr ""
+msgstr "<em>Either</em> upload a file or enter a URL."
 
 msgid "Show for the listed pages"
-msgstr ""
+msgstr "Visa för de angivna sidorna"
 
 msgid "Hide for the listed pages"
-msgstr ""
+msgstr "Dölj för de angivna sidorna"
 
 msgid "Duplicate @display_title"
-msgstr ""
+msgstr "Dubblett @display_title"
 
 msgid "Overriding default settings"
-msgstr ""
+msgstr "Overriding default settings"
 
 msgid ""
 "This page provides a list of all comment types on the site and allows you to"
 " manage the fields, form and display settings for each."
 msgstr ""
+"Denna sida tillhandahåller en lista av alla kommentarstyper på webbplatsen "
+"och låter dig hantera fälten, formulären och visningsinställningarna för "
+"vart och ett."
 
 msgid "Comment type %label has been updated."
-msgstr ""
+msgstr "Comment type %label has been updated."
 
 msgid "Comment type %label has been added."
-msgstr ""
+msgstr "Comment type %label has been added."
 
 msgid "The comment author's email address."
-msgstr ""
+msgstr "The comment author's email address."
 
 msgid "Comment Type"
-msgstr ""
+msgstr "Comment Type"
 
 msgid "The comment type."
-msgstr ""
+msgstr "The comment type."
 
 msgid ""
 "Example: 'webmaster@example.com' or 'sales@example.com,support@example.com' "
 ". To specify multiple recipients, separate each email address with a comma."
 msgstr ""
+"Example: 'webmaster@example.com' or 'sales@example.com,support@example.com' "
+". To specify multiple recipients, separate each email address with a comma."
 
 msgid "%recipient is an invalid email address."
-msgstr ""
+msgstr "%recipient is an invalid email address."
 
 msgctxt "Abbreviated month name"
 msgid "Jan"
-msgstr ""
+msgstr "jan"
 
 msgctxt "Abbreviated month name"
 msgid "Feb"
-msgstr ""
+msgstr "feb"
 
 msgctxt "Abbreviated month name"
 msgid "Mar"
-msgstr ""
+msgstr "mars"
 
 msgctxt "Abbreviated month name"
 msgid "Apr"
-msgstr ""
+msgstr "apr"
 
 msgctxt "Abbreviated month name"
 msgid "May"
-msgstr ""
+msgstr "maj"
 
 msgctxt "Abbreviated month name"
 msgid "Jun"
-msgstr ""
+msgstr "juni"
 
 msgctxt "Abbreviated month name"
 msgid "Jul"
-msgstr ""
+msgstr "juli"
 
 msgctxt "Abbreviated month name"
 msgid "Aug"
-msgstr ""
+msgstr "aug"
 
 msgctxt "Abbreviated month name"
 msgid "Sep"
-msgstr ""
+msgstr "sept"
 
 msgctxt "Abbreviated month name"
 msgid "Oct"
-msgstr ""
+msgstr "okt"
 
 msgctxt "Abbreviated month name"
 msgid "Nov"
-msgstr ""
+msgstr "nov"
 
 msgctxt "Abbreviated month name"
 msgid "Dec"
-msgstr ""
+msgstr "dec"
 
 msgctxt "Abbreviated weekday"
 msgid "Sun"
-msgstr ""
+msgstr "sön"
 
 msgctxt "Abbreviated weekday"
 msgid "Mon"
-msgstr ""
+msgstr "mån"
 
 msgctxt "Abbreviated weekday"
 msgid "Tue"
-msgstr ""
+msgstr "tis"
 
 msgctxt "Abbreviated weekday"
 msgid "Wed"
-msgstr ""
+msgstr "ons"
 
 msgctxt "Abbreviated weekday"
 msgid "Thu"
-msgstr ""
+msgstr "tor"
 
 msgctxt "Abbreviated weekday"
 msgid "Fri"
-msgstr ""
+msgstr "fre"
 
 msgctxt "Abbreviated weekday"
 msgid "Sat"
-msgstr ""
+msgstr "lör"
 
 msgctxt "Abbreviated weekday"
 msgid "Su"
-msgstr ""
+msgstr "sö"
 
 msgctxt "Abbreviated weekday"
 msgid "Mo"
-msgstr ""
+msgstr "må"
 
 msgctxt "Abbreviated weekday"
 msgid "Tu"
-msgstr ""
+msgstr "ti"
 
 msgctxt "Abbreviated weekday"
 msgid "We"
-msgstr ""
+msgstr "on"
 
 msgctxt "Abbreviated weekday"
 msgid "Th"
-msgstr ""
+msgstr "to"
 
 msgctxt "Abbreviated weekday"
 msgid "Fr"
-msgstr ""
+msgstr "fr"
 
 msgctxt "Abbreviated weekday"
 msgid "Sa"
-msgstr ""
+msgstr "lö"
 
 msgctxt "Abbreviated 1 letter weekday Sunday"
 msgid "S"
-msgstr ""
+msgstr "S"
 
 msgctxt "Abbreviated 1 letter weekday Monday"
 msgid "M"
-msgstr ""
+msgstr "M"
 
 msgctxt "Abbreviated 1 letter weekday Tuesday"
 msgid "T"
-msgstr ""
+msgstr "T"
 
 msgctxt "Abbreviated 1 letter weekday Wednesday"
 msgid "W"
-msgstr ""
+msgstr "O"
 
 msgctxt "Abbreviated 1 letter weekday Thursday"
 msgid "T"
-msgstr ""
+msgstr "T"
 
 msgctxt "Abbreviated 1 letter weekday Friday"
 msgid "F"
-msgstr ""
+msgstr "F"
 
 msgctxt "Abbreviated 1 letter weekday Saturday"
 msgid "S"
-msgstr ""
+msgstr "L"
 
 msgid "Web page addresses and email addresses turn into links automatically."
-msgstr ""
+msgstr "Webbadresser och e-postadresser görs automatiskt om till länkar."
 
 msgid "Configuring content languages"
-msgstr ""
+msgstr "Configuring content languages"
 
 msgid ""
 "<em>Selected language</em> allows you to specify the site's default language"
 " or a specific language as the fall-back language. This method should be "
 "listed last."
 msgstr ""
+"<em>Selected language</em> allows you to specify the site's default language"
+" or a specific language as the fall-back language. This method should be "
+"listed last."
 
 msgid "Comma-separated list of recipient email addresses."
-msgstr ""
+msgstr "Comma-separated list of recipient email addresses."
 
 msgid "Syndicate block"
-msgstr ""
+msgstr "Syndicate block"
 
 msgid "Use shortcuts"
-msgstr ""
+msgstr "Use shortcuts"
 
 msgid "Diff settings"
-msgstr ""
+msgstr "Diff settings"
 
 msgid "Branding block"
-msgstr ""
+msgstr "Branding block"
 
 msgid "Use site logo"
-msgstr ""
+msgstr "Use site logo"
 
 msgid "The current theme is not @theme"
-msgstr ""
+msgstr "The current theme is not @theme"
 
 msgid "The current theme is @theme"
-msgstr ""
+msgstr "The current theme is @theme"
 
 msgid "Request Path"
-msgstr ""
+msgstr "Request Path"
 
 msgid "Username or email address"
 msgstr "Ditt användarnamn eller din e-postadress"
 
 msgid "Email addresses to notify when updates are available"
-msgstr ""
+msgstr "E-postadresser att meddela när uppdateringar finns tillgängliga"
 
 msgid "%email is not a valid email address."
-msgstr ""
+msgstr "%email är inte en giltig e-postadress."
 
 msgid "%emails are not valid email addresses."
-msgstr ""
+msgstr "%emails are not valid email addresses."
 
 msgid ""
 "A valid email address. All emails from the system will be sent to this "
@@ -18226,9 +19682,13 @@ msgid ""
 "wish to receive a new password or wish to receive certain news or "
 "notifications by email."
 msgstr ""
+"En giltig e-postadress. All e-post från systemet kommer skickas till denna "
+"adress. E-postadressen kommer inte synas offentligt och kommer enbart "
+"användas när du vill ta emot ett nytt lösenord, vissa nyheter eller "
+"meddelanden via e-post."
 
 msgid "This account's preferred language for emails."
-msgstr ""
+msgstr "Det här kontots föredragna språk för e-post."
 
 msgid ""
 "New users will be required to validate their email address prior to logging "
@@ -18236,9 +19696,13 @@ msgid ""
 "setting disabled, users will be logged in immediately upon registering, and "
 "may select their own passwords during registration."
 msgstr ""
+"Nya användare måste bekräfta sin e-postadress innan de kan logga in på "
+"webbplatsen och kommer att tilldelas ett systemgenererat lösenord. Med denna"
+" inställning avaktiverad loggas användare in direkt efter registrering och "
+"de ges också möjlighet att välja sina egna lösenord i samband med detta."
 
 msgid "Notification email address"
-msgstr ""
+msgstr "E-postadress för meddelanden"
 
 msgid ""
 "The email address to be used as the 'from' address for all account "
@@ -18247,806 +19711,870 @@ msgid ""
 "this address for any new registrations. Leave empty to use the default "
 "system email address <em>(%site-email).</em>"
 msgstr ""
+"The email address to be used as the 'from' address for all account "
+"notifications listed below. If <em>'Visitors, but administrator approval is "
+"required'</em> is selected above, a notification email will also be sent to "
+"this address for any new registrations. Leave empty to use the default "
+"system email address <em>(%site-email).</em>"
 
 msgid "Further instructions have been sent to your email address."
-msgstr ""
+msgstr "Ytterligare instruktioner har skickats till din e-postadress."
 
 msgid "When the user has the following roles"
-msgstr ""
+msgstr "When the user has the following roles"
 
 msgid "The user is not a member of @roles"
-msgstr ""
+msgstr "The user is not a member of @roles"
 
 msgid "The user is a member of @roles"
-msgstr ""
+msgstr "The user is a member of @roles"
 
 msgid "Use Replica Server"
-msgstr ""
+msgstr "Use Replica Server"
 
 msgid "Query parameter"
-msgstr ""
+msgstr "Parameter för databasfråga"
 
 msgid "The query parameter to use."
-msgstr ""
+msgstr "The query parameter to use."
 
 msgid "Fallback value"
-msgstr ""
+msgstr "Värde i reserv"
 
 msgid ""
 "The fallback value to use when the above query parameter is not present."
 msgstr ""
+"Värdet för reserv att använda när ovanstående parameter för databasfråga "
+"inte finns."
 
 msgid ""
 "Conjunction to use when handling multiple values. E.g. "
 "\"?value[0]=a&value[1]=b\"."
 msgstr ""
+"Förbindelse att använda vid hantering flera värden. Till exempel "
+"\"?value[0]=a&value[1]=b\"."
 
 msgid "Use Secondary Server"
-msgstr ""
+msgstr "Use Secondary Server"
 
 msgid "Type attribute"
-msgstr ""
+msgstr "Attribut för typ"
 
 msgid "The type of this row."
-msgstr ""
+msgstr "The type of this row."
 
 msgid "Text attribute"
-msgstr ""
+msgstr "Attribut för text"
 
 msgid ""
 "The field that is going to be used as the OPML text attribute for each row."
 msgstr ""
+"The field that is going to be used as the OPML text attribute for each row."
 
 msgid "Created attribute"
-msgstr ""
+msgstr "Attribut för skapad"
 
 msgid ""
 "The field that is going to be used as the OPML created attribute for each "
 "row."
 msgstr ""
+"The field that is going to be used as the OPML created attribute for each "
+"row."
 
 msgid "Description attribute"
-msgstr ""
+msgstr "Attribut för beskrivning"
 
 msgid ""
 "The field that is going to be used as the OPML description attribute for "
 "each row."
 msgstr ""
+"The field that is going to be used as the OPML description attribute for "
+"each row."
 
 msgid "HTML URL attribute"
-msgstr ""
+msgstr "Attribut för HTML URL"
 
 msgid ""
 "The field that is going to be used as the OPML htmlUrl attribute for each "
 "row."
 msgstr ""
+"The field that is going to be used as the OPML htmlUrl attribute for each "
+"row."
 
 msgid "Language attribute"
-msgstr ""
+msgstr "Attribut för språk"
 
 msgid ""
 "The field that is going to be used as the OPML language attribute for each "
 "row."
 msgstr ""
+"The field that is going to be used as the OPML language attribute for each "
+"row."
 
 msgid "XML URL attribute"
-msgstr ""
+msgstr "Attribut för XML URL"
 
 msgid "URL attribute"
-msgstr ""
+msgstr "Attribut för URL"
 
 msgid ""
 "Row style plugin requires specifying which views field to use for OPML text "
 "attribute."
 msgstr ""
+"Row style plugin requires specifying which views field to use for OPML text "
+"attribute."
 
 msgid ""
 "Row style plugin requires specifying which views field to use for XML URL "
 "attribute."
 msgstr ""
+"Row style plugin requires specifying which views field to use for XML URL "
+"attribute."
 
 msgid ""
 "Row style plugin requires specifying which views field to use for URL "
 "attribute."
 msgstr ""
+"Row style plugin requires specifying which views field to use for URL "
+"attribute."
 
 msgid "OPML fields"
-msgstr ""
+msgstr "OPML fields"
 
 msgid "Display fields as OPML items."
-msgstr ""
+msgstr "Display fields as OPML items."
 
 msgid "OPML Feed"
-msgstr ""
+msgstr "OPML Feed"
 
 msgid "Generates an OPML feed from a view."
-msgstr ""
+msgstr "Generates an OPML feed from a view."
 
 msgid "Duplicate of @label"
-msgstr ""
+msgstr "Dubblett av @label"
 
 msgid "Site header"
-msgstr ""
+msgstr "Sidhuvud för webbplats"
 
 msgid ""
 "The default administration theme for Drupal 8 was designed with clean lines,"
 " simple blocks, and sans-serif font to emphasize the tools and tasks at "
 "hand."
 msgstr ""
+"Det förvalda administrationstemat för Drupal 8 utformades med rena linjer, "
+"enkla block och typsnitt sans-serif för att betona verktygen och uppgifter "
+"som finns till hands."
 
 msgid "\"On\" label"
-msgstr ""
+msgstr "Etikett för \"På\""
 
 msgid "\"Off\" label"
-msgstr ""
+msgstr "Etikett för \"Av\""
 
 msgid "Edit menu link %title"
-msgstr ""
+msgstr "Redigera menylänk %title"
 
 msgid ""
 "This link is provided by the @name module. The title and path cannot be "
 "edited."
 msgstr ""
+"Denna länk tillhandahålls av modulen @name. Titeln och sökvägen kan inte "
+"redigeras."
 
 msgid "Add comment type"
-msgstr ""
+msgstr "Lägg till kommentarstyp"
 
 msgid "Format type machine name"
-msgstr ""
+msgstr "Maskinläsbart namn för formattyp"
 
 msgid "Boolean settings"
-msgstr ""
+msgstr "Inställningar för boolesk"
 
 msgid "On label"
-msgstr ""
+msgstr "Etikett för på"
 
 msgid "Off label"
-msgstr ""
+msgstr "Etikett för av"
 
 msgid "The comment type"
-msgstr ""
+msgstr "The comment type"
 
 msgid "Comments without subject field"
-msgstr ""
+msgstr "Comments without subject field"
 
 msgid "Allows commenting on content, comments without subject field"
-msgstr ""
+msgstr "Tillåter kommentering på innehåll, kommentarer utan ämnesfält"
 
 msgid "The comment type label"
-msgstr ""
+msgstr "The comment type label"
 
 msgid "The comment type description"
-msgstr ""
+msgstr "The comment type description"
 
 msgid "The language of the content or translation."
-msgstr ""
+msgstr "The language of the content or translation."
 
 msgid "The language the original content is in."
-msgstr ""
+msgstr "The language the original content is in."
 
 msgid "Allowed value with label"
-msgstr ""
+msgstr "Tillåtet värde med etikett"
 
 msgid "Data type callback"
-msgstr ""
+msgstr "Data type callback"
 
 msgid "Callable"
-msgstr ""
+msgstr "Callable"
 
 msgid "Interaction type"
-msgstr ""
+msgstr "Interaction type"
 
 msgid "Enabling REST support for an entity type"
-msgstr ""
+msgstr "Enabling REST support for an entity type"
 
 msgid "Configuring search pages"
-msgstr ""
+msgstr "Configuring search pages"
 
 msgid "Managing the search index"
-msgstr ""
+msgstr "Managing the search index"
 
 msgid "Displaying the Search block"
-msgstr ""
+msgstr "Displaying the Search block"
 
 msgid "Searching your site"
-msgstr ""
+msgstr "Searching your site"
 
 msgid "Extending the Search module"
-msgstr ""
+msgstr "Extending the Search module"
 
 msgid "Search index progress"
-msgstr ""
+msgstr "Search index progress"
 
 msgid "@percent% (@remaining remaining)"
-msgstr ""
+msgstr "@percent% (@remaining remaining)"
 
 msgid "Indexing progress"
-msgstr ""
+msgstr "Indexing progress"
 
 msgid "Updating default configuration (@percent%)."
-msgstr ""
+msgstr "Updating default configuration (@percent%)."
 
 msgid "Allows commenting on content"
-msgstr ""
+msgstr "Tillåter kommentering på innehåll"
 
 msgid "Manage form and displays settings of comments."
-msgstr ""
+msgstr "Hantera formulär och visar inställningar för kommentarer."
 
 msgid "%num_indexed of %num_total indexed"
-msgstr ""
+msgstr "%num_indexed of %num_total indexed"
 
 msgid "Does not use index"
-msgstr ""
+msgstr "Does not use index"
 
 msgid "Overall results:"
-msgstr ""
+msgstr "Overall results:"
 
 msgid "Converts an image to grayscale."
-msgstr ""
+msgstr "Converts an image to grayscale."
 
 msgid "Activity Tracker"
-msgstr ""
+msgstr "Activity Tracker"
 
 msgid "Add \"…\" at the end of trimmed text"
-msgstr ""
+msgstr "Add \"…\" at the end of trimmed text"
 
 msgid "First page"
-msgstr ""
+msgstr "First page"
 
 msgid "Base field bundle override"
-msgstr ""
+msgstr "Åsidosättande av hopsamlade basfält"
 
 msgid "Datetime timestamp display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt tidsstämpel"
 
 msgid "Boolean checkbox display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt boolesk kryssruta"
 
 msgid "Installed themes"
-msgstr ""
+msgstr "Installerade teman"
 
 msgid "The %file does not exist."
-msgstr ""
+msgstr "%file finns inte."
 
 msgid "The %file exists."
-msgstr ""
+msgstr "%file finns redan."
 
 msgid "The %file is not readable."
-msgstr ""
+msgstr "%file är inte läsbar."
 
 msgid "The %file is not writable."
-msgstr ""
+msgstr "%file är inte skrivbar."
 
 msgid "The @file is writable."
-msgstr ""
+msgstr "@file är skrivbar."
 
 msgid "The @file is owned by the web server."
-msgstr ""
+msgstr "The @file is owned by the web server."
 
 msgid "Negate the condition"
-msgstr ""
+msgstr "Negera villkoret"
 
 msgid "Datetime Timestamp"
-msgstr ""
+msgstr "Tidsstämpel för tidsdatum"
 
 msgid "%theme theme installed."
-msgstr ""
+msgstr "Tema %theme installerat."
 
 msgid "Display prefix and suffix"
-msgstr ""
+msgstr "Visa prefix och suffix"
 
 msgid "Text (plain)"
-msgstr ""
+msgstr "Text (ren)"
 
 msgid "A field containing a plain string value."
-msgstr ""
+msgstr "Ett fält som innehåller ett rent strängvärde."
 
 msgid "Text (plain, long)"
-msgstr ""
+msgstr "Text (ren, lång)"
 
 msgid "A field containing a long string value."
-msgstr ""
+msgstr "Ett fält som innehåller ett långt strängvärde."
 
 msgid "You cannot use an external URL, please enter a relative path."
-msgstr ""
+msgstr "Du kan inte använda en extern URL. Var vänlig ange en relativ sökväg."
 
 msgid ""
 "This path does not exist or you do not have permission to link to %path."
 msgstr ""
+"Denna sökväg finns inte eller så har du inte behörighet att länka till "
+"%path."
 
 msgid "Install newly added themes"
-msgstr ""
+msgstr "Installera nyligen tillagda teman"
 
 msgid ""
 "Blocks are placed and configured specifically for each theme. The Block "
 "layout page opens with the default theme, but you can toggle to other "
 "installed themes."
 msgstr ""
+"Block placeras och konfigureras specifikt för varje tema. Layoutsidan för "
+"block öppnas med standardtemat men du kan skifta till andra installerade "
+"teman."
 
 msgid "Enable the personal contact form by default for new users"
 msgstr ""
+"Aktivera det personliga kontaktformuläret som standard för nya användare"
 
 msgid "Add contact form"
-msgstr ""
+msgstr "Add contact form"
 
 msgid "Default form identifier"
-msgstr ""
+msgstr "Default form identifier"
 
 msgid ""
 "When listing forms, those with lighter (smaller) weights get listed before "
 "forms with heavier (larger) weights. Forms with equal weights are sorted "
 "alphabetically."
 msgstr ""
+"When listing forms, those with lighter (smaller) weights get listed before "
+"forms with heavier (larger) weights. Forms with equal weights are sorted "
+"alphabetically."
 
 msgid "Make this the default form"
-msgstr ""
+msgstr "Make this the default form"
 
 msgid "Send yourself a copy"
-msgstr ""
+msgstr "Skicka en kopia till dig själv"
 
 msgid "Content translation field settings"
-msgstr ""
+msgstr "Content translation field settings"
 
 msgid "Allowed types: @extensions."
-msgstr ""
+msgstr "Tillåtna filtyper: @extensions."
 
 msgid "Back to content editing"
-msgstr ""
+msgstr "Tillbaka till redigering av innehåll"
 
 msgid "Align images"
-msgstr ""
+msgstr "Align images"
 
 msgid ""
 "Uses a <code>data-align</code> attribute on <code>&lt;img&gt;</code> tags to"
 " align images."
 msgstr ""
+"Uses a <code>data-align</code> attribute on <code>&lt;img&gt;</code> tags to"
+" align images."
 
 msgid "Caption images"
-msgstr ""
+msgstr "Caption images"
 
 msgid ""
 "Uses a <code>data-caption</code> attribute on <code>&lt;img&gt;</code> tags "
 "to caption images."
 msgstr ""
+"Uses a <code>data-caption</code> attribute on <code>&lt;img&gt;</code> tags "
+"to caption images."
 
 msgid "Display author and date information"
-msgstr ""
+msgstr "Visa information om författare och datum"
 
 msgid "Breakpoint ID"
-msgstr ""
+msgstr "Breakpoint ID"
 
 msgid "Unable to delete the shortcut for %title."
-msgstr ""
+msgstr "Unable to delete the shortcut for %title."
 
 msgid "Maximum number of levels"
-msgstr ""
+msgstr "Maximum number of levels"
 
 msgid "All errors have been logged."
-msgstr ""
+msgstr "Alla fel har loggats."
 
 msgid ""
 "You may need to check the <code>watchdog</code> database table manually."
 msgstr ""
+"You may need to check the <code>watchdog</code> database table manually."
 
 msgid "Failed:"
-msgstr ""
+msgstr "Failed:"
 
 msgid "Update #@count"
-msgstr ""
+msgstr "Update #@count"
 
 msgid "The following updates returned messages:"
-msgstr ""
+msgstr "The following updates returned messages:"
 
 msgid "Review updates"
-msgstr ""
+msgstr "Granska uppdateringar"
 
 msgid "Starting updates"
-msgstr ""
+msgstr "Starting updates"
 
 msgid "Installed theme"
 msgid_plural "Installed themes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Installerat tema"
+msgstr[1] "Installerade teman"
 
 msgid "Uninstalled theme"
 msgid_plural "Uninstalled themes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Avinstallerat tema"
+msgstr[1] "Avinstallerade teman"
 
 msgid "%theme is the default theme and cannot be uninstalled."
-msgstr ""
+msgstr "%theme is the default theme and cannot be uninstalled."
 
 msgid "The %theme theme has been uninstalled."
-msgstr ""
+msgstr "The %theme theme has been uninstalled."
 
 msgid "The %theme theme has been installed."
-msgstr ""
+msgstr "The %theme theme has been installed."
 
 msgid "Empty time zone"
-msgstr ""
+msgstr "Empty time zone"
 
 msgid "Users may set their own time zone at registration"
-msgstr ""
+msgstr "Users may set their own time zone at registration"
 
 msgid "Menu levels"
-msgstr ""
+msgstr "Menu levels"
 
 msgid "Whether or not the content related to a term is sticky."
-msgstr ""
+msgstr "Whether or not the content related to a term is sticky."
 
 msgid "The date the content related to a term was posted."
-msgstr ""
+msgstr "The date the content related to a term was posted."
 
 msgid "Text (formatted) settings"
-msgstr ""
+msgstr "Inställningar för text (formaterad)"
 
 msgid "Text (formatted, long) settings"
-msgstr ""
+msgstr "Inställningar för text (formaterad, lång)"
 
 msgid "Text (formatted, long, with summary) settings"
-msgstr ""
+msgstr "Inställningar för text (formaterad, lång, med sammanfattning)"
 
 msgid "Text (formatted)"
-msgstr ""
+msgstr "Text (formaterad)"
 
 msgid "This field stores a text with a text format."
-msgstr ""
+msgstr "This field stores a text with a text format."
 
 msgid "This field stores a long text with a text format."
-msgstr ""
+msgstr "This field stores a long text with a text format."
 
 msgid "This field stores long text with a format and an optional summary."
-msgstr ""
+msgstr "This field stores long text with a format and an optional summary."
 
 msgid "Require email verification when a visitor creates an account"
-msgstr ""
+msgstr "Kräv e-postverifiering när en besökare skapar ett konto"
 
 msgid "@entity_type revision"
-msgstr ""
+msgstr "Version av typ @entity_type"
 
 msgid "@entity_type revisions"
-msgstr ""
+msgstr "Versioner av typ @entity_type"
 
 msgid "Include reset button (resets all applied exposed filters)"
-msgstr ""
+msgstr "Include reset button (resets all applied exposed filters)"
 
 msgid "REST export settings"
-msgstr ""
+msgstr "Inställningar för REST export"
 
 msgid "Provide a REST export"
-msgstr ""
+msgstr "Tillhandahåll REST export"
 
 msgid "REST export path"
-msgstr ""
+msgstr "REST export path"
 
 msgid "Default value callback"
-msgstr ""
+msgstr "Förvalt värde för återanrop"
 
 msgid "URI as link display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt URI som länk"
 
 msgid "Timestamp ago display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt tid sedan"
 
 msgid "Link to URI"
-msgstr ""
+msgstr "Länk till URI"
 
 msgid "The description of this feed"
-msgstr ""
+msgstr "The description of this feed"
 
 msgid ""
 "The length of time between feed updates. Requires a correctly configured "
 "cron maintenance task."
 msgstr ""
+"The length of time between feed updates. Requires a correctly configured "
+"cron maintenance task."
 
 msgid "Edit storage settings."
-msgstr ""
+msgstr "Redigera inställningar för lagring."
 
 msgid ""
 "The minimum allowed image size expressed as WIDTH×HEIGHT (e.g. 640×480). "
 "Leave blank for no restriction. If a smaller image is uploaded, it will be "
 "rejected."
 msgstr ""
+"The minimum allowed image size expressed as WIDTH×HEIGHT (e.g. 640×480). "
+"Leave blank for no restriction. If a smaller image is uploaded, it will be "
+"rejected."
 
 msgid "Improving table accessibility"
-msgstr ""
+msgstr "Improving table accessibility"
 
 msgid "OPML field options"
-msgstr ""
+msgstr "Alternativ för OPML-fält"
 
 msgid "Testing multilingual"
-msgstr ""
+msgstr "Testa flerspråkighet"
 
 msgid "Minimal profile for running tests with a multilingual installer."
-msgstr ""
+msgstr "Minimal profil för att köra tester med en flerspråkig installation."
 
 msgid ""
 "This block is broken or missing. You may be missing content or you might "
 "need to enable the original module."
 msgstr ""
+"Detta block är trasigt eller saknas. Antingen saknar du innehåll eller så "
+"kan du behöva du aktivera den ursprungliga modulen."
 
 msgid "Broken/Missing"
-msgstr ""
+msgstr "Trasig/Saknas"
 
 msgctxt "Validation"
 msgid "Email"
-msgstr ""
+msgstr "E-post"
 
 msgid "Comments are responses to content."
-msgstr ""
+msgstr "Comments are responses to content."
 
 msgid "Filename: %name"
-msgstr ""
+msgstr "Filename: %name"
 
 msgid "Recipient username"
-msgstr ""
+msgstr "Mottagarens användarnamn"
 
 msgid "Content language of view row"
-msgstr ""
+msgstr "Språk för innehåll på vyrad"
 
 msgid "Install and set as default"
-msgstr ""
+msgstr "Installera och ställ in som förvalt"
 
 msgid "Create and manage contact forms."
-msgstr ""
+msgstr "Skapa och hantera kontaktformulär."
 
 msgid "Site administration toolbar"
-msgstr ""
+msgstr "Site administration toolbar"
 
 msgid "Base field override"
-msgstr ""
+msgstr "Åsidosätt basfält"
 
 msgid "Text (formatted, long, with summary)"
-msgstr ""
+msgstr "Text (formaterad, lång, med sammanfattning)"
 
 msgid "Text (formatted, long)"
-msgstr ""
+msgstr "Text (formaterad, lång)"
 
 msgid ""
 "You can align images (<code>data-align=\"center\"</code>), but also videos, "
 "blockquotes, and so on."
 msgstr ""
+"You can align images (<code>data-align=\"center\"</code>), but also videos, "
+"blockquotes, and so on."
 
 msgid "Making this field required is recommended."
-msgstr ""
+msgstr "Making this field required is recommended."
 
 msgid "Leave preview?"
-msgstr ""
+msgstr "Lämna förhandsgranskning?"
 
 msgid "Leave preview"
-msgstr ""
+msgstr "Lämna förhandsgranskning"
 
 msgid ""
 "Leaving the preview will cause unsaved changes to be lost. Are you sure you "
 "want to leave the preview?"
 msgstr ""
+"Om du lämnar förhandsgranskningen kommer du att förlora ändringar som inte "
+"har sparats. Är du säker på att du vill lämna förhandsgranskningen?"
 
 msgid ""
 "The human-readable name of this content type. This text will be displayed as"
 " part of the list on the <em>Add content</em> page. This name must be "
 "unique."
 msgstr ""
+"Det läsbara namnet för denna innehållstyp. Denna text kommer att visas som "
+"en del av listan på sidan <em>Lägg till innehåll</em>. Detta namn måste vara"
+" unikt."
 
 msgid "Search for @keywords"
-msgstr ""
+msgstr "Sök efter @keywords"
 
 msgid "Set a new image"
-msgstr ""
+msgstr "Set a new image"
 
 msgid "The text with the text format applied."
-msgstr ""
+msgstr "The text with the text format applied."
 
 msgid "Processed summary"
-msgstr ""
+msgstr "Processed summary"
 
 msgid "The summary text with the text format applied."
-msgstr ""
+msgstr "The summary text with the text format applied."
 
 msgid "Trays"
-msgstr ""
+msgstr "Trays"
 
 msgid "Original language of the user information"
-msgstr ""
+msgstr "Original language of the user information"
 
 msgid "Preferred language of the user"
-msgstr ""
+msgstr "Preferred language of the user"
 
 msgid "Preferred admin language"
-msgstr ""
+msgstr "Preferred admin language"
 
 msgid "Preferred administrative language of the user"
-msgstr ""
+msgstr "Preferred administrative language of the user"
 
 msgid "Cache metadata"
-msgstr ""
+msgstr "Metadata för cache"
 
 msgid "Cache contexts"
-msgstr ""
+msgstr "Sammanhang för cache"
 
 msgid "Path is empty."
-msgstr ""
+msgstr "Sökväg är tom."
 
 msgid "No query allowed."
-msgstr ""
+msgstr "Ingen databasfråga tillåten."
 
 msgid ""
 "Invalid path. Valid characters are alphanumerics as well as \"-\", \".\", "
 "\"_\" and \"~\"."
 msgstr ""
+"Invalid path. Valid characters are alphanumerics as well as \"-\", \".\", "
+"\"_\" and \"~\"."
 
 msgid "Classy"
-msgstr ""
+msgstr "Classy"
 
 msgid "Select a @context value:"
-msgstr ""
+msgstr "Välj ett värde för @context:"
 
 msgid "Configuration entity dependencies"
-msgstr ""
+msgstr "Konfigurerar objektsberoenden"
 
 msgid "Content entity dependencies"
-msgstr ""
+msgstr "Beroenden för objektsinnehåll"
 
 msgid "Enforced configuration dependencies"
-msgstr ""
+msgstr "Påtvingade konfigurationsberoenden"
 
 msgid "String (long) settings"
-msgstr ""
+msgstr "Inställningar av sträng (lång text)"
 
 msgid "URI settings"
-msgstr ""
+msgstr "Inställningar för URI"
 
 msgid "Created timestamp settings"
-msgstr ""
+msgstr "Inställningar för skapad tidsstämpel"
 
 msgid "Changed timestamp settings"
-msgstr ""
+msgstr "Inställningar för ändrad tidsstämpel"
 
 msgid "Page @items.current"
-msgstr ""
+msgstr "Page @items.current"
 
 msgid "The selected style or row format does not use fields."
-msgstr ""
+msgstr "Den valda stilen eller radformatet använder inte fält."
 
 msgid "The selected display type does not use @type plugins"
-msgstr ""
+msgstr "Den valda visningstypen använder inte insticksprogram av typ @type"
 
 msgid "The entity type"
-msgstr ""
+msgstr "The entity type"
 
 msgid "Database storage size"
-msgstr ""
+msgstr "Lagringsstorlek för databas"
 
 msgid "Text with text format"
-msgstr ""
+msgstr "Text med textformat"
 
 msgid "Field widgets"
-msgstr ""
+msgstr "Gränssnittskomponenter för fält"
 
 msgid "Field widget"
-msgstr ""
+msgstr "Gränssnittskomponent för fält"
 
 msgid "Widget type machine name"
-msgstr ""
+msgstr "Maskinläsbart namn för gränssnittskomponent"
 
 msgid "Textarea display format settings"
-msgstr ""
+msgstr "Formatinställningar för visning av textfält"
 
 msgid "Email field display format settings"
-msgstr ""
+msgstr "Inställningar för e-postfälts visningsformat"
 
 msgid "Link to the entity"
-msgstr ""
+msgstr "Länk till objektet"
 
 msgid "Synchronizing extensions: @op @name."
-msgstr ""
+msgstr "Synkroniserar tillägg: @op @name."
 
 msgid "Link to the @entity_label"
-msgstr ""
+msgstr "Länka till @entity_label"
 
 msgid "Linked to the @entity_label"
-msgstr ""
+msgstr "Länkad till @entity_label"
 
 msgid "Simple page"
-msgstr ""
+msgstr "Enkel sida"
 
 msgid "Jump to the first comment."
-msgstr ""
+msgstr "Jump to the first comment."
 
 msgid "Jump to the first new comment."
-msgstr ""
+msgstr "Jump to the first new comment."
 
 msgid "Share your thoughts and opinions."
-msgstr ""
+msgstr "Dela med dig av dina tankar och åsikter."
 
 msgid "Content translation content settings"
-msgstr ""
+msgstr "Content translation content settings"
 
 msgid "Content translation enabled"
-msgstr ""
+msgstr "Content translation enabled"
 
 msgid "Group by column"
-msgstr ""
+msgstr "Group by column"
 
 msgid "Group by columns"
-msgstr ""
+msgstr "Group by columns"
 
 msgid "Re-use an existing field"
-msgstr ""
+msgstr "Re-use an existing field"
 
 msgid "You need to select a field type or an existing field."
-msgstr ""
+msgstr "You need to select a field type or an existing field."
 
 msgid "Log in to post new content in the forum."
-msgstr ""
+msgstr "Logga in för att lägga in nytt innehåll i forumet."
 
 msgid "Influence of '@title'"
-msgstr ""
+msgstr "Influence of '@title'"
 
 msgid "Installing supporting modules"
-msgstr ""
+msgstr "Installing supporting modules"
 
 msgid "The default search index will be rebuilt."
-msgstr ""
+msgstr "The default search index will be rebuilt."
 
 msgid "All search indexes will be rebuilt."
-msgstr ""
+msgstr "All search indexes will be rebuilt."
 
 msgid "Add shortcut link"
-msgstr ""
+msgstr "Add shortcut link"
 
 msgid "Popular content block settings"
-msgstr ""
+msgstr "Popular content block settings"
 
 msgid "Publish status"
-msgstr ""
+msgstr "Publish status"
 
 msgid "The corresponding entity field"
-msgstr ""
+msgstr "The corresponding entity field"
 
 msgid "The plugin ID"
-msgstr ""
+msgstr "The plugin ID"
 
 msgid "Row options"
-msgstr ""
+msgstr "Radalternativ"
 
 msgid "Display extender settings"
-msgstr ""
+msgstr "Inställningar för utökning av visning"
 
 msgid "View block"
-msgstr ""
+msgstr "Visa block"
 
 msgid "Number integer display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt heltalsnummer"
 
 msgid "Static menu link overrides"
-msgstr ""
+msgstr "Statisk menylänk åsidosätter"
 
 msgctxt "Plural"
 msgid "Disabled"
-msgstr ""
+msgstr "Ej aktiverade"
 
 msgid ""
 "Alternative text is required.<br />(Only in rare cases should this be left "
 "empty. To create empty alternative text, enter <code>\"\"</code> — two "
 "double quotes without any content)."
 msgstr ""
+"Alternative text is required.<br />(Only in rare cases should this be left "
+"empty. To create empty alternative text, enter <code>\"\"</code> — two "
+"double quotes without any content)."
 
 msgid ""
 "Images must be larger than <strong>@min</strong> pixels. Images larger than "
 "<strong>@max</strong> pixels will be resized."
 msgstr ""
+"Images must be larger than <strong>@min</strong> pixels. Images larger than "
+"<strong>@max</strong> pixels will be resized."
 
 msgid "Images must be larger than <strong>@min</strong> pixels."
-msgstr ""
+msgstr "Images must be larger than <strong>@min</strong> pixels."
 
 msgid "Node authored by (uid)"
-msgstr ""
+msgstr "Node authored by (uid)"
 
 msgid "Revision authored by (uid)"
-msgstr ""
+msgstr "Revision authored by (uid)"
 
 msgid "The location this shortcut points to."
-msgstr ""
+msgstr "The location this shortcut points to."
 
 msgid ""
 "Unable to install @extension, %config_names already exists in active "
@@ -19055,303 +20583,323 @@ msgid_plural ""
 "Unable to install @extension, %config_names already exist in active "
 "configuration."
 msgstr[0] ""
+"Unable to install @extension, %config_names already exists in active "
+"configuration."
 msgstr[1] ""
+"Unable to install @extension, %config_names already exist in active "
+"configuration."
 
 msgid "narrow"
-msgstr ""
+msgstr "narrow"
 
 msgctxt "Plural"
 msgid "Enabled"
-msgstr ""
+msgstr "Aktiverade"
 
 msgid "Active menu trail"
-msgstr ""
+msgstr "Aktiv menylänkstig"
 
 msgid "Configuration updates"
-msgstr ""
+msgstr "Uppdateringar av konfiguration"
 
 msgid "The listed configuration will be updated."
-msgstr ""
+msgstr "Den listade konfigurationen kommer uppdateras."
 
 msgid "An entity field containing a password value."
-msgstr ""
+msgstr "Ett objektsfält som innehåller ett lösenordsvärde."
 
 msgid "Selected default language no longer exists."
-msgstr ""
+msgstr "Selected default language no longer exists."
 
 msgid "The username of the content author."
-msgstr ""
+msgstr "Användarnamnet för innehållets författare."
 
 msgid "Defining responsive image styles"
-msgstr ""
+msgstr "Defining responsive image styles"
 
 msgid "Using responsive image styles in Image fields"
-msgstr ""
+msgstr "Using responsive image styles in Image fields"
 
 msgid "Responsive image styles"
-msgstr ""
+msgstr "Responsive image styles"
 
 msgid "Edit responsive image style"
-msgstr ""
+msgstr "Edit responsive image style"
 
 msgid "Duplicate responsive image style"
-msgstr ""
+msgstr "Duplicate responsive image style"
 
 msgid "Add responsive image style"
-msgstr ""
+msgstr "Add responsive image style"
 
 msgid "Responsive image style"
-msgstr ""
+msgstr "Responsive image style"
 
 msgid "Image style mappings"
-msgstr ""
+msgstr "Image style mappings"
 
 msgid "Image style mapping"
-msgstr ""
+msgstr "Image style mapping"
 
 msgid "Responsive image mapping type"
-msgstr ""
+msgstr "Responsive image mapping type"
 
 msgid "Sizes attribute"
-msgstr ""
+msgstr "Sizes attribute"
 
 msgid "<em>Duplicate responsive image style</em> @label"
-msgstr ""
+msgstr "<em>Duplicate responsive image style</em> @label"
 
 msgid "<em>Edit responsive image style</em> @label"
-msgstr ""
+msgstr "<em>Edit responsive image style</em> @label"
 
 msgid "Responsive image style @label saved."
-msgstr ""
+msgstr "Responsive image style @label saved."
 
 msgid "Responsive image style: @responsive_image_style"
-msgstr ""
+msgstr "Responsive image style: @responsive_image_style"
 
 msgid "Select a responsive image style."
-msgstr ""
+msgstr "Select a responsive image style."
 
 msgid "The target entity"
-msgstr ""
+msgstr "The target entity"
 
 msgid ""
 "Change site name, email address, slogan, default front page, and error "
 "pages."
 msgstr ""
+"Ändra webbplatsens namn, e-postadress, slogan, förvald startsida  samt sidor"
+" för felmeddelanden."
 
 msgid "Content Language Settings"
-msgstr ""
+msgstr "Content Language Settings"
 
 msgid "Original language of content in view row"
-msgstr ""
+msgstr "Ursprungligt språk för innehåll på vyrad"
 
 msgid "@entity_type_label ID"
-msgstr ""
+msgstr "@entity_type_label id"
 
 msgid "Rendering Language"
-msgstr ""
+msgstr "Rendering Language"
 
 msgid ""
 "All content that supports translations will be displayed in the selected "
 "language."
 msgstr ""
+"All content that supports translations will be displayed in the selected "
+"language."
 
 msgid "The contextual filter values are provided by the URL."
-msgstr ""
+msgstr "The contextual filter values are provided by the URL."
 
 msgid "Entity reference field storage settings"
-msgstr ""
+msgstr "Inställningar för lagring av objektsreferensfält"
 
 msgid "Entity reference field settings"
-msgstr ""
+msgstr "Inställningar för objektsreferensfält"
 
 msgid "Entity reference selection plugin settings"
-msgstr ""
+msgstr "Inställningar för insticksprogram åt objektsreferens"
 
 msgid "Display in native language"
-msgstr ""
+msgstr "Visa i ursprungsspråket"
 
 msgid "HTTP cookies"
-msgstr ""
+msgstr "HTTP-kakor"
 
 msgid "HTTP headers"
-msgstr ""
+msgstr "HTTP-sidhuvuden"
 
 msgid "Is super user"
-msgstr ""
+msgstr "Är systemadministratör"
 
 msgid "Displayed in native language"
-msgstr ""
+msgstr "Visas på modersmål"
 
 msgid "Submitted by @username on @datetime"
-msgstr ""
+msgstr "Inlagt av @username @datetime"
 
 msgid "Submitted by @author_name on @date"
-msgstr ""
+msgstr "Inlagt av @author_name @date"
 
 msgid "User is admin"
-msgstr ""
+msgstr "User is admin"
 
 msgid "Account's permissions"
-msgstr ""
+msgstr "Kontots behörighet"
 
 msgid "Existing password"
-msgstr ""
+msgstr "Befintligt lösenord"
 
 msgid "Display the author name."
-msgstr ""
+msgstr "Display the author name."
 
 msgid "Using the personal contact form"
-msgstr ""
+msgstr "Using the personal contact form"
 
 msgid "Adding content to contact forms"
-msgstr ""
+msgstr "Adding content to contact forms"
 
 msgid "Display an icon"
-msgstr ""
+msgstr "Display an icon"
 
 msgid "Speeding up your site"
-msgstr ""
+msgstr "Speeding up your site"
 
 msgid "Site default language code"
-msgstr ""
+msgstr "Site default language code"
 
 msgid "Page caching"
-msgstr ""
+msgstr "Sidcachning"
 
 msgid "Contains US ASCII characters only"
-msgstr ""
+msgstr "Innehåller endast US ASCII-tecken"
 
 msgid "Delete @language translation"
-msgstr ""
+msgstr "Radera översättningen @language"
 
 msgid "The core.extension configuration does not exist."
-msgstr ""
+msgstr "Konfigurationen core.extension finns inte."
 
 msgid "Unable to install the %module module since it does not exist."
-msgstr ""
+msgstr "Kunde inte installera modulen %module då den inte finns."
 
 msgid "Unable to install the %theme theme since it does not exist."
-msgstr ""
+msgstr "Kunde inte installera temat %theme eftersom det inte existerar."
 
 msgid "Interface text"
-msgstr ""
+msgstr "Gränssnittstext"
 
 msgid ""
 "Order of language detection methods for interface text. If a translation of "
 "interface text is available in the detected language, it will be displayed."
 msgstr ""
+"Order of language detection methods for interface text. If a translation of "
+"interface text is available in the detected language, it will be displayed."
 
 msgid "Interface text language selected for page"
-msgstr ""
+msgstr "Interface text language selected for page"
 
 msgid ""
 "Customize %language_name language detection to differ from Interface text "
 "language detection settings"
 msgstr ""
+"Customize %language_name language detection to differ from Interface text "
+"language detection settings"
 
 msgid "Entity link"
-msgstr ""
+msgstr "Länk till objekt"
 
 msgid "Select pager"
-msgstr ""
+msgstr "Select pager"
 
 msgid "Timestamp display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt tidsstämpel"
 
 msgid "Future format"
-msgstr ""
+msgstr "Framtida format"
 
 msgid "Past format"
-msgstr ""
+msgstr "Tidigare format"
 
 msgid "@requirements_message (Currently using @item version @version)"
 msgstr ""
+"@requirements_message (Använder för närvarande @item version @version)"
 
 msgid "The MyISAM storage engine is not supported."
-msgstr ""
+msgstr "Lagringsmotorn MyISAM stöds inte."
 
 msgid ""
 "Unable to uninstall the %profile profile since it is the install profile."
 msgstr ""
+"Kunde inte avinstallera profilen %profile eftersom det är "
+"installationsprofilen."
 
 msgid "The @module module is required"
-msgstr ""
+msgstr "Modulen @module krävs"
 
 msgid "- Default site/user time zone -"
-msgstr ""
+msgstr "- Förvald tidszon för webbplats/användare -"
 
 msgid "Date format: @date_format"
-msgstr ""
+msgstr "Datumformat: @date_format"
 
 msgid "Custom date format: @custom_date_format"
-msgstr ""
+msgstr "Anpassat datumformat: @custom_date_format"
 
 msgid "Time zone: @timezone"
-msgstr ""
+msgstr "Tidzon: @timezone"
 
 msgid "Translate interface text"
-msgstr ""
+msgstr "Translate interface text"
 
 msgid "Last run: %time ago."
-msgstr ""
+msgstr "Last run: %time ago."
 
 msgid "Plural variants"
-msgstr ""
+msgstr "Pluralformer"
 
 msgid "Place block <span class=\"visually-hidden\">in the %region region</span>"
-msgstr ""
+msgstr "Place block <span class=\"visually-hidden\">in the %region region</span>"
 
 msgid "@date by @username"
-msgstr ""
+msgstr "@date av @username"
 
 msgid "Apache version"
-msgstr ""
+msgstr "Apache version"
 
 msgid "%type: @message in %function (line %line of %file)."
-msgstr ""
+msgstr "%type: @message i %function (rad %line av %file)."
 
 msgid "Container cannot be saved to cache."
-msgstr ""
+msgstr "Forumgrupp kan inte sparas till cache."
 
 msgid ""
 "The database server version %version is less than the minimum required "
 "version %minimum_version."
 msgstr ""
+"Databasens serverversion %version är lägre än den lägst tillåtna versionen "
+"%minimum_version."
 
 msgid "1 error has been found: "
 msgid_plural "@count errors have been found: "
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 fel har upptäckts: "
+msgstr[1] "@count fel har upptäckts: "
 
 msgid "imminently"
-msgstr ""
+msgstr "imminently"
 
 msgid "The blocked IP address."
-msgstr ""
+msgstr "The blocked IP address."
 
 msgid "The time that the comment was created, as a Unix timestamp."
-msgstr ""
+msgstr "The time that the comment was created, as a Unix timestamp."
 
 msgid "Location of the comment form."
-msgstr ""
+msgstr "Location of the comment form."
 
 msgid "Do not use this breakpoint."
-msgstr ""
+msgstr "Do not use this breakpoint."
 
 msgid "Run database updates"
-msgstr ""
+msgstr "Run database updates"
 
 msgid "The weight of the role."
-msgstr ""
+msgstr "The weight of the role."
 
 msgid ""
 "Security warning: Couldn't write .htaccess file. Please create a .htaccess "
 "file in your %directory directory which contains the following lines: "
 "<pre><code>@htaccess</code></pre>"
 msgstr ""
+"Säkerhetsvarning: Kunde inte skriva till filen .htaccess. Var vänlig skapa "
+"en .htaccess i din katalog %directory som innehåller följande rader: "
+"<pre><code>@htaccess</code></pre>"
 
 msgid "Please continue to <a href=\":error_url\">the error page</a>"
-msgstr ""
+msgstr "Fortsätt till <a href=\":error_url\">felsidan</a>"
 
 msgid ""
 "The installer requires that you create a translations directory as part of "
@@ -19359,18 +20907,28 @@ msgid ""
 "More details about installing Drupal are available in <a "
 "href=\":install_txt\">INSTALL.txt</a>."
 msgstr ""
+"Som del av installationsprocessen krävs det att du skapar en "
+"översättningskatalog. Skapa katalogen %translations_directory. Fler detaljer"
+" kring installationen av Drupal finns tillgängligt i <a "
+"href=\":install_txt\">INSTALL.txt</a>"
 
 msgid ""
 "The installer requires read permissions to %translations_directory at all "
 "times. The <a href=\":handbook_url\">webhosting issues</a> documentation "
 "section offers help on this and other topics."
 msgstr ""
+"Installationen kräver alltid läsbehörigheter till %translations_directory. "
+"Handbokens dokumentation om <a href=\":handbook_url\">frågor om "
+"webbhotell</a> erbjuder hjälp om detta och andra ämnen."
 
 msgid ""
 "The installer requires write permissions to %translations_directory during "
 "the installation process. The <a href=\":handbook_url\">webhosting "
 "issues</a> documentation section offers help on this and other topics."
 msgstr ""
+"Installationen kräver skrivbehörigheter till %translations_directory under "
+"installationen. Handbokens dokumentation om <a href=\":handbook_url\">frågor"
+" om webbhotell</a> erbjuder hjälp om detta och andra ämnen."
 
 msgid ""
 "The installer requires to contact the translation server to download a "
@@ -19378,85 +20936,97 @@ msgid ""
 "website can reach the translation server at <a "
 "href=\":server_url\">@server_url</a>."
 msgstr ""
+"Installationen behöver kontakta översättningsservern för att hämta en "
+"översättningsfil. Kontrollera din internetanslutning och bekräfta att din "
+"webbplats kan nå översättningsservern på <a "
+"href=\":server_url\">@server_url</a>."
 
 msgid ""
 "The %language translation file is not available at the translation server. "
 "<a href=\":url\">Choose a different language</a> or select English and "
 "translate your website later."
 msgstr ""
+"Översättningsfilen för %language är inte tillgänglig på "
+"översättningsservern. <a href=\":url\">Välj ett annat språk</a> eller välj "
+"engelska och översätt din webbplats senare."
 
 msgid "contact form"
-msgstr ""
+msgstr "kontaktformulär"
 
 msgid "0 seconds"
-msgstr ""
+msgstr "0 sekunder"
 
 msgid "Primary admin actions"
-msgstr ""
+msgstr "Primary admin actions"
 
 msgid "Basic block"
-msgstr ""
+msgstr "Grundläggande block"
 
 msgid "Website feedback"
-msgstr ""
+msgstr "Återkoppling till webbplats"
 
 msgid ""
 "Enter a comma-separated list. For example: Amsterdam, Mexico City, "
 "\"Cleveland, Ohio\""
 msgstr ""
+"Ange en kommaseparerad lista. Till exempel: Stockholm, Lilla Edet, "
+"\"Linköping, Östergötland\""
 
 msgid "Basic HTML"
-msgstr ""
+msgstr "Grundläggande HTML"
 
 msgid "Restricted HTML"
-msgstr ""
+msgstr "Begränsad HTML"
 
 msgid "Default long date"
-msgstr ""
+msgstr "Förvalt långt datum"
 
 msgid "Default medium date"
-msgstr ""
+msgstr "Förvalt mellanlångt datum"
 
 msgctxt "PHP date format"
 msgid "D, m/d/Y - H:i"
-msgstr ""
+msgstr "D, m/d/Y - H:i"
 
 msgid "Default short date"
-msgstr ""
+msgstr "Förvalt kort datum"
 
 msgctxt "PHP date format"
 msgid "m/d/Y - H:i"
-msgstr ""
+msgstr "m/d/Y - H:i"
 
 msgid "Block the selected user(s)"
-msgstr ""
+msgstr "Spärra vald(a) användare"
 
 msgid "Cancel the selected user account(s)"
-msgstr ""
+msgstr "Radera de valda användarkontona"
 
 msgid "Unblock the selected user(s)"
-msgstr ""
+msgstr "Återaktivera vald(a) användare"
 
 msgid "Configuration synchronization"
-msgstr ""
+msgstr "Configuration synchronization"
 
 msgid "Import and export your configuration."
-msgstr ""
+msgstr "Importera och exportera din konfigurering."
 
 msgid "Entity/field definitions"
-msgstr ""
+msgstr "Entity/field definitions"
 
 msgid "@local-task-title@active"
-msgstr ""
+msgstr "@local-task-title@active"
 
 msgid "Core (Experimental)"
-msgstr ""
+msgstr "Core (Experimental)"
 
 msgid ""
 "The %language translation file could not be downloaded. <a "
 "href=\":url\">Choose a different language</a> or select English and "
 "translate your website later."
 msgstr ""
+"Översättningsfilen för %language kunde inte laddas ned. <a "
+"href=\":url\">Välj ett annat språk</a> eller välj engelska och översätt din "
+"webbplats senare."
 
 msgid ""
 "The @drupal installer requires that you create a %file as part of the "
@@ -19464,18 +21034,27 @@ msgid ""
 "about installing Drupal are available in <a "
 "href=\":install_txt\">INSTALL.txt</a>."
 msgstr ""
+"@drupal kräver att du skapar en %file som del av installationsprocessen. "
+"Kopiera filen %default_file till %file. Fler detaljer kring installationen "
+"av Drupal finns tillgängligt i <a href=\":install_txt\">INSTALL.txt</a>"
 
 msgid ""
 "@drupal requires read permissions to %file at all times. The <a "
 "href=\":handbook_url\">webhosting issues</a> documentation section offers "
 "help on this and other topics."
 msgstr ""
+"@drupal kräver alltid läsbehörigheter till %file. Handbokens dokumentation "
+"om <a href=\":handbook_url\">frågor om webbhotell</a> erbjuder hjälp om "
+"detta och andra ämnen."
 
 msgid ""
 "The @drupal installer requires write permissions to %file during the "
 "installation process. The <a href=\":handbook_url\">webhosting issues</a> "
 "documentation section offers help on this and other topics."
 msgstr ""
+"Installationen för @drupal kräver skrivbehörigheter till %file under "
+"installationen. Handbokens dokumentation om <a href=\":handbook_url\">frågor"
+" om webbhotell</a> erbjuder hjälp om detta och andra ämnen."
 
 msgid ""
 "The @drupal installer failed to create a %file file with proper file "
@@ -19486,54 +21065,69 @@ msgid ""
 "href=\":handbook_url\">webhosting issues</a> documentation section offers "
 "help on this and other topics."
 msgstr ""
+"Installeraren för @drupal kunde inte skapa en fil %file med rätt "
+"filägarskap. Logga in på din webbserver och radera den nuvarande filen "
+"%file, och skapa en ny genom att kopiera filen %default_file till %file. Mer"
+" information om att installera Drupal finns tillgänglig i <a "
+"href=\":install_txt\">INSTALL.txt</a>. Handbokens dokumentation om <a "
+"href=\":handbook_url\">frågor om webbhotell</a> erbjuder hjälp om detta och "
+"andra ämnen."
 
 msgid ""
 "Check the messages and <a href=\":retry\">retry</a>, or you may choose to <a"
 " href=\":cont\">continue anyway</a>."
 msgstr ""
+"Kontrollera meddelandena och <a href=\":retry\">försök igen</a>, eller så "
+"kan du välja att <a href=\":cont\">fortsätta ändå</a>."
 
 msgid "Check the messages and <a href=\":url\">try again</a>."
-msgstr ""
+msgstr "Kontrollera alla meddelanden och <a href=\":url\">försök igen</a>"
 
 msgid ""
 "The following modules are required but were not found. Move them into the "
 "appropriate modules subdirectory, such as <em>/modules</em>. Missing "
 "modules: @modules"
 msgstr ""
+"Följande moduler krävs, men hittades inte. Flytta dem till den tillämpliga "
+"underkatalogen, såsom <em>/modules</em>. Saknade moduler: @modules"
 
 msgid "Updating @module"
-msgstr ""
+msgstr "Uppdaterar @module"
 
 msgid "Post updating @module"
-msgstr ""
+msgstr "Senarelägg uppdatering av @module"
 
 msgid "Date (e.g. @format)"
-msgstr ""
+msgstr "Datum (t.ex. @format)"
 
 msgid "Time (e.g. @format)"
-msgstr ""
+msgstr "Tid (t.ex. @format)"
 
 msgid "@uri"
-msgstr ""
+msgstr "@uri"
 
 msgid "Operating in maintenance mode. <a href=\":url\">Go online.</a>"
-msgstr ""
+msgstr "Arbetar i underhållsläge. <a href=\":url\">Koppla upp.</a>"
 
 msgid "Textfield size: @size"
-msgstr ""
+msgstr "Storlek på textfält: @size"
 
 msgid "Number of rows: @rows"
-msgstr ""
+msgstr "Antal rader: @rows"
 
 msgid ""
 "WARNING: You are not using an encrypted connection, so your password will be"
 " sent in plain text. <a href=\":https-link\">Learn more</a>."
 msgstr ""
+"VARNING: Du använder inte en krypterad anslutning, så ditt lösenord kommer "
+"att skickas i klartext. <a href=\":https-link\">Lär mer</a>"
 
 msgid ""
 "@name cannot be longer than %max characters but is currently %length "
 "characters long."
 msgstr ""
+"@name kan inte vara längre än %max tecken, men är för närvarande %length "
+"tecken lång."
 
 msgid ""
 "All necessary changes to %dir and %file have been made, so you should remove"
@@ -19541,59 +21135,77 @@ msgid ""
 "unsure how to do so, consult the <a href=\":handbook_url\">online "
 "handbook</a>."
 msgstr ""
+"All necessary changes to %dir and %file have been made, so you should remove"
+" write permissions to them now in order to avoid security risks. If you are "
+"unsure how to do so, consult the <a href=\":handbook_url\">online "
+"handbook</a>."
 
 msgid ""
 "A working <a href=\":cron\">cron maintenance task</a> is required to update "
 "feeds automatically."
 msgstr ""
+"A working <a href=\":cron\">cron maintenance task</a> is required to update "
+"feeds automatically."
 
 msgid ""
 "The length of time between feed updates. Requires a correctly configured <a "
 "href=\":cron\">cron maintenance task</a>."
 msgstr ""
+"The length of time between feed updates. Requires a correctly configured <a "
+"href=\":cron\">cron maintenance task</a>."
 
 msgid ""
 "Requires a correctly configured <a href=\":cron\">cron maintenance task</a>."
 msgstr ""
+"Requires a correctly configured <a href=\":cron\">cron maintenance task</a>."
 
 msgid ""
 "<a href=\":login\">Log in</a> or <a href=\":register\">register</a> to post "
 "comments"
 msgstr ""
+"<a href=\":login\">Logga in</a> eller <a href=\":register\">registrera "
+"dig</a> för att kunna kommentera"
 
 msgid "<a href=\":login\">Log in</a> to post comments"
-msgstr ""
+msgstr "<a href=\":login\">Log in</a> to post comments"
 
 msgid "[@form] @subject"
-msgstr ""
+msgstr "[@form] @subject"
 
 msgid "Hello @recipient-name,"
-msgstr ""
+msgstr "Hej @recipient-name,"
 
 msgid "@name (not verified)"
-msgstr ""
+msgstr "@name (ej verifierad)"
 
 msgid ""
 "Before you can translate content, there must be at least two languages added"
 " on the <a href=\":url\">languages administration</a> page."
 msgstr ""
+"Before you can translate content, there must be at least two languages added"
+" on the <a href=\":url\">languages administration</a> page."
 
 msgid "Date part order: @order"
-msgstr ""
+msgstr "Date part order: @order"
 
 msgid "Time type: @time_type"
-msgstr ""
+msgstr "Time type: @time_type"
 
 msgid ""
 "The Database Logging module logs system events in the Drupal database. For "
 "more information, see the <a href=\":dblog\">online documentation for the "
 "Database Logging module</a>."
 msgstr ""
+"The Database Logging module logs system events in the Drupal database. For "
+"more information, see the <a href=\":dblog\">online documentation for the "
+"Database Logging module</a>."
 
 msgid ""
 "The maximum number of messages to keep in the database log. Requires a <a "
 "href=\":cron\">cron maintenance task</a>."
 msgstr ""
+"The maximum number of messages to keep in the database log. Requires a <a "
+"href=\":cron\">cron maintenance task</a>."
 
 msgid ""
 "Pages which are suitable for caching are cached the first time they are "
@@ -19601,25 +21213,33 @@ msgid ""
 " content is handled automatically so that both cache correctness and hit "
 "ratio is maintained."
 msgstr ""
+"Pages which are suitable for caching are cached the first time they are "
+"requested, then the cached version is served for all later requests. Dynamic"
+" content is handled automatically so that both cache correctness and hit "
+"ratio is maintained."
 
 msgid "@size limit."
-msgstr ""
+msgstr "Begränsning @size."
 
 msgid "Limit allowed HTML tags and correct faulty HTML"
-msgstr ""
+msgstr "Limit allowed HTML tags and correct faulty HTML"
 
 msgid ""
 "Explanation of the language options is found on the <a "
 "href=\":languages_list_page\">languages list page</a>."
 msgstr ""
+"Explanation of the language options is found on the <a "
+"href=\":languages_list_page\">languages list page</a>."
 
 msgid "Site's default language (@language)"
-msgstr ""
+msgstr "Webbplatsens förvalda språk (@language)"
 
 msgid ""
 "Each menu has a corresponding block that is managed on the <a "
 "href=\":blocks\">Block layout page</a>."
 msgstr ""
+"Each menu has a corresponding block that is managed on the <a "
+"href=\":blocks\">Block layout page</a>."
 
 msgid ""
 "When new content is created, the Node module records basic information about"
@@ -19630,19 +21250,31 @@ msgid ""
 "Default settings can be configured for each <a href=\":content-type\">type "
 "of content</a> on your site."
 msgstr ""
+"When new content is created, the Node module records basic information about"
+" the content, including the author, date of creation, and the <a href"
+"=\":content-type\">Content type</a>. It also manages the <em>publishing "
+"options</em>, which define whether or not the content is published, promoted"
+" to the front page of the site, and/or sticky at the top of content lists. "
+"Default settings can be configured for each <a href=\":content-type\">type "
+"of content</a> on your site."
 
 msgid "This text will be displayed on the <em>Add new content</em> page."
 msgstr ""
+"Denna text kommer att visas på sidan <em>Lägg till nytt innehåll</em>."
 
 msgid ""
 "Set and configure the default theme for your website.  Alternative <a "
 "href=\":themes\">themes</a> are available."
 msgstr ""
+"Ange och konfigurera standardtemat för din webbplats. Alternativa <a "
+"href=\":themes\">teman</a> finns tillgängliga."
 
 msgid ""
 "You can place blocks for each theme on the <a href=\":blocks\">block "
 "layout</a> page."
 msgstr ""
+"Du kan placera block för varje tema på sidan <a "
+"href=\":blocks\">blocklayout</a>."
 
 msgid ""
 "Regularly review available updates to maintain a secure and current site. "
@@ -19650,88 +21282,109 @@ msgid ""
 "is updated. Enable the <a href=\":update-manager\">Update Manager module</a>"
 " to update and install modules and themes."
 msgstr ""
+"Se regelbundet över tillgängliga uppdateringar för att upprätthålla en säker"
+" och aktuell webbplats. Kör alltid <a href=\":update-"
+"php\">uppdateringsskriptet</a> varje gång en modul uppdaterats. Aktivera "
+"modulen <a href=\":update-manager\">Update Manager</a> för att uppdatera och"
+" installera moduler och teman."
 
 msgid "Configure your <a href=\":user-edit\">account time zone setting</a>."
-msgstr ""
+msgstr "Configure your <a href=\":user-edit\">account time zone setting</a>."
 
 msgid ""
 "One or more problems were detected with your Drupal installation. Check the "
 "<a href=\":status\">status report</a> for more information."
 msgstr ""
+"Ett eller flera problem upptäcktes i din installation av Drupal. Titta på <a"
+" href=\":status\">statusrapporten</a> för mer information."
 
 msgid "Uninstall @theme theme"
-msgstr ""
+msgstr "Avinstallera temat @theme"
 
 msgid "Set @theme as default theme"
-msgstr ""
+msgstr "Ställ in @theme som förvalt tema"
 
 msgid "Install @theme theme"
-msgstr ""
+msgstr "Installera temat @theme"
 
 msgid "Install @theme as default theme"
-msgstr ""
+msgstr "Installera @theme som förvalt tema"
 
 msgid ""
 "Defined on the <a href=\":appearance\">Appearance Settings</a> or <a "
 "href=\":theme\">Theme Settings</a> page."
 msgstr ""
+"Defined on the <a href=\":appearance\">Appearance Settings</a> or <a "
+"href=\":theme\">Theme Settings</a> page."
 
 msgid "Defined on the <a href=\":information\">Site Information</a> page."
-msgstr ""
+msgstr "Defined on the <a href=\":information\">Site Information</a> page."
 
 msgid "Installation tasks"
-msgstr ""
+msgstr "Installation tasks"
 
 msgid "Uninstalled modules"
-msgstr ""
+msgstr "Avinstallerade moduler"
 
 msgid "Uninstalled themes"
-msgstr ""
+msgstr "Avinstallerade teman"
 
 msgid "Check for updates of uninstalled modules and themes"
-msgstr ""
+msgstr "Sök efter uppdateringar av avinstallerade moduler och teman"
 
 msgid "@label:@column"
-msgstr ""
+msgstr "@label:@column"
 
 msgid "@label (@name:delta)"
-msgstr ""
+msgstr "@label (@name:delta)"
 
 msgid "Add section"
-msgstr ""
+msgstr "Lägg till sektion"
 
 msgid ""
 "There was a problem checking <a href=\":update-report\">available "
 "updates</a> for your modules or themes."
 msgstr ""
+"There was a problem checking <a href=\":update-report\">available "
+"updates</a> for your modules or themes."
 
 msgid ""
 "Download additional <a href=\":modules\">contributed modules</a> to extend "
 "your site's functionality."
 msgstr ""
+"Ladda ned ytterligare <a href=\":modules\">bidragna moduler</a> för att "
+"utöka din webbplats funktioner."
 
 msgid ""
 "For more information, see the <a href=\":views\">online documentation for "
 "the Views module</a>."
 msgstr ""
+"For more information, see the <a href=\":views\">online documentation for "
+"the Views module</a>."
 
 msgid "You must select a language to continue the installation."
-msgstr ""
+msgstr "Du måste välja ett språk för att fortsätta installationen."
 
 msgid ""
 "Several special characters are allowed, including space, period (.), hyphen "
 "(-), apostrophe ('), underscore (_), and the @ sign."
 msgstr ""
+"Flera specialtecken är tillåtna, inklusive mellanslag, punkt (.), "
+"bindestreck (-), apostrof ('), understreck (_) och @-tecknet."
 
 msgid ""
 "Block placement is specific to each theme on your site. Changes will not be "
 "saved until you click <em>Save blocks</em> at the bottom of the page."
 msgstr ""
+"Blockplacering är specifikt för varje tema på din webbplats. Ändringar "
+"sparas inte förrän du klickar på <em>Spara block</em> längst ned på sidan."
 
 msgid ""
 "The Database Logging module logs system events in the Drupal database. "
 "Monitor your site or debug site problems on this page."
 msgstr ""
+"Modulen Database Logging loggar systemhändelser i Drupals databas. Övervaka "
+"din webbplats eller felsök problem på den här sidan."
 
 msgid ""
 "There has been more than one failed login attempt for this account. It is "
@@ -19742,55 +21395,64 @@ msgid_plural ""
 "is temporarily blocked. Try again later or <a href=\":url\">request a new "
 "password</a>."
 msgstr[0] ""
+"There has been more than one failed login attempt for this account. It is "
+"temporarily blocked. Try again later or <a href=\":url\">request a new "
+"password</a>."
 msgstr[1] ""
+"There have been more than @count failed login attempts for this account. It "
+"is temporarily blocked. Try again later or <a href=\":url\">request a new "
+"password</a>."
 
 msgid "Delete %label"
-msgstr ""
+msgstr "Radera %label"
 
 msgid "Max 1300x1300"
-msgstr ""
+msgstr "Maximalt 1300x1300"
 
 msgid "Max 2600x2600"
-msgstr ""
+msgstr "Maximalt 2600x2600"
 
 msgid "Max 325x325"
-msgstr ""
+msgstr "Maximalt 325x325"
 
 msgid "Max 650x650"
-msgstr ""
+msgstr "Maximalt 650x650"
 
 msgid "Narrow"
-msgstr ""
+msgstr "Smal"
 
 msgid "Config override test"
-msgstr ""
+msgstr "Åsidosättande av testkonfiguration"
 
 msgid "This entity (%type: %label) cannot be referenced."
-msgstr ""
+msgstr "Detta objekt (%type: %label) kan inte refereras."
 
 msgid "Importing configuration"
-msgstr ""
+msgstr "Importerar konfiguration"
 
 msgid "Starting configuration import."
-msgstr ""
+msgstr "Påbörjar konfigurationsimport."
 
 msgid "Configuration import has encountered an error."
-msgstr ""
+msgstr "Konfigurationsimporten har stött på ett fel."
 
 msgid "Authored on @date"
-msgstr ""
+msgstr "Authored on @date"
 
 msgid "Add @entity-type"
-msgstr ""
+msgstr "Lägg till @entity-type"
 
 msgid "Size of email field"
-msgstr ""
+msgstr "Storlek på e-postfält"
 
 msgid ""
 "Operations on Unicode strings are emulated on a best-effort basis. Install "
 "the <a href=\"http://php.net/mbstring\">PHP mbstring extension</a> for "
 "improved Unicode support."
 msgstr ""
+"Operationer på strängar av typen Unicode emuleras efter bästa förmåga. "
+"Installera <a href=\"http://php.net/mbstring\">PHP:s tillägg mbstring</a> "
+"för att få bättre stöd för Unicode."
 
 msgid ""
 "Multibyte string function overloading in PHP is active and must be disabled."
@@ -19798,6 +21460,10 @@ msgid ""
 "the <a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for "
 "more information."
 msgstr ""
+"Överlagring av multibyte-strängfunktioner i PHP är aktivt och måste "
+"inaktiveras. Kontrollera inställningen <em>mbstring.func_overload</em> i "
+"php.ini. Se <a href=\"http://php.net/mbstring\">PHP:s dokumentation om "
+"mbstring</a> för mer information."
 
 msgid ""
 "Multibyte string input conversion in PHP is active and must be disabled. "
@@ -19805,6 +21471,11 @@ msgid ""
 "refer to the <a href=\"http://php.net/mbstring\">PHP mbstring "
 "documentation</a> for more information."
 msgstr ""
+"Konvertering av multibyte-strängindata i PHP är aktivt och måste "
+"inaktiveras. Kontrollera inställningen för "
+"<em>mbstring.encoding_translation</em> i php.ini. Se <a "
+"href=\"http://php.net/mbstring\">PHP:s dokumentation om mbstring</a> för mer"
+" information."
 
 msgid ""
 "Multibyte string input conversion in PHP is active and must be disabled. "
@@ -19812,6 +21483,10 @@ msgid ""
 "<a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for more "
 "information."
 msgstr ""
+"Konvertering av multibyte-strängindata i PHP är aktivt och måste "
+"inaktiveras. Kontrollera inställningen för <em>mbstring.http_input</em> i "
+"php.ini. Se <a href=\"http://php.net/mbstring\">PHP:s dokumentation om "
+"mbstring</a> för mer information."
 
 msgid ""
 "Multibyte string output conversion in PHP is active and must be disabled. "
@@ -19819,176 +21494,200 @@ msgid ""
 " <a href=\"http://php.net/mbstring\">PHP mbstring documentation</a> for more"
 " information."
 msgstr ""
+"Konvertering av multibyte-strängutdata i PHP är aktivt och måste "
+"inaktiveras. Kontrollera inställningen för <em>mbstring.http_output</em> i "
+"php.ini. Se <a href=\"http://php.net/mbstring\">PHP:s dokumentation om "
+"mbstring</a> för mer information."
 
 msgid "United Nations' official languages"
-msgstr ""
+msgstr "Förenta Nationernas officiella språk"
 
 msgid "All @count languages"
-msgstr ""
+msgstr "Alla @count språk"
 
 msgid "Completed step @current of @total."
-msgstr ""
+msgstr "Genomförde steg @current av @total."
 
 msgid ""
 "Control which roles can \"View the administration theme\" on the <a "
 "href=\":permissions\">Permissions page</a>."
 msgstr ""
+"Styr vilka roller som kan \"Visa administrationstemat\" på <a "
+"href=\":permissions\">inställningssidan för behörigheter</a>."
 
 msgid "Bundle assigned to the auto-created entities."
-msgstr ""
+msgstr "Hopsamling som är tilldelad till de automatiskt skapade objekten."
 
 msgid "Revision create time"
-msgstr ""
+msgstr "Tid för skapande av version"
 
 msgid "Administrative task links"
-msgstr ""
+msgstr "Länkar för administrativa uppgifter"
 
 msgid "Site information links"
-msgstr ""
+msgstr "Länkar för information om webbplats"
 
 msgid "Site section links"
-msgstr ""
+msgstr "Länkar för sektion i webbplats"
 
 msgid "All content, by month."
-msgstr ""
+msgstr "Allt innehåll, månadsvis."
 
 msgid "All content promoted to the front page."
-msgstr ""
+msgstr "Allt innehåll som visas på startsidan."
 
 msgid "Name or email contains"
-msgstr ""
+msgstr "Namn eller e-post innehåller"
 
 msgid "A list of new users"
-msgstr ""
+msgstr "En lista på nya användare"
 
 msgid "Who's online block"
-msgstr ""
+msgstr "Block för vilka som är inloggade"
 
 msgid ""
 "Shows the user names of the most recently active users, and the total number"
 " of active users."
 msgstr ""
+"Visar de användarnamnen för de senast aktiva användarna samt de totalt antal"
+" aktiva användare."
 
 msgid "There are currently @total users online."
-msgstr ""
+msgstr "För närvarande är @total användare inloggade."
 
 msgid "There are currently 0 users online."
-msgstr ""
+msgstr "För närvarande är 0 användare inloggade."
 
 msgid "A list of users that are currently logged in."
-msgstr ""
+msgstr "En lista på användare som för närvarande är inloggade."
 
 msgid "View edit page"
-msgstr ""
+msgstr "Visa redigeringssida"
 
 msgid "Manage view settings"
-msgstr ""
+msgstr "Hantera vyinställningar"
 
 msgid "View or edit the configuration."
-msgstr ""
+msgstr "Visa eller redigera konfigurationen."
 
 msgid "Displays in this view"
-msgstr ""
+msgstr "Visas i denna vy"
 
 msgid ""
 "A display is a way of outputting the results, e.g., as a page or a block. A "
 "view can contain multiple displays, which are listed here. The active "
 "display is highlighted."
 msgstr ""
+"En visning är ett sätt att mata ut resultaten, till exempel som en sida "
+"eller ett block. En vy kan innehålla flera visningar som visas här. Den "
+"aktiva visningen markeras."
 
 msgid "View administration"
-msgstr ""
+msgstr "Visa administration"
 
 msgid "Filter your view"
-msgstr ""
+msgstr "Filtrera din vy"
 
 msgid "Filter actions"
-msgstr ""
+msgstr "Filtrera åtgärder"
 
 msgid "Add, rearrange or remove filters."
-msgstr ""
+msgstr "Lägg till, ordna om eller ta bort filter."
 
 msgid ""
 "Control the order in which the results are output. Click on an active sort "
 "rule to configure it."
 msgstr ""
+"Styr ordningen för hur resultaten skall matas ut. Klicka på en aktiv "
+"sorteringsregel för att konfigurera den."
 
 msgid "Sort actions"
-msgstr ""
+msgstr "Sortera åtgärder"
 
 msgid "Add, rearrange or remove sorting rules."
-msgstr ""
+msgstr "Lägg till, ordna om eller ta bort sorteringsregler."
 
 msgid "Default revision"
-msgstr ""
+msgstr "Förvald version"
 
 msgid "Basic site settings"
-msgstr ""
+msgstr "Grundläggande inställningar för webbplats"
 
 msgid ""
 "Create and manage fields, forms, and display settings for your content."
 msgstr ""
+"Skapa och hantera fält, formulär och visa inställningar för ditt innehåll."
 
 msgid "Manage menus and menu links."
-msgstr ""
+msgstr "Hantera menyer och menylänkar."
 
 msgid ""
 "Configure default user account settings, including fields, registration "
 "requirements, and email messages."
 msgstr ""
+"Konfigurera inställningar för förvalt konto, inklusive fält, krav vid "
+"registrering och e-postmeddelanden."
 
 msgid ""
 "Select and configure text editors, and how content is filtered when "
 "displayed."
 msgstr ""
+"Välj och konfigurera textredigerare och hur innehåll filtreras när det "
+"visas."
 
 msgid "Configure caching and bandwidth optimization."
-msgstr ""
+msgstr "Konfigurera cachning och bandbreddsoptimering."
 
 msgid "Configure the display of error messages and database logging."
-msgstr ""
+msgstr "Konfigurera visningen av felmeddelanden och loggning av databasen."
 
 msgid "Take the site offline for updates and other maintenance tasks."
-msgstr ""
+msgstr "Koppla ned webbplatsen för uppdateringar och annat underhåll."
 
 msgid "Configure and use development tools."
-msgstr ""
+msgstr "Configure and use development tools."
 
 msgid "Configure the location of uploaded files and how they are accessed."
-msgstr ""
+msgstr "Konfigurera platsen för uppladdade filer och åtkomsten till dem."
 
 msgid "Add custom URLs to existing paths."
-msgstr ""
+msgstr "Lägg till anpassade URL:er till befintliga sökvägar."
 
 msgid "Configure site search, metadata, and search engine optimization."
-msgstr ""
+msgstr "Configure site search, metadata, and search engine optimization."
 
 msgid "Configure the locale and timezone settings."
-msgstr ""
+msgstr "Konfigurera inställningarna för plats och tidszon."
 
 msgid "Configure how dates and times are displayed."
-msgstr ""
+msgstr "Konfigurera hur datum och tider visas."
 
 msgid "Configure languages for content, interface, and configuration."
-msgstr ""
+msgstr "Ställ in språk för innehåll, användargränssnitt och konfiguration."
 
 msgid ""
 "Configure the import of translation files, and add or customize interface "
 "translations."
 msgstr ""
+"Konfigurera importen av översättningsfiler och lägga till eller anpassa "
+"översättningar för gränssnitt."
 
 msgid "Configure regional settings, localization, and translation."
-msgstr ""
+msgstr "Configure regional settings, localization, and translation."
 
 msgid ""
 "Configure the site description, the number of items per feed, and whether "
 "feeds should be titles/teasers/full-text."
 msgstr ""
+"Ställ in beskrivning av webbplatsen, antal poster per nyhetsflöde och "
+"huruvida flöden skall vara titlar/ingresser/fullständiga texter."
 
 msgid ""
 "The specified file %file could not be moved/copied because no file by that "
 "name exists. Please check that you supplied the correct filename."
 msgstr ""
+"Den angivna filen %file kunde inte flyttas/kopieras eftersom ingen fil med "
+"det namnet existerar. Var vänlig kontrollera att du angav rätt filnamn."
 
 msgid ""
 "The specified file %file could not be moved/copied because the destination "
@@ -19996,40 +21695,55 @@ msgid ""
 "file or directory permissions. More information is available in the system "
 "log."
 msgstr ""
+"Den angivna filen %file kunde inte flyttas/kopieras eftersom målkatalogen "
+"inte är korrekt konfigurerad. Detta kan orsakas av ett problem med fil- "
+"eller katalogbehörigheter. Mer information finns i systemloggen."
 
 msgid ""
 "The file %file could not be moved/copied because a file by that name already"
 " exists in the destination directory."
 msgstr ""
+"Filen %file kunde inte flyttas/kopieras eftersom en fil med det namnet redan"
+" finns i målkatalogen."
 
 msgid ""
 "The specified file %file was not moved/copied because it would overwrite "
 "itself."
 msgstr ""
+"Den angivna filen %file flyttades/kopierades inte eftersom den skulle ha "
+"skrivit över sig själv."
 
 msgid ""
 "File %file (%realpath) could not be moved/copied because it does not exist."
 msgstr ""
+"Fil %file (%realpath) kunde inte flyttas/kopieras eftersom den inte "
+"existerar."
 
 msgid "File %file could not be moved/copied because it does not exist."
-msgstr ""
+msgstr "Fil %file kunde inte flyttas/kopieras eftersom den inte existerar."
 
 msgid ""
 "File %file could not be moved/copied because the destination directory "
 "%destination is not configured correctly."
 msgstr ""
+"Fil %file kunde inte flyttas/kopieras eftersom målkatalogen %destination "
+"inte är korrekt konfigurerad."
 
 msgid ""
 "File %file could not be moved/copied because a file by that name already "
 "exists in the destination directory (%destination)"
 msgstr ""
+"Fil %file kunde inte flyttas/kopieras eftersom en fil med det namnet redan "
+"finns i målkatalogen (%destination)."
 
 msgid ""
 "File %file could not be moved/copied because it would overwrite itself."
 msgstr ""
+"Fil %file flyttades/kopierades inte eftersom den skulle ha skrivit över sig "
+"själv."
 
 msgid "%type: @message in %function (line %line of %file) @backtrace_string."
-msgstr ""
+msgstr "%type: @message i %function (rad %line av %file) @backtrace_string."
 
 msgid ""
 "The directory %directory could not be created. To proceed with the "
@@ -20037,339 +21751,371 @@ msgid ""
 "the permissions to create it automatically. For more information, see the <a"
 " href=\":handbook_url\">online handbook</a>."
 msgstr ""
+"Katalogen %directory kunde inte skapas. För att gå vidare med installationen"
+" måste du antingen skapa katalogen och redigera behörigheterna manuellt, "
+"eller så ser du till att installeraren har behörigheten att skapa katalogen "
+"automatiskt. För mer information, se <a "
+"href=\":handbook_url\">onlinehandboken</a>."
 
 msgid "Starting execution of @module_cron()."
-msgstr ""
+msgstr "Påbörjar körning av @module_cron()."
 
 msgid ""
 "Starting execution of @module_cron(), execution of @module_previous_cron() "
 "took @time."
 msgstr ""
+"Påbörjar körning av @module_cron(), körning av @module_previous_cron() tog "
+"@time."
 
 msgid "Execution of @module_previous_cron() took @time."
-msgstr ""
+msgstr "Execution of @module_previous_cron() took @time."
 
 msgid ""
 "The message to display to the user after submission of this form. Leave "
 "blank for no message."
 msgstr ""
+"The message to display to the user after submission of this form. Leave "
+"blank for no message."
 
 msgid ""
 "Path to redirect the user to after submission of this form. For example, "
 "type \"/about\" to redirect to that page. Use a relative path with a slash "
 "in front."
 msgstr ""
+"Path to redirect the user to after submission of this form. For example, "
+"type \"/about\" to redirect to that page. Use a relative path with a slash "
+"in front."
 
 msgid ""
 "Specify an alternative path by which this data can be accessed. For example,"
 " type \"/about\" when writing an about page."
 msgstr ""
+"Ange en alternativ sökväg där dessa data kan nås. Skriv till exempel \"/om\""
+" när du skriver en sida \"om webbplatsen\"."
 
 msgid ""
 "Control default display settings for your site, across all themes. Use "
 "theme-specific settings to override these defaults."
 msgstr ""
+"Control default display settings for your site, across all themes. Use "
+"theme-specific settings to override these defaults."
 
 msgid "Page element display"
-msgstr ""
+msgstr "Page element display"
 
 msgid "Use the logo supplied by the theme"
-msgstr ""
+msgstr "Använd temats logotyp"
 
 msgid ""
 "Your shortcut icon, or favicon, is displayed in the address bar and "
 "bookmarks of most browsers."
 msgstr ""
+"Bokmärkesikonen visas i de flesta webbläsares adressfält och bokmärken."
 
 msgid "Use the favicon supplied by the theme"
-msgstr ""
+msgstr "Använd temats bokmärkesikon"
 
 msgid "Upload favicon image"
-msgstr ""
+msgstr "Upload favicon image"
 
 msgid "Apply to selected items"
-msgstr ""
+msgstr "Applicera på markerade objekt"
 
 msgid "Recommendations to make your password stronger:"
-msgstr ""
+msgstr "Recommendations to make your password stronger:"
 
 msgid "Combine multiple fields together and search by them."
-msgstr ""
+msgstr "Combine multiple fields together and search by them."
 
 msgid "Field %field set in %filter is not set in display %display."
 msgstr ""
+"Fält %field som är inställt i %filter är inte inställt i visning %display."
 
 msgid "A label is required for the specified operator."
-msgstr ""
+msgstr "Ett värde krävs för den angivna operatorn."
 
 msgid "A label is required if the value for this item is defined."
-msgstr ""
+msgstr "Ett värde krävs om värdet för detta objekt är definierat."
 
 msgid "A value is required if the label for this item is defined."
-msgstr ""
+msgstr "Ett värde krävs om etiketten för detta objekt är definierat."
 
 msgid "Leave empty to show all pages."
-msgstr ""
+msgstr "Lämna tomt för att visa alla sidor."
 
 msgid "@label moderation state"
-msgstr ""
+msgstr "@label moderation state"
 
 msgid "Date range settings"
-msgstr ""
+msgstr "Date range settings"
 
 msgid "Default start date type"
-msgstr ""
+msgstr "Default start date type"
 
 msgid "Default start date value"
-msgstr ""
+msgstr "Default start date value"
 
 msgid "Default end date type"
-msgstr ""
+msgstr "Default end date type"
 
 msgid "Default end date value"
-msgstr ""
+msgstr "Default end date value"
 
 msgid "Date separator"
-msgstr ""
+msgstr "Date separator"
 
 msgid "The string to separate the start and end dates"
-msgstr ""
+msgstr "The string to separate the start and end dates"
 
 msgid ""
 "Specify pages by using their paths. Enter one path per line. The '*' "
 "character is a wildcard. An example path is %user-wildcard for every user "
 "page. %front is the front page."
 msgstr ""
+"Specify pages by using their paths. Enter one path per line. The '*' "
+"character is a wildcard. An example path is %user-wildcard for every user "
+"page. %front is the front page."
 
 msgid "Is front page"
-msgstr ""
+msgstr "Är startsidan"
 
 msgid "Recipient email address"
-msgstr ""
+msgstr "Mottagarens e-postadress"
 
 msgid "Are you sure you want to remove the @entity-type %label?"
-msgstr ""
+msgstr "Are you sure you want to remove the @entity-type %label?"
 
 msgid "The @entity-type %label has been removed."
-msgstr ""
+msgstr "The @entity-type %label has been removed."
 
 msgid "General System Information"
-msgstr ""
+msgstr "General System Information"
 
 msgid "Disclaimer block"
-msgstr ""
+msgstr "Disclaimer block"
 
 msgid "A locally hosted audio file."
-msgstr ""
+msgstr "A locally hosted audio file."
 
 msgid "A locally hosted video file."
-msgstr ""
+msgstr "A locally hosted video file."
 
 msgid "Tell us what you think"
-msgstr ""
+msgstr "Tell us what you think"
 
 msgid "Banner block"
-msgstr ""
+msgstr "Banner block"
 
 msgid "A disclaimer block contains disclaimer and copyright text."
-msgstr ""
+msgstr "A disclaimer block contains disclaimer and copyright text."
 
 msgid "Footer promo block"
-msgstr ""
+msgstr "Footer promo block"
 
 msgid ""
 "A footer promo block contains a title, promo text, and a \"find out more\" "
 "link."
 msgstr ""
+"A footer promo block contains a title, promo text, and a \"find out more\" "
+"link."
 
 msgid "Recipe Name"
-msgstr ""
+msgstr "Recipe Name"
 
 msgid "Content Link"
-msgstr ""
+msgstr "Content Link"
 
 msgid "Find out more link"
-msgstr ""
+msgstr "Find out more link"
 
 msgid "Promo text"
-msgstr ""
+msgstr "Promo text"
 
 msgid "Promo title"
-msgstr ""
+msgstr "Promo title"
 
 msgid ""
 "This image will be used on both the recipe page and wherever the recipe is "
 "promoted."
 msgstr ""
+"This image will be used on both the recipe page and wherever the recipe is "
+"promoted."
 
 msgid "List the ingredients required for this recipe, one per item."
-msgstr ""
+msgstr "List the ingredients required for this recipe, one per item."
 
 msgid "Recipe category"
-msgstr ""
+msgstr "Recipe category"
 
 msgid "Recipe instruction"
-msgstr ""
+msgstr "Recipe instruction"
 
 msgid "Provide a short overview of this recipe."
-msgstr ""
+msgstr "Provide a short overview of this recipe."
 
 msgid "Large 21:9 (1440x620)"
-msgstr ""
+msgstr "Large 21:9 (1440x620)"
 
 msgid "Large 21:9 2x (2880x1240)"
-msgstr ""
+msgstr "Large 21:9 2x (2880x1240)"
 
 msgid "Large 3:2 2x (1536x1024)"
-msgstr ""
+msgstr "Large 3:2 2x (1536x1024)"
 
 msgid "Large 3:2 (768x512)"
-msgstr ""
+msgstr "Large 3:2 (768x512)"
 
 msgid "Medium 21:9 (1024x440)"
-msgstr ""
+msgstr "Medium 21:9 (1024x440)"
 
 msgid "Medium 3:2 2x (1200x800)"
-msgstr ""
+msgstr "Medium 3:2 2x (1200x800)"
 
 msgid "Medium 3:2 (600x400)"
-msgstr ""
+msgstr "Medium 3:2 (600x400)"
 
 msgid "Medium 8:7 (266x236)"
-msgstr ""
+msgstr "Medium 8:7 (266x236)"
 
 msgid "Scale crop 7:3 large"
-msgstr ""
+msgstr "Scale crop 7:3 large"
 
 msgid "Small 21:9 (768x330)"
-msgstr ""
+msgstr "Small 21:9 (768x330)"
 
 msgid "Square Large"
-msgstr ""
+msgstr "Square Large"
 
 msgid "Square Medium"
-msgstr ""
+msgstr "Square Medium"
 
 msgid "Square Small"
-msgstr ""
+msgstr "Square Small"
 
 msgid "3:2 Image"
-msgstr ""
+msgstr "3:2 Bild"
 
 msgid "Configuration validation"
-msgstr ""
+msgstr "Konfigurationskontroll"
 
 msgid "Preset Name"
-msgstr ""
+msgstr "Namn på förhandsinställning"
 
 msgid "Audio"
-msgstr ""
+msgstr "Ljud"
 
 msgid "Node type"
-msgstr ""
+msgstr "Typ av nod"
 
 msgid "content types"
-msgstr ""
+msgstr "innehållstyper"
 
 msgid "Heading"
-msgstr ""
+msgstr "Rubrik"
 
 msgid "Andorra"
-msgstr ""
+msgstr "Andorra"
 
 msgid "Configure content formatting and authoring."
-msgstr ""
+msgstr "Configure content formatting and authoring."
 
 msgid "Configure the administrative user interface."
-msgstr ""
+msgstr "Configure the administrative user interface."
 
 msgid "Manage the content workflow."
-msgstr ""
+msgstr "Manage the content workflow."
 
 msgid "Get a status report about your site's operation."
-msgstr ""
+msgstr "Visa en statusrapport om din webbplats funktion."
 
 msgid ""
 "Unrecognized username or password. <a href=\":password\">Forgot your "
 "password?</a>"
 msgstr ""
+"Unrecognized username or password. <a href=\":password\">Forgot your "
+"password?</a>"
 
 msgid "Video"
-msgstr ""
+msgstr "Video"
 
 msgid "Unauthorized"
-msgstr ""
+msgstr "Ej auktoriserad"
 
 msgid "users"
-msgstr ""
+msgstr "användare"
 
 msgid "RDF"
-msgstr ""
+msgstr "RDF"
 
 msgid "About"
-msgstr ""
+msgstr "Om"
 
 msgid "Edit action"
-msgstr ""
+msgstr "Redigera åtgärd"
 
 msgid "Any text to display before this link. You may include HTML."
-msgstr ""
+msgstr "En text att visas före denna länk. Du kan använda HTML."
 
 msgid "Display score"
-msgstr ""
+msgstr "Visa poäng"
 
 msgid "Save book pages"
-msgstr ""
+msgstr "Spara boksidor"
 
 msgid "Last checked: @time ago"
-msgstr ""
+msgstr "Senast kontrollerad: för @time sedan"
 
 msgid "Provider name"
-msgstr ""
+msgstr "Leverantörsnamn"
 
 msgid "Moderation state"
-msgstr ""
+msgstr "Modereringsstatus"
 
 msgid "This identifier is used by another handler."
-msgstr ""
+msgstr "Den här identifieraren används av en annan hanterare."
 
 msgid ""
 "An error occurred while processing %error_operation with arguments: "
 "@arguments"
 msgstr ""
+"Ett fel uppstod när %error_operation utfördes med argumenten: @arguments"
 
 msgid "Formatter settings"
-msgstr ""
+msgstr "Inställningar för formaterare"
 
 msgid "Users cannot post comments."
-msgstr ""
+msgstr "Användare kan inte skriva kommentarer."
 
 msgid "Displaying menus"
-msgstr ""
+msgstr "Visning av menyer"
 
 msgid ""
 "%capital_name contains terms with multiple parents. Drag and drop of terms "
 "with multiple parents is not supported, but you can re-enable drag-and-drop "
 "support by editing each term to include only a single parent."
 msgstr ""
+"%capital_name innehåller termer med flera ovanliggande termer. Drag-och-"
+"släpp av termer med flera ovanliggande termer stöds inte, men du kan "
+"återaktivera drag-och-släpp genom att redigera varje term så att den bara "
+"har en ovanliggande term."
 
 msgid "Inline Form Errors"
-msgstr ""
+msgstr "Felmeddelanden inuti formulär"
 
 msgid "Last access timestamp"
-msgstr ""
+msgstr "Tidsstämpel för senare åtkomst"
 
 msgid "Severity level"
-msgstr ""
+msgstr "Severity level"
 
 msgid "Transitions"
-msgstr ""
+msgstr "Övergångar"
 
 msgid "Vocabulary machine name"
-msgstr ""
+msgstr "Maskinläsbart namn för vokabulär"
 
 msgid "Preset ID"
-msgstr ""
+msgstr "ID-nummer för förhandsinställning"
 
 msgid ""
 "A unique machine-readable name for this content type. It must only contain "
@@ -20377,21 +22123,25 @@ msgid ""
 "constructing the URL of the %node-add page, in which underscores will be "
 "converted into hyphens."
 msgstr ""
+"A unique machine-readable name for this content type. It must only contain "
+"lowercase letters, numbers, and underscores. This name will be used for "
+"constructing the URL of the %node-add page, in which underscores will be "
+"converted into hyphens."
 
 msgid "The author's host name."
-msgstr ""
+msgstr "Värdnamnet för författaren."
 
 msgid "Default moderation state"
-msgstr ""
+msgstr "Förvald modereringsstatus"
 
 msgid "Full data (serialized)"
-msgstr ""
+msgstr "Fullständig data (seriell)"
 
 msgid "HTTP method"
-msgstr ""
+msgstr "Metod för HTTP"
 
 msgid "User limit"
-msgstr ""
+msgstr "Användargräns"
 
 msgid ""
 "If checked, multiple values for this field will be shown in the same row. If"
@@ -20399,65 +22149,75 @@ msgid ""
 " by, please make sure to group by \"Entity ID\" for this setting to have any"
 " effect."
 msgstr ""
+"Om markerad, kommer flera värden för detta fält visas på samma rad. Om inte "
+"markerad, kommer varje värde på detta fält skapa en ny rad. Om du använder "
+"gruppera på, var vänlig se till att gruppera på \"ID för objekt\" för att "
+"denna inställning skall ha någon effekt."
 
 msgid "Filter HTML"
-msgstr ""
+msgstr "Filtrerad HTML"
 
 msgid "Configuration Manager"
-msgstr ""
+msgstr "Konfigurationshanterare"
 
 msgid "Maximum attempts"
-msgstr ""
+msgstr "Maximalt antal försök"
 
 msgid "No blocked IP addresses available."
-msgstr ""
+msgstr "Inga spärrade IP-adresser tillgängliga."
 
 msgid ""
 "The first mlid in the materialized path. If N = depth, then pN must equal "
 "the mlid. If depth > 1 then p(N-1) must equal the plid. All pX where X > "
 "depth must equal zero. The columns p1 .. p9 are also called the parents."
 msgstr ""
+"Den första mlid i den materialiserade sökvägen. Om N = djup, då måste pN "
+"vara lika med mlid. Om djup > 1 då måste p(N-1) vara lika med plid. Alla pX "
+"där X > djup måste vara lika med noll. Kolumnerna p1 ... p9 kallas också "
+"ovanliggande."
 
 msgid "The third mlid in the materialized path. See p1."
-msgstr ""
+msgstr "Den tredje mlid i den materialiserade sökvägen. Se p1."
 
 msgid "The fourth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "Den fjärde mlid i den materialiserade sökvägen. Se p1."
 
 msgid "The fifth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "Den femte mlid i den materialiserade sökvägen. Se p1."
 
 msgid "The sixth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "Den sjätte mlid i den materialiserade sökvägen. Se p1."
 
 msgid "The seventh mlid in the materialized path. See p1."
-msgstr ""
+msgstr "Den sjunde mlid i den materialiserade sökvägen. Se p1."
 
 msgid "The eighth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "Den åttonde mlid i den materialiserade sökvägen. Se p1."
 
 msgid "The ninth mlid in the materialized path. See p1."
-msgstr ""
+msgstr "Den nionde mlid i den materialiserade sökvägen. Se p1."
 
 msgid ""
 "Flag that indicates that this link was generated during the update from "
 "Drupal 5."
 msgstr ""
+"Flagga som indikerar att denna länk genererades under uppdateringen från "
+"Drupal 5."
 
 msgid "Displaying @start - @end of @total"
-msgstr ""
+msgstr "Visar @start - @end av @total"
 
 msgid "The revision ID."
-msgstr ""
+msgstr "ID-nummer för versionen."
 
 msgid "All field aliases must be unique"
-msgstr ""
+msgstr "Alla fältalias måste vara unika"
 
 msgid "Editorial"
-msgstr ""
+msgstr "Redaktionell"
 
 msgid "Enter a part of the block name to filter by."
-msgstr ""
+msgstr "Ange en del av blocknamnet att filtrera på."
 
 msgid ""
 "The width of each column will be calculated automatically based on the "
@@ -20465,106 +22225,134 @@ msgid ""
 "injects classes based on a grid system, disabling this option may prove "
 "beneficial."
 msgstr ""
+"Bredden på varje kolumn kommer att beräknas automatiskt baserat på antalet "
+"kolumner som tillhandahålls. Att inaktivera det här alternativet kan vara "
+"till nytta om ytterligare klasser är angivna eller om ett tema injicerar "
+"klasser baserade på ett rutnät."
 
 msgid ""
 "Add the default views column classes like views-col, col-1 and clearfix to "
 "the output. You can use this to quickly reduce the amount of markup the view"
 " provides by default, at the cost of making it more difficult to apply CSS."
 msgstr ""
+"Lägg förvalda kolumnklasserna för visningar som views-col, col-1 och "
+"clearfix till utmatningen. Du kan använda detta för att snabbt minska "
+"mängden uppmärkning som vyn ger som standard, på bekostnad av att det blir "
+"svårare att tillämpa CSS."
 
 msgid "The most recent of last comment posted or entity updated time."
-msgstr ""
+msgstr "Den senast inlagda kommentaren eller uppdateringstid för objekt."
 
 msgid "The User ID of the author of the last comment of an entity."
-msgstr ""
+msgstr "Användar-ID till författaren för den sista kommentaren på ett objekt."
 
 msgid ""
 "The handler for this item is broken or missing. The following details are "
 "available:"
 msgstr ""
+"Hanteraren för det här objektet är felaktig eller saknas. Följande uppgifter"
+" finns tillgängliga:"
 
 msgid "View basic information"
-msgstr ""
+msgstr "Visa grundläggande information"
 
 msgid ""
 "@groupName button group in position @position of @positionCount in row @row "
 "of @rowCount."
 msgstr ""
+"Knappgrupp @groupName i position @position av @positionCount i rad @row av "
+"@rowCount."
 
 msgid ""
 "@name @type in position @position of @positionCount in @groupName button "
 "group in row @row of @rowCount."
 msgstr ""
+"@name @type i position @position av @positionCount i knappgrupp @groupName i"
+" rad @row av @rowCount."
 
 msgid "Press the down arrow key to create a new button group in a new row."
-msgstr ""
+msgstr "Tryck på pil ned för att skapa en ny knappgrupp i en ny rad."
 
 msgid "Editing the name of the new button group in a dialog."
-msgstr ""
+msgstr "Redigerar namnet på den nya gruppknappen i en dialog."
 
 msgid "Editing the name of the \"@groupName\" button group in a dialog."
-msgstr ""
+msgstr "Redigerar namnet på gruppknappen \"@groupName\" i en dialog."
 
 msgid ""
 "An entity with this machine name already exists but the import did not "
 "specify a UUID."
 msgstr ""
+"Ett objekt med detta maskinläsbara namn finns redan men importen "
+"specificerade inget UUID."
 
 msgid ""
 "An entity with this machine name already exists but the UUID does not match."
 msgstr ""
+"Ett objekt med detta maskinläsbara namn finns redan men UUID stämmer inte "
+"överens."
 
 msgid ""
 "An entity with this UUID already exists but the machine name does not match."
 msgstr ""
+"Ett objekt med detta UUID finns redan men det maskinläsbara namnet stämmer "
+"inte överens."
 
 msgid "Enter a part of the field or @bundle to filter by."
-msgstr ""
+msgstr "Ange en del av fältet eller @bundle att filtrera på."
 
 msgid "Add @language translation for %label"
-msgstr ""
+msgstr "Lägg till @language översättning för %label"
 
 msgid "@language translation of %label was deleted"
-msgstr ""
+msgstr "@language översättning för %label raderades"
 
 msgid "Edit @language translation for %label"
-msgstr ""
+msgstr "Redigera @language översättning för %label"
 
 msgid ""
 "Are you sure you want to apply the updated %name image effect to all images?"
 msgstr ""
+"Är du säker på att du vill tillämpa den uppdaterade bildeffekten %name på "
+"alla bilder?"
 
 msgid ""
 "The rebuild_access setting is enabled in settings.php. It is recommended to "
 "have this setting disabled unless you are performing a rebuild."
 msgstr ""
+"Inställningen rebuild_access är aktiverat i settings.php. Det rekommenderas "
+"att inaktivera den här inställningen om du inte bygger om behörigheterna."
 
 msgid "Preferred admin language code"
-msgstr ""
+msgstr "Föredragen språkkod för administration"
 
 msgid ""
 "The user's preferred language code for receiving emails and viewing the "
 "site."
 msgstr ""
+"Användarens föredragna språkkod för mottagning av e-post och visning av "
+"webbplatsen."
 
 msgid "Preferred language code"
-msgstr ""
+msgstr "Föredragen språkkod"
 
 msgid "The user's preferred language code for viewing administration pages."
-msgstr ""
+msgstr "Användarens föredragna språkkod för visning av administrationssidor."
 
 msgid "The password of this user (hashed)."
-msgstr ""
+msgstr "Lösenordet för den här användaren (hashad)"
 
 msgid "Initial email"
-msgstr ""
+msgstr "Första e-postadress"
 
 msgid "User ID from route context"
-msgstr ""
+msgstr "ID för användare från ruttsammanhang"
 
 msgid ""
 "Changing the title here means it cannot be dynamically altered anymore."
 msgstr ""
+"Genom att ändra på den här titeln innebär det att den inte kan ändras "
+"dynamiskt längre."
 
 msgid ""
 "This view will be displayed by visiting this path on your site. You may use "
@@ -20572,78 +22360,92 @@ msgid ""
 "filters: For example, \"node/%/feed\". If needed you can even specify named "
 "route parameters like taxonomy/term/%taxonomy_term"
 msgstr ""
+"Denna vy kommer att visas genom att besöka denna sökväg på din webbplats. Du"
+" kan använda \"%\" i din URL för att representera värden som kommer att "
+"användas för sammanhängande filtreringar: Till exempel \"node/%/feed\". Vid "
+"behov kan du även ange namngivna ruttparametrar som "
+"taxonomy/term/%taxonomy_term"
 
 msgid ""
 "Some of the pending updates cannot be applied because their dependencies "
 "were not met."
 msgstr ""
+"Några av de väntande uppdateringar kan inte genomföras eftersom deras "
+"beroenden inte var uppfyllda."
 
 msgid "taxonomy term"
-msgstr ""
+msgstr "taxonomiterm"
 
 msgid "Revision user"
-msgstr ""
+msgstr "Användare för version"
 
 msgid "In-place content editing."
-msgstr ""
+msgstr "Redigering av innehåll direkt på plats."
 
 msgid ""
 "An entity field containing a UNIX timestamp of when the entity has been last"
 " updated."
 msgstr ""
+"Ett objektsfält som innehåller en UNIX-tidsstämpel för när objektet senast "
+"uppdaterades."
 
 msgid ""
 "An entity field containing a UNIX timestamp of when the entity has been "
 "created."
 msgstr ""
+"Ett objektsfält som innehåller en UNIX-tidsstämpel för när objektet "
+"skapades."
 
 msgid "An entity field for storing a serialized array of values."
-msgstr ""
+msgstr "Ett objektsfält för att lagra en seriell lista (array) av värden."
 
 msgid "The config name @config_name is invalid."
-msgstr ""
+msgstr "Konfigurationsnamnet @config_name är ogiltigt."
 
 msgid "The configuration was imported with errors."
-msgstr ""
+msgstr "Konfigurationen importerades, men med fel."
 
 msgid "Deleted and replaced configuration entity \"@name\""
-msgstr ""
+msgstr "Raderade och ersatte objektskonfiguration \"@name\""
 
 msgid "HTML help"
-msgstr ""
+msgstr "HTML-hjälp"
 
 msgid "Title field required"
-msgstr ""
+msgstr "Titelfält är obligatoriskt"
 
 msgid "Updates for: @module_list"
-msgstr ""
+msgstr "Uppdateringar för: @module_list"
 
 msgid ""
 "You have not created any content types yet. Go to the <a "
 "href=\"@create_content\">content type creation page</a> to add a new content"
 " type."
 msgstr ""
+"Du har inte skapat någon innehållstyp ännu. Gå till sidan <a "
+"href=\"@create_content\">skapa innehållstyp</a> för att lägga till en ny "
+"innehållstyp."
 
 msgid "Embed display options"
-msgstr ""
+msgstr "Alternativ för inbäddad visning"
 
 msgid "Boolean sort expose settings"
-msgstr ""
+msgstr "Inställningar för exponerad boolesk sortering"
 
 msgid "Standard sort expose settings"
-msgstr ""
+msgstr "Exponerade inställningar för standardsortering"
 
 msgid "Random sort expose settings"
-msgstr ""
+msgstr "Exponerade inställningar för slumpvis sortering"
 
 msgid "Default views column classes"
-msgstr ""
+msgstr "Förvalda kolumnklasser för vyer"
 
 msgid "Book traversal links for"
-msgstr ""
+msgstr "Genomkorsande boklänkar för"
 
 msgid "Administer comment types and settings"
-msgstr ""
+msgstr "Administrera kommentarstyper och inställningar"
 
 msgid ""
 "Allow other users to contact you via a personal contact form which keeps "
@@ -20651,35 +22453,48 @@ msgid ""
 "administrators are still able to contact you even if you choose to disable "
 "this feature."
 msgstr ""
+"Tillåter andra användare att kontakta dig via ett personligt kontaktformulär"
+" som döljer din e-postadress. Observera att vissa privilegierade användare "
+"som administratörer kan fortfarande kontakta dig även om du väljer att "
+"stänga av denna funktion."
 
 msgid "%sender-name (@sender-from) sent %recipient-name an email."
 msgstr ""
+"%sender-name (@sender-from) skickade ett e-postmeddelande till %recipient-"
+"name."
 
 msgid "Email notification threshold"
-msgstr ""
+msgstr "Tröskelvärde för e-postmeddelande"
 
 msgid ""
 "Whenever your site checks for available updates and finds new releases, it "
 "can notify a list of users via email. Put each address on a separate line. "
 "If blank, no emails will be sent."
 msgstr ""
+"﻿﻿När din webbplats söker efter tillgängliga uppdateringar och finner nya "
+"utgåvor, kan den meddela en lista av användare via e-post. Skriv varje "
+"adress på en separat rad. Om det är tomt, skickas inga e-postmeddelanden."
 
 msgid "This account's preferred language for emails and site presentation."
 msgstr ""
+"Det här kontots föredragna språk för e-post och presentation av webbplatsen."
 
 msgid ""
 "Password reset instructions will be mailed to %email. You must log out to "
 "use the password reset link in the email."
 msgstr ""
+"Instruktioner för återställning av lösenord kommer att skickas till %email. "
+"Du måste logga ut för att kunna använda länken för återställning som finns i"
+" e-postmeddelandet."
 
 msgid "Duplicate view"
-msgstr ""
+msgstr "Kopiera vy"
 
 msgid "@field_name: @label"
-msgstr ""
+msgstr "@field_name: @label"
 
 msgid "This link is provided by the Views module from view %label."
-msgstr ""
+msgstr "Denna länk tillhandahålls av modulen Views från vy %label."
 
 msgid ""
 "\n"
@@ -20691,6 +22506,14 @@ msgid ""
 "          <li>… and you can apply this to other elements as well: <code>&lt;video src=\"\" data-align=\"center\" /&gt;</code></li>\n"
 "        </ul>"
 msgstr ""
+"\n"
+"        <p>Du kan justera bilder, videor, blockcitat och så vidare åt vänster, höger eller till mitten. Exempel:</p>\r\n"
+"        <ul>\r\n"
+"          <li>Justera en bild till vänster: <code>&lt;img src=\"\" data-align=\"left\" /&gt;</code></li>\r\n"
+"          <li>Justera en bild till mitten: <code>&lt;img src=\"\" data-align=\"center\" /&gt;</code></li>\r\n"
+"          <li>Justera en bild till höger: <code>&lt;img src=\"\" data-align=\"right\" /&gt;</code></li>\r\n"
+"          <li>… och du kan också använda detta med andra element: <code>&lt;video src=\"\" data-align=\"center\" /&gt;</code></li>\r\n"
+"        </ul>"
 
 msgid ""
 "\n"
@@ -20702,98 +22525,127 @@ msgid ""
 "            <li><code>&lt;code data-caption=\"Hello world in JavaScript.\"&gt;alert(\"Hello world!\");&lt;/code&gt;</code></li>\n"
 "        </ul>"
 msgstr ""
+"\n"
+"        <p>Du kan lägga till text till bilder, videos, blockcitat och så vidare. Exempel:</p>\r\n"
+"        <ul>\r\n"
+"            <li><code>&lt;img src=\"\" data-caption=\"Det här är en bildtext\" /&gt;</code></li>\r\n"
+"            <li><code>&lt;video src=\"\" data-caption=\"Drupals dans\" /&gt;</code></li>\r\n"
+"            <li><code>&lt;blockquote data-caption=\"Dries Buytaert\"&gt;Drupal är häftigt!&lt;/blockquote&gt;</code></li>\r\n"
+"            <li><code>&lt;code data-caption=\"Hello world i JavaScript.\"&gt;alert(\"Hello world!\");&lt;/code&gt;</code></li>\r\n"
+"        </ul>"
 
 msgid "Drupal database update"
-msgstr ""
+msgstr "Databasuppdatering för Drupal"
 
 msgid ""
 "Use this utility to update your database whenever a new release of Drupal or"
 " a module is installed."
 msgstr ""
+"Använd detta verktyg för att uppdatera din databas när en ny version av "
+"Drupal eller en modul installerats."
 
 msgid ""
 "<strong>Back up your code</strong>. Hint: when backing up module code, do "
 "not leave that backup in the 'modules' or 'sites/*/modules' directories as "
 "this may confuse Drupal's auto-discovery mechanism."
 msgstr ""
+"<strong>Säkerhetskopiera din kod</strong>. Tips: när du säkerhetskopierar "
+"modulkod, lämna inte säkerhetskopian i filkatalogerna \"modules\" eller "
+"\"sites/*/modules\" eftersom detta kan förvirra Drupals mekanism för "
+"automatisk upptäckt."
 
 msgid ""
 "<strong>Back up your database</strong>. This process will change your "
 "database values and in case of emergency you may need to revert to a backup."
 msgstr ""
+"<strong>Säkerhetskopiera din databas</strong>. Denna process kommer att "
+"ändra innehållet i databasen och i nödfall kan du behöva återgå till en "
+"säkerhetskopia."
 
 msgid ""
 "Install your new files in the appropriate location, as described in the "
 "handbook."
-msgstr ""
+msgstr "Installera dina nya filer på rätt plats, som beskrivs i handboken."
 
 msgid "When you have performed the steps above, you may proceed."
-msgstr ""
+msgstr "När du har utfört stegen ovan, kan du fortsätta."
 
 msgid "Formatted text default display format settings"
-msgstr ""
+msgstr "Inställningar för förvalt visningsformat åt formaterad text"
 
 msgid "Summary or trimmed formatted text display format settings"
-msgstr ""
+msgstr "Inställningar för visningsformat åt sammanfattad eller nedkortad text"
 
 msgid "%field settings for %bundle"
-msgstr ""
+msgstr "%field inställningar för %bundle"
 
 msgctxt "Validation"
 msgid "Entity Reference reference access"
-msgstr ""
+msgstr "Åtkomst till refererat objekt"
 
 msgid "You do not have access to the referenced entity (%type: %id)."
-msgstr ""
+msgstr "Du har inte åtkomst till det refererade objektet (%type: %id)."
 
 msgid ""
 "You can caption images (<code>data-caption=\"Text\"</code>), but also "
 "videos, blockquotes, and so on."
 msgstr ""
+"Du kan lägga till text till bilder (<code>data-caption=\"Text\"</code>), men"
+" också videos, blockcitat och så vidare."
 
 msgid ""
 "CTRL+Left click will prevent this dialog from showing and proceed to the "
 "clicked link."
 msgstr ""
+"Ctrl + vänsterklick kommer att förhindra den här dialogrutan från att visas "
+"och går vidare till den klickade länken."
 
 msgid ""
 "If more than one application will be sharing this database, a unique table "
 "name prefix – such as %prefix – will prevent collisions."
 msgstr ""
+"Om fler än en applikation kommer dela denna databas kan ett unikt prefix på "
+"tabellnamn, som till exempel %prefix, göra att du undviker konflikter."
 
 msgctxt "Validation"
 msgid "Regex"
-msgstr ""
+msgstr "Regex"
 
 msgid "The formatted text of the area"
-msgstr ""
+msgstr "Den formaterade texten för fältet"
 
 msgid ""
 "Entities exist of type %entity_type and %bundle_label %bundle. These "
 "entities need to be deleted before importing."
 msgstr ""
+"Objekt existerar av typ %entity_type och %bundle_label %bundle. Dessa objekt"
+" måste raderas innan import."
 
 msgid "The message language code."
-msgstr ""
+msgstr "Meddelandets språkkod."
 
 msgid ""
 "A boolean indicating whether the translation is visible to non-translators."
 msgstr ""
+"En boolesk som indikerar huruvida en översättning är synlig eller ej för "
+"icke översättare."
 
 msgid "Fields and field types"
-msgstr ""
+msgstr "Fält och fälttyper"
 
 msgid "Enabling field types, widgets, and formatters"
 msgstr ""
+"Aktiverar fälttyper, gränssnittskomponenter och formateringsfunktioner"
 
 msgid "Images larger than <strong>@max</strong> pixels will be resized."
 msgstr ""
+"Bilder som är större än <strong>@max</strong> pixlar kommer skalas ned."
 
 msgid "The reference view %view_name cannot be found."
-msgstr ""
+msgstr "Den refererade vyn %view_name kan inte hittas."
 
 msgid "An autocomplete text field with tagging support."
-msgstr ""
+msgstr "Ett automatiskt kompletterande textfält med stöd för etiketter."
 
 msgid ""
 "You can also configure a default image that will be used if no image is "
@@ -20801,145 +22653,186 @@ msgid ""
 " the field in the field storage settings when you create a field, and the "
 "setting can be overridden for each entity sub-type that uses the field."
 msgstr ""
+"Du kan också konfigurera en förvald bild som ska användas om ingen bild "
+"laddas upp i ett bildfält. Denna förvalda bild kan definieras för alla "
+"instanser av fältet i fältlagringsinställningarna när du skapar ett fält, "
+"och inställningen kan åsidosättas för varje deltyp av objektet som använder "
+"fältet."
 
 msgid "@title [%language translation]"
-msgstr ""
+msgstr "@title [%language översättning]"
 
 msgid "Provides links to perform entity operations."
-msgstr ""
+msgstr "Tillhandahåller länkar för att genomföra funktioner på objekt."
 
 msgid "@label (@id)"
-msgstr ""
+msgstr "@label (@id)"
 
 msgid "Query arguments"
-msgstr ""
+msgstr "Argument för databasfråga"
 
 msgid "Request format"
-msgstr ""
+msgstr "Format på begäran"
 
 msgid "A flag indicating whether this is the default translation."
 msgstr ""
+"En flagga som indikerar huruvida detta är den förvalda översättningen eller "
+"ej."
 
 msgid "Field settings (@on_label / @off_label)"
-msgstr ""
+msgstr "Fältinställningar (@on_label / @off_label)"
 
 msgid "@on_label / @off_label"
-msgstr ""
+msgstr "@on_label / @off_label"
 
 msgid "By @author @time ago"
-msgstr ""
+msgstr "Av @author @time sedan"
 
 msgid ""
 "Search looks for exact, case-insensitive keywords; keywords shorter than a "
 "minimum length are ignored."
 msgstr ""
+"Sökning letar efter exakta, ej skiftlägeskänsliga nyckelord. Nyckelord "
+"ignoreras om de är kortare än en minsta längd."
 
 msgid ""
 "Use upper-case OR to get more results. Example: cat OR dog (content contains"
 " either \"cat\" or \"dog\")."
 msgstr ""
+"Använd versalt OR för att få fler resultat. Exempel: katt OR hund "
+"(innehåller antingen \"katt\" eller \"hund\")."
 
 msgid "Fallback date format"
-msgstr ""
+msgstr "Datumformat i reserv"
 
 msgid "Primary tabs display toggle"
-msgstr ""
+msgstr "Växla visningsläge av primära länkar"
 
 msgid "Hide lower priority columns"
-msgstr ""
+msgstr "Dölj lägre prioriterade kolumner"
 
 msgid "Allows users to configure languages and apply them to content."
 msgstr ""
+"Tillåter användare att konfigurera språk och applicera dem på innehåll."
 
 msgid ""
 "You can use upper-case AND to require all words, but this is the same as the"
 " default behavior. Example: cat AND dog (same as cat dog, content must "
 "contain both \"cat\" and \"dog\")."
 msgstr ""
+"Du kan använda versalt AND för att kräva alla ord, men det är samma som "
+"standardbeteende. Exempel: katt AND hund (samma som katt hund, måste "
+"innehåll både \"katt\" och \"hund\")."
 
 msgid "Use quotes to search for a phrase. Example: \"the cat eats mice\"."
 msgstr ""
+"Använd citationstecken för att söka efter en fras. Exempel: \"katten äter "
+"möss\"."
 
 msgid ""
 "You can precede keywords by - to exclude them; you must still have at least "
 "one \"positive\" keyword. Example: cat -dog (content must contain cat and "
 "cannot contain dog)."
 msgstr ""
+"Du kan inleda sökord med - för att utesluta dem. Du måste fortfarande ha "
+"minst ett \"positivt\" sökord. Exempel: katt -hund (innehållet måste "
+"innehålla katt och kan inte innehålla hund)."
 
 msgid "No eligible views were found."
-msgstr ""
+msgstr "Ingen valbara vyer hittades."
 
 msgid "Testing config overrides"
-msgstr ""
+msgstr "Testar konfigurationsåsidosättanden"
 
 msgid "Minimal profile for running tests with config overrides in a profile."
 msgstr ""
+"Minimal profil för att köra tester med konfigurationsåsidosättande i en "
+"profil."
 
 msgid "The hashed password"
-msgstr ""
+msgstr "Det hashade lösenordet"
 
 msgid "@entity using @field_name"
-msgstr ""
+msgstr "@entity använder @field_name"
 
 msgid ""
 "The <em>Autocomplete (Tags style)</em> widget displays a multi-text field in"
 " which users can type in a comma-separated list of entity labels."
 msgstr ""
+"Gränssnittskomponenten <em>automatisk komplettering (etiketter)</em> visar "
+"ett fält med flera rader där användare kan skriva in en kommaseparerad lista"
+" av objektsetiketter."
 
 msgid ""
 "Revisions allow you to track differences between multiple versions of your "
 "content, and revert to older versions."
 msgstr ""
+"Med versioner kan du spåra skillnader mellan flera versioner av ditt "
+"innehåll och återgå till äldre versioner."
 
 msgid "Testing multilingual with English"
-msgstr ""
+msgstr "Testar flerspråkighet med engelska."
 
 msgid "Checkout complete! Thank you for your purchase."
-msgstr ""
+msgstr "Beställning slutförd! Tack för ert köp."
 
 msgid "Resolving missing content"
-msgstr ""
+msgstr "Löser saknat innehåll"
 
 msgid "The following @entity-type translations will be deleted:"
-msgstr ""
+msgstr "Följande översättningar för @entity-type kommer raderas:"
 
 msgid "The @entity-type %label @language translation has been deleted."
-msgstr ""
+msgstr "Översättningen för @entity-type %label @language har raderats."
 
 msgid ""
 "Are you sure you want to delete the @language translation of the @entity-"
 "type %label?"
 msgstr ""
+"Är du säker på att du vill radera den @language översättningen av @entity-"
+"type %label?"
 
 msgid ""
 "Unable to uninstall the %module module since the %dependent_module module is"
 " installed."
 msgstr ""
+"Kunde inte avinstallera modulen %module eftersom modulen %dependent_module "
+"är installerad."
 
 msgid ""
 "Unable to install the %theme theme since it requires the %required_theme "
 "theme."
 msgstr ""
+"Kunde inte installera temat %theme eftersom det kräver temat "
+"%required_theme."
 
 msgid ""
 "Unable to uninstall the %theme theme since the %dependent_theme theme is "
 "installed."
 msgstr ""
+"Kunde inte avinstallera temat %theme eftersom temat %dependent_theme är "
+"installerat."
 
 msgid ""
 "Configuration %name depends on the %owner module that will not be installed "
 "after import."
 msgstr ""
+"Konfiguration %name behöver modulen %owner som inte kommer installeras efter"
+" import."
 
 msgid ""
 "Configuration %name depends on the %owner theme that will not be installed "
 "after import."
 msgstr ""
+"Konfiguration %name behöver temat %owner som inte kommer installeras efter "
+"import."
 
 msgid ""
 "Configuration %name depends on the %owner extension that will not be "
 "installed after import."
 msgstr ""
+"Konfiguration %name behöver tillägget %owner som inte kommer installeras "
+"efter import."
 
 msgid ""
 "Unable to install the %module module since it requires the %required_module "
@@ -20948,7 +22841,11 @@ msgid_plural ""
 "Unable to install the %module module since it requires the %required_module "
 "modules."
 msgstr[0] ""
+"Kunde inte installera modulen %module eftersom den kräver modulen "
+"%required_module."
 msgstr[1] ""
+"Kunde inte installera modulen %module eftersom den kräver modulerna "
+"%required_module."
 
 msgid ""
 "Configuration %name depends on the %module module that will not be installed"
@@ -20957,7 +22854,11 @@ msgid_plural ""
 "Configuration %name depends on modules (%module) that will not be installed "
 "after import."
 msgstr[0] ""
+"Konfiguration %name behöver modulen %module som inte kommer installeras "
+"efter import."
 msgstr[1] ""
+"Konfiguration %name behöver modulerna %module som inte kommer installeras "
+"efter import."
 
 msgid ""
 "Configuration %name depends on the %theme theme that will not be installed "
@@ -20966,7 +22867,11 @@ msgid_plural ""
 "Configuration %name depends on themes (%theme) that will not be installed "
 "after import."
 msgstr[0] ""
+"Konfiguration %name behöver temat %theme som inte kommer installeras efter "
+"import."
 msgstr[1] ""
+"Konfiguration %name behöver teman %theme som inte kommer installeras efter "
+"import."
 
 msgid ""
 "Configuration %name depends on the %config configuration that will not exist"
@@ -20975,15 +22880,19 @@ msgid_plural ""
 "Configuration %name depends on configuration (%config) that will not exist "
 "after import."
 msgstr[0] ""
+"Konfiguration %name behöver konfigurationen %configuration som inte kommer "
+"existera efter import."
 msgstr[1] ""
+"Konfiguration %name behöver konfigurationerna %configuration som inte kommer"
+" existera efter import."
 
 msgctxt "Validation"
 msgid "NotNull"
-msgstr ""
+msgstr "Ej innehållslöst"
 
 msgctxt "Validation"
 msgid "Null"
-msgstr ""
+msgstr "Innehållslöst"
 
 msgid ""
 "For more detailed information, see the <a "
@@ -20991,61 +22900,70 @@ msgid ""
 "unsure what these terms mean you should probably contact your hosting "
 "provider."
 msgstr ""
+"För mer detaljerad information, se <a "
+"href=\"https://www.drupal.org/upgrade\">uppgraderingshandboken</a>. Om du är"
+" osäker på vad dessa termer betyder bör du förmodligen kontakta ditt "
+"webbhotell."
 
 msgid "Entity delete link"
-msgstr ""
+msgstr "Länk för att radera objekt"
 
 msgid "Entity edit link"
-msgstr ""
+msgstr "Länk för att redigera objekt"
 
 msgid "Link to @entity_type_label"
-msgstr ""
+msgstr "Länka till @entity_type_label"
 
 msgid "Provide a view link to the @entity_type_label."
-msgstr ""
+msgstr "Tillhandahåll en vylänk till @entity_type_label."
 
 msgid "Link to edit @entity_type_label"
-msgstr ""
+msgstr "Länk för att redigera @entity_type_label"
 
 msgid "Provide an edit link to the @entity_type_label."
-msgstr ""
+msgstr "Tillhandahåll en redigeringslänk till @entity_type_label."
 
 msgid "Link to delete @entity_type_label"
-msgstr ""
+msgstr "Länk för att radera @entity_type_label"
 
 msgid "Provide a delete link to the @entity_type_label."
-msgstr ""
+msgstr "Provide a delete link to the @entity_type_label."
 
 msgid "Cache tags"
-msgstr ""
+msgstr "Etiketter för cache"
 
 msgid ""
 "Use <em>@interval</em> where you want the formatted interval text to appear."
 msgstr ""
+"Använd <em>@interval</em> där du vill att det formaterade textintervallet "
+"skall visas."
 
 msgid "How many time interval units should be shown in the formatted output."
 msgstr ""
+"Hur många tidsintervallsenheter skall visas i den formaterade utmatningen."
 
 msgid "Future date: %display"
-msgstr ""
+msgstr "Framtida datum: %display"
 
 msgid "Past date: %display"
-msgstr ""
+msgstr "Tidigare datum: %display"
 
 msgid ""
 "Indicates if the last edit of a translation belongs to current revision."
 msgstr ""
+"Indikerar om den senaste redigeringen av en översättning hör till nuvarande "
+"version."
 
 msgid "Testing config import"
-msgstr ""
+msgstr "Testar konfigurationsimport"
 
 msgid "Tests install profiles in the config importer."
-msgstr ""
+msgstr "Testar installationsprofiler i konfigurationsimporteraren."
 
 msgid "Module %name has been enabled."
 msgid_plural "@count modules have been enabled: %names."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Modul %name har aktiverats."
+msgstr[1] "Modulerna @count har aktiverats: %names."
 
 msgid ""
 "The MySQLnd driver version %version is less than the minimum required "
@@ -21053,6 +22971,10 @@ msgid ""
 "alternatively switch mysql drivers to libmysqlclient version "
 "%libmysqlclient_minimum_version or up."
 msgstr ""
+"Drivrutinversionen %version för MySQLnd är lägre än den lägst tillåtna "
+"versionen. Uppgradera MySQLnd till version %mysqlnd_minimum_version eller "
+"högre, eller så byter du drivrutinerna för mysql till libmysqlclient version"
+" %libmysqlclient_minimum_version eller högre."
 
 msgid ""
 "The libmysqlclient driver version %version is less than the minimum required"
@@ -21060,96 +22982,109 @@ msgid ""
 "or up, or alternatively switch mysql drivers to MySQLnd version "
 "%mysqlnd_minimum_version or up."
 msgstr ""
+"Drivrutinversionen version %version för libmysqlclient är lägre än den lägst"
+" tillåtna versionen. Uppgradera libmysqlclient till version "
+"%libmysqlclient_minimum_version eller högre, eller så byter du drivrutinerna"
+" för mysql till MySQLnd version %mysqlnd_minimum_version eller högre."
 
 msgid ""
 "Drupal could not be correctly setup with the existing database due to the "
 "following error: @error."
 msgstr ""
+"Drupal kunde inte installeras korrekt med den befintliga databasen på grund "
+"av följande fel: @error."
 
 msgid "A value must be selected for %part."
-msgstr ""
+msgstr "Ett värde måste väljas för %part."
 
 msgid "@title (value @number)"
-msgstr ""
+msgstr "@title (värde @number)"
 
 msgid "Shown tabs"
-msgstr ""
+msgstr "Synliga flikar"
 
 msgid "Select tabs being shown in the block"
-msgstr ""
+msgstr "Välj flikar som skall synas i blocket"
 
 msgid "Show primary tabs"
-msgstr ""
+msgstr "Visa primära flikar"
 
 msgid "Show secondary tabs"
-msgstr ""
+msgstr "Visa sekundära flikar"
 
 msgid "@label (@type)"
-msgstr ""
+msgstr "@label (@type)"
 
 msgid "Comment_forum"
-msgstr ""
+msgstr "Comment_forum"
 
 msgid "Default comment field"
-msgstr ""
+msgstr "Förvalt kommentarsfält"
 
 msgid "Overridden block the selected user(s)"
-msgstr ""
+msgstr "Åsidosatta block för vald(a) användare"
 
 msgid ""
 "Entity type mismatch on rename. @old_type not equal to @new_type for "
 "existing configuration @old_name and staged configuration @new_name."
 msgstr ""
+"Objektstyp stämde inte överens vid namnbyte. @old_type är inte lika med "
+"@new_type för aktuell konfiguration @old_name och iscensatt konfiguration "
+"@new_name."
 
 msgid ""
 "Rename operation for simple configuration. Existing configuration @old_name "
 "and staged configuration @new_name."
 msgstr ""
+"Byt namn på funktion för enkel konfiguration. Aktuell konfiguration "
+"@old_name och iscensatt konfiguration @new_name."
 
 msgid ""
 "Back up your database and site before you continue. <a "
 "href=\":backup_url\">Learn how</a>."
 msgstr ""
+"Säkerhetskopiera din databas och webbplats innan du fortsätter. <a "
+"href=\":backup_url\">Lär dig hur</a>."
 
 msgid "Revision translation affected"
-msgstr ""
+msgstr "Översatt version berörd"
 
 msgid "Medium (220×220)"
-msgstr ""
+msgstr "Mellan (220×220)"
 
 msgid "Thumbnail (100×100)"
-msgstr ""
+msgstr "Miniatyr (100×100)"
 
 msgid "HTML Date"
-msgstr ""
+msgstr "HTML datum"
 
 msgid "HTML Datetime"
-msgstr ""
+msgstr "HTML tidsdatum"
 
 msgid "HTML Month"
-msgstr ""
+msgstr "HTML månad"
 
 msgid "HTML Time"
-msgstr ""
+msgstr "HTML tid"
 
 msgid "HTML Year"
-msgstr ""
+msgstr "HTML år"
 
 msgid "HTML Yearless date"
-msgstr ""
+msgstr "HTML datum utan år"
 
 msgctxt "PHP date format"
 msgid "l, F j, Y - H:i"
-msgstr ""
+msgstr "l, F j, Y - H:i"
 
 msgid "Inaccessible"
-msgstr ""
+msgstr "Otillgänglig"
 
 msgid "Filter by name or description"
-msgstr ""
+msgstr "Filtrera på namn eller beskrivning"
 
 msgid "The response failed verification so will not be processed."
-msgstr ""
+msgstr "Gensvaret misslyckades med verifiering så det kommer inte behandlas."
 
 msgid ""
 "Your MySQL server and PHP MySQL driver must support utf8mb4 character "
@@ -21158,27 +23093,42 @@ msgid ""
 "compiled in. See the <a href=\":documentation\" target=\"_blank\">MySQL "
 "documentation</a> for more information."
 msgstr ""
+"Din MySQL-server och PHP MySQL-driver måste stödja teckenkodning av typ "
+"utf8mb4 . Se till att använda en databas som stöder detta (såsom "
+"MySQL/MariaDB/Percona 5.5.3 och uppåt), och att teckenuppsättningen utf8mb4 "
+"är kompilerad. Se <a href=\":documentation\" "
+"target=\"_blank\">Dokumentationen om  MySQL</a> för mer information."
 
 msgid ""
 "The %driver database must use %encoding encoding to work with Drupal. "
 "Recreate the database with %encoding encoding. See <a "
 "href=\"INSTALL.pgsql.txt\">INSTALL.pgsql.txt</a> for more details."
 msgstr ""
+"Drivrutinen %driver för databas måste använda kodning %encoding för att "
+"fungera med Drupal. Återskapa databasen med kodning %encoding. Se <a "
+"href=\"INSTALL.pgsql.txt\">INSTALL.pgsql.txt</a> för mer information."
 
 msgid ""
 "The %setting setting is currently set to '%current_value', but needs to be "
 "'%needed_value'. Change this by running the following query: "
 "<code>@query</code>"
 msgstr ""
+"Inställningen %setting är för närvarande satt till \"%current_value\", men "
+"behöver vara \"%needed_value\". Ändra detta genom att köra följande "
+"databasfråga: <code>@query</code>"
 
 msgid "URI field size: @size"
-msgstr ""
+msgstr "Fältstorlek på URI: @size"
 
 msgid ""
 "Failed to connect to the server. The server reports the following message: "
 "<p class=\"error\">@message</p> For more help installing or updating code on"
 " your server, see the <a href=\":handbook_url\">handbook</a>."
 msgstr ""
+"Misslyckades med att ansluta till servern. Servern rapporterade följande "
+"meddelande: <p class=\"error\">@message</p>För mer hjälp med att installera "
+"eller uppdatera kod på din server, se <a "
+"href=\":handbook_url\">handboken</a>."
 
 msgid ""
 "<ul>\n"
@@ -21187,53 +23137,68 @@ msgid ""
 "<li>View your <a href=\":base-url\">existing site</a>.</li>\n"
 "</ul>"
 msgstr ""
+"<ul>\r\n"
+"<li>För att börja om måste du tömma din befintliga databas, radera din aktuella konfiguration och kopiera <em>default.settings.php</em> över <em>settings.php</em>.</li>\r\n"
+"<li>Gå vidare till <a href=\":update-url\">uppdateringsskriptet</a> för att uppgradera en befintlig installation.</li>\r\n"
+"<li>Visa din <a href=\":base-url\">befintliga webbplats</a>.</li>\r\n"
+"</ul>"
 
 msgid "File Transfer failed, reason: @reason"
-msgstr ""
+msgstr "Filöverföring misslyckades på grund av: @reason"
 
 msgctxt "Validation"
 msgid "Unique field constraint"
-msgstr ""
+msgstr "Begränsning av unikt fält"
 
 msgid "A @entity_type with @field_name %value already exists."
-msgstr ""
+msgstr "Ett @entity_type med @field_name %value finns redan."
 
 msgid "In reply to @parent_title by @parent_username"
-msgstr ""
+msgstr "Som svar på @parent_title av @parent_username"
 
 msgid "Name for @anonymous"
-msgstr ""
+msgstr "Namn för @anonymous"
 
 msgid "@source_name to @target_name"
-msgstr ""
+msgstr "@source_name till @target_name"
 
 msgid "@label <span class=\"visually-hidden\">(@source_language)</span>"
-msgstr ""
+msgstr "@label <span class=\"visually-hidden\">(@source_language)</span>"
 
 msgid ""
 "@sender-name (@sender-url) sent a message using the contact form at @form-"
 "url."
 msgstr ""
+"@sender-name (@sender-url) har skickat ett meddelande genom "
+"kontaktformuläret på @form-url."
 
 msgid "[@site-name] @subject"
-msgstr ""
+msgstr "[@site-name] @subject"
 
 msgid ""
 "@sender-name (@sender-url) has sent you a message via your contact form at "
 "@site-name."
 msgstr ""
+"@sender-name (@sender-url) har skickat ett meddelande till dig genom ditt "
+"kontaktformulär på @site-name."
 
 msgid ""
 "No eligible views were found. <a href=\":create\">Create a view</a> with an "
 "<em>Entity Reference</em> display, or add such a display to an <a "
 "href=\":existing\">existing view</a>."
 msgstr ""
+"Inga valbara vyer hittades. <a href=\":create\">Skapa en vy</a> med en "
+"visning av typ <em>Objetsreferens</em>, eller lägg till en sådan visning "
+"till en <a href=\":existing\">befintlig vy</a>."
 
 msgid ""
 "For more information see W3C's <a href=\":html-specifications\">HTML "
 "Specifications</a> or use your favorite search engine to find other sites "
 "that explain HTML."
 msgstr ""
+"För mer information, se W3C:s <a href=\":html-specifications\">HTML "
+"Specifications</a> eller använd en sökmotor för att hitta andra webbplatser "
+"som förklarar HTML."
 
 msgid ""
 "If you do encounter problems, try using HTML character entities. A common "
@@ -21241,9 +23206,13 @@ msgid ""
 "list of entities see HTML's <a href=\":html-entities\">entities</a> page. "
 "Some of the available characters include:"
 msgstr ""
+"Försök använda HTML-teckenenheter om du råkar ut för problem. Ett vanligt "
+"exempel är &amp;amp; för ett &amp;-tecken. En komplett lista över "
+"teckenenheter finns på sidan <a href=\":html-entities\">HTML entities</a> . "
+"Några av de tillgängliga tecknen är:"
 
 msgid "image from @field_name"
-msgstr ""
+msgstr "bild från @field_name"
 
 msgid ""
 "Define how to decide which language is used to display page elements "
@@ -21257,9 +23226,19 @@ msgid ""
 "page. The default language can be changed in the <a href=\":admin-change-"
 "language\">list of languages</a>."
 msgstr ""
+"Ange hur det skall bestämmas vilket språk som används för att visa "
+"sidelement (främst text som tillhandahålls av moduler såsom fältetiketter "
+"och hjälptext). Beslutet tas genom att utvärdera en rad metoder för upptäckt"
+" av språk, den första identifieringsmetod som får ett resultat kommer att "
+"avgöra vilket språk som används för den typen av text. Var medveten om att "
+"vissa metoder får upptäckt av språk är opålitliga under vissa förhållanden, "
+"såsom webbläsaridentifiering när sidcachning är aktiverad och en användare "
+"för närvarande inte är inloggad. Ange ordningen av utvärderingsmetoder för "
+"språkidentifiering på denna sida. Det förvalda språket kan ändras i <a href"
+"=\":admin-change-language\">listan av språk</a>."
 
 msgid "@message (@percent%)."
-msgstr ""
+msgstr "@message (@percent%)."
 
 msgid ""
 "One translation string was skipped because of disallowed or malformed HTML. "
@@ -21268,7 +23247,11 @@ msgid_plural ""
 "@count translation strings were skipped because of disallowed or malformed "
 "HTML. <a href=\":url\">See the log</a> for details."
 msgstr[0] ""
+"En översättningssträng hoppades över på grund av ej tillåten eller felaktig "
+"HTML. <a href=\":url\">Se loggen</a> för mer information."
 msgstr[1] ""
+"@count översättningssträngar hoppades över på grund av ej tillåten eller "
+"felaktig HTML. <a href=\":url\">Se loggen</a> för mer information."
 
 msgid ""
 "The Node module gives users with the <em>Administer content types</em> "
@@ -21278,6 +23261,12 @@ msgid ""
 "href=\":field\">fields</a> and configure default settings that suit the "
 "differing needs of various site content."
 msgstr ""
+"Modulen Node ger användare med behörigheten <em>Administrera "
+"innehållstyper</em> möjligheten att <a href=\":content-new\">skapa nya "
+"innehållstyper</a> jämte de förvalda som redan är konfigurerade. Vid "
+"skapande av anpassade innehållstyper ger det dig flexibiliteten att lägga "
+"till <a href=\":field\">fält</a> och konfigurera standardinställningar som "
+"passar de olika behoven för olika innehåll på webbplatsen."
 
 msgid ""
 "If the site is experiencing problems with permissions to content, you may "
@@ -21288,25 +23277,37 @@ msgid ""
 "automatically use the new permissions. <a href=\":rebuild\">Rebuild "
 "permissions</a>"
 msgstr ""
+"Om webbplatsen har problem med behörigheterna till innehåll kan du behöva "
+"bygga om behörighetscachen. Vid en ombyggnad tas alla gamla behörigheter "
+"bort och ersätts med nya baserade på nuvarande moduler och inställningar. "
+"Ombyggnaden kan ta lång tid om det finns mycket innehåll eller om "
+"behörigheterna är komplexa. När det är klart kommer inläggen automatiskt att"
+" använda de nya behörigheterna. <a href=\":rebuild\">Bygg om "
+"behörigheterna</a>"
 
 msgid "No content types available. <a href=\":link\">Add content type</a>."
 msgstr ""
+"Det finns inga innehållstyper. <a href=\":link\">Lägg till innehållstyp</a>."
 
 msgid "… @excerpt … @excerpt …"
-msgstr ""
+msgstr "… @excerpt … @excerpt …"
 
 msgid ""
 "For more information, see the online handbook entry for <a href=\":memory-"
 "limit\">increasing the PHP memory limit</a>."
 msgstr ""
+"Läs mer om att <a href=\":memory-limit\">öka PHP:s minnesgräns</a> i "
+"onlinehandboken."
 
 msgid "Last run @time ago"
-msgstr ""
+msgstr "Kördes senast för @time sedan"
 
 msgid ""
 "For more information, see the online handbook entry for <a href=\":cron-"
 "handbook\">configuring cron jobs</a>."
 msgstr ""
+"Läs mer om att ställa in <a href=\":cron-handbook\">schemalagda "
+"aktiviteter</a> i onlinehandboken."
 
 msgid ""
 "Update notifications are not enabled. It is <strong>highly "
@@ -21315,6 +23316,11 @@ msgid ""
 "on new releases. For more information, <a href=\":update\">Update status "
 "handbook page</a>."
 msgstr ""
+"Meddelanden om uppdateringar är inte aktiverat. Det <strong>rekommenderas "
+"starkt</strong> att du aktiverar modulen Update manager på <a "
+"href=\":module\">administrationssidan för moduler</a> så att du kan hålla "
+"dig underrättad om nya utgåvor. Läs mer på <a href=\":update\">handbokssidan"
+" om Update manager</a>."
 
 msgid ""
 "The trusted_host_patterns setting is not configured in settings.php. This "
@@ -21323,37 +23329,48 @@ msgid ""
 "href=\":url\">Protecting against HTTP HOST Header attacks</a> for more "
 "information."
 msgstr ""
+"Inställningen trusted_host_patterns är inte konfigurerad i settings.php. Det"
+" kan leda till säkerhetshål. Det <strong>rekommenderas starkt</strong> att "
+"du konfigurerar detta. För mer information, se <a href=\":url\">Skydd mot "
+"attacker av typ HTTP HOST Header</a>."
 
 msgid "Put your site into <a href=\":url\">maintenance mode</a>."
-msgstr ""
+msgstr "Sätt din webbplats i <a href=\":url\">underhållsläge</a>."
 
 msgid "All errors have been <a href=\":url\">logged</a>."
-msgstr ""
+msgstr "Alla fel har <a href=\":url\">loggats</a>."
 
 msgid "Screenshot for @theme theme"
-msgstr ""
+msgstr "Skärmdump för temat @theme"
 
 msgid "Settings for @theme theme"
-msgstr ""
+msgstr "Inställningar för temat @theme"
 
 msgid "Powered by <a href=\":poweredby\">Drupal</a>"
-msgstr ""
+msgstr "Drivs av <a href=\":poweredby\">Drupal</a>"
 
 msgid "Number of summary rows: @rows"
-msgstr ""
+msgstr "Antal rader för sammanfattning: @rows"
 
 msgid "Boolean indicating whether the node is published."
-msgstr ""
+msgstr "Boolesk som indikerar huruvida en nod är publicerad eller ej."
 
 msgid ""
 "Your site is currently configured to send these emails when any updates are "
 "available. To get notified only for security updates, @url."
 msgstr ""
+"Din webbplats är för närvarande konfigurerad att skicka dessa "
+"e-postmeddelanden när en uppdatering finns tillgänglig. För att enbart få "
+"meddelanden om säkerhetsuppdateringar, var vänlig besök @url."
 
 msgid ""
 "Your site is currently configured to send these emails only when security "
 "updates are available. To get notified for any available updates, @url."
 msgstr ""
+"Din webbplats är för närvarande konfigurerad att skicka dessa "
+"e-postmeddelanden enbart när säkerhetsuppdateringar finns tillgängliga. För "
+"att få meddelanden om alla tillgängliga uppdateringar, var vänlig besök "
+"@url."
 
 msgid ""
 "You can choose to send email only if a security update is available, or to "
@@ -21363,162 +23380,192 @@ msgid ""
 "page, and will also display an error message on administration pages if "
 "there is a security update."
 msgstr ""
+"Du kan välja att skicka e-post enbart om en säkerhetsuppdatering finns "
+"tillgänglig, eller att bli meddelad om alla nyare versioner. Om det finns "
+"tillgängliga uppdateringar av kärnan för Drupal eller någon av dina "
+"installerade moduler och teman kommer din webbplats alltid skriva ut ett "
+"meddelande på sidan <a href=\":status_report\">statusrapport</a>, och kommer"
+" också visa ett felmeddelande på administrationssidor om det finns en "
+"säkerhetsuppdatering."
 
 msgid "PHP OPcode caching"
-msgstr ""
+msgstr "Cachning av PHP OPcode"
 
 msgid "@tour_item of @total"
-msgstr ""
+msgstr "@tour_item av @total"
 
 msgid "Version: @module-version"
-msgstr ""
+msgstr "Version: @module-version"
 
 msgid "Requires: @module-list"
-msgstr ""
+msgstr "Kräver: @module-list"
 
 msgid "Required by: @module-list"
-msgstr ""
+msgstr "Krävs av: @module-list"
 
 msgid ""
 "Required if you want to change the %mail or %pass below. <a "
 "href=\":request_new_url\" title=\"Send password reset instructions via "
 "email.\">Reset your password</a>."
 msgstr ""
+"Krävs om du vill ändra %mail eller %pass nedan. <a href=\":request_new_url\""
+" title=\"Skicka instruktioner om lösenordsåterställning via "
+"e-post.\">Återställ ditt lösenord</a>."
 
 msgid ""
 "Password reset instructions will be sent to your registered email address."
 msgstr ""
+"Instruktioner om hur du återställer ditt lösenord kommer skickas till din "
+"registrerade e-postadress."
 
 msgid ""
 "This link is provided by the Views module. The path can be changed by "
 "editing the view <a href=\":url\">@label</a>"
 msgstr ""
+"Denna länk tillhandahålls av modulen Views. Sökvägen kan ändras genom att "
+"redigera vyn <a href=\":url\">@label</a>"
 
 msgid "@type language selected for page"
-msgstr ""
+msgstr "Språk @type valt för sida"
 
 msgid "Will not be accessible."
-msgstr ""
+msgstr "Kommer inte vara tillgänglig."
 
 msgid "@code (@title)"
-msgstr ""
+msgstr "@code (@title)"
 
 msgid ""
 "The following tokens are available. You may use Twig syntax in this field."
 msgstr ""
+"Följande ersättningstecken är tillgängliga. Du kan använda syntax av typ "
+"Twig i detta fält."
 
 msgid ""
 "Override the view and other argument titles. You may use Twig syntax in this"
 " field as well as the \"arguments\" and \"raw_arguments\" arrays."
 msgstr ""
+"Åsidosätt vyn och andra argumenttitlar. Du kan använda syntax av typ Twig i "
+"detta fält såväl som array \"arguments\" och \"raw_arguments\""
 
 msgid ""
 "Override the view and other argument titles. You may use Twig syntax in this"
 " field."
 msgstr ""
+"Åsidosätt vyn och andra argumenttitlar. Du kan använda syntax av typ Twig i "
+"detta fält."
 
 msgid "The following replacement tokens are available for this argument."
-msgstr ""
+msgstr "Följande ersättningstecken är tillgängliga för detta argument."
 
 msgid ""
 "The category this block will appear under on the <a href=\":href\">blocks "
 "placement page</a>."
 msgstr ""
+"Kategorin detta block kommer visas under på <a href=\":href\">sidan "
+"placering av block</a>."
 
 msgid ""
 "You may also adjust the @settings for the currently selected access "
 "restriction."
-msgstr ""
+msgstr "Du kan också ändra @settings för den valda åtkomstrestriktionen."
 
 msgid ""
 "You may also adjust the @settings for the currently selected cache "
 "mechanism."
-msgstr ""
+msgstr "Du kan också ändra @settings för den valda cache-metoden."
 
 msgid "You may also adjust the @settings for the currently selected style."
-msgstr ""
+msgstr "Du kan också ändra @settings för den valda stilen."
 
 msgid ""
 "You may also adjust the @settings for the currently selected row style."
-msgstr ""
+msgstr "Du kan också ändra @settings för den valda radutformningen."
 
 msgid "You may also adjust the @settings for the currently selected pager."
-msgstr ""
+msgstr "Du kan också ändra @settings för den valda pagineraren."
 
 msgid ""
 "Views can be exported and imported as configuration files by using the <a "
 "href=\":config\">Configuration Manager module</a>."
 msgstr ""
+"Vyer kan exporteras och importeras som konfigurationsfiler genom att använda"
+" modulen <a href=\":config\">Konfigurationshanterare</a>."
 
 msgid "Advanced Views settings"
-msgstr ""
+msgstr "Inställningar för utökade vyer"
 
 msgid "View @display_title"
-msgstr ""
+msgstr "Visa @display_title"
 
 msgid "Duplicate as @type"
-msgstr ""
+msgstr "Kopiera som @type"
 
 msgid "Add @display"
-msgstr ""
+msgstr "Lägg till @display"
 
 msgid "By breaking this lock, any unsaved changes made by @user will be lost."
 msgstr ""
+"Genom att bryta detta lås kommer ej sparade ändringar gjorda av @user "
+"försvinna."
 
 msgid ""
 "@display '@id': Component '@name' was disabled because its settings depend "
 "on removed dependencies."
 msgstr ""
+"@display \"@id\": Komponent \"@name\" inaktiverades eftersom dess "
+"inställningar beror på borttagna beroenden."
 
 msgid "No widget available for: %type."
-msgstr ""
+msgstr "Ingen gränssnittskomponent tillgänglig för: %type."
 
 msgid "Create tasks that the system can execute."
-msgstr ""
+msgstr "Skapa uppgifter som systemet kan utföra."
 
 msgid "Selection handler for entity reference fields have been adjusted."
-msgstr ""
+msgstr "Urvalshanterare för fält i objektreferens har ändrats."
 
 msgid ""
 "Configure how content is filtered when displayed, including which HTML tags "
 "are rendered, and enable module-provided filters."
 msgstr ""
+"Konfigurera hur innehåll filtreras vid visning inklusive vilka HTML-taggar "
+"som ska genereras, och aktivera filter tillhandahållna av moduler."
 
 msgid "- None (original image) -"
-msgstr ""
+msgstr "- Ingen (originalbild) -"
 
 msgid "Checking site status"
-msgstr ""
+msgstr "Kontrollerar webbplatsens status"
 
 msgid "Cache maximum age"
-msgstr ""
+msgstr "Äldsta ålder på cache"
 
 msgid "Creating and managing views"
-msgstr ""
+msgstr "Skapa och hantera vyer"
 
 msgid "Enabling and disabling views"
-msgstr ""
+msgstr "Aktivera och inaktivera vyer"
 
 msgid "Exporting and importing views"
-msgstr ""
+msgstr "Export och import av vyer"
 
 msgid "Stable"
-msgstr ""
+msgstr "Stabil"
 
 msgid "Aggregator RSS feed"
-msgstr ""
+msgstr "RSS-flöder för nyhetssamlare"
 
 msgid "Aggregator sources"
-msgstr ""
+msgstr "Källor för nyhetssamlare"
 
 msgid "@label (@name:@column)"
-msgstr ""
+msgstr "@label (@name:@column)"
 
 msgid "Account cancellation request for [user:display-name] at [site:name]"
-msgstr ""
+msgstr "Begäran om avslutande av konto för [user:display-name] på [site:name]"
 
 msgid "Replacement login information for [user:display-name] at [site:name]"
-msgstr ""
+msgstr "Replacement login information for [user:display-name] at [site:name]"
 
 msgid ""
 "[user:display-name],\n"
@@ -21536,6 +23583,20 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\r\n"
+"\r\n"
+"En administratör på [site:name] har skapat ett konto åt dig. Du kan nu logga in genom att klicka på länken eller kopiera och klistra in den i din webbläsare.\r\n"
+"\r\n"
+"[user:one-time-login-url]\r\n"
+"\r\n"
+"Denna länk kan bara användas en gång och kommer ta dig till en sida där du kan ange ditt lösenord.\r\n"
+"\r\n"
+"Efter att du angivit ditt lösenord kan du i framtiden logga in på [site:login-url] genom att använda:\r\n"
+"\r\n"
+"användarnamn: [user:name]\r\n"
+"lösenord: Ditt lösenord\r\n"
+"\r\n"
+"--  Administratörerna på [site:name]"
 
 msgid ""
 "[user:display-name],\n"
@@ -21553,20 +23614,39 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\r\n"
+"\r\n"
+"Tack för att du har registrerat dig på [site:name]. Du kan nu logga in genom att klicka på denna länk eller genom att klippa ut och klistra in den i din webbläsare:\r\n"
+"\r\n"
+"[user:one-time-login-url]\r\n"
+"\r\n"
+"Detta är en engångsinloggning, så den kan bara användas en gång och kommer att leda dig till en sida där du kan välja ett eget lösenord.\r\n"
+"\r\n"
+"Efter detta kommer du kunna logga in på [site:login-url] med följande uppgifter:\r\n"
+"\r\n"
+"användarnamn: [user:name]\r\n"
+"lösenord: Ditt lösenord\r\n"
+"\r\n"
+"--  Administratörerna på [site:name]"
 
 msgid "Account details for [user:display-name] at [site:name]"
-msgstr ""
+msgstr "Kontouppgifter för [user:display-name] på [site:name]"
 
 msgid ""
 "Account details for [user:display-name] at [site:name] (pending admin "
 "approval)"
 msgstr ""
+"Kontodetaljer för [user:display-name] på [site:name] (väntar på godkännande "
+"av administratör)"
 
 msgid ""
 "[user:display-name] has applied for an account.\n"
 "\n"
 "[user:edit-url]"
 msgstr ""
+"[user:display-name] har ansökt om ett konto.\r\n"
+"\r\n"
+"[user:edit-url]"
 
 msgid ""
 "[user:display-name],\n"
@@ -21586,12 +23666,28 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\r\n"
+"\r\n"
+"Ditt konto på [site:name] har aktiverats.\r\n"
+"\r\n"
+"Du kan nu logga in genom att klicka på denna länk eller genom att kopiera den till din webbläsare:\r\n"
+"\r\n"
+"[user:one-time-login-url]\r\n"
+"\r\n"
+"Denna länk kan enbart användas en gång och kommer att leda dig till en sida där du kan ange ditt lösenord.\r\n"
+"\r\n"
+"Efter att du angett ett lösenord kommer du i framtiden att kunna logga in på [site:login-url] genom att använda:\r\n"
+"\r\n"
+"användarnamn: [user:account-name]\r\n"
+"lösenord: Ditt lösenord\r\n"
+"\r\n"
+"-- Administratörerna på [site:name]"
 
 msgid "Account details for [user:display-name] at [site:name] (approved)"
-msgstr ""
+msgstr "Kontodetaljer för [user:display-name] på [site:name] (godkänd)"
 
 msgid "Account details for [user:display-name] at [site:name] (blocked)"
-msgstr ""
+msgstr "Kontouppgifter för [user:display-name] på [site:name] (spärrad)"
 
 msgid ""
 "[user:display-name],\n"
@@ -21600,172 +23696,199 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\r\n"
+"\r\n"
+"Ditt konto på [site:name] har tagits bort.\r\n"
+"\r\n"
+"--  Administratörerna på [site:name]"
 
 msgid "Account details for [user:display-name] at [site:name] (canceled)"
-msgstr ""
+msgstr "Kontouppgifter för [user:display-name] på [site:name] (borttagen)"
 
 msgid "Find and manage custom blocks."
-msgstr ""
+msgstr "Hitta och hantera anpassade block."
 
 msgid "Recent comments."
-msgstr ""
+msgstr "Senaste kommentarer."
 
 msgid "Find and manage files."
-msgstr ""
+msgstr "Hitta och hantera filer."
 
 msgid "Files overview"
-msgstr ""
+msgstr "Översikt av filer"
 
 msgid "File usage information for {{ arguments.fid }}"
-msgstr ""
+msgstr "Information om filanvändande för {{ arguments.fid }}"
 
 msgid ""
 "<p>This page provides the ability to add common languages to your "
 "site.</p><p>If the desired language is not available, you can add a custom "
 "language.</p>"
 msgstr ""
+"<p>Den här sidan ger möjligheten att lägga till vanliga språk på din "
+"webbplats.</p><p>Om det önskade språket inte är tillgängligt kan du lägga "
+"till ett anpassat språk.</p>"
 
 msgid "Editing languages"
-msgstr ""
+msgstr "Redigerar språk"
 
 msgid "Recent content."
-msgstr ""
+msgstr "Nytt innehåll."
 
 msgid "All content, by letter."
-msgstr ""
+msgstr "All innehåll, i bokstavsordning."
 
 msgid "Content belonging to a certain taxonomy term."
-msgstr ""
+msgstr "Innehåll som hör till en viss taxonomiterm."
 
 msgid "Shows a list of the newest user accounts on the site."
-msgstr ""
+msgstr "Visar en lista över de senast användarkontona på webbplatsen."
 
 msgid ""
 "The following reason prevents @module.module_name from being uninstalled:"
 msgid_plural ""
 "The following reasons prevent @module.module_name from being uninstalled:"
 msgstr[0] ""
+"@module.module_name kan inte avinstalleras på grund av följande anledning:"
 msgstr[1] ""
+"@module.module_name kan inte avinstalleras på grund av följande anledningar:"
 
 msgid "Fallback sort expose settings"
-msgstr ""
+msgstr "Exponerade inställningar för resersortering"
 
 msgid "width @data.width"
-msgstr ""
+msgstr "bredd @data.width"
 
 msgid "height @data.height"
-msgstr ""
+msgstr "höjd @data.height"
 
 msgid "This entity (%type: %id) cannot be referenced."
-msgstr ""
+msgstr "Detta objekt (%type: %id) kan inte refereras."
 
 msgid "A default base theme using Drupal 8.0.0's core markup and CSS."
 msgstr ""
+"Ett förvalt bastema som använder kärnans uppmärkning och CSS för Drupal "
+"8.0.0"
 
 msgid "Install configuration"
-msgstr ""
+msgstr "Installera konfiguration"
 
 msgid "Show &mdash; @configuration.label"
-msgstr ""
+msgstr "Visa &mdash; @configuration.label"
 
 msgid "Hide &mdash; @configuration.label"
-msgstr ""
+msgstr "Dölj &mdash; @configuration.label"
 
 msgid "Session exists"
-msgstr ""
+msgstr "Session existerar"
 
 msgid "Default configuration hash"
-msgstr ""
+msgstr "Förvald konfigurationshash"
 
 msgid ""
 "Field %field set in %filter is not usable for this filter type. Combined "
 "field filter only works for simple fields."
 msgstr ""
+"Fält %field som är inställt i %filter är inte användbar för denna "
+"filtreringstyp. Kombinerade filterfält fungerar enbart för enkla fält."
 
 msgid "Renders an entity in a view mode."
-msgstr ""
+msgstr "Genererar ett objekt i ett vyläge."
 
 msgctxt "decimal places"
 msgid "Scale"
-msgstr ""
+msgstr "Skala"
 
 msgid "The new size setting for email widgets has been added."
 msgstr ""
+"Den nya inställningen för storlek på gränssnittskomponent för e-post har "
+"lagts till."
 
 msgid "Did not save to map table due to NULL value for key field @field"
 msgstr ""
+"Sparade inte till karttabell på grund av INNEHÅLLSLÖST värde för nyckelfält "
+"@field"
 
 msgid "A boolean indicating whether the node is visible on the front page."
 msgstr ""
+"En boolesk som indikerar huruvida noden är synlig på startsidan eller ej."
 
 msgid ""
 "A boolean indicating whether the node should sort to the top of content "
 "lists."
 msgstr ""
+"En boolesk som indikerar huruvida noden skall sorteras överst i "
+"innehållslistor eller ej."
 
 msgid "The %entity_type entity type needs to be installed."
-msgstr ""
+msgstr "Objektet av typ %entity_type måste installeras."
 
 msgid "The %entity_type entity type needs to be updated."
-msgstr ""
+msgstr "Objektet av typ %entity_type måste uppdateras."
 
 msgid "The %field_name field needs to be installed."
-msgstr ""
+msgstr "Fältet %field_name måste installeras."
 
 msgid "The %field_name field needs to be updated."
-msgstr ""
+msgstr "Fältet %field_name måste uppdateras."
 
 msgid "The %field_name field needs to be uninstalled."
-msgstr ""
+msgstr "Fältet %field_name måste avinstalleras."
 
 msgid "Custom text: @true_label / @false_label"
-msgstr ""
+msgstr "Anpassad text: @true_label / @false_label"
 
 msgid "Display: @true_label / @false_label"
-msgstr ""
+msgstr "Visning: @true_label / @false_label"
 
 msgid ""
 "See <a href=\"http://php.net/manual/function.date.php\" "
 "target=\"_blank\">the documentation for PHP date formats</a>."
 msgstr ""
+"Se <a href=\"http://php.net/manual/function.date.php\" "
+"target=\"_blank\">dokumentationen om datumformat för PHP</a>."
 
 msgid "An icon that links to the feed URL"
-msgstr ""
+msgstr "En ikon som länkar till innehållsflödets URL"
 
 msgid "Parent website of the feed."
-msgstr ""
+msgstr "Ovanliggande hemsida för innehållsflödet."
 
 msgid "Parent website's description of the feed."
-msgstr ""
+msgstr "Beskrivning av ovanliggande hemsida för innehållsflödet."
 
 msgid "Check my spelling as I type"
-msgstr ""
+msgstr "Kontrollera min stavning medan jag skriver"
 
 msgid "Language list ID"
-msgstr ""
+msgstr "ID-nummer för språklista"
 
 msgid "Remove content from front page"
-msgstr ""
+msgstr "Ta bort inlägg från startsidan"
 
 msgid "Continuing on"
-msgstr ""
+msgstr "Fortsätter på"
 
 msgid ""
 "The %field_type_label field type is used in the following field: @fields"
 msgid_plural ""
 "The %field_type_label field type is used in the following fields: @fields"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Fälttypen %field_type_label används i följande fält: @fields"
+msgstr[1] "Fälttypen %field_type_label används i följande fält: @fields"
 
 msgid ""
 "<p>This page provides the ability to edit a language on your site, including"
 " custom languages.</p>"
 msgstr ""
+"<p>Denna sida tillhandahåller möjligheten att redigera språk på din "
+"webbplats, inklusive anpassade språk.</p>"
 
 msgid ""
 "<p>You cannot change the code of a language on the site, since it is used by"
 " the system to keep track of the language.</p>"
 msgstr ""
+"<p>Du kan inte ändra koden för ett språk på webbplatsen eftersom det används"
+" av systemet för att hålla reda på språket.</p>"
 
 msgid ""
 "<p>The language name is used throughout the site for all users and is "
@@ -21773,32 +23896,45 @@ msgid ""
 "Interface Translation module, and names of both built-in and custom "
 "languages can be translated using the Configuration Translation module.</p>"
 msgstr ""
+"<p>Språknamnet används på hela webbplatsen för alla användare och är skrivet"
+" på engelska. Namn på inbyggda språk kan översättas med hjälp av modulen "
+"Interface Translation och namnen på både inbyggda och anpassade språk kan "
+"översättas med hjälp av modulen Configuration Translation.</p>"
 
 msgid ""
 "<p>Choose if the language is a \"Left to right\" or \"Right to left\" "
 "language.</p><p>Note that not all themes support \"Right to left\" layouts, "
 "so test your theme if you are using \"Right to left\".</p>"
 msgstr ""
+"<p>Välj om språket är ett språk som läses \"Vänster till höger\" eller "
+"\"Höger till vänster\".</p><p>Observera att inte alla teman stöder layouter "
+"för \"Höger till vänster\" så testa ditt tema om du använder \"Höger till "
+"vänster\".</p>"
 
 msgid ""
 "<p>The \"Languages\" page allows you to add, edit, delete, and reorder "
 "languages for the site.</p>"
 msgstr ""
+"<p>Sidan \"Språk\" låter dig lägga till, redigera, ta bort och ändra "
+"ordningen på språk för webbplatsen.</p>"
 
 msgid ""
 "<p>To add more languages to your site, click the \"Add language\" "
 "button.</p><p>Added languages will be displayed in the language list and can"
 " then be edited or deleted.</p>"
 msgstr ""
+"<p>Klicka på knappen \"Lägg till språk\" för att lägga till fler språk på "
+"din webbplats.</p><p>Tillagda språk kommer att visas i språklistan och kan "
+"sedan redigeras eller tas bort.</p>"
 
 msgid "Reordering languages"
-msgstr ""
+msgstr "Ändrar ordningen på språk"
 
 msgid "Set a language as default"
-msgstr ""
+msgstr "Ställ in ett språk som förvalt"
 
 msgid "Modifying languages"
-msgstr ""
+msgstr "Ändrar språk"
 
 msgid ""
 "<p>Operations are provided for editing and deleting your "
@@ -21808,61 +23944,81 @@ msgid ""
 "it, and content in this language will be set to be language neutral. Note "
 "that you cannot delete the default language of the site.</p>"
 msgstr ""
+"<p>Funktioner tillhandahålls för redigering och borttagning av dina "
+"språk.</p><p>Du kan redigera namnet och riktningen av "
+"språket.</p><p>Borttagna språk kan läggas tillbaka vid ett senare tillfälle."
+" Borttagning av ett språk kommer att ta bort alla gränssnittsöversättningar "
+"i samband med det, och innehåll i detta språk kommer att sättas till att "
+"vara språkneutralt. Observera att du inte kan ta bort standardspråket på "
+"webbplatsen.</p>"
 
 msgid "Choose the language you want to translate."
-msgstr ""
+msgstr "Välj det språk du vill översätta."
 
 msgid ""
 "Enter the specific word or sentence you want to translate, you can also "
 "write just a part of a word."
 msgstr ""
+"Ange specifikt ord eller en mening som du vill översätta. Du kan också "
+"skriva bara en del av ett ord."
 
 msgid "Filter the search"
-msgstr ""
+msgstr "Filtrera sökningen"
 
 msgid ""
 "You can search for untranslated strings if you want to translate something "
 "that isn't translated yet. If you want to modify an existing translation, "
 "you might want to search only for translated strings."
 msgstr ""
+"Du kan söka efter ej översatta strängar om du vill översätta något som inte "
+"är översatt ännu. Om du vill ändra en befintlig översättning kanske du "
+"enbart vill söka efter översatta strängar."
 
 msgid "Apply your search criteria"
-msgstr ""
+msgstr "Tillämpa dina sökkriterier"
 
 msgid "To apply your search criteria, click on the <em>Filter</em> button."
-msgstr ""
+msgstr "Klicka på knappen <em>Filter</em> för att tillämpa dina sökkriterier."
 
 msgid ""
 "You can write your own translation in the text fields of the right column. "
 "Try to figure out in which context the text will be used in order to "
 "translate it in the appropriate way."
 msgstr ""
+"Du kan skriva din egen översättning i textfälten i den högra kolumnen. "
+"Försök att räkna ut i vilket sammanhang texten kommer att användas för att "
+"översätta det på lämpligt sätt."
 
 msgid "Validate the translation"
-msgstr ""
+msgstr "Bekräfta översättningen"
 
 msgid ""
 "When you have finished your translations, click on the <em>Save "
 "translations</em> button. You must save your translations, each time before "
 "changing the page or making a new search."
 msgstr ""
+"Klicka på knappen <em>Spara översättningar</em> när du är klar med dina "
+"översättningar. Du måste spara dina översättningar innan du byter sida eller"
+" gör en ny sökning."
 
 msgid "{{ arguments.created_year_month }}"
-msgstr ""
+msgstr "{{ arguments.created_year_month }}"
 
 msgid "Find and manage content"
-msgstr ""
+msgstr "Hitta och hantera innehåll"
 
 msgid "Welcome to [site:name]"
-msgstr ""
+msgstr "Välkommen till [site:name]"
 
 msgid "{{ arguments.tid }}"
-msgstr ""
+msgstr "{{ arguments.tid }}"
 
 msgid ""
 "Perform administrative tasks, including adding a description and creating a "
 "clone. Click the drop-down button to view the available options."
 msgstr ""
+"Utföra administrativa uppgifter, inklusive att lägga till en beskrivning och"
+" skapa en klon. Klicka på listrutan för att se tillgängliga alternativ."
 
 msgid ""
 "Choose how to output results. E.g., choose <em>Content</em> to output each "
@@ -21871,20 +24027,31 @@ msgid ""
 "result. Additional formats can be added by installing modules to "
 "<em>extend</em> Drupal's base functionality."
 msgstr ""
+"Välj hur du vill mata ut resultaten. Välj exempelvis <em>Innehåll</em> för "
+"att mata ut varje punkt helt med hjälp av dina konfigurerade "
+"visningsinställningar. Eller välj <em>Fält</em> som gör det möjligt att mata"
+" ut enbart särskilda fält för varje resultat. Ytterligare format kan läggas "
+"till genom att installera moduler för att <em>utöka</em> Drupals "
+"grundfunktionalitet."
 
 msgid ""
 "If this view uses fields, they are listed here. You can click on a field to "
 "configure it."
 msgstr ""
+"Om denna vy använder fält visas de här. Du kan klicka på ett fält för att "
+"konfigurera det."
 
 msgid ""
 "Add filters to limit the results in the output. E.g., to only show content "
 "that is <em>published</em>, you would add a filter for <em>Published</em> "
 "and select <em>Yes</em>."
 msgstr ""
+"Lägg till filter för att begränsa resultaten i utmatningen. Till exempel för"
+" att enbart visa innehåll som är <em>publicerat</em> lägger du till ett "
+"filter för <em>Publicerat</em> och välj <em>Ja</em>."
 
 msgid "Show a preview of the view output."
-msgstr ""
+msgstr "Visa en förhandsgranskning från vyns utmatning."
 
 msgid ""
 "PHP OPcode caching can improve your site's performance considerably. It is "
@@ -21892,249 +24059,265 @@ msgid ""
 "href=\"http://php.net/manual/opcache.installation.php\" "
 "target=\"_blank\">OPcache</a> installed on your server."
 msgstr ""
+"Cachning av PHP OPcode kan förbättra webbplatsens resultat avsevärt. Det "
+"<strong>rekommenderas starkt</strong> att ha <a "
+"href=\"http://php.net/manual/opcache.installation.php\" "
+"target=\"_blank\">OPcache</a> installerad på din server."
 
 msgid "This identifier has illegal characters."
-msgstr ""
+msgstr "Denna identifierare har ogiltiga tecken."
 
 msgid "Add a new @entity_type."
-msgstr ""
+msgstr "Lägg till en ny @entity_type."
 
 msgid "There is no @entity_type yet. @add_link"
-msgstr ""
+msgstr "Det finns ingen @entity_type än. @add_link"
 
 msgid "Store new items in"
-msgstr ""
+msgstr "Lagra nya objekt i"
 
 msgid "Delete @entity_type"
-msgstr ""
+msgstr "Radera @entity_type"
 
 msgctxt "Entity type label"
 msgid "@count @label"
 msgid_plural "@count @label entities"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "@count @label"
+msgstr[1] "@count @label objekt"
 
 msgid "Parent path"
-msgstr ""
+msgstr "Ovanliggande sökväg"
 
 msgid "Selected combination of day and month is not valid."
-msgstr ""
+msgstr "Vald kombination av dag och månad är inte giltig."
 
 msgid "Determines if a password needs hashing"
-msgstr ""
+msgstr "Avgör om ett lösenord behöver hashning"
 
 msgid ""
 "View display '@id': Comment field formatter '@name' was disabled because it "
 "is using the comment view display '@display' (@mode) that was just disabled."
 msgstr ""
+"Visning av vy \"@id\": Fältformaterare för kommentar \"@name\" inaktiverades"
+" eftersom den använder vyvisningen för kommentar \"@display\" (@mode) som "
+"precis inaktiverades."
 
 msgid "No entity view display updated."
-msgstr ""
+msgstr "Ingen visning av vyobjekt uppdaterades."
 
 msgid "administration theme"
-msgstr ""
+msgstr "administrationstema"
 
 msgid "All @entity_type_plural have been deleted."
-msgstr ""
+msgstr "Alla @entity_type_plural har raderats."
 
 msgid "Content moderation state"
-msgstr ""
+msgstr "Modereringsstatus för innehåll"
 
 msgid "content moderation state"
-msgstr ""
+msgstr "modereringsstatus för innehåll"
 
 msgid "content moderation states"
-msgstr ""
+msgstr "modereringsstatusar för innehåll"
 
 msgid "Configure Content Moderation permissions"
-msgstr ""
+msgstr "Konfigurera behörigheter för moderering av innehåll"
 
 msgid "Testing missing dependencies"
-msgstr ""
+msgstr "Testning saknade beroenden"
 
 msgid ""
 "Minimal profile for running a test when dependencies are listed but missing."
-msgstr ""
+msgstr "Minimal profil för att köra tester när beroenden listats men saknas."
 
 msgid "The field ID."
-msgstr ""
+msgstr "ID-numret för fält."
 
 msgid "Last upgrade: @date"
-msgstr ""
+msgstr "Senaste uppdatering: @date"
 
 msgid "A boolean indicating the published state."
-msgstr ""
+msgstr "En booleska som indikerar status för publiceringen."
 
 msgid "Warnings found"
-msgstr ""
+msgstr "Varningar hittades"
 
 msgid "Errors found"
-msgstr ""
+msgstr "Fel hittades"
 
 msgid ""
 "An intentionally plain theme with no styling to demonstrate default Drupal’s"
 " HTML and CSS. Learn how to build a custom theme from Stark in the <a "
 "href=\"https://www.drupal.org/docs/8/theming\">Theming Guide</a>."
 msgstr ""
+"Ett medvetet enkelt tema utan stilmallar för att visa Drupals förvalda HTML "
+"och CSS. Lär dig skapa ett anpassat tema utifrån Stark i <a "
+"href=\"https://www.drupal.org/docs/8/theming\">Temautvecklingsguiden</a>."
 
 msgid "There are no @label yet."
-msgstr ""
+msgstr "Det finns ingen @label än."
 
 msgid "The %field date is incomplete."
-msgstr ""
+msgstr "Datumfältet %field är ej komplett."
 
 msgid "Remove the @label role from the selected user(s)"
-msgstr ""
+msgstr "Ta bort rollen @label från vald(a) användare"
 
 msgid "!!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz"
-msgstr ""
+msgstr "!!binary MSBwbGFjZQNAY291bnQgcGxhY2Vz"
 
 msgid "!!binary MQNAY291bnQ="
-msgstr ""
+msgstr "!!binary MQNAY291bnQ="
 
 msgid "Entity reference selection handler settings"
-msgstr ""
+msgstr "Inställningar för urvalshanterare åt objektreferens"
 
 msgid "Default selection handler settings"
-msgstr ""
+msgstr "Inställningar för förvald urvalshanterare"
 
 msgid "File selection handler settings"
-msgstr ""
+msgstr "Inställningar för urvalshanterare åt fil"
 
 msgid "User selection handler settings"
-msgstr ""
+msgstr "Inställningar för urvalshanterare åt användare"
 
 msgid "Views selection handler settings"
-msgstr ""
+msgstr "Inställningar för urvalshanterare åt vyer"
 
 msgid "The \"%plugin_id\" was not found"
-msgstr ""
+msgstr "\"%plugin_id\" hittades inte"
 
 msgid ""
 "You must have the pdo_sqlite PHP extension installed. See "
 "core/INSTALL.sqlite.txt for instructions."
 msgstr ""
+"Du måste ha PHP-tillägget pdo_sqlite installerat. Se instruktioner i "
+"core/INSTALL.sqlite.txt."
 
 msgid "No installation found. Use the 'install' command."
-msgstr ""
+msgstr "Ingen installation hittades. Använd kommandot 'install'."
 
 msgid "Select and configure themes."
-msgstr ""
+msgstr "Välj och konfigurera teman."
 
 msgid "Breadcrumbs"
-msgstr ""
+msgstr "Länkstigar"
 
 msgid "Powered by Drupal"
-msgstr ""
+msgstr "Drivs av Drupal"
 
 msgid "Help"
-msgstr ""
+msgstr "Hjälp"
 
 msgid "Primary tabs"
-msgstr ""
+msgstr "Primära flikar"
 
 msgid "Status messages"
-msgstr ""
+msgstr "Statusmeddelande"
 
 msgid "Block"
-msgstr ""
+msgstr "Block"
 
 msgid ""
 "Use <em>articles</em> for time-sensitive content like news, press releases "
 "or blog posts."
 msgstr ""
+"Använd <em>artiklar</em> för tidskänsligt innehåll som nyheter, "
+"pressreleaser eller blogginlägg."
 
 msgid "Tools"
-msgstr ""
+msgstr "Verktyg"
 
 msgid "Comments published"
-msgstr ""
+msgstr "Kommentarer publicerade"
 
 msgid "Main page content"
-msgstr ""
+msgstr "Huvudsakligt sidinnehåll"
 
 msgid "Footer menu"
-msgstr ""
+msgstr "Sidfotsmeny"
 
 msgid "Tabs"
-msgstr ""
+msgstr "Flikar"
 
 msgid "Page title"
-msgstr ""
+msgstr "Sidtitel"
 
 msgid "A basic block contains a title and a body."
-msgstr ""
+msgstr "Ett enkelt block innehåller en titel och en brödtext."
 
 msgid "Default comments"
-msgstr ""
+msgstr "Standardkommentarer"
 
 msgid "Promoted to front page"
-msgstr ""
+msgstr "Visas på startsidan"
 
 msgid "Image"
-msgstr ""
+msgstr "Bild"
 
 msgid "Basic page"
-msgstr ""
+msgstr "Enkel sida"
 
 msgid ""
 "Use <em>basic pages</em> for your static content, such as an 'About us' "
 "page."
 msgstr ""
+"Använd <em>enkla sidor</em> för ditt statiska innehåll, såsom en sida \"Om "
+"oss\"."
 
 msgid "Administrator"
-msgstr ""
+msgstr "Administratör"
 
 msgid "Authenticated user"
-msgstr ""
+msgstr "Inloggad användare"
 
 msgid "Full comment"
-msgstr ""
+msgstr "Fullständig kommentar"
 
 msgid "Save comment"
-msgstr ""
+msgstr "Spara kommentar"
 
 msgid "Unpublish comment"
-msgstr ""
+msgstr "Avpublicera kommentaren"
 
 msgid "Personal contact form"
-msgstr ""
+msgstr "Personligt kontaktformulär"
 
 msgid "Your message has been sent."
-msgstr ""
+msgstr "Ditt meddelande har skickats."
 
 msgid "Large (480×480)"
-msgstr ""
+msgstr "Stor (480×480)"
 
 msgid "English"
-msgstr ""
+msgstr "Engelska"
 
 msgid "Not specified"
-msgstr ""
+msgstr "Ej angivet"
 
 msgid "Full content"
-msgstr ""
+msgstr "Fullständigt innehåll"
 
 msgid "Search result highlighting input"
-msgstr ""
+msgstr "Sökresultat framhäver inmatning"
 
 msgid "Make content sticky"
-msgstr ""
+msgstr "Visa inlägg överst i listor"
 
 msgid "Site branding"
-msgstr ""
+msgstr "Site branding"
 
 msgid "Comments unapproved"
-msgstr ""
+msgstr "Kommentarer ej godkända"
 
 msgid "The unapproved comments listing."
-msgstr ""
+msgstr "Den ej godkända kommentarlistan."
 
 msgid "User account menu"
-msgstr ""
+msgstr "Meny för användarkonto"
 
 msgid "{{ message }}"
-msgstr ""
+msgstr "{{ meddelande }}"
 
 msgid ""
 "<p>Now that you have an overview of the \"Edit language\" feature, you can "
@@ -22142,6 +24325,10 @@ msgid ""
 "href=\"[site:url]admin/config/regional/language\">Viewing configured "
 "languages</a></li></ul></p>"
 msgstr ""
+"<p>Nu när du har en översikt över funktionen \"Redigera språk\" kan du "
+"fortsätta genom att:<ul><li>Redigera ett språk</li><li><a "
+"href=\"[site:url]admin/config/regional/language\">Visa konfigurerade "
+"språk</a></li></ul></p>"
 
 msgid ""
 "<p>Now that you have an overview of the \"Languages\" page, you can continue"
@@ -22149,6 +24336,10 @@ msgid ""
 "a language</a></li><li>Reordering languages</li><li>Editing a "
 "language</li><li>Deleting a language</li></ul></p>"
 msgstr ""
+"<p>Nu när du har en översikt över sidan \"Språk\" kan du fortsätta genom "
+"att:<ul><li><a href=\"[site:url]admin/config/regional/language/add\">Lägga "
+"till ett språk</a></li><li>Ändra ordningen på språk</li><li>Redigera ett "
+"språk</li><li>Radera ett språk</li></ul></p>"
 
 msgid ""
 "This page allows you to translate the user interface or modify existing "
@@ -22157,6 +24348,11 @@ msgid ""
 "href=\"[site:url]admin/config/regional/language\">Languages page</a>, in "
 "order to use this page."
 msgstr ""
+"Denna sida låter dig översätta användargränssnittet eller ändra befintliga "
+"översättningar. Om du först har installerat din webbplats på engelska måste "
+"du först lägga ett annat språk på sidan <a "
+"href=\"[site:url]admin/config/regional/language\">Språk</a> för att kunna "
+"använda denna sida."
 
 msgid ""
 "The translations you have made here will be used on your site's user "
@@ -22167,6 +24363,13 @@ msgid ""
 "href=\"[site:url]admin/config/regional/translate/import\">import them</a> "
 "later."
 msgstr ""
+"Översättningar du har gjort här kommer att användas på användargränssnittet "
+"för din webbplats. Om du vill använda dem på en annan webbplats eller ändra "
+"dem på en extern översättningsredigerare kan du <a "
+"href=\"[site:url]admin/config/regional/translate/export\">exportera dem</a> "
+"till en fil av typ .po och <a "
+"href=\"[site:url]admin/config/regional/translate/import\">importera dem</a> "
+"senare."
 
 msgid ""
 "No front page content has been created yet.<br/>Follow the <a "
@@ -22174,31 +24377,39 @@ msgid ""
 "href=\"https://www.drupal.org/docs/user_guide/en/index.html\">User Guide</a>"
 " to start building your site."
 msgstr ""
+"Inget innehåll för framsidan har skapats ännu.<br />Följ <a "
+"target=\"_blank\" "
+"href=\"https://www.drupal.org/docs/user_guide/en/index.html\">användarguiden</a>"
+" för att börja bygga din webbplats."
 
 msgid ""
 "There is content for the entity type: @entity_type. <a href=\":url\">Remove "
 "@entity_type_plural</a>."
 msgstr ""
+"Det finns innehåll för objektstypen: @entity_type. <a href=\":url\">Ta bort "
+"@entity_type_plural</a>."
 
 msgid "HTML Week"
-msgstr ""
+msgstr "HTML vecka"
 
 msgid ""
 "@site is currently under maintenance. We should be back shortly. Thank you "
 "for your patience."
 msgstr ""
+"@site underhålls för närvarande. Vi bör vara tillbaka inom kort. Tack för "
+"ert tålamod."
 
 msgid "Links related to the active user account"
-msgstr ""
+msgstr "Länkar relaterade till det aktiva användarkontot"
 
 msgid "User tool links, often added by modules"
-msgstr ""
+msgstr "Länkar för användare som ofta läggs till av moduler"
 
 msgid "Taxonomy term page"
-msgstr ""
+msgstr "Sida för taxonomitermer"
 
 msgid "Compact"
-msgstr ""
+msgstr "Kompakt"
 
 msgid ""
 "[user:display-name],\n"
@@ -22215,6 +24426,19 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\r\n"
+"\r\n"
+"Det har gjorts en begäran om att ta bort ditt konto på [site:name].\r\n"
+"\r\n"
+"Du kan nu ta bort ditt konto på [site:url-brief] genom att klicka på denna länk eller genom att klippa ut och klistra in den i din webbläsare:\r\n"
+"\r\n"
+"[user:cancel-url]\r\n"
+"\r\n"
+"OBSERVERA: Borttagandet av ditt konto kan inte ångras.\r\n"
+"\r\n"
+"Den här länken  är giltig en dag och inget händer om den inte används.\r\n"
+"\r\n"
+"--  Administratörerna på [site:name]"
 
 msgid ""
 "[user:display-name],\n"
@@ -22229,6 +24453,17 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\r\n"
+"\r\n"
+"En begäran om att återställa lösenordet för ditt kontot har gjorts på [site:name].\r\n"
+"\r\n"
+"Du kan nu logga in genom att klicka på länken eller kopiera och klistra in den i din webbläsare.\r\n"
+"\r\n"
+"[user:one-time-login-url]\r\n"
+"\r\n"
+"Denna länk kan bara användas en gång och kommer ta dig till en sida där du kan ange ditt lösenord. Denna länk upphör efter en dag och inget kommer hända om du inte använder den.\r\n"
+"\r\n"
+"--  Administratörerna på [site:name]"
 
 msgid ""
 "[user:display-name],\n"
@@ -22237,6 +24472,11 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\n"
+"\n"
+"Thank you for registering at [site:name]. Your application for an account is currently pending approval. Once it has been approved, you will receive another email containing information about how to log in, set your password, and other details.\n"
+"\n"
+"--  [site:name] team"
 
 msgid ""
 "[user:display-name],\n"
@@ -22245,9 +24485,14 @@ msgid ""
 "\n"
 "--  [site:name] team"
 msgstr ""
+"[user:display-name],\r\n"
+"\r\n"
+"Ditt konto på [site:name] har spärrats.\r\n"
+"\r\n"
+"--  Administratörerna  på [site:name]"
 
 msgid "Custom block library"
-msgstr ""
+msgstr "Bibliotek med anpassade block"
 
 msgid ""
 "<p>Now that you have an overview of the \"Add languages\" feature, you can "
@@ -22256,30 +24501,35 @@ msgid ""
 "href=\"[site:url]admin/config/regional/language\">Viewing configured "
 "languages</a></li></ul></p>"
 msgstr ""
+"<p>Nu när du har en översikt över funktionen \"Lägg till språk\" kan du "
+"fortsätta genom att:<ul><li>Lägga till ett språk</li><li>Lägga till ett "
+"anpassat språk</li><li><a "
+"href=\"[site:url]admin/config/regional/language\">Visa konfigurerade "
+"språk</a></li></ul></p>"
 
 msgid "There are no custom blocks available."
-msgstr ""
+msgstr "There are no custom blocks available."
 
 msgid "Find and manage comments."
-msgstr ""
+msgstr "Find and manage comments."
 
 msgid "Language direction"
-msgstr ""
+msgstr "Riktning på språk"
 
 msgid "Adding languages"
-msgstr ""
+msgstr "Adding languages"
 
 msgid "The approved comments listing."
-msgstr ""
+msgstr "The approved comments listing."
 
 msgid "Lists (Views)"
-msgstr ""
+msgstr "Lists (Views)"
 
 msgid "Watchdog"
-msgstr ""
+msgstr "Övervakning"
 
 msgid "Recent log messages"
-msgstr ""
+msgstr "Senaste loggmeddelanden"
 
 msgid ""
 "<p>To reorder the languages on your site, use the drag icons next to each "
@@ -22289,12 +24539,19 @@ msgid ""
 "done with reordering the languages, click the \"Save configuration\" button "
 "for the changes to take effect.</p>"
 msgstr ""
+"<p>Använd dragikoner bredvid varje språk för att ändra om ordningen på "
+"språken för webbplatsen.</p><p>Ordning som visas här är visningsordningen "
+"för språklistor på webbplatsen såsom i de språkbytarblock som tillhandahålls"
+" av modulerna Översättning av gränssnitt och Översättning av "
+"innehåll.</p><p>Klicka på knappen \"Spara konfiguration\" för att "
+"ändringarna ska träda i kraft när du är klar med att ändra ordningen på "
+"språken.</p>"
 
 msgid "No log messages available."
-msgstr ""
+msgstr "Inga loggmeddelanden tillgängliga."
 
 msgid "Manage user accounts, roles, and permissions."
-msgstr ""
+msgstr "Hantera användarkonton, roller och behörigheter."
 
 msgid ""
 "One translation file imported. %number translations were added, %update "
@@ -22303,41 +24560,45 @@ msgid_plural ""
 "@count translation files imported. %number translations were added, %update "
 "translations were updated and %delete translations were removed."
 msgstr[0] ""
+"En översättningsfil importerades. %number översättningar lades till, %update"
+" översättningar uppdaterades och %delete översättningar togs bort."
 msgstr[1] ""
+"@count översättningsfiler importerades. %number översättningar lades till, "
+"%update översättningar uppdaterades och %delete översättningar togs bort."
 
 msgid "Fid"
-msgstr ""
+msgstr "Fid"
 
 msgid "MIME type"
-msgstr ""
+msgstr "Typ av MIME"
 
 msgid "Size"
-msgstr ""
+msgstr "Storlek"
 
 msgid "Items per page"
-msgstr ""
+msgstr "Inlägg per sida"
 
 msgid "Temporary"
-msgstr ""
+msgstr "Temporär"
 
 msgid "1 place"
 msgid_plural "@count places"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 place"
+msgstr[1] "@count places"
 
 msgid "Registering module"
-msgstr ""
+msgstr "Registrerar modul"
 
 msgid "1"
 msgid_plural "@count"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1"
+msgstr[1] "@count"
 
 msgid "User"
-msgstr ""
+msgstr "Användare"
 
 msgid "Select language"
-msgstr ""
+msgstr "Välj språk"
 
 msgid ""
 "<p>Choose a language from the list, or choose \"Custom language...\" at the "
@@ -22346,6 +24607,10 @@ msgid ""
 " additional form where you can provide the name, code, and direction of the "
 "language.</p>"
 msgstr ""
+"<p>Välj ett språk från listan, eller välj \"Anpassat språk...\" i slutet av "
+"listan.</p><p>Klicka på knappen \"Lägg till språk\" när du har valt ditt "
+"språk.</p><p>När du lägger till ett anpassat språk får du ytterligare ett "
+"formulär där du kan ange namn, kod och riktning för språket.</p>"
 
 msgid ""
 "<p>You can change the default language of the site by choosing one of your "
@@ -22353,604 +24618,646 @@ msgid ""
 "situations where no choice is made but a language should be set, for example"
 " as the language of the displayed interface.</p>"
 msgstr ""
+"<p>Du kan ändra standardspråket på webbplatsen genom att välja ett av dina "
+"konfigurerade språk som förvalt. Webbplatsen kommer använda standardspråket "
+"i situationer där inget val görs men ett språk bör ställas in, till exempel "
+"som språket för det visade gränssnittet.</p>"
 
 msgid "User interface translation"
-msgstr ""
+msgstr "Översättning av användargränssnitt"
 
 msgid "Translation language"
-msgstr ""
+msgstr "Översättningsspråk"
 
 msgid "Monthly archive"
-msgstr ""
+msgstr "Månatligt arkiv"
 
 msgid ""
 "A user is considered online for this long after they have last viewed a "
 "page."
 msgstr ""
+"En användare anses vara inloggad så här länge efter att de senast tittat på "
+"en sida."
 
 msgid "Main navigation"
-msgstr ""
+msgstr "Huvudmeny"
 
 msgid "Initializing."
-msgstr ""
+msgstr "Initierar."
 
 msgid "Starting configuration update"
-msgstr ""
+msgstr "Startar uppdatering av konfiguration"
 
 msgid "Custom block type"
-msgstr ""
+msgstr "Anpassad blocktyp"
 
 msgctxt "View entity type"
 msgid "View"
-msgstr ""
+msgstr "View"
 
 msgid "No content available."
-msgstr ""
+msgstr "Inget innehåll tillgängligt."
 
 msgid "@type_label bundle"
-msgstr ""
+msgstr "bundle @type_label"
 
 msgid "Custom menu link"
-msgstr ""
+msgstr "Custom menu link"
 
 msgid "Small"
-msgstr ""
+msgstr "Liten"
 
 msgid "Large"
-msgstr ""
+msgstr "Stor"
 
 msgid "Author"
-msgstr ""
+msgstr "Författare"
 
 msgid "Icons"
-msgstr ""
+msgstr "Ikoner"
 
 msgid "Down"
-msgstr ""
+msgstr "Ned"
 
 msgid "E-mail from name"
-msgstr ""
+msgstr "Namn för utgående e-post"
 
 msgid "Status"
-msgstr ""
+msgstr "Status"
 
 msgid "Solid"
-msgstr ""
+msgstr "Solid"
 
 msgid "Light"
-msgstr ""
+msgstr "Light"
 
 msgid "Animation"
-msgstr ""
+msgstr "Animering"
 
 msgid "Local"
-msgstr ""
+msgstr "Lokal"
 
 msgid "Variants"
-msgstr ""
+msgstr "Varianter"
 
 msgid "Libraries"
-msgstr ""
+msgstr "Bibliotek"
 
 msgid ""
 "The %dependency library, which the %library library depends on, is not "
 "installed."
 msgstr ""
+"Biblioteket %dependency som biblioteket %library behöver är inte "
+"installerat."
 
 msgid ""
 "The version %dependency_version of the %dependency library is not compatible"
 " with the %library library."
 msgstr ""
+"Version %dependency_version för biblioteket %dependency är inte kompatibel "
+"med biblioteket %library."
 
 msgid "The %library library could not be found."
-msgstr ""
+msgstr "Biblioteket %library kunde inte hittas."
 
 msgid "The version of the %library library could not be detected."
-msgstr ""
+msgstr "Versionen av biblioteket %library  kunde inte hittas."
 
 msgid ""
 "The installed version %version of the %library library is not supported."
 msgstr ""
+"Den installerade versionen %version för biblioteket %library stöds inte."
 
 msgid "The %variant variant of the %library library could not be found."
-msgstr ""
+msgstr "Varianten %variant för biblioteket %library kunde inte hittas."
 
 msgid "Accept"
-msgstr ""
+msgstr "Accepterar"
 
 msgid "E-mail from address"
-msgstr ""
+msgstr "Adress för utgående e-post"
 
 msgid "SMTP Authentication"
-msgstr ""
+msgstr "Verifiering för SMTP"
 
 msgid "Enable debugging"
-msgstr ""
+msgstr "Aktivera felkodsavsökning"
 
 msgid "Use SSL"
-msgstr ""
+msgstr "Används SSL"
 
 msgid "Install options"
-msgstr ""
+msgstr "Alternativ för inställningar"
 
 msgid "To uninstall this module you must turn it off here first."
 msgstr ""
+"För att avinstallera den här modulen måste du stänga av den här först."
 
 msgid "SMTP server settings"
-msgstr ""
+msgstr "Inställningar för SMTP-server"
 
 msgid "The address of your outgoing SMTP server."
-msgstr ""
+msgstr "Adressen för din utgående SMTP-server."
 
 msgid ""
 "The address of your outgoing SMTP backup server. If the primary server can't"
 " be found this one will be tried. This is optional."
 msgstr ""
+"Adressen för din utgående backupserver för SMTP. Om den primära servern inte"
+" kan hittas kommer ett försök att göras med denna. Detta är en frivillig "
+"inställning."
 
 msgid "SMTP port"
-msgstr ""
+msgstr "Port för SMTP"
 
 msgid "Use TLS"
-msgstr ""
+msgstr "Använd TLS"
 
 msgid ""
 "This allows connection to an SMTP server that requires SSL encryption such "
 "as Gmail."
 msgstr ""
+"Detta möjliggör anslutning till en SMTP-server som kräver SSL-kryptering "
+"såsom Gmail."
 
 msgid "Use encrypted protocol"
-msgstr ""
+msgstr "Använd krypterat protokoll"
 
 msgid "Leave blank if your SMTP server does not require authentication."
-msgstr ""
+msgstr "Lämna detta blankt om din SMTP-server inte kräver verifiering."
 
 msgid "SMTP Username."
-msgstr ""
+msgstr "Användarnamn för SMTP"
 
 msgid "E-mail options"
-msgstr ""
+msgstr "Alternativ för E-post"
 
 msgid "Turn this module on or off"
-msgstr ""
+msgstr "Sätt på eller stäng av den här modulen"
 
 msgid "SMTP server"
-msgstr ""
+msgstr "SMTP-server"
 
 msgid "SMTP backup server"
-msgstr ""
+msgstr "Backupserver för SMTP"
 
 msgid "The e-mail address that all e-mails will be from."
-msgstr ""
+msgstr "E-postadressen som all e-post skall vara från."
 
 msgid "Send test e-mail"
-msgstr ""
+msgstr "Skicka testmeddelande"
 
 msgid "E-mail address to send a test e-mail to"
-msgstr ""
+msgstr "E-postadress att skicka ett testmeddelande till"
 
 msgid "Type in an address to have a test e-mail sent there."
-msgstr ""
+msgstr "Skriv in en e-postadress som ett testmeddelande skall skickas till."
 
 msgid ""
 "Checking this box will print SMTP messages from the server for every e-mail "
 "that is sent."
 msgstr ""
+"Kryssas denna ruta i visas meddelanden från servern för varje e-post som "
+"skickas genom SMTP."
 
 msgid "You must enter an SMTP server address."
-msgstr ""
+msgstr "Du måste ange en adress för SMTP-servern."
 
 msgid "You must enter an SMTP port number."
-msgstr ""
+msgstr "Du måste ange portnummer för SMTP."
 
 msgid "The provided from e-mail address is not valid."
-msgstr ""
+msgstr "Den angivna e-postadressen \"från\" är inte giltig."
 
 msgid "Sending mail to: @to"
-msgstr ""
+msgstr "Skickar e-post till: @to"
 
 msgid "Attahment could not be found or accessed."
-msgstr ""
+msgstr "Bilaga kunde inte hittas eller nås."
 
 msgid "Attachment could not be found or accessed."
-msgstr ""
+msgstr "Bilaga kunde inte hittas eller nås."
 
 msgid "Token"
-msgstr ""
+msgstr "Ersättningstecken"
 
 msgid "custom block"
-msgstr ""
+msgstr "custom block"
 
 msgid "content item"
-msgstr ""
+msgstr "content item"
 
 msgid "custom menu link"
-msgstr ""
+msgstr "custom menu link"
 
 msgid "Pathauto pattern"
-msgstr ""
+msgstr "Pathauto pattern"
 
 msgid "The first element of the array."
-msgstr ""
+msgstr "Det första elementet i arrayen."
 
 msgid "Update URL alias"
-msgstr ""
+msgstr "Uppdatera URL-alias"
 
 msgid "Previous"
-msgstr ""
+msgstr "Föregående"
 
 msgid "Information"
-msgstr ""
+msgstr "Information"
 
 msgid "Add required context"
-msgstr ""
+msgstr "Add required context"
 
 msgid "Finish"
-msgstr ""
+msgstr "Slutför"
 
 msgid "@description"
-msgstr ""
+msgstr "@description"
 
 msgid "Pager offset"
-msgstr ""
+msgstr "Pager offset"
 
 msgid "The name of the menu."
-msgstr ""
+msgstr "Menyns namn."
 
 msgid "Tokens"
-msgstr ""
+msgstr "Ersättningstecken"
 
 msgid "Available tokens"
-msgstr ""
+msgstr "Tillgängliga ersättningstecken"
 
 msgid "No tokens available."
-msgstr ""
+msgstr "Inga ersättningstecken tillgängliga."
 
 msgid "Click a token to insert it into the field you've last clicked."
 msgstr ""
+"Klicka på ett ersättningstecken för att infoga det i det fält du senaste "
+"klickade på."
 
 msgid "Insert this token into your form"
-msgstr ""
+msgstr "Infoga detta ersättningstecken i ditt formulär"
 
 msgid "First click a text field to insert your tokens into."
-msgstr ""
+msgstr "Klicka först på ett textfält att infoga dina ersättningstecken i."
 
 msgid "The explanation of the most recent changes made to the node."
-msgstr ""
+msgstr "Förklaringen av den senaste ändringen gjord på noden."
 
 msgid "The title of the current page."
-msgstr ""
+msgstr "Titeln för aktuell sida."
 
 msgid "The URL of the current page."
-msgstr ""
+msgstr "URL:en för aktuell sida."
 
 msgid "The page number of the current page when viewing paged lists."
-msgstr ""
+msgstr "Sidnumret för aktuell sida vid visning av paginerad lista."
 
 msgid "The source node for this current node's translation set."
-msgstr ""
+msgstr "Källnoden för den här nuvarande nodens översättningsgrupp."
 
 msgid "The URL of the confirm delete page for the user account."
-msgstr ""
+msgstr "URL:en till sidan att bekräfta borttagning för användarkontot."
 
 msgid "The URL of the one-time login page for the user account."
-msgstr ""
+msgstr "URL:en till sidan för engångsinloggning för användarkontot."
 
 msgid "Tokens related to menu links."
-msgstr ""
+msgstr "Ersättningstecken relaterade till menylänkar."
 
 msgid "The unique ID of the menu link."
-msgstr ""
+msgstr "Det unika ID för menylänken."
 
 msgid "The title of the menu link."
-msgstr ""
+msgstr "Titeln för menylänken."
 
 msgid "The URL of the menu link."
-msgstr ""
+msgstr "URL:en för menylänken."
 
 msgid "The menu link's parent."
-msgstr ""
+msgstr "Menylänkens ovanliggande alternativ."
 
 msgid "Tokens related to the current page request."
-msgstr ""
+msgstr "Ersättningstecken relaterade till det nuvarande sidanropet."
 
 msgid "The book page associated with the node."
-msgstr ""
+msgstr "Boksidan associerade med noden."
 
 msgid "The menu link for this node."
-msgstr ""
+msgstr "Menylänen för den här noden."
 
 msgid "The menu link's root."
-msgstr ""
+msgstr "Menylänkens rot."
 
 msgid "Tokens related to the current date and time."
-msgstr ""
+msgstr "Ersättningstecken relaterade till nuvarande datum och tid."
 
 msgid "The URL of the @entity."
-msgstr ""
+msgstr "URL:en för @entity."
 
 msgid "The content type of the node."
-msgstr ""
+msgstr "Innehållstypen för noden."
 
 msgid "Tokens related to content types."
-msgstr ""
+msgstr "Ersättningstecken relaterade till innehållstyper."
 
 msgid "The name of the content type."
-msgstr ""
+msgstr "Namet för innehållstypen."
 
 msgid "The unique machine-readable name of the content type."
-msgstr ""
+msgstr "Det maskinläsbara namnet för innehållstypen."
 
 msgid "The optional description of the content type."
-msgstr ""
+msgstr "Den valfria beskrivningen för innehållstypen."
 
 msgid "The number of nodes belonging to the content type."
-msgstr ""
+msgstr "Det antal noder som hör till innehållstypen."
 
 msgid "The URL of the content type's edit page."
-msgstr ""
+msgstr "URL:en för innehållstypens redigeringssida."
 
 msgid "The URL of the taxonomy term's edit page."
-msgstr ""
+msgstr "URL:en för taxonomitermens redigeringssida."
 
 msgid "The unique machine-readable name of the vocabulary."
-msgstr ""
+msgstr "Det unika maskinläsbara namnet för vokabulären."
 
 msgid "The URL of the vocabulary's edit page."
-msgstr ""
+msgstr "URL:en för vokabulärens redigeringssida."
 
 msgid ""
 "The specific argument of the current page (e.g. 'arg:1' on the page 'node/1'"
 " returns '1')."
 msgstr ""
+"Det angivna argument för nuvarande sida (till exempel \"arg:1\" på sidan "
+"\"nod/1\" återger \"1\")."
 
 msgid "Tokens related to URLs."
-msgstr ""
+msgstr "Ersättningstecken relaterade till URL:er"
 
 msgid "The relative URL."
-msgstr ""
+msgstr "Den relativa URL:en."
 
 msgid "The absolute URL."
-msgstr ""
+msgstr "Den fullständiga URL:en."
 
 msgid "Tokens related to menus."
-msgstr ""
+msgstr "Ersättningstecken relaterade till menyer."
 
 msgid "The unique machine-readable name of the menu."
-msgstr ""
+msgstr "Det unika maskinläsbara namnet för menyn."
 
 msgid "The optional description of the menu."
-msgstr ""
+msgstr "Den valfria beskrivningen för menyn."
 
 msgid "The number of menu links belonging to the menu."
-msgstr ""
+msgstr "Det antal menylänkar som hör till menyn."
 
 msgid "The URL of the menu's edit page."
-msgstr ""
+msgstr "URL:en för menyns redigeringssida."
 
 msgid "The menu of the menu link."
-msgstr ""
+msgstr "Menyn för menylänken."
 
 msgid "The URL of the menu link's edit page."
-msgstr ""
+msgstr "URL:en för menylänkens redigeringssida."
 
 msgid "The user roles associated with the user account."
-msgstr ""
+msgstr "Användarrollerna associerade med användarkontot."
 
 msgid "The URL without the protocol and trailing backslash."
-msgstr ""
+msgstr "URL:en utan protokoll och avslutande snedstreck."
 
 msgid "Tokens related to arrays of strings."
-msgstr ""
+msgstr "Ersättningstecken relaterade till arrayer av strängar."
 
 msgid "The last element of the array."
-msgstr ""
+msgstr "Det sista elementet i arrayen."
 
 msgid "The number of elements in the array."
-msgstr ""
+msgstr "Antalet element i arrayen."
 
 msgid "The array reversed."
-msgstr ""
+msgstr "Arrayen omvänd."
 
 msgid "The array of keys of the array."
-msgstr ""
+msgstr "Arrayen av nycklar för arrayen."
 
 msgid ""
 "The values of the array joined together with a custom string in-between each"
 " value."
 msgstr ""
+"Värdena i arrayen hopfogade med en anpassad sträng mellan varje värde."
 
 msgid "A date in '@type' format. (%date)"
-msgstr ""
+msgstr "Ett datum i format \"@type\". (%date)"
 
 msgid "The root term of the taxonomy term."
-msgstr ""
+msgstr "Källterm för taxonomitermen"
 
 msgid "The size of the file, in bytes."
-msgstr ""
+msgstr "Storleken på filen, i bytes."
 
 msgid "SMTP Authentication Support"
-msgstr ""
+msgstr "Verifiering av SMTP"
 
 msgid "Chaos tool suite"
-msgstr ""
+msgstr "Chaos tool suite"
 
 msgid ""
 "Provides a user interface for the Token API and some missing core tokens."
 msgstr ""
+"Tillhandahåller ett användargränssnitt till Token API och några saknade "
+"ersättningstecken från kärnan."
 
 msgid "The value of a specific query string field of the current page."
-msgstr ""
+msgstr "Värdet på en specifik databasfrågas fält för den aktuella sidan."
 
 msgid "A random number from 0 to @max."
-msgstr ""
+msgstr "Ett slumpmässigt tal från 0 till @max."
 
 msgid "A random hash. The possible hashing algorithms are: @hash-algos."
-msgstr ""
+msgstr "En slumpmässig hash. De möjliga hashalgoritmerna är: @hash-algos."
 
 msgid ""
 "Attempting to perform token replacement for token type %type without "
 "required data"
 msgstr ""
+"Försökte genomföra byte av ersättningstecken för ersättningstypen %type utan"
+" obligatorisk data"
 
 msgid "@type field."
-msgstr ""
+msgstr "Fält @type."
 
 msgid "No tokens available"
-msgstr ""
+msgstr "Inga ersättningstecken tillgängliga"
 
 msgid "Token registry caches cleared."
-msgstr ""
+msgstr "Registercache för ersättningstecken tömdes."
 
 msgid "The path component of the URL."
-msgstr ""
+msgstr "Sökvägskomponenten för URL:en."
 
 msgid "The unaliased URL."
-msgstr ""
+msgstr "URL:en utan alias"
 
 msgid "The specific value of the array."
-msgstr ""
+msgstr "Det specifika värdet på arrayen."
 
 msgid ""
 "The list of available tokens that can be used in e-mails is provided below."
 msgstr ""
+"Listan på tillgängliga ersättningstecken som kan användas i "
+"e-postmeddelanden finns nedan."
 
 msgid "An array of all the term's parents, starting with the root."
-msgstr ""
+msgstr "En array med alla ovanliggande termer, med början i roten."
 
 msgid "An array of all the menu link's parents, starting with the root."
-msgstr ""
+msgstr "En array med alla ovanliggande menylänkar, med början i roten."
 
 msgid "The original @entity data if the @entity is being updated or saved."
-msgstr ""
+msgstr "Den ursprungliga data för @entity om @entity uppdateras eller sparas."
 
 msgid "The base name of the file."
-msgstr ""
+msgstr "Filens grundnamn."
 
 msgid "Tokens for lists of @type values."
-msgstr ""
+msgstr "Ersättningstecken för listor av värden av typ @type."
 
 msgid "Browse available tokens."
-msgstr ""
+msgstr "Bläddra igenom tillgängliga ersättningstecken."
 
 msgid "Conditions"
-msgstr ""
+msgstr "Villkor"
 
 msgid "Verbose"
-msgstr ""
+msgstr "Detaljerad"
 
 msgid "Display alias changes (except during bulk updates)."
-msgstr ""
+msgstr "Visa ändringar av alias (förutom under massuppdateringar)."
 
 msgid "Replace by separator"
-msgstr ""
+msgstr "Ersätt med avskiljare"
 
 msgid "Maximum alias length"
-msgstr ""
+msgstr "Längsta längd för alias"
 
 msgid "Maximum component length"
-msgstr ""
+msgstr "Längsta längd för komponent"
 
 msgid "Update action"
-msgstr ""
+msgstr "Åtgärd för uppdatering"
 
 msgid "Strings to Remove"
-msgstr ""
+msgstr "Strängar att ta bort"
 
 msgid "Pathauto"
-msgstr ""
+msgstr "Pathauto"
 
 msgid "Period"
-msgstr ""
+msgstr "Period"
 
 msgid "Asterisk"
-msgstr ""
+msgstr "Asterisk"
 
 msgid ""
 "The automatically generated alias %original_alias conflicted with an "
 "existing alias. Alias changed to %alias."
 msgstr ""
+"Det automatiskt genererade aliaset %original_alias hamnade i konflikt med "
+"ett existerande alias. Alias ändrades till %alias."
 
 msgid "Delete aliases"
-msgstr ""
+msgstr "Radera alias"
 
 msgid "Automatic alias"
-msgstr ""
+msgstr "Automatiskt alias"
 
 msgid ""
 "Character used to separate words in titles. This will replace any spaces and"
 " punctuation characters. Using a space or + character can cause unexpected "
 "results."
 msgstr ""
+"Tecken som används för att separera ord i titlar. Detta kommer ersätta alla "
+"mellanrum och skiljetecken. Används tecken som mellanslag eller + kan det "
+"orsaka oväntat resultat."
 
 msgid "Character case"
-msgstr ""
+msgstr "Gemener eller versaler"
 
 msgid "Do nothing. Leave the old alias intact."
-msgstr ""
+msgstr "Gör inget. Lämna gamla alias intakta."
 
 msgid "Create a new alias. Leave the existing alias functioning."
-msgstr ""
+msgstr "Skapa ett nytt alias. Spara det gamla."
 
 msgid "Create a new alias. Delete the old alias."
-msgstr ""
+msgstr "Skapa ett nytt alias. Ta bort det gamla."
 
 msgid "Transliterate prior to creating alias"
-msgstr ""
+msgstr "Skriv om innan alias skapas"
 
 msgid ""
 "Filters the new alias to only letters and numbers found in the ASCII-96 set."
 msgstr ""
+"Filtrerar det nya aliaset till endast bokstäver och siffror som finns i "
+"ASCII-96."
 
 msgid "No action (do not replace)"
-msgstr ""
+msgstr "Ingen åtgärd (ersätt inte)"
 
 msgid "Delete all aliases. Number of aliases which will be deleted: %count."
-msgstr ""
+msgstr "Ta bort alla alias. Antal alias som kommer att tas bort: %count."
 
 msgid ""
 "Delete aliases for all @label. Number of aliases which will be deleted: "
 "%count."
 msgstr ""
+"Ta bort alias för alla @label. Antal alias som kommer att tas bort: %count."
 
 msgid "Delete aliases now!"
-msgstr ""
+msgstr "Ta bort alias nu!"
 
 msgid "All of your path aliases have been deleted."
-msgstr ""
+msgstr "Alla dina URL-alias har raderats."
 
 msgid "Patterns"
-msgstr ""
+msgstr "Mönster"
 
 msgid "Colon"
-msgstr ""
+msgstr "Kolon"
 
 msgid "Semicolon"
-msgstr ""
+msgstr "Semikolon"
 
 msgid "Slash"
-msgstr ""
+msgstr "Snedstreck"
 
 msgid "Punctuation"
-msgstr ""
+msgstr "Skiljetecken"
 
 msgid ""
 "What should Pathauto do when updating an existing content item which already"
 " has an alias?"
 msgstr ""
+"Vad skall Pathauto göra vid uppdatering av en existerande innehållspost som "
+"redan har ett alias?"
 
 msgid "Reduce strings to letters and numbers"
-msgstr ""
+msgstr "Reducera strängar till bokstäver och siffror"
 
 msgid ""
 "Words to strip out of the URL alias, separated by commas. Do not use this to"
 " remove punctuation."
 msgstr ""
+"Ord att ta bort från URL-aliaset, separerade med kommatecken. Använd inte "
+"detta för att ta bort skiljetecken."
 
 msgid "Choose aliases to delete"
-msgstr ""
+msgstr "Välj alias att ta bort"
 
 msgid "All aliases"
-msgstr ""
+msgstr "Alla alias"
 
 msgid ""
 "<strong>Note:</strong> there is no confirmation. Be sure of your action "
@@ -22958,232 +25265,246 @@ msgid ""
 "make a backup of the database and/or the url_alias table prior to using this"
 " feature."
 msgstr ""
+"<strong>Observera:</strong> det kommer ingen bekräftelse. Var säker på det "
+"du gör innan du klickar på knappen \"Ta bort alias nu!\".<br />Du kanske "
+"vill göra en backup på din databas och/eller tabellen \"url_alias\" innan du"
+" använder den här funktionen."
 
 msgid "Ignoring alias %alias because it is the same as the internal path."
-msgstr ""
+msgstr "Ignorerar alias %alias då det är detsamma som den interna sökvägen."
 
 msgid "Created new alias %alias for %source, replacing %old_alias."
-msgstr ""
+msgstr "Skapade nytt alias %alias för %source, som ersätter %old_alias."
 
 msgid "Created new alias %alias for %source."
-msgstr ""
+msgstr "Skapade nytt alias %alias för %source."
 
 msgid "Administer pathauto"
-msgstr ""
+msgstr "Administrera URL-alias"
 
 msgid ""
 "Allows a user to configure patterns for automated aliases and bulk delete "
 "URL-aliases."
 msgstr ""
+"Tillåter en användare att konfigurera mönster för automatiska alias och "
+"massradera URL-alias."
 
 msgid "Notify of Path Changes"
-msgstr ""
+msgstr "Meddela om ändringar av sökvägar"
 
 msgid "Determines whether or not users are notified."
-msgstr ""
+msgstr "Avgör huruvida användare meddelas eller ej."
 
 msgid "Bulk updating URL aliases"
-msgstr ""
+msgstr "Massuppdaterar URL-alias"
 
 msgid "An error occurred while processing @operation with arguments : @args"
-msgstr ""
+msgstr "Ett fel inträffade vid bearbetning av @operation med argument: @args"
 
 msgid "Generated 1 URL alias."
 msgid_plural "Generated @count URL aliases."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Skapade 1 URL-alias."
+msgstr[1] "Skapade @count URL-alias."
 
 msgid "Underscore"
-msgstr ""
+msgstr "Understreck"
 
 msgid "No new URL aliases to generate."
-msgstr ""
+msgstr "Inga nya URL-alias att generera."
 
 msgid "Double quotation marks"
-msgstr ""
+msgstr "Dubbla citattecken"
 
 msgid "Single quotation marks (apostrophe)"
-msgstr ""
+msgstr "Enkla citattecken"
 
 msgid "Back tick"
-msgstr ""
+msgstr "Grav accent"
 
 msgid "Hyphen"
-msgstr ""
+msgstr "Bindestreck"
 
 msgid "Vertical bar (pipe)"
-msgstr ""
+msgstr "Lodrätt streck"
 
 msgid "Left curly bracket"
-msgstr ""
+msgstr "Vänster klammerparentes"
 
 msgid "Left square bracket"
-msgstr ""
+msgstr "Vänster hakparentes"
 
 msgid "Right curly bracket"
-msgstr ""
+msgstr "Höger klammerparentes"
 
 msgid "Right square bracket"
-msgstr ""
+msgstr "Höger hakparentes"
 
 msgid "Plus sign"
-msgstr ""
+msgstr "Plustecken"
 
 msgid "Equal sign"
-msgstr ""
+msgstr "Liktstecken"
 
 msgid "Percent sign"
-msgstr ""
+msgstr "Procenttecken"
 
 msgid "Caret"
-msgstr ""
+msgstr "Cirkumflex"
 
 msgid "Dollar sign"
-msgstr ""
+msgstr "Dollartecken"
 
 msgid "Number sign (pound sign, hash)"
-msgstr ""
+msgstr "Nummertecken (hash)"
 
 msgid "At sign"
-msgstr ""
+msgstr "Snabel-a"
 
 msgid "Exclamation mark"
-msgstr ""
+msgstr "Utropstecken"
 
 msgid "Tilde"
-msgstr ""
+msgstr "Tilde"
 
 msgid "Left parenthesis"
-msgstr ""
+msgstr "Vänsterparentes"
 
 msgid "Right parenthesis"
-msgstr ""
+msgstr "Högerparentes"
 
 msgid "Question mark"
-msgstr ""
+msgstr "Frågetecken"
 
 msgid "Less-than sign"
-msgstr ""
+msgstr "Tecken för mindre än"
 
 msgid "Greater-than sign"
-msgstr ""
+msgstr "Tecken för större än"
 
 msgid "Backslash"
-msgstr ""
+msgstr "Omvänt snedstreck"
 
 msgid "Generate automatic URL alias"
-msgstr ""
+msgstr "Generera automatiska URL-alias"
 
 msgid "Uncheck this to create a custom alias below."
-msgstr ""
+msgstr "Avmarkera detta för att skapa ett anpassat alias nedan."
 
 msgid ""
 "The array values each cleaned by Pathauto and then joined with the slash "
 "into a string that resembles an URL."
 msgstr ""
+"Matrisvärdena har var och en rensats av Pathauto och sen sammanfogats med "
+"snedstreck till en sträng som liknar en webbadress."
 
 msgid "General settings"
-msgstr ""
+msgstr "Allmänna inställningar"
 
 msgid "Red"
-msgstr ""
+msgstr "Röd"
 
 msgid "Green"
-msgstr ""
+msgstr "Grön"
 
 msgid "Blue"
-msgstr ""
+msgstr "Blå"
 
 msgid "Secret Key"
-msgstr ""
+msgstr "Hemlig nyckel"
 
 msgid "Installation"
-msgstr ""
+msgstr "Installation"
 
 msgid "Public Key"
-msgstr ""
+msgstr "Offentlig nyckel"
 
 msgid "Orange"
-msgstr ""
+msgstr "Orange"
 
 msgid "Behavior"
-msgstr ""
+msgstr "Beteende"
 
 msgid "Captcha Point"
-msgstr ""
+msgstr "Captcha Point"
 
 msgid "Joined path"
-msgstr ""
+msgstr "Hopslagna sökvägar"
 
 msgid ""
 "Provides a mechanism for modules to automatically generate aliases for the "
 "content they manage."
 msgstr ""
+"Tillhandahåll en mekanism för moduler att automatiskt generera alias för "
+"innehållstypen som de handhar."
 
 msgid ""
 "This question is for testing whether or not you are a human visitor and to "
 "prevent automated spam submissions."
 msgstr ""
+"Den här frågan testar om du är en mänsklig besökare och förhindrar "
+"automatiska spaminsändningar."
 
 msgid "Example"
-msgstr ""
+msgstr "Exempel"
 
 msgid "normal"
-msgstr ""
+msgstr "normal"
 
 msgid "Code length"
-msgstr ""
+msgstr "Antal tecken"
 
 msgid "Font size"
-msgstr ""
+msgstr "Teckenstorlek"
 
 msgid "Characters to use in the code"
-msgstr ""
+msgstr "Tecken som får användas"
 
 msgid "The list of characters to use should not contain spaces."
-msgstr ""
+msgstr "Listan över tecken som skall användas bör inte innehålla mellanslag."
 
 msgid "Math question"
-msgstr ""
+msgstr "Mattefråga"
 
 msgid ""
 "Encountered an illegal byte while splitting an utf8 string in characters."
-msgstr ""
+msgstr "Hittade en otillåten byte när en UTF-8-sträng skulle delas upp."
 
 msgid "low"
-msgstr ""
+msgstr "låg"
 
 msgid "medium"
-msgstr ""
+msgstr "mellan"
 
 msgid "high"
-msgstr ""
+msgstr "hög"
 
 msgid "Add CAPTCHA administration links to forms"
-msgstr ""
+msgstr "Lägg till administrationslänkar för CAPTCHA till alla formulär"
 
 msgid "Challenge description"
-msgstr ""
+msgstr "Beskrivning av utmaningen"
 
 msgid "Persistence"
-msgstr ""
+msgstr "Beständighet"
 
 msgid "Always add a challenge."
-msgstr ""
+msgstr "Lägg alltid till en utmaning."
 
 msgid "Log wrong responses"
-msgstr ""
+msgstr "Logga felaktiga svar"
 
 msgid "Challenge type"
-msgstr ""
+msgstr "Typ av utmaning"
 
 msgid ""
 "This page gives an overview of all available challenge types, generated with"
 " their current settings."
 msgstr ""
+"Sidan ger överblick över alla tillgängliga typer av utmaningar, genererade "
+"med sina aktuella inställningar."
 
 msgid "10 more examples of this challenge."
-msgstr ""
+msgstr "Ytterligare tio exempel för denna utmaning."
 
 msgid ""
 "\"CAPTCHA\" is an acronym for \"Completely Automated Public Turing test to "
@@ -23195,69 +25516,86 @@ msgid ""
 "for a human to solve correctly, but hard enough to keep automated scripts "
 "and spam bots out."
 msgstr ""
+"\"CAPTCHA\" är en engelsk akronym för \"Completely Automated Public Turing "
+"test to tell Computers and Humans Apart\". Den består ofta av en utmaning "
+"som användaren måste svara rätt på för att bevisa att han eller hon är en "
+"människa. Modulen CAPTCHA är ett verktyg som hindrar automatiska verktyg "
+"från att skapa spam i till exempel formulär för kommentarer, "
+"användarregistreringar och gästböcker. Modulen CAPTCHA gör att du på dina "
+"formulär kan lägga till frågor som är lätta att besvara för människor men "
+"svåra nog för att hålla ute automatiska skript och spamrobotar."
 
 msgid "CAPTCHA is a trademark of Carnegie Mellon University."
-msgstr ""
+msgstr "CAPTCHA är ett varumärke som tillhör Carnegie Mellon University."
 
 msgid "Enabled challenge"
-msgstr ""
+msgstr "Aktiverade utmaning"
 
 msgid "Place a CAPTCHA here for untrusted users."
-msgstr ""
+msgstr "Placera en CAPTCHA här för ej betrodda användare."
 
 msgid "The answer you entered for the CAPTCHA was not correct."
-msgstr ""
+msgstr "Svaret du angav för CAPTCHA var inte rätt."
 
 msgid ""
 "Solve this simple math problem and enter the result. E.g. for 1+3, enter 4."
 msgstr ""
+"Lös det här enkla matteproblemet och ange svaret. Till exempel för 1+3, ange"
+" 4."
 
 msgid "Code settings"
-msgstr ""
+msgstr "Teckeninställningar"
 
 msgid ""
 "The code length influences the size of the image. Note that larger values "
 "make the image generation more CPU intensive."
 msgstr ""
+"Antalet tecken påverkar bildstorleken. Observera att större värden ger "
+"större bilder som kräver mer processorkraft."
 
 msgid "Font settings"
-msgstr ""
+msgstr "Inställningar för font"
 
 msgid "tiny"
-msgstr ""
+msgstr "pytteliten"
 
 msgid "small"
-msgstr ""
+msgstr "liten"
 
 msgid "large"
-msgstr ""
+msgstr "stor"
 
 msgid ""
 "The font size influences the size of the image. Note that larger values make"
 " the image generation more CPU intensive."
 msgstr ""
+"Textstorleken påverkar bildstorleken. Observera att större värden ger större"
+" bilder som kräver mer processorkraft."
 
 msgid "Character spacing"
-msgstr ""
+msgstr "Mellanrum mellan tecken"
 
 msgid ""
 "Define the average spacing between characters. Note that larger values make "
 "the image generation more CPU intensive."
 msgstr ""
+"Ange det genomsnittliga avståndet mellan tecknen. Observera att större "
+"värden ger större bilder som kräver mer processorkraft."
 
 msgid "Enter the hexadecimal code for the text color (e.g. #000 or #004283)."
-msgstr ""
+msgstr "Ange hexkoden för önskad textfärg (tlll exempel #000 eller #004283)."
 
 msgid "Additional variation of text color"
-msgstr ""
+msgstr "Ytterligare variation i textfärg"
 
 msgid ""
 "The different characters will have randomized colors in the specified range "
 "around the text color."
 msgstr ""
+"Olika tecken får slumpmässiga färger i angivet intervall kring textfärgen"
 
 msgid "Distortion and noise"
-msgstr ""
+msgstr "Förvridning och brus"
 
 msgid ""
 "With these settings you can control the degree of obfuscation by distortion "
@@ -23265,64 +25603,74 @@ msgid ""
 "in the image is reasonably readable. For example, do not combine high levels"
 " of distortion and noise."
 msgstr ""
+"Här kan du välja hur mycket tecknen skall förvanskas genom förvridning och "
+"brus. Överdriv inte nivån och se till att tecknen i bilden är tillräckligt "
+"läsbar. Kombinera till exempel inte höga nivåer av förvridning och brus."
 
 msgid "Distortion level"
-msgstr ""
+msgstr "Nivå av förvridning"
 
 msgid "severe"
-msgstr ""
+msgstr "mycket hög"
 
 msgid "Set the degree of wave distortion in the image."
-msgstr ""
+msgstr "Ange vågrörelsens storlek i bilden."
 
 msgid "Smooth distortion"
-msgstr ""
+msgstr "Jämn förvridning"
 
 msgid "This option adds randomly colored point noise."
 msgstr ""
+"Detta alternativ lägger till brus i form av slumpmässigt färgade punkter."
 
 msgid "Add line noise"
-msgstr ""
+msgstr "Lägg till linjebrus"
 
 msgid "This option enables lines randomly drawn on top of the text code."
 msgstr ""
+"Detta alternativ lägger till linjer som ritas slumpmässigt ovanpå "
+"bokstäverna."
 
 msgid "Noise level"
-msgstr ""
+msgstr "Brusnivå"
 
 msgid "Background color is not a valid hexadecimal color value."
-msgstr ""
+msgstr "Bakgrundsfärgen är inte ett giltig hexadecimalt färgvärde."
 
 msgid "Text color is not a valid hexadecimal color value."
-msgstr ""
+msgstr "Textfärgen är inte ett giltigt hexadecimalt färgvärde."
 
 msgid ""
 "Generation of image CAPTCHA failed. Check your image CAPTCHA configuration "
 "and especially the used font."
 msgstr ""
+"Generering av bild-CAPTCHA misslyckades. Kontrollera dina inställningar för "
+"bild-CAPTCHA och i synnerhet den valda fonten."
 
 msgid "Image CAPTCHA"
-msgstr ""
+msgstr "Bild-CAPTCHA"
 
 msgid "What code is in the image?"
-msgstr ""
+msgstr "Vilka tecken ser du i bilden?"
 
 msgid "Enable statistics"
-msgstr ""
+msgstr "Enable statistics"
 
 msgid "File format"
-msgstr ""
+msgstr "Filformat"
 
 msgid "Fonts"
-msgstr ""
+msgstr "Fonter"
 
 msgid ""
 "This option enables bilinear interpolation of the distortion which makes the"
 " image look smoother, but it is more CPU intensive."
 msgstr ""
+"Använder bilinjär interpolation i förvridningen vilket gör att bilden ser "
+"jämnare ut, men det kräver mer processorkraft."
 
 msgid "Add salt and pepper noise"
-msgstr ""
+msgstr "Lägg till salt- och pepparbrus"
 
 msgid ""
 "The image CAPTCHA is a popular challenge where a random textual code is "
@@ -23330,194 +25678,233 @@ msgid ""
 "which is rather CPU intensive for the server. Be careful with the size and "
 "computation related settings."
 msgstr ""
+"Bild-CAPTCHA är en populär utmaning som består av slumpmässigt valda tecken "
+"som visas förvanskade i en bild. Bilden genereras på nytt för varje "
+"tillfälle. Detta kräver mycket processorkraft av servern. Var försiktig när "
+"du väljer bildstorlek och gör andra beräkningsintensiva inställningar"
 
 msgid "@type (from module @module)"
-msgstr ""
+msgstr "@type (från modulen @module)"
 
 msgid "Form protection"
-msgstr ""
+msgstr "Skydd av formulär"
 
 msgid "Default challenge type"
-msgstr ""
+msgstr "Förvald typ av utmaning"
 
 msgid ""
 "Allow CAPTCHAs and CAPTCHA administration links on administrative pages"
 msgstr ""
+"Tillåt CAPTCHA och administrationslänkar för CAPTCHA  på "
+"administrationssidor."
 
 msgid "Add a description to the CAPTCHA"
-msgstr ""
+msgstr "Lägg till en beskrivning för CAPTCHA."
 
 msgid ""
 "Add a configurable description to explain the purpose of the CAPTCHA to the "
 "visitor."
 msgstr ""
+"Lägg till en konfigurerbar beskrivning som förklarar för besökaren varför de"
+" måste besvara en CAPTCHA."
 
 msgid "Default CAPTCHA validation"
-msgstr ""
+msgstr "Förval bekräftelse av CAPTCHA"
 
 msgid ""
 "Define how the response should be processed by default. Note that the "
 "modules that provide the actual challenges can override or ignore this."
 msgstr ""
+"Ange hur svaret skall bearbetas som standard. Observera att moduler som "
+"tillhandahåller de aktuella utmaningarna kan bortse från detta val."
 
 msgid ""
 "Case sensitive validation: the response has to exactly match the solution."
 msgstr ""
+"Skiftlägeskänslig bekräftelse: svaret måste stämma överens helt och hållet "
+"med lösningen."
 
 msgid "Case insensitive validation: lowercase/uppercase errors are ignored."
 msgstr ""
+"Ej skiftlägeskänslig bekräftelse: skillnader på små och stora bokstäver "
+"ignoreras"
 
 msgid "CAPTCHA: challenge \"@type\" enabled"
-msgstr ""
+msgstr "CAPTCHA: utmaning \"@type\" aktiverad"
 
 msgid "CAPTCHA: no challenge enabled"
-msgstr ""
+msgstr "CAPTCHA: ingen utmaning aktiverad"
 
 msgid "Test one two three"
-msgstr ""
+msgstr "Test ett två tre"
 
 msgid "Already 1 blocked form submission"
 msgid_plural "Already @count blocked form submissions"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Redan ett spärrat inlägg i formulär"
+msgstr[1] "Redan @count spärrade inlägg i formulär"
 
 msgid "Presolved image CAPTCHA example, generated with the current settings."
 msgstr ""
+"Exempel på bild-CAPTCHA, med lösning, genererad med nuvarande inställningar."
 
 msgid "extra large"
-msgstr ""
+msgstr "extra stor"
 
 msgid "tight"
-msgstr ""
+msgstr "smal"
 
 msgid "extra wide"
-msgstr ""
+msgstr "extra bred"
 
 msgid ""
 "The built-in font only supports Latin2 characters. Only use \"a\" to \"z\" "
 "and numbers."
 msgstr ""
+"Den inbyggda fonten stödjer enbart tecken av typen Latin2. Använd enbart "
+"\"a\" till \"z\" och siffror."
 
 msgid ""
 "CAPTCHA validation error: unknown CAPTCHA session ID. Contact the site "
 "administrator if this problem persists."
 msgstr ""
+"Fel bekräftelse av CAPTCHA: okänt sessions-ID för CAPTCHA. Kontakta "
+"webbplatsens administratör om detta problemet kvarstår."
 
 msgid "CAPTCHA validation error: unknown CAPTCHA session ID (%csid)."
-msgstr ""
+msgstr "Fel bekräftelse av CAPTCHA: okänt sessions-ID för CAPTCHA (%csid)."
 
 msgid "Color and image settings"
-msgstr ""
+msgstr "Inställningar för färg och bild"
 
 msgid ""
 "Configuration of the background, text colors and file format of the image "
 "CAPTCHA."
-msgstr ""
+msgstr "Konfiguration av bakgrund, textfärg och filformat för bild-CAPTCHA."
 
 msgid "Add URL redirect from this page to another location"
-msgstr ""
+msgstr "Add URL redirect from this page to another location"
 
 msgid "Invalid number of redirects."
-msgstr ""
+msgstr "Invalid number of redirects."
 
 msgid "Spam control"
-msgstr ""
+msgstr "Reglerar spam"
 
 msgid ""
 "Enter the hexadecimal code for the background color (e.g. #FFF or #FFCE90). "
 "When using the PNG file format with transparent background, it is "
 "recommended to set this close to the underlying background color."
 msgstr ""
+"Ange den hexadecimala koden för bakgrundsfärgen (till exempel #FFF eller "
+"#FFCE90). Vid användande av filformatet PNG med genomskinlig bakgrund "
+"rekommenderas det att ange detta nära till den underliggande "
+"bakgrundsfärgen."
 
 msgid ""
 "Select the file format for the image. JPEG usually results in smaller files,"
 " PNG allows tranparency."
 msgstr ""
+"Välj filformat för bilden. JPEG resulterar oftast i mindre bilder, PNG "
+"tillåter genomskinlighet."
 
 msgid "JPEG"
-msgstr ""
+msgstr "JPEG"
 
 msgid "PNG"
-msgstr ""
+msgstr "PNG"
 
 msgid "PNG with transparent background"
-msgstr ""
+msgstr "PNG med genomskinlig bakgrund"
 
 msgid "@level - no distortion"
-msgstr ""
+msgstr "@level - ingen förvridning"
 
 msgid "@level - low"
-msgstr ""
+msgstr "@level - låg"
 
 msgid "@level - medium"
-msgstr ""
+msgstr "@level - mellan"
 
 msgid "@level - high"
-msgstr ""
+msgstr "@level - hög"
 
 msgid "No TrueType support"
-msgstr ""
+msgstr "Inget stöd för TrueType"
 
 msgid ""
 "The Image CAPTCHA module can not use TrueType fonts because your PHP setup "
 "does not support it. You can only use a PHP built-in bitmap font of fixed "
 "size."
 msgstr ""
+"Modulen Image CAPCHA kan inte använda fonter av typen TrueType eftersom din "
+"installation av PHP inte stödjer det. Du kan enbart använda PHP:s inbyggda "
+"punktmatrisfont med fast storlek."
 
 msgid "Font preview of @font (@file)"
-msgstr ""
+msgstr "Förhandsgranskning av font @font (@file)"
 
 msgid "Preview of built-in font"
-msgstr ""
+msgstr "Förhandsgranskning av inbyggd font."
 
 msgid "You need to select at least one font."
-msgstr ""
+msgstr "Du måste välja åtminstone en font."
 
 msgid "The following fonts are not readable: %fonts."
-msgstr ""
+msgstr "Följande fonter är inte läsbara: %fonts."
 
 msgid "Enter the characters shown in the image."
-msgstr ""
+msgstr "Ange de tecken som visas i bilden."
 
 msgid ""
 "CAPTCHA problem: unexpected result from hook_captcha() of module %module "
 "when trying to retrieve challenge type %type for form %form_id."
 msgstr ""
+"Problem med CAPTCHA: oväntat resultat från hook_captcha() från modul %module"
+" vid försök att erhålla utmaning av typ %type från formulär %form_id."
 
 msgid ""
 "Omit challenges in a multi-step/preview workflow once the user successfully "
 "responds to a challenge."
 msgstr ""
+"Utelämna utmaningar i ett arbetsflöde med flera steg eller med "
+"förhandsgranskning, när användaren lyckats svara svara rätt på en utmaning."
 
 msgid ""
 "Omit challenges on a form type once the user successfully responds to a "
 "challenge on a form of that type."
 msgstr ""
+"Utelämna utmaningar på en typ av formulär när användaren lyckats svara rätt "
+"på en utmaning av den typen av formulär."
 
 msgid ""
 "Omit challenges on all forms once the user successfully responds to any "
 "challenge on the site."
 msgstr ""
+"Utelämna utmaningar på alla formulär när användare lyckats svara rätt på en "
+"utmaning på webbplatsen."
 
 msgid ""
 "Define if challenges should be omitted during the rest of a session once the"
 " user successfully responds to a challenge."
 msgstr ""
+"Ange om utmaningar skall utelämnas under resten av sessionen när användaren "
+"lyckats svara rätt på en utmaning."
 
 msgid "CAPTCHA session reuse attack detected."
-msgstr ""
+msgstr "Attack av återanvändning av session för CAPTCHA upptäcktes."
 
 msgid "CAPTCHA placement caching"
-msgstr ""
+msgstr "Placeringscache av CAPTCHA"
 
 msgid "Administer CAPTCHA settings"
-msgstr ""
+msgstr "Administrera inställningar för CAPTCHA"
 
 msgid "Skip CAPTCHA"
-msgstr ""
+msgstr "Hoppa över CAPTCHA"
 
 msgid "Users with this permission will not be offered a CAPTCHA."
 msgstr ""
+"Användare med den här behörigheten kommer inte att erbjudas en CAPTCHA."
 
 msgid ""
 "Select the fonts to use for the text in the image CAPTCHA. Apart from the "
@@ -23525,179 +25912,200 @@ msgid ""
 "extension .ttf) by putting them in %fonts_library_general or "
 "%fonts_library_specific."
 msgstr ""
+"Välj de fonter som skall användas för texten i bild-CAPTCHA. Förutom de "
+"tillhandahålla förvalda, så kan du också använda dina egna fonter av typen "
+"TrueType (med filändelsen .ttf) genom att lägga dem i %fonts_library_general"
+" eller %fonts_library_specific."
 
 msgid "RTL support"
-msgstr ""
+msgstr "Stöd för RTL"
 
 msgid "The CAPTCHA settings have been saved."
-msgstr ""
+msgstr "The CAPTCHA settings have been saved."
 
 msgid "Cleared the CAPTCHA placement cache."
-msgstr ""
+msgstr "Cleared the CAPTCHA placement cache."
 
 msgid "The CAPTCHA type to use for this form."
-msgstr ""
+msgstr "The CAPTCHA type to use for this form."
 
 msgid "Challenge %challenge by module %module"
-msgstr ""
+msgstr "Challenge %challenge by module %module"
 
 msgid "No variation"
-msgstr ""
+msgstr "No variation"
 
 msgid "Little variation"
-msgstr ""
+msgstr "Little variation"
 
 msgid "Medium variation"
-msgstr ""
+msgstr "Medium variation"
 
 msgid "High variation"
-msgstr ""
+msgstr "High variation"
 
 msgid "Very high variation"
-msgstr ""
+msgstr "Very high variation"
 
 msgid ""
 "Enable this option to render the code from right to left for right to left "
 "languages."
 msgstr ""
+"Aktivera detta alternativ för att generera koden från höger till vänster för"
+" språk som skrivs från höger till vänster."
 
 msgid "Widget settings"
-msgstr ""
+msgstr "Inställningar för widget"
 
 msgid "Dark"
-msgstr ""
+msgstr "Dark"
 
 msgid "@error"
-msgstr ""
+msgstr "@error"
 
 msgid "Image (default)"
-msgstr ""
+msgstr "Bild (förvalt)"
 
 msgid "Delete redirect"
-msgstr ""
+msgstr "Delete redirect"
 
 msgid "Redirect"
-msgstr ""
+msgstr "Omdirigera"
 
 msgid "List of redirects"
-msgstr ""
+msgstr "List of redirects"
 
 msgid "Filter"
-msgstr ""
+msgstr "Filtrera"
 
 msgid "With selection"
-msgstr ""
+msgstr "Med urval"
 
 msgid "Status code"
-msgstr ""
+msgstr "Statuskod"
 
 msgid "300 Multiple Choices"
-msgstr ""
+msgstr "300 Multiple Choices"
 
 msgid "301 Moved Permanently"
-msgstr ""
+msgstr "301 Moved Permanently"
 
 msgid "302 Found"
-msgstr ""
+msgstr "302 Found"
 
 msgid "303 See Other"
-msgstr ""
+msgstr "303 See Other"
 
 msgid "304 Not Modified"
-msgstr ""
+msgstr "304 Not Modified"
 
 msgid "305 Use Proxy"
-msgstr ""
+msgstr "305 Use Proxy"
 
 msgid "307 Temporary Redirect"
-msgstr ""
+msgstr "307 Temporary Redirect"
 
 msgid "Original language"
-msgstr ""
+msgstr "Ursprungsspråk"
 
 msgid "There is no redirect yet."
-msgstr ""
+msgstr "There is no redirect yet."
 
 msgid "Destination"
-msgstr ""
+msgstr "Mål"
 
 msgid "Add redirect"
-msgstr ""
+msgstr "Add redirect"
 
 msgid "Status Code"
-msgstr ""
+msgstr "Status Code"
 
 msgid ""
 "You are attempting to redirect the page to itself. This will result in an "
 "infinite loop."
 msgstr ""
+"You are attempting to redirect the page to itself. This will result in an "
+"infinite loop."
 
 msgid "Generate"
-msgstr ""
+msgstr "Generate"
 
 msgid "All languages"
-msgstr ""
+msgstr "Alla språk"
 
 msgid ""
 "A redirect set for a specific language will always be used when requesting "
 "this page in that language, and takes precedence over redirects set for "
 "<em>All languages</em>."
 msgstr ""
+"A redirect set for a specific language will always be used when requesting "
+"this page in that language, and takes precedence over redirects set for "
+"<em>All languages</em>."
 
 msgid "Redirect status"
-msgstr ""
+msgstr "Redirect status"
 
 msgid "Display a warning message to users when they are redirected."
-msgstr ""
+msgstr "Display a warning message to users when they are redirected."
 
 msgid "Automatically create redirects when URL aliases are changed."
-msgstr ""
+msgstr "Automatically create redirects when URL aliases are changed."
 
 msgid "Default redirect status"
-msgstr ""
+msgstr "Default redirect status"
 
 msgid "Configure behavior for URL redirects."
-msgstr ""
+msgstr "Ställ in beteendet för URL-vidareskickningar."
 
 msgid ""
 "You can find more information about HTTP redirect status codes at <a href"
 "=\"@status-codes\">@status-codes</a>."
 msgstr ""
+"You can find more information about HTTP redirect status codes at <a href"
+"=\"@status-codes\">@status-codes</a>."
 
 msgid "The redirect has been saved."
-msgstr ""
+msgstr "The redirect has been saved."
 
 msgid "No URL redirects available."
-msgstr ""
+msgstr "No URL redirects available."
 
 msgid ""
 "The source path %source is already being redirected. Do you want to <a href"
 "=\"@edit-page\">edit the existing redirect</a>?"
 msgstr ""
+"The source path %source is already being redirected. Do you want to <a href"
+"=\"@edit-page\">edit the existing redirect</a>?"
 
 msgid "How many URL redirects would you like to generate?"
-msgstr ""
+msgstr "How many URL redirects would you like to generate?"
 
 msgid "Delete all URL redirects before generating new URL redirects."
-msgstr ""
+msgstr "Delete all URL redirects before generating new URL redirects."
 
 msgid ""
 "The source path %path is likely a valid path. It is preferred to <a href"
 "=\"@url-alias\">create URL aliases</a> for existing paths rather than "
 "redirects."
 msgstr ""
+"The source path %path is likely a valid path. It is preferred to <a href"
+"=\"@url-alias\">create URL aliases</a> for existing paths rather than "
+"redirects."
 
 msgid ""
 "The base source path %source is already being redirected. Do you want to <a "
 "href=\"@edit-page\">edit the existing redirect</a>?"
 msgstr ""
+"The base source path %source is already being redirected. Do you want to <a "
+"href=\"@edit-page\">edit the existing redirect</a>?"
 
 msgid ""
 "Are you sure you want to delete the URL redirect from %source to %redirect?"
 msgstr ""
+"Are you sure you want to delete the URL redirect from %source to %redirect?"
 
 msgid "Retain query string through redirect."
-msgstr ""
+msgstr "Retain query string through redirect."
 
 msgid ""
 "For example, given a redirect from %source to %redirect, if a user visits "
@@ -23705,65 +26113,69 @@ msgid ""
 "in the redirection will always take precedence over the current query "
 "string."
 msgstr ""
+"For example, given a redirect from %source to %redirect, if a user visits "
+"%sourcequery they would be redirected to %redirectquery. The query strings "
+"in the redirection will always take precedence over the current query "
+"string."
 
 msgid "(formerly Global Redirect features)"
-msgstr ""
+msgstr "(formerly Global Redirect features)"
 
 msgid "Allow redirections on admin paths."
-msgstr ""
+msgstr "Allow redirections on admin paths."
 
 msgid "Last accessed"
-msgstr ""
+msgstr "Senaste åtkomst"
 
 msgid "Filter 404s"
-msgstr ""
+msgstr "Filter 404s"
 
 msgid "Fix 404 pages"
-msgstr ""
+msgstr "Fix 404 pages"
 
 msgid "Add redirects for 404 pages."
-msgstr ""
+msgstr "Add redirects for 404 pages."
 
 msgid "Fix 404 pages with URL redirects"
-msgstr ""
+msgstr "Fix 404 pages with URL redirects"
 
 msgid "‹ previous"
-msgstr ""
+msgstr "‹ föregående"
 
 msgid "Redirect type"
-msgstr ""
+msgstr "Redirect type"
 
 msgid "URL redirects"
-msgstr ""
+msgstr "URL redirects"
 
 msgid "Redirect users from one URL to another."
-msgstr ""
+msgstr "Redirect users from one URL to another."
 
 msgid "Deleted URL redirect @rid."
-msgstr ""
+msgstr "Deleted URL redirect @rid."
 
 msgid "One URL redirect created."
 msgid_plural "@count URL redirects created."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "One URL redirect created."
+msgstr[1] "@count URL redirects created."
 
 msgid "Redirect module form elements"
-msgstr ""
+msgstr "Redirect module form elements"
 
 msgid "URL Redirects"
-msgstr ""
+msgstr "URL Redirects"
 
 msgid "The user ID of the node author."
-msgstr ""
+msgstr "Användar-ID till nodens författare."
 
 msgid "Add another"
-msgstr ""
+msgstr "Lägg till fler"
 
 msgid "Search server"
-msgstr ""
+msgstr "Search server"
 
 msgid "Fields indexed in this index"
-msgstr ""
+msgstr "Fields indexed in this index"
 
 msgid ""
 "This page lists which fields are indexed in this index, grouped by "
@@ -23772,33 +26184,47 @@ msgid ""
 "search displays based on the index. Fields with type \"Fulltext\" can also "
 "be used for fulltext searching."
 msgstr ""
+"This page lists which fields are indexed in this index, grouped by "
+"datasource. (Datasource-independent fields are listed under \"General\".) "
+"Indexed fields can be used to add filters or sorting to views or other "
+"search displays based on the index. Fields with type \"Fulltext\" can also "
+"be used for fulltext searching."
 
 msgid "Add fields"
-msgstr ""
+msgstr "Add fields"
 
 msgid ""
 "With the \"Add fields\" button you can add additional fields to this index."
 msgstr ""
+"With the \"Add fields\" button you can add additional fields to this index."
 
 msgid ""
 "A label for the field that will be used to refer to the field in most places"
 " in the user interface."
 msgstr ""
+"A label for the field that will be used to refer to the field in most places"
+" in the user interface."
 
 msgid ""
 "The internal ID to use for this field. Can safely be ignored by "
 "inexperienced users in most cases. Changing a field's machine name requires "
 "reindexing of the index."
 msgstr ""
+"The internal ID to use for this field. Can safely be ignored by "
+"inexperienced users in most cases. Changing a field's machine name requires "
+"reindexing of the index."
 
 msgid "Property path"
-msgstr ""
+msgstr "Property path"
 
 msgid ""
 "The internal relationship linking the indexed item to the field, with links "
 "being separated by colons (:). This can be useful information for advanced "
 "users, but can otherwise be ignored."
 msgstr ""
+"The internal relationship linking the indexed item to the field, with links "
+"being separated by colons (:). This can be useful information for advanced "
+"users, but can otherwise be ignored."
 
 msgid ""
 "The data type to use when indexing the field. Determines how a field can be "
@@ -23806,74 +26232,98 @@ msgid ""
 "=\"#search-api-data-types-table\">\"Data types\" box</a> at the bottom of "
 "the page."
 msgstr ""
+"The data type to use when indexing the field. Determines how a field can be "
+"used in searches. For information on the available types, see the <a href"
+"=\"#search-api-data-types-table\">\"Data types\" box</a> at the bottom of "
+"the page."
 
 msgid "Boost"
-msgstr ""
+msgstr "Boost"
 
 msgid ""
 "Only applicable for fulltext fields. Determines how \"important\" the field "
 "is compared to other fulltext fields, to influence scoring of fulltext "
 "searches."
 msgstr ""
+"Only applicable for fulltext fields. Determines how \"important\" the field "
+"is compared to other fulltext fields, to influence scoring of fulltext "
+"searches."
 
 msgid "Edit field"
-msgstr ""
+msgstr "Redigera fält"
 
 msgid ""
 "Some fields have additional configuration available, in which case an "
 "\"Edit\" link is displayed in the \"Operations\" column."
 msgstr ""
+"Some fields have additional configuration available, in which case an "
+"\"Edit\" link is displayed in the \"Operations\" column."
 
 msgid "Remove field"
-msgstr ""
+msgstr "Ta bort fält"
 
 msgid ""
 "Removes a field from the index again. (Note: Sometimes, a field is required "
 "(for example, by a processor) and cannot be removed.)"
 msgstr ""
+"Removes a field from the index again. (Note: Sometimes, a field is required "
+"(for example, by a processor) and cannot be removed.)"
 
 msgid "Save changes"
-msgstr ""
+msgstr "Spara ändringar"
 
 msgid ""
 "This saves all changes made to the fields for this index. Until this button "
 "is pressed, all added, changed or removed fields will only be stored "
 "temporarily and not effect the actual index used in the rest of the site."
 msgstr ""
+"This saves all changes made to the fields for this index. Until this button "
+"is pressed, all added, changed or removed fields will only be stored "
+"temporarily and not effect the actual index used in the rest of the site."
 
 msgid "Cancel changes"
-msgstr ""
+msgstr "Avbryt ändringar"
 
 msgid ""
 "If you have made changes to the index's fields but not yet saved them, the "
 "\"Cancel\" link lets you discard those changes."
 msgstr ""
+"If you have made changes to the index's fields but not yet saved them, the "
+"\"Cancel\" link lets you discard those changes."
 
 msgid "Add or edit a Search API index"
-msgstr ""
+msgstr "Add or edit a Search API index"
 
 msgid "Adding or editing an index"
-msgstr ""
+msgstr "Adding or editing an index"
 
 msgid ""
 "This form can be used to edit an existing index or add a new index to your "
 "site. Indexes define a set of data that will be indexed and can then be "
 "searched."
 msgstr ""
+"This form can be used to edit an existing index or add a new index to your "
+"site. Indexes define a set of data that will be indexed and can then be "
+"searched."
 
 msgid "Index name"
-msgstr ""
+msgstr "Index name"
 
 msgid ""
 "Enter a name to identify this index. For example, \"Content index\". This "
 "will only be displayed in the admin user interface."
 msgstr ""
+"Enter a name to identify this index. For example, \"Content index\". This "
+"will only be displayed in the admin user interface."
 
 msgid ""
 "Datasources define the types of items that will be indexed in this index. By"
 " default, all content entities (like content, comments and taxonomy terms) "
 "will be available here, but modules can also add their own."
 msgstr ""
+"Datasources define the types of items that will be indexed in this index. By"
+" default, all content entities (like content, comments and taxonomy terms) "
+"will be available here, but modules can also add their own."
 
 msgid ""
 "An index's tracker is the system that keeps track of which items there are "
@@ -23881,48 +26331,64 @@ msgid ""
 "Changing the tracker of an existing index will lead to reindexing of all "
 "items."
 msgstr ""
+"An index's tracker is the system that keeps track of which items there are "
+"available for the index, and which of them still need to be indexed. "
+"Changing the tracker of an existing index will lead to reindexing of all "
+"items."
 
 msgid "If the index is attached to a server, this server is listed here."
-msgstr ""
+msgstr "If the index is attached to a server, this server is listed here."
 
 msgid ""
 "The search server that the index should use for indexing and searching. If "
 "no server is selected here, the index cannot be enabled. An index can only "
 "have one server, but a server can have any number of indexes."
 msgstr ""
+"The search server that the index should use for indexing and searching. If "
+"no server is selected here, the index cannot be enabled. An index can only "
+"have one server, but a server can have any number of indexes."
 
 msgid "Index description"
-msgstr ""
+msgstr "Index description"
 
 msgid ""
 "Optionally, enter a description to explain the function of the index in more"
 " detail. This will only be displayed in the admin user interface."
 msgstr ""
+"Optionally, enter a description to explain the function of the index in more"
+" detail. This will only be displayed in the admin user interface."
 
 msgid ""
 "These options allow more detailed configuration of index behavior, but can "
 "usually safely be ignored by inexperienced users."
 msgstr ""
+"These options allow more detailed configuration of index behavior, but can "
+"usually safely be ignored by inexperienced users."
 
 msgid "Processors used for this index"
-msgstr ""
+msgstr "Processors used for this index"
 
 msgid ""
 "Processors customize different aspects of an index's functionality. They can"
 " keep items from being indexed, change how certain fields are indexed and "
 "influence searches."
 msgstr ""
+"Processors customize different aspects of an index's functionality. They can"
+" keep items from being indexed, change how certain fields are indexed and "
+"influence searches."
 
 msgid "Enable processors"
-msgstr ""
+msgstr "Enable processors"
 
 msgid ""
 "This lists all processors available for this index and lets you choose the "
 "ones that should be active. (Note: Some processors cannot be disabled.)"
 msgstr ""
+"This lists all processors available for this index and lets you choose the "
+"ones that should be active. (Note: Some processors cannot be disabled.)"
 
 msgid "Processor order"
-msgstr ""
+msgstr "Processor order"
 
 msgid ""
 "This shows you which enabled processors will be active in the different "
@@ -23930,49 +26396,60 @@ msgid ""
 " should usually not be necessary, and only be used by advanced users as some"
 " processors will lead to unexpected results when used in the wrong order."
 msgstr ""
+"This shows you which enabled processors will be active in the different "
+"parts of the indexing/searching workflow, and lets you re-arrange them. This"
+" should usually not be necessary, and only be used by advanced users as some"
+" processors will lead to unexpected results when used in the wrong order."
 
 msgid "Processor settings"
-msgstr ""
+msgstr "Processor settings"
 
 msgid ""
 "Some processors have additional configuration available, which you are able "
 "to change here."
 msgstr ""
+"Some processors have additional configuration available, which you are able "
+"to change here."
 
 msgid "Information about an index"
-msgstr ""
+msgstr "Information about an index"
 
 msgid "This page shows a summary of a search index and its status."
-msgstr ""
+msgstr "This page shows a summary of a search index and its status."
 
 msgid "Index status"
-msgstr ""
+msgstr "Index status"
 
 msgid ""
 "This gives a summary about how many items are known for this index, and how "
 "many have been indexed in their latest version. Items that are not indexed "
 "yet cannot be found by searches."
 msgstr ""
+"This gives a summary about how many items are known for this index, and how "
+"many have been indexed in their latest version. Items that are not indexed "
+"yet cannot be found by searches."
 
 msgid "Shows whether the index is currently enabled or disabled."
-msgstr ""
+msgstr "Shows whether the index is currently enabled or disabled."
 
 msgid "Datasources"
-msgstr ""
+msgstr "Datasources"
 
 msgid "Lists all datasources that are enabled for this index."
-msgstr ""
+msgstr "Lists all datasources that are enabled for this index."
 
 msgid ""
 "The tracker used by the index. Only one (\"Default\") is available by "
 "default."
 msgstr ""
+"The tracker used by the index. Only one (\"Default\") is available by "
+"default."
 
 msgid "Server"
-msgstr ""
+msgstr "Server"
 
 msgid "Server index status"
-msgstr ""
+msgstr "Server index status"
 
 msgid ""
 "For enabled indexes, the number of items that can actually be retrieved from"
@@ -23982,24 +26459,30 @@ msgid ""
 "/frequently-asked-questions#server-index-status\">see the module's "
 "documentation</a>."
 msgstr ""
+"For enabled indexes, the number of items that can actually be retrieved from"
+" the server is listed here. For reasons why this number might differ from "
+"the number under \"Index status\", <a "
+"href=\"https://www.drupal.org/docs/8/modules/search-api/getting-started"
+"/frequently-asked-questions#server-index-status\">see the module's "
+"documentation</a>."
 
 msgid "Cron batch size"
-msgstr ""
+msgstr "Cron batch size"
 
 msgid "The number of items that will be indexed at once during cron runs."
-msgstr ""
+msgstr "The number of items that will be indexed at once during cron runs."
 
 msgid "Start indexing now"
-msgstr ""
+msgstr "Start indexing now"
 
 msgid "Meta tags"
-msgstr ""
+msgstr "Metataggar"
 
 msgid "Country name"
-msgstr ""
+msgstr "Namn på land"
 
 msgid "Relation"
-msgstr ""
+msgstr "Relation"
 
 msgid ""
 "The \"Start indexing now\" form allows indexing items manually right away, "
@@ -24007,9 +26490,13 @@ msgid ""
 "The form might be disabled if indexing is currently not possible for some "
 "reason, or not necessary."
 msgstr ""
+"The \"Start indexing now\" form allows indexing items manually right away, "
+"with a batch process. Otherwise, items are only indexed during cron runs. "
+"The form might be disabled if indexing is currently not possible for some "
+"reason, or not necessary."
 
 msgid "Track items for index"
-msgstr ""
+msgstr "Track items for index"
 
 msgid ""
 "In certain situations, the index's tracker doesn't have the latest state of "
@@ -24017,54 +26504,70 @@ msgid ""
 "during cron runs, but can also be manually triggered here, with the \"Track "
 "now\" button."
 msgstr ""
+"In certain situations, the index's tracker doesn't have the latest state of "
+"the items available for indexing. This will be automatically rectified "
+"during cron runs, but can also be manually triggered here, with the \"Track "
+"now\" button."
 
 msgid "Queue all items for reindexing"
-msgstr ""
+msgstr "Queue all items for reindexing"
 
 msgid ""
 "This will queue all items on this index for reindexing. Previously indexed "
 "data will remain on the search server, so searches on this index will "
 "continue to yield results."
 msgstr ""
+"This will queue all items on this index for reindexing. Previously indexed "
+"data will remain on the search server, so searches on this index will "
+"continue to yield results."
 
 msgid "Clear all indexed data"
-msgstr ""
+msgstr "Clear all indexed data"
 
 msgid ""
 "This will remove all indexed content for this index from the search server "
 "and queue it for reindexing. Searches on this index will not return any "
 "results until items are reindexed."
 msgstr ""
+"This will remove all indexed content for this index from the search server "
+"and queue it for reindexing. Searches on this index will not return any "
+"results until items are reindexed."
 
 msgid "Add or edit a Search API server"
-msgstr ""
+msgstr "Add or edit a Search API server"
 
 msgid "Adding or editing a Server"
-msgstr ""
+msgstr "Adding or editing a Server"
 
 msgid ""
 "This form can be used to edit an existing server or add a new server to your"
 " site. Servers will hold your indexed data."
 msgstr ""
+"This form can be used to edit an existing server or add a new server to your"
+" site. Servers will hold your indexed data."
 
 msgid "Server name"
-msgstr ""
+msgstr "Server name"
 
 msgid ""
 "Enter a name to identify this server. For example, \"Solr server\". This "
 "will only be displayed in the admin user interface."
 msgstr ""
+"Enter a name to identify this server. For example, \"Solr server\". This "
+"will only be displayed in the admin user interface."
 
 msgid "Server description"
-msgstr ""
+msgstr "Server description"
 
 msgid ""
 "Optionally, enter a description to explain the function of the server in "
 "more detail. This will only be displayed in the admin user interface."
 msgstr ""
+"Optionally, enter a description to explain the function of the server in "
+"more detail. This will only be displayed in the admin user interface."
 
 msgid "Server backend"
-msgstr ""
+msgstr "Server backend"
 
 msgid ""
 "Servers can be based on different technologies. These are called "
@@ -24074,33 +26577,42 @@ msgid ""
 "href=\"https://www.drupal.org/project/search_api_solr\">\"Solr\"</a>, which "
 "requires to be set up separately."
 msgstr ""
+"Servers can be based on different technologies. These are called "
+"\"backends\". A server uses exactly one backend and cannot change it later. "
+"You can make the \"Database\" backend available by enabling the \"Database "
+"Search\" module. Another very common backend is <a "
+"href=\"https://www.drupal.org/project/search_api_solr\">\"Solr\"</a>, which "
+"requires to be set up separately."
 
 msgid "Information about a server"
-msgstr ""
+msgstr "Information about a server"
 
 msgid "This page shows a summary of a search server."
-msgstr ""
+msgstr "This page shows a summary of a search server."
 
 msgid "Shows whether the server is currently enabled or disabled."
-msgstr ""
+msgstr "Shows whether the server is currently enabled or disabled."
 
 msgid "Backend class"
-msgstr ""
+msgstr "Backend class"
 
 msgid ""
 "The backend plugin used for this server. The backend plugin determines how "
 "items are indexed and searched – for example, using the database or an "
 "Apache Solr server."
 msgstr ""
+"The backend plugin used for this server. The backend plugin determines how "
+"items are indexed and searched – for example, using the database or an "
+"Apache Solr server."
 
 msgid "Search indexes"
-msgstr ""
+msgstr "Search indexes"
 
 msgid "Lists all search indexes that are attached to this server."
-msgstr ""
+msgstr "Lists all search indexes that are attached to this server."
 
 msgid "Delete all indexed data"
-msgstr ""
+msgstr "Delete all indexed data"
 
 msgid ""
 "This will permanently remove all data currently indexed on this server for "
@@ -24108,223 +26620,250 @@ msgid ""
 "reindexing occurs, searches for the affected indexes will not return any "
 "results."
 msgstr ""
+"This will permanently remove all data currently indexed on this server for "
+"indexes that aren't read-only. Items are queued for reindexing. Until "
+"reindexing occurs, searches for the affected indexes will not return any "
+"results."
 
 msgid "enabled"
-msgstr ""
+msgstr "aktiverad"
 
 msgid "all"
-msgstr ""
+msgstr "alla"
 
 msgid "Total"
-msgstr ""
+msgstr "Totalt"
 
 msgid "Always"
-msgstr ""
+msgstr "Alltid"
 
 msgid "Field ID"
-msgstr ""
+msgstr "ID för fält"
 
 msgid "Transliteration"
-msgstr ""
+msgstr "Omskrivning"
 
 msgid "Read only"
-msgstr ""
+msgstr "Endast läsa"
 
 msgid "Exception"
-msgstr ""
+msgstr "Undantag"
 
 msgid ""
 "You must include at least one positive keyword with @count characters or "
 "more."
 msgstr ""
+"Du måste ha med minst ett positivt sökord med @count bokstäver eller mer."
 
 msgid "Add server"
-msgstr ""
+msgstr "Add server"
 
 msgid "Unavailable"
-msgstr ""
+msgstr "Ej tillgänglig"
 
 msgid "Data types"
-msgstr ""
+msgstr "Data types"
 
 msgid "Relevance"
-msgstr ""
+msgstr "Relevance"
 
 msgid "HTML filter"
-msgstr ""
+msgstr "HTML-filter"
 
 msgid ""
 "The number of characters a word has to be to be indexed. A lower setting "
 "means better search result ranking, but also a larger database. Each search "
 "query must contain at least one keyword that is this size (or longer)."
 msgstr ""
+"Antalet tecken ett ord måste ha för att det skall indexeras. Ett lägre värde"
+" betyder bättre sökresultat, men också större databas. Varje sökning måste "
+"innehålla minst ett sökord som har denna längd (eller längre)."
 
 msgid "Indexed"
-msgstr ""
+msgstr "Indexed"
 
 msgid "The changes were successfully saved."
-msgstr ""
+msgstr "The changes were successfully saved."
 
 msgid "Add index"
-msgstr ""
+msgstr "Add index"
 
 msgid "Save and add fields"
-msgstr ""
+msgstr "Spara och lägg till fält"
 
 msgid "Machine name: @name"
-msgstr ""
+msgstr "Maskinläsbart namn: @name"
 
 msgid "Autocomplete settings"
-msgstr ""
+msgstr "Inställningar för automatisk komplettering"
 
 msgid "Ignore case"
-msgstr ""
+msgstr "Ignorera skiftläge"
 
 msgid "Default content index"
-msgstr ""
+msgstr "Default content index"
 
 msgid "Default content index created by the Database Search Defaults module"
-msgstr ""
+msgstr "Default content index created by the Database Search Defaults module"
 
 msgid "Database Server"
-msgstr ""
+msgstr "Database Server"
 
 msgid "Default database server created by the Database Search Defaults module"
 msgstr ""
+"Default database server created by the Database Search Defaults module"
 
 msgid "Add tracking for specific roles"
-msgstr ""
+msgstr "Lägg till spårning för specifika roller"
 
 msgid "Search content"
-msgstr ""
+msgstr "Söka efter innehåll"
 
 msgid "A search page preconfigured to search through the content of your site"
 msgstr ""
+"A search page preconfigured to search through the content of your site"
 
 msgid "Please enter some keywords to search."
-msgstr ""
+msgstr "Please enter some keywords to search."
 
 msgid "Search Content"
-msgstr ""
+msgstr "Search Content"
 
 msgid "Displaying results @start - @end of @total"
-msgstr ""
+msgstr "Displaying results @start - @end of @total"
 
 msgid "Module %module granted %permission permission to authenticated users."
-msgstr ""
+msgstr "Module %module granted %permission permission to authenticated users."
 
 msgid "Opt-in or out of tracking"
-msgstr ""
+msgstr "Opt-in or out of tracking"
 
 msgid "Message type"
-msgstr ""
+msgstr "Meddelandetyp"
 
 msgid "Downloads"
-msgstr ""
+msgstr "Nedladdningar"
 
 msgid "Privacy"
-msgstr ""
+msgstr "Privacy"
 
 msgid "Not configured"
-msgstr ""
+msgstr "Ej inställd"
 
 msgid "Create field"
-msgstr ""
+msgstr "Skapa fält"
 
 msgid "Domains"
-msgstr ""
+msgstr "Domäner"
 
 msgid "@module (<span class=\"admin-enabled\">enabled</span>)"
-msgstr ""
+msgstr "@module (<span class=\"admin-enabled\">aktiverad</span>)"
 
 msgid "Add tracking to specific pages"
-msgstr ""
+msgstr "Lägg till spårning till specifika sidor"
 
 msgid "Track translation sets as one unit"
-msgstr ""
+msgstr "Spåra uppsättningar av översättningar som en enhet."
 
 msgid ""
 "When a node is part of a translation set, record statistics for the "
 "originating node instead. This allows for a translation set to be treated as"
 " a single unit."
 msgstr ""
+"When a node is part of a translation set, record statistics for the "
+"originating node instead. This allows for a translation set to be treated as"
+" a single unit."
 
 msgid "Track internal search"
-msgstr ""
+msgstr "Spåra intern sökning"
 
 msgid "Track AdSense ads"
-msgstr ""
+msgstr "Spåra annonser från AdSense"
 
 msgid ""
 "If checked, your AdSense ads will be tracked in your Google Analytics "
 "account."
 msgstr ""
+"Om ikryssad kommer dina annonser från AdSense att spåras i ditt konto hos "
+"Google Analytics."
 
 msgid "Custom JavaScript code"
-msgstr ""
+msgstr "Egen JavaScriptkod."
 
 msgid "Code snippet (before)"
-msgstr ""
+msgstr "Kodsnutt (före)"
 
 msgid "Code snippet (after)"
-msgstr ""
+msgstr "Kodsnutt (efter)"
 
 msgid ""
 "Do not add the tracker code provided by Google into the javascript code "
 "snippets! This module already builds the tracker code based on your Google "
 "Analytics account number and settings."
 msgstr ""
+"Lägg inte in spårningskoden från Google i kodsnuttarna! Denna modul bygger "
+"redan upp spårningskoden baserat på ditt kontonummer för Google Analytics "
+"och dina inställningar."
 
 msgid ""
 "Do not include the &lt;script&gt; tags in the javascript code snippets."
-msgstr ""
+msgstr "Inkludera inte &lt;script&gt;-taggarna i javscriptkodsnuttarna."
 
 msgid "Users are tracked by default, but you are able to opt out."
-msgstr ""
+msgstr "Användare spåras som standard, men du har möjlighet till opt-out."
 
 msgid "Enable user tracking"
-msgstr ""
+msgstr "Aktivera användarspårning"
 
 msgid "Users are <em>not</em> tracked by default, but you are able to opt in."
 msgstr ""
+"Användare spåras <em>inte</em> som standard, men du har möjlighet till opt-"
+"in."
 
 msgid "Google Analytics"
-msgstr ""
+msgstr "Google Analytics"
 
 msgid "Google Analytics module"
-msgstr ""
+msgstr "Modulen Google Analytics"
 
 msgid ""
 "Specify pages by using their paths. Enter one path per line. The '*' "
 "character is a wildcard. Example paths are %blog for the blog page and "
 "%blog-wildcard for every personal blog. %front is the front page."
 msgstr ""
+"Specificera sidor genom att använda dess sökvägar. Ange en sökväg per rad. "
+"Jokertecken är '*'. Sökvägsexempel: %blog för bloggsidan, %blog-wildcard för"
+" alla personliga bloggar. %front är startsidan."
 
 msgid "Pages on which this PHP code returns <code>TRUE</code> (experts only)"
 msgstr ""
+"Sidor där följande PHP-kod returnerar <code>TRUE</code> (enbart för "
+"experter)."
 
 msgid "Pages or PHP code"
-msgstr ""
+msgstr "Sidor eller PHP-kod"
 
 msgid ""
 "If the PHP option is chosen, enter PHP code between %php. Note that "
 "executing incorrect PHP code can break your Drupal site."
 msgstr ""
+"Om alternativet PHP är valt, ange PHP-kod mellan %php. Observera att "
+"felaktig PHP-kod kan förstöra din Drupal-webbplats."
 
 msgid "Not customizable"
-msgstr ""
+msgstr "Ej anpassningsbart"
 
 msgid "Colorbox"
-msgstr ""
+msgstr "Colorbox"
 
 msgid "Site search"
-msgstr ""
+msgstr "Site search"
 
 msgid "Web Property ID"
-msgstr ""
+msgstr "ID för webbsida"
 
 msgid "Anonymize visitors IP address"
-msgstr ""
+msgstr "IP-adress för gäster."
 
 msgid ""
 "Tell Google Analytics to anonymize the information sent by the tracker "
@@ -24334,9 +26873,15 @@ msgid ""
 "information for privacy reasons and this setting may help you to comply with"
 " the local laws."
 msgstr ""
+"Tell Google Analytics to anonymize the information sent by the tracker "
+"objects by removing the last octet of the IP address prior to its storage. "
+"Note that this will slightly reduce the accuracy of geographic reporting. In"
+" some countries it is not allowed to collect personally identifying "
+"information for privacy reasons and this setting may help you to comply with"
+" the local laws."
 
 msgid "Locally cache tracking code file"
-msgstr ""
+msgstr "Locally cache tracking code file"
 
 msgid ""
 "If checked, the tracking code file is retrieved from Google Analytics and "
@@ -24344,347 +26889,377 @@ msgid ""
 "to tracking code are reflected in the local copy. Do not activate this until"
 " after Google Analytics has confirmed that site tracking is working!"
 msgstr ""
+"If checked, the tracking code file is retrieved from Google Analytics and "
+"cached locally. It is updated daily from Google's servers to ensure updates "
+"to tracking code are reflected in the local copy. Do not activate this until"
+" after Google Analytics has confirmed that site tracking is working!"
 
 msgid "Custom variables"
-msgstr ""
+msgstr "Custom variables"
 
 msgid ""
 "The %element-title is using the following forbidden tokens with personal "
 "identifying information: @invalid-tokens."
 msgstr ""
+"The %element-title is using the following forbidden tokens with personal "
+"identifying information: @invalid-tokens."
 
 msgid ""
 "The role names the user account is a member of as comma separated list."
 msgstr ""
+"The role names the user account is a member of as comma separated list."
 
 msgid "The role ids the user account is a member of as comma separated list."
-msgstr ""
+msgstr "The role ids the user account is a member of as comma separated list."
 
 msgid "Locally cached tracking code file has been updated."
-msgstr ""
+msgstr "Locally cached tracking code file has been updated."
 
 msgid "Locally cached tracking code file has been saved."
-msgstr ""
+msgstr "Locally cached tracking code file has been saved."
 
 msgid "Local cache has been purged."
-msgstr ""
+msgstr "Local cache has been purged."
 
 msgid "Tracking scope"
-msgstr ""
+msgstr "Tracking scope"
 
 msgid "Allow users to customize tracking on their account page"
-msgstr ""
+msgstr "Allow users to customize tracking on their account page"
 
 msgid "No customization allowed"
-msgstr ""
+msgstr "No customization allowed"
 
 msgid "Tracking on by default, users with %permission permission can opt out"
-msgstr ""
+msgstr "Tracking on by default, users with %permission permission can opt out"
 
 msgid "Tracking off by default, users with %permission permission can opt in"
-msgstr ""
+msgstr "Tracking off by default, users with %permission permission can opt in"
 
 msgid "Every page except the listed pages"
-msgstr ""
+msgstr "Every page except the listed pages"
 
 msgid "The listed pages only"
-msgstr ""
+msgstr "The listed pages only"
 
 msgid "Links and downloads"
-msgstr ""
+msgstr "Links and downloads"
 
 msgid "Track clicks on mailto links"
-msgstr ""
+msgstr "Track clicks on mailto links"
 
 msgid "Track downloads (clicks on file links) for the following extensions"
-msgstr ""
+msgstr "Track downloads (clicks on file links) for the following extensions"
 
 msgid "List of download file extensions"
-msgstr ""
+msgstr "List of download file extensions"
 
 msgid ""
 "A valid Google Analytics Web Property ID is case sensitive and formatted "
 "like UA-xxxxxxx-yy."
 msgstr ""
+"A valid Google Analytics Web Property ID is case sensitive and formatted "
+"like UA-xxxxxxx-yy."
 
 msgid "Administer Google Analytics"
-msgstr ""
+msgstr "Administrera Google Analytics"
 
 msgid "Perform maintenance tasks for Google Analytics."
-msgstr ""
+msgstr "Perform maintenance tasks for Google Analytics."
 
 msgid "Allow users to decide if tracking code will be added to pages or not."
-msgstr ""
+msgstr "Allow users to decide if tracking code will be added to pages or not."
 
 msgid "Use PHP for tracking visibility"
-msgstr ""
+msgstr "Use PHP for tracking visibility"
 
 msgid "On by default with opt out"
-msgstr ""
+msgstr "On by default with opt out"
 
 msgid "Off by default with opt in"
-msgstr ""
+msgstr "Off by default with opt in"
 
 msgid "Not tracked"
-msgstr ""
+msgstr "Spåras inte"
 
 msgid "What are you tracking?"
-msgstr ""
+msgstr "Vad spårar du?"
 
 msgid "A single domain (default)"
-msgstr ""
+msgstr "En enstaka domän (standard)"
 
 msgid "Domain: @domain"
-msgstr ""
+msgstr "Domän: @domain"
 
 msgid "One domain with multiple subdomains"
-msgstr ""
+msgstr "En domän med flera underdomäner"
 
 msgid "Examples: @domains"
-msgstr ""
+msgstr "Exempel: @domains"
 
 msgid "Multiple top-level domains"
-msgstr ""
+msgstr "Flera toppdomäner"
 
 msgid "List of top-level domains"
-msgstr ""
+msgstr "Lista över toppdomäner"
 
 msgid "Add to the selected roles only"
-msgstr ""
+msgstr "Add to the selected roles only"
 
 msgid "Add to every role except the selected ones"
-msgstr ""
+msgstr "Add to every role except the selected ones"
 
 msgid ""
 "If none of the roles are selected, all users will be tracked. If a user has "
 "any of the roles checked, that user will be tracked (or excluded, depending "
 "on the setting above)."
 msgstr ""
+"If none of the roles are selected, all users will be tracked. If a user has "
+"any of the roles checked, that user will be tracked (or excluded, depending "
+"on the setting above)."
 
 msgid "Track clicks on outbound links"
-msgstr ""
+msgstr "Track clicks on outbound links"
 
 msgid ""
 "A list of top-level domains is required if <em>Multiple top-level "
 "domains</em> has been selected."
 msgstr ""
+"A list of top-level domains is required if <em>Multiple top-level "
+"domains</em> has been selected."
 
 msgid "All pages with exceptions"
-msgstr ""
+msgstr "Alla sidor utom"
 
 msgid "Excepted: @roles"
-msgstr ""
+msgstr "Undantagna: @roles"
 
 msgid "A single domain"
-msgstr ""
+msgstr "En domän"
 
 msgid "No privacy"
-msgstr ""
+msgstr "No privacy"
 
 msgid "@items enabled"
-msgstr ""
+msgstr "@items enabled"
 
 msgid "Outbound links"
-msgstr ""
+msgstr "Outbound links"
 
 msgid "Enter PHP code in the field for tracking visibility settings."
-msgstr ""
+msgstr "Enter PHP code in the field for tracking visibility settings."
 
 msgid "Google Analytics module form element."
-msgstr ""
+msgstr "Google Analytics module form element."
 
 msgid "Mailto links"
-msgstr ""
+msgstr "Mailto links"
 
 msgid "AdSense ads"
-msgstr ""
+msgstr "AdSense ads"
 
 msgid "Anonymize IP"
-msgstr ""
+msgstr "Anonymize IP"
 
 msgid "Track messages of type"
-msgstr ""
+msgstr "Track messages of type"
 
 msgid "Search and Advertising"
-msgstr ""
+msgstr "Search and Advertising"
 
 msgid "Metric"
-msgstr ""
+msgstr "Metriskt"
 
 msgid ""
 "To adjust global defaults, go to admin/config/search/metatag. If you need to"
 " set meta tags for a specific entity, edit its bundle and add the Metatag "
 "field."
 msgstr ""
+"To adjust global defaults, go to admin/config/search/metatag. If you need to"
+" set meta tags for a specific entity, edit its bundle and add the Metatag "
+"field."
 
 msgid "Metatag defaults"
-msgstr ""
+msgstr "Metatag defaults"
 
 msgid "403 access denied"
-msgstr ""
+msgstr "403 access denied"
 
 msgid "[node:title] | [site:name]"
-msgstr ""
+msgstr "[node:title] | [site:name]"
 
 msgid "404 page not found"
-msgstr ""
+msgstr "404 page not found"
 
 msgid "[site:url]"
-msgstr ""
+msgstr "[site:url]"
 
 msgid "[current-page:url]"
-msgstr ""
+msgstr "[current-page:url]"
 
 msgid "[current-page:title] | [site:name]"
-msgstr ""
+msgstr "[current-page:title] | [site:name]"
 
 msgid "[node:summary]"
-msgstr ""
+msgstr "[node:summary]"
 
 msgid "[node:url]"
-msgstr ""
+msgstr "[node:url]"
 
 msgid "[term:url]"
-msgstr ""
+msgstr "[term:url]"
 
 msgid "[term:description]"
-msgstr ""
+msgstr "[term:description]"
 
 msgid "[term:name] | [site:name]"
-msgstr ""
+msgstr "[term:name] | [site:name]"
 
 msgid "[user:url]"
-msgstr ""
+msgstr "[user:url]"
 
 msgid "[site:name]"
-msgstr ""
+msgstr "[site:name]"
 
 msgid "[user:display-name] | [site:name]"
-msgstr ""
+msgstr "[user:display-name] | [site:name]"
 
 msgid "Audience"
-msgstr ""
+msgstr "Målgrupp"
 
 msgid "License"
-msgstr ""
+msgstr "License"
 
 msgid "Date Created"
-msgstr ""
+msgstr "Date Created"
 
 msgid "Id"
-msgstr ""
+msgstr "Id"
 
 msgid "Latitude"
-msgstr ""
+msgstr "Latitud"
 
 msgid "Longitude"
-msgstr ""
+msgstr "Longitud"
 
 msgid "Phone number"
-msgstr ""
+msgstr "Telefonnummer"
 
 msgid "Google"
-msgstr ""
+msgstr "Google"
 
 msgid "Street address"
-msgstr ""
+msgstr "Gatuadress"
 
 msgid "Publisher"
-msgstr ""
+msgstr "Publisher"
 
 msgid "Publisher URL"
-msgstr ""
+msgstr "Publisher URL"
 
 msgid "Rating"
-msgstr ""
+msgstr "Betyg"
 
 msgid "Creator"
-msgstr ""
+msgstr "Upphovsman"
 
 msgid ""
 "Allows your site to be tracked by Google Analytics by adding a Javascript "
 "tracking code to every page."
 msgstr ""
+"Allows your site to be tracked by Google Analytics by adding a Javascript "
+"tracking code to every page."
 
 msgid "Image type"
-msgstr ""
+msgstr "Image type"
 
 msgid "References"
-msgstr ""
+msgstr "Referenser"
 
 msgid "Canonical URL"
-msgstr ""
+msgstr "Canonical URL"
 
 msgid "Robots"
-msgstr ""
+msgstr "Robots"
 
 msgid "Bing"
-msgstr ""
+msgstr "Bing"
 
 msgid "Shortlink URL"
-msgstr ""
+msgstr "Shortlink URL"
 
 msgid ""
 "Provides search engines with specific directions for what to do when this "
 "page is indexed."
 msgstr ""
+"Provides search engines with specific directions for what to do when this "
+"page is indexed."
 
 msgid "Using defaults"
-msgstr ""
+msgstr "Using defaults"
 
 msgid "Image URL"
-msgstr ""
+msgstr "URL för bild"
 
 msgid "Fax number"
-msgstr ""
+msgstr "Faxnummer"
 
 msgid "See also"
-msgstr ""
+msgstr "Se även"
 
 msgid "Video width"
-msgstr ""
+msgstr "Bredd på video"
 
 msgid "Video height"
-msgstr ""
+msgstr "Höjd på video"
 
 msgid "Abstract"
-msgstr ""
+msgstr "Abstrakt"
 
 msgid "Origin"
-msgstr ""
+msgstr "Ursprung"
 
 msgid "Lifetime"
-msgstr ""
+msgstr "Giltighetstid"
 
 msgid "Honeypot"
-msgstr ""
+msgstr "Honeypot"
 
 msgid ""
 "Congratulations on installing Honeypot on your site! With just a few clicks, you can have your site well-protected against automated spam bots.\r\n"
 "\r\n"
 "Click Next to be guided through this configuration page."
 msgstr ""
+"Grattis till installationen av Honeypot på din webbplats! Med bara några få klick kan du ha din webbplats väl skyddad mot automatiska skräppostrobotar.\n"
+"\n"
+"Klicka på Nästa för att vägledas genom den här konfigurationssidan."
 
 msgid "Protect all forms"
-msgstr ""
+msgstr "Skydda alla formulär"
 
 msgid ""
 "Protecting all the forms is the easiest way to quickly cut down on spam on your site, but doing this disables Drupal's caching for every page where a form is displayed.\r\n"
 "\r\n"
 "Note: If you have the honeypot time limit enabled, this option may cause issues with Drupal Commerce product forms or similarly-sparse forms that are able to be completed in a very short time."
 msgstr ""
+"Att skydda alla formulär är det enklaste sättet att snabbt skära ned skräppost på din webbplats, men att göra detta avaktiverar Drupals cachning för varje sida där ett formulär visas.\n"
+"\n"
+"Observa!: Om du har aktiverat tidsbegränsningen för honungsfälla kan det här alternativet orsaka problem med produktformulär för Drupal Commerce eller liknande kringspridda formulär som kan fyllas i på mycket kort tid."
 
 msgid "Log blocked form submissions"
-msgstr ""
+msgstr "Logga spärrade formulärsinlägg"
 
 msgid ""
 "Check this box to log every form submission using watchdog. If you have "
 "Database Logging enabled, you can view these log entries in the Recent log "
 "messages page under Reports."
 msgstr ""
+"Markera den här rutan för att logga varje formulärsinlägg med övervakning. "
+"Om du har databasloggning aktiverad kan du visa dessa loggposter på sidan "
+"Senaste loggmeddelanden under Rapporter."
 
 msgid "Honeypot Element Name"
-msgstr ""
+msgstr "Elementnamn för Honeypot"
 
 msgid ""
 "Spam bots typically fill out any field they believe will help get links back"
@@ -24692,9 +27267,14 @@ msgid ""
 "'homepage', or 'link' makes it hard for them to resist filling in the "
 "field—and easy to catch them in the trap and reject their submissions!"
 msgstr ""
+"Skräppostrobotar fyller vanligtvis i alla fält som de tror kommer att hjälpa"
+" till att få länkar tillbaka till deras webbplats. Så att fresta dem med ett"
+" fält som heter något som \"url\", \"homepage\" eller \"link\" gör det svårt"
+" för dem att motstå att fylla i fältet - och lätt att fånga dem i fällan och"
+" avvisa deras inlägg!"
 
 msgid "Honeypot Time Limit"
-msgstr ""
+msgstr "Tidsbegränsning för Honepot"
 
 msgid ""
 "If you enter a positive value, Honeypot will require that all protected "
@@ -24702,27 +27282,35 @@ msgid ""
 "least 5-10 seconds to complete (if you're a human), so setting this to a "
 "value < 5 will help protect against spam bots. Set to 0 to disable."
 msgstr ""
+"Om du anger ett positivt värde kräver Honeypot att alla skyddade formulär "
+"tar minst så många sekunder att fylla i. De flesta formulär tar minst 5-10 "
+"sekunder att slutföra (om du är en människa), så att sätta detta till ett "
+"värde <5 hjälper till att skydda mot spamrobotar. Ställ in detta 0 för att "
+"inaktivera."
 
 msgid "Honeypot form-specific settings"
-msgstr ""
+msgstr "Inställningar för specifika formulär i Honepot"
 
 msgid ""
 "If you would like to choose particular forms to be protected by Honeypot, "
 "check the forms you wish to protect in this section. Most common types of "
 "forms are available for protection."
 msgstr ""
+"Om du vill välja vissa formulär som skall skyddas av Honeypot, kontrollera "
+"de formulär du vill skydda i det här avsnittet. De vanligaste typerna av "
+"formulär är tillgängliga för skydd."
 
 msgid "Expiration"
-msgstr ""
+msgstr "Utgångsdatum"
 
 msgid "seconds"
-msgstr ""
+msgstr "sekunder"
 
 msgid "Footer_en"
-msgstr ""
+msgstr "Footer_en"
 
 msgid "Footer links (en)"
-msgstr ""
+msgstr "Footer links (en)"
 
 msgid "Thursday"
 msgstr "torsdag"
@@ -24733,489 +27321,493 @@ msgstr "september"
 
 msgid "1 minute"
 msgid_plural "@count minutes"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 minut"
+msgstr[1] "@count minuter"
 
 msgid "Contact message"
-msgstr ""
+msgstr "Kontaktmeddelande"
 
 msgid "Search task"
-msgstr ""
+msgstr "Search task"
 
 msgid "Shortcut link"
-msgstr ""
+msgstr "Shortcut link"
 
 msgid "Reusable"
-msgstr ""
+msgstr "Reusable"
 
 msgid "Form ID"
-msgstr ""
+msgstr "ID för formulär"
 
 msgid "The sender's name"
-msgstr ""
+msgstr "The sender's name"
 
 msgid "The sender's email"
-msgstr ""
+msgstr "The sender's email"
 
 msgid "Recipient ID"
-msgstr ""
+msgstr "ID-nummer för mottagare"
 
 msgid "Redirect ID"
-msgstr ""
+msgstr "Redirect ID"
 
 msgid "User ID"
-msgstr ""
+msgstr "Användar-ID"
 
 msgid "Task type"
-msgstr ""
+msgstr "Task type"
 
 msgid "Server ID"
-msgstr ""
+msgstr "Server ID"
 
 msgid "Index ID"
-msgstr ""
+msgstr "Index ID"
 
 msgid "Task data"
-msgstr ""
+msgstr "Task data"
 
 msgid "Path"
-msgstr ""
+msgstr "Sökväg"
 
 msgid "Enabled"
-msgstr ""
+msgstr "Aktiverad"
 
 msgid "Menu link title"
-msgstr ""
+msgstr "Titel på menylänken"
 
 msgid "Indicates whether the menu link should be rediscovered"
-msgstr ""
+msgstr "Indicates whether the menu link should be rediscovered"
 
 msgid "Show as expanded"
-msgstr ""
+msgstr "Visa som utfälld"
 
 msgid "Parent plugin ID"
-msgstr ""
+msgstr "Parent plugin ID"
 
 msgid "Content types"
-msgstr ""
+msgstr "Innehållstyper"
 
 msgid "URL"
-msgstr ""
+msgstr "URL"
 
 msgid "Array"
-msgstr ""
+msgstr "Array"
 
 msgid "Random"
-msgstr ""
+msgstr "Slumpvis"
 
 msgid "Image with image style"
-msgstr ""
+msgstr "Bild med bildstil"
 
 msgid "Menus"
-msgstr ""
+msgstr "Menyer"
 
 msgid "Nodes"
-msgstr ""
+msgstr "Noder"
 
 msgid "Site information"
-msgstr ""
+msgstr "Information om webbplatsen"
 
 msgid "Taxonomy terms"
-msgstr ""
+msgstr "Taxonomitermer"
 
 msgid "Vocabularies"
-msgstr ""
+msgstr "Vokabulärer"
 
 msgid "Menu links"
-msgstr ""
+msgstr "Menylänkar"
 
 msgid "List of @type values"
-msgstr ""
+msgstr "Lista av värden av typ @type"
 
 msgid "Translation source node"
-msgstr ""
+msgstr "Översättningens källnod"
 
 msgid "Comment count"
-msgstr ""
+msgstr "Antal kommentarer"
 
 msgid "Menu link"
-msgstr ""
+msgstr "Menylänk"
 
 msgid "Summary"
-msgstr ""
+msgstr "Sammanfattning"
 
 msgid "Original @entity"
-msgstr ""
+msgstr "Ursprunglig @entity"
 
 msgid "Edit URL"
-msgstr ""
+msgstr "URL för redigering"
 
 msgid "Date created"
-msgstr ""
+msgstr "Datum för skapande"
 
 msgid "Date changed"
-msgstr ""
+msgstr "Ändrad datum"
 
 msgid "Machine-readable name"
-msgstr ""
+msgstr "Maskinläsbart namn"
 
 msgid "Parents"
-msgstr ""
+msgstr "Ovanliggande"
 
 msgid "Root term"
-msgstr ""
+msgstr "Källterm"
 
 msgid "Term ID"
-msgstr ""
+msgstr "Termens ID"
 
 msgid "Parent term"
-msgstr ""
+msgstr "Ovanliggande term"
 
 msgid "Vocabulary ID"
-msgstr ""
+msgstr "Vokabulärets ID"
 
 msgid "Term count"
-msgstr ""
+msgstr "Antal termer"
 
 msgid "Base name"
-msgstr ""
+msgstr "Grundnamn"
 
 msgid "File byte size"
-msgstr ""
+msgstr "Filstorlek i bytes"
 
 msgid "File ID"
-msgstr ""
+msgstr "Filens ID"
 
 msgid "File name"
-msgstr ""
+msgstr "Filnamn"
 
 msgid "File size"
-msgstr ""
+msgstr "Filstorlek"
 
 msgid "Owner"
-msgstr ""
+msgstr "Ägare"
 
 msgid "Account cancellation URL"
-msgstr ""
+msgstr "URL för avbrytande av konto"
 
 msgid "One-time login URL"
-msgstr ""
+msgstr "URL för engångsinloggning"
 
 msgid "User role names"
-msgstr ""
+msgstr "User role names"
 
 msgid "User role ids"
-msgstr ""
+msgstr "User role ids"
 
 msgid "Deprecated: User Name"
-msgstr ""
+msgstr "Deprecated: User Name"
 
 msgid "Account Name"
-msgstr ""
+msgstr "Namn på konto"
 
 msgid "Display Name"
-msgstr ""
+msgstr "Visningsnamn"
 
 msgid "Email"
-msgstr ""
+msgstr "E-post"
 
 msgid "Last login"
-msgstr ""
+msgstr "Senaste inloggning"
 
 msgid "Link ID"
-msgstr ""
+msgstr "Länk-ID"
 
 msgid "Parent"
-msgstr ""
+msgstr "Ovanliggande"
 
 msgid "Root"
-msgstr ""
+msgstr "Rot"
 
 msgid "Page number"
-msgstr ""
+msgstr "Sidnummer"
 
 msgid "Query string value"
-msgstr ""
+msgstr "Värde på databasfråga"
 
 msgid "Relative URL"
-msgstr ""
+msgstr "Relativ URL"
 
 msgid "Absolute URL"
-msgstr ""
+msgstr "Fullständig URL"
 
 msgid "Brief URL"
-msgstr ""
+msgstr "Kort URL"
 
 msgid "Unaliased URL"
-msgstr ""
+msgstr "URL utan alias"
 
 msgid "Arguments"
-msgstr ""
+msgstr "Argument"
 
 msgid "First"
-msgstr ""
+msgstr "Första"
 
 msgid "Last"
-msgstr ""
+msgstr "Sista"
 
 msgid "Count"
-msgstr ""
+msgstr "Antal"
 
 msgid "Reversed"
-msgstr ""
+msgstr "Omvänd"
 
 msgid "Keys"
-msgstr ""
+msgstr "Nycklar"
 
 msgid "Imploded"
-msgstr ""
+msgstr "Imploderad"
 
 msgid "Value"
-msgstr ""
+msgstr "Värde"
 
 msgid "Number"
-msgstr ""
+msgstr "Tal"
 
 msgid "Height"
-msgstr ""
+msgstr "Höjd"
 
 msgid "Width"
-msgstr ""
+msgstr "Bredd"
 
 msgid "SEO"
-msgstr ""
+msgstr "Sökmotoroptimering"
 
 msgid "URI"
-msgstr ""
+msgstr "URI"
 
 msgid "Comment ID"
-msgstr ""
+msgstr "Kommentarens ID"
 
 msgid "IP Address"
-msgstr ""
+msgstr "IP-adress"
 
 msgid "Email address"
-msgstr ""
+msgstr "E-postadress"
 
 msgid "Home page"
-msgstr ""
+msgstr "Hemsida"
 
 msgid "Menu link count"
-msgstr ""
+msgstr "Antal menylänkar"
 
 msgid "Slogan"
-msgstr ""
+msgstr "Slogan"
 
 msgid "URL (brief)"
-msgstr ""
+msgstr "URL (kort)"
 
 msgid "Login page"
-msgstr ""
+msgstr "Inloggningssida"
 
 msgid "Short format"
-msgstr ""
+msgstr "Kort format"
 
 msgid "Medium format"
-msgstr ""
+msgstr "Mellanlångt format"
 
 msgid "Long format"
-msgstr ""
+msgstr "Långt format"
 
 msgid "Time-since"
-msgstr ""
+msgstr "Tid sedan"
 
 msgid "Raw timestamp"
-msgstr ""
+msgstr "Obearbetad tidsstämpel"
 
 msgid "Total rows"
-msgstr ""
+msgstr "Totalt antal rader"
 
 msgid "@label ID"
-msgstr ""
+msgstr "@label id"
 
 msgid "Text"
-msgstr ""
+msgstr "Text"
 
 msgid "Comment status"
-msgstr ""
+msgstr "Status för kommenterar"
 
 msgid "Last comment timestamp"
-msgstr ""
+msgstr "Tidsstämpel för senaste kommentar"
 
 msgid "Last comment name"
-msgstr ""
+msgstr "Namn för senaste kommentar"
 
 msgid "Last comment user ID"
-msgstr ""
+msgstr "ID-nummer för användare för senaste kommentar"
 
 msgid "Number of comments"
-msgstr ""
+msgstr "Antal kommentarer"
 
 msgid "Disqus status value"
-msgstr ""
+msgstr "Disqus status value"
 
 msgid "Disqus thread identifier"
-msgstr ""
+msgstr "Disqus thread identifier"
 
 msgid "Alternative text"
-msgstr ""
+msgstr "Alternativ text"
 
 msgid "@type type with delta @delta"
-msgstr ""
+msgstr "Typ @type med @delta"
 
 msgid "Link text"
-msgstr ""
+msgstr "Länktext"
 
 msgid "Guide menu (en)"
-msgstr ""
+msgstr "Guide menu (en)"
 
 msgid "Menu for guide page (en)"
-msgstr ""
+msgstr "Menu for guide page (en)"
 
 msgid "Appears in: @bundles."
-msgstr ""
+msgstr "Förekommer i: @bundles."
 
 msgid "Also known as:"
-msgstr ""
+msgstr "Also known as:"
 
 msgid "@label (@name)"
-msgstr ""
+msgstr "@label (@name)"
 
 msgid "Main navigation (en)"
-msgstr ""
+msgstr "Main navigation (en)"
 
 msgid "User guide"
-msgstr ""
+msgstr "User guide"
 
 msgid "contact_message_event_form"
-msgstr ""
+msgstr "contact_message_event_form"
 
 msgid "Event"
-msgstr ""
+msgstr "Event"
 
 msgid "Event submission received."
-msgstr ""
+msgstr "Event submission received."
 
 msgid "Address"
-msgstr ""
+msgstr "Address"
 
 msgid "Where the event is located"
-msgstr ""
+msgstr "Where the event is located"
 
 msgid "End time"
-msgstr ""
+msgstr "End time"
 
 msgid "End time for the event."
-msgstr ""
+msgstr "End time for the event."
 
 msgid "Event link"
-msgstr ""
+msgstr "Event link"
 
 msgid ""
 "Link to event's official page, or a page with more information regarding the"
 " event."
 msgstr ""
+"Link to event's official page, or a page with more information regarding the"
+" event."
 
 msgid "Event picture"
-msgstr ""
+msgstr "Event picture"
 
 msgid "Picture or logo that can be used for the event page."
-msgstr ""
+msgstr "Picture or logo that can be used for the event page."
 
 msgid "Start time"
-msgstr ""
+msgstr "Start time"
 
 msgid "Start time of the event."
-msgstr ""
+msgstr "Start time of the event."
 
 msgid "Guide search"
-msgstr ""
+msgstr "Guide search"
 
 msgid "Guide search view"
-msgstr ""
+msgstr "Guide search view"
 
 msgid "Master"
-msgstr ""
+msgstr "Huvud"
 
 msgid "No matching results"
-msgstr ""
+msgstr "No matching results"
 
 msgid "Synchronizing configuration: @op @name."
-msgstr ""
+msgstr "Synkroniserar konfiguration: @op @name."
 
 msgid "Finalizing configuration synchronization."
-msgstr ""
+msgstr "Avslutar synkronisering av konfiguration."
 
 msgid "Unexpected error during import with operation @op for @name: @message"
-msgstr ""
+msgstr "Oväntat fel under import med funktion @op för @name: @message"
 
 msgid "This will also remove 1 placed block instance."
 msgid_plural "This will also remove @count placed block instances."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "This will also remove 1 placed block instance."
+msgstr[1] "This will also remove @count placed block instances."
 
 msgid "Upload requirements"
-msgstr ""
+msgstr "Upload requirements"
 
 msgid "Deleted 1 comment."
 msgid_plural "Deleted @count comments."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Deleted 1 comment."
+msgstr[1] "Deleted @count comments."
 
 msgid "Deleted 1 post."
 msgid_plural "Deleted @count posts."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Deleted 1 post."
+msgstr[1] "Deleted @count posts."
 
 msgid "Recently modified"
-msgstr ""
+msgstr "Recently modified"
 
 msgid "for text search"
-msgstr ""
+msgstr "for text search"
 
 msgid "The username %value is already taken."
-msgstr ""
+msgstr "The username %value is already taken."
 
 msgid "The email address %value is already taken."
-msgstr ""
+msgstr "The email address %value is already taken."
 
 msgid "Development version open data portal."
-msgstr ""
+msgstr "Development version open data portal."
 
 msgid "%name is not recognized as a username or an email address."
-msgstr ""
+msgstr "%name is not recognized as a username or an email address."
 
 msgid "Read more"
-msgstr ""
+msgstr "Read more"
 
 msgid ""
 "In case there is an open data event missing from the list below, you may "
 "submit event information to us and we'll add it."
 msgstr ""
+"In case there is an open data event missing from the list below, you may "
+"submit event information to us and we'll add it."
 
 msgid "Submit an event"
-msgstr ""
+msgstr "Submit an event"
 
 msgid "Free text search"
-msgstr ""
+msgstr "Free text search"
 
 msgid "Showing events"
-msgstr ""
+msgstr "Showing events"
 
 msgid "Show past events"
-msgstr ""
+msgstr "Show past events"
 
 msgid "Read more >>"
-msgstr ""
+msgstr "Read more >>"
 
 msgid "No recently modified data sets found"
-msgstr ""
+msgstr "No recently modified data sets found"
 
 msgid "No new data sets found"
-msgstr ""
+msgstr "No new data sets found"
 
 msgid "No popular data sets found"
-msgstr ""
+msgstr "No popular data sets found"
 
 msgid "News and articles"
 msgstr "Aktuellt"
@@ -25224,42 +27816,47 @@ msgid "Categories"
 msgstr "Kategorier"
 
 msgid "Finnish open data portal"
-msgstr ""
+msgstr "Finnish open data portal"
 
 msgid "No articles found."
 msgstr "Inga artiklar hittades."
 
 msgid "1 block is available in the modified list."
 msgid_plural "@count blocks are available in the modified list."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "1 block is available in the modified list."
+msgstr[1] "@count blocks are available in the modified list."
 
 msgid ""
 "Events calendar displays various open data related events hosted in Finland "
 "and abroad."
 msgstr ""
+"Events calendar displays various open data related events hosted in Finland "
+"and abroad."
 
 msgid "All Finnish open data from one place"
-msgstr ""
+msgstr "All Finnish open data from one place"
 
 msgid ""
 "Open data is information that is stored on a computer, for example "
 "structural text, tables, maps and images. Open data can be used freely when "
 "also providing it's origin."
 msgstr ""
+"Open data is information that is stored on a computer, for example "
+"structural text, tables, maps and images. Open data can be used freely when "
+"also providing it's origin."
 
 msgid "Search datasets..."
-msgstr ""
+msgstr "Search datasets..."
 
 msgid "Recent"
-msgstr ""
+msgstr "Recent"
 
 msgid "Popular"
-msgstr ""
+msgstr "Popular"
 
 msgctxt "x datasets"
 msgid "Datasets"
-msgstr ""
+msgstr "Datasets"
 
 msgctxt "x organizations"
 msgid "Organizations"
@@ -25267,13 +27864,13 @@ msgstr "Organisationer"
 
 msgctxt "x applications"
 msgid "Applications"
-msgstr ""
+msgstr "Applications"
 
 msgid "Datasets"
-msgstr ""
+msgstr "Datasets"
 
 msgid "Applications"
-msgstr ""
+msgstr "Applications"
 
 msgid "Organizations"
 msgstr "Organisationer"
@@ -25282,408 +27879,443 @@ msgid "Open data categories"
 msgstr "Öppna data kategorier"
 
 msgid "Utilize data sets"
-msgstr ""
+msgstr "Utilize data sets"
 
 msgid "Browse data sets"
-msgstr ""
+msgstr "Browse data sets"
 
 msgid "Offer data for use"
-msgstr ""
+msgstr "Offer data for use"
 
 msgid ""
 "Does your organization generate data, which could be useful or interesting "
 "for other users? We offer guidance and a way to distribute your data sets."
 msgstr ""
+"Does your organization generate data, which could be useful or interesting "
+"for other users? We offer guidance and a way to distribute your data sets."
 
 msgid "Begin data distribution"
-msgstr ""
+msgstr "Begin data distribution"
 
 msgid "Find and examine applications"
-msgstr ""
+msgstr "Find and examine applications"
 
 msgid ""
 "Different ways of applying data bring it alive in a concrete way. You can "
 "find a collection of applications and visualizations that use open data from"
 " our gallery."
 msgstr ""
+"Different ways of applying data bring it alive in a concrete way. You can "
+"find a collection of applications and visualizations that use open data from"
+" our gallery."
 
 msgid "Application gallery"
-msgstr ""
+msgstr "Application gallery"
 
 msgctxt "recently modified datasets"
 msgid "Recently modified"
-msgstr ""
+msgstr "Recently modified"
 
 msgctxt "new datasets"
 msgid "New"
-msgstr ""
+msgstr "New"
 
 msgctxt "popular datasets"
 msgid "Popular"
-msgstr ""
+msgstr "Popular"
 
 msgid "More recently modified datasets"
-msgstr ""
+msgstr "More recently modified datasets"
 
 msgid "Release date"
-msgstr ""
+msgstr "Release date"
 
 msgid "More new data sets"
-msgstr ""
+msgstr "More new data sets"
 
 msgid "More popular datasets"
-msgstr ""
+msgstr "More popular datasets"
 
 msgid ""
 "Central Open Data distribution platform for datasets released by finnish "
 "individuals, companies and public organizations."
 msgstr ""
+"Central Open Data distribution platform for datasets released by finnish "
+"individuals, companies and public organizations."
 
 msgid "Service provided by Population Register Centre"
-msgstr ""
+msgstr "Service provided by Population Register Centre"
 
 msgid "Follow us"
 msgstr "Följ oss"
 
 msgid "Updating translations for JavaScript and default configuration."
-msgstr ""
+msgstr "Updating translations for JavaScript and default configuration."
 
 msgid "Updated default configuration."
-msgstr ""
+msgstr "Updated default configuration."
 
 msgid "Finnish"
-msgstr ""
+msgstr "Finnish"
 
 msgid "Swedish"
-msgstr ""
+msgstr "Swedish"
 
 msgid "JavaScript"
-msgstr ""
+msgstr "JavaScript"
 
 msgid "Popovers"
-msgstr ""
+msgstr "Popovers"
 
 msgid "Tooltips"
-msgstr ""
+msgstr "Tooltips"
 
 msgid "Modals"
-msgstr ""
+msgstr "Modals"
 
 msgid "CDN (Content Delivery Network)"
-msgstr ""
+msgstr "CDN (Content Delivery Network)"
 
 msgid "Advanced Cache"
-msgstr ""
+msgstr "Advanced Cache"
 
 msgid "Custom URLs"
-msgstr ""
+msgstr "Custom URLs"
 
 msgid "Navbar"
-msgstr ""
+msgstr "Navbar"
 
 msgid "Region Wells"
-msgstr ""
+msgstr "Region Wells"
 
 msgid "Images"
-msgstr ""
+msgstr "Images"
 
 msgid "Container"
-msgstr ""
+msgstr "Container"
 
 msgid "Tables"
-msgstr ""
+msgstr "Tables"
 
 msgid "Etusivu"
-msgstr ""
+msgstr "Etusivu"
 
 msgid "Tietoaineistot"
-msgstr ""
+msgstr "Tietoaineistot"
 
 msgid "Organisaatiot"
-msgstr ""
+msgstr "Organisaatiot"
 
 msgid "Käyttösovellukset"
-msgstr ""
+msgstr "Käyttösovellukset"
 
 msgid "Ajankohtaista"
-msgstr ""
+msgstr "Ajankohtaista"
 
 msgid "Opas"
-msgstr ""
+msgstr "Opas"
 
 msgid "Lisää"
-msgstr ""
+msgstr "Lisää"
 
 msgid "Kirjaudu sisään"
-msgstr ""
+msgstr "Kirjaudu sisään"
 
 msgid "Rekisteröidy palveluun"
-msgstr ""
+msgstr "Rekisteröidy palveluun"
 
 msgid "Profiili"
-msgstr ""
+msgstr "Profiili"
 
 msgid "Kirjaudu ulos"
-msgstr ""
+msgstr "Kirjaudu ulos"
 
 msgid "Tapahtumakalenteri"
-msgstr ""
+msgstr "Tapahtumakalenteri"
 
 msgid "Avoindata.fi"
-msgstr ""
+msgstr "Avoindata.fi"
 
 msgid "All Finnish open data from one place."
-msgstr ""
+msgstr "All Finnish open data from one place."
 
 msgid "Show all"
-msgstr ""
+msgstr "Show all"
 
 msgid "Type what are you searching for"
-msgstr ""
+msgstr "Type what are you searching for"
 
 msgid ""
 "Avoindata.fi service offers over 1000 interesting data sets available for "
 "everyone to download, inspect and use freely."
 msgstr ""
+"Avoindata.fi service offers over 1000 interesting data sets available for "
+"everyone to download, inspect and use freely."
 
 msgid "Date modified"
-msgstr ""
+msgstr "Date modified"
 
 msgid "Most recent applications"
-msgstr ""
+msgstr "Most recent applications"
 
 msgid "Show all applications"
-msgstr ""
+msgstr "Show all applications"
 
 msgid "Newsfeed"
-msgstr ""
+msgstr "Newsfeed"
 
 msgid "All News"
-msgstr ""
+msgstr "All News"
 
 msgid "Events"
-msgstr ""
+msgstr "Events"
 
 msgid "All Events"
-msgstr ""
+msgstr "All Events"
 
 msgid "Enter the password that accompanies your username."
-msgstr ""
+msgstr "Ange lösenordet för ditt konto."
 
 msgid "Register new account"
 msgstr "Registrera ett nytt konto"
 
 msgid "Download feature"
-msgstr ""
+msgstr "Download feature"
 
 msgid "Add and configure"
-msgstr ""
+msgstr "Add and configure"
 
 msgid "Save and add"
-msgstr ""
+msgstr "Save and add"
 
 msgid "Update style"
-msgstr ""
+msgstr "Update style"
 
 msgid "Write"
-msgstr ""
+msgstr "Write"
 
 msgid "Restore"
-msgstr ""
+msgstr "Restore"
 
 msgid "Rebuild"
-msgstr ""
+msgstr "Rebuild"
 
 msgid "format"
-msgstr ""
+msgstr "format"
 
 msgid "Comment types"
-msgstr ""
+msgstr "Kommentarstyper"
 
 msgid "Form modes"
-msgstr ""
+msgstr "Form modes"
 
 msgid "Disqus"
-msgstr ""
+msgstr "Disqus"
 
 msgid "Date and time formats"
-msgstr ""
+msgstr "Format för datum och tid"
 
 msgid "Search API"
-msgstr ""
+msgstr "Search API"
 
 msgid "Metatag"
-msgstr ""
+msgstr "Metatag"
 
 msgid "Easy Breadcrumb"
-msgstr ""
+msgstr "Easy Breadcrumb"
 
 msgid "Text formats and editors"
-msgstr ""
+msgstr "Textformat och redigerare"
 
 msgid "Font Awesome Settings"
-msgstr ""
+msgstr "Font Awesome Settings"
 
 msgid "Honeypot configuration"
-msgstr ""
+msgstr "Konfiguration av Honeypot"
 
 msgid "CAPTCHA module settings"
-msgstr ""
+msgstr "CAPTCHA module settings"
 
 msgid "Field list"
-msgstr ""
+msgstr "Fältlista"
 
 msgid "Available translation updates"
-msgstr ""
+msgstr "Tillgängliga uppdateringar för översättning"
 
 msgid "List and edit site comments and the comment approval queue."
 msgstr ""
+"Visa och redigera webbplatsen kommentarer och godkännandekön för "
+"kommentarer."
 
 msgid "Manage custom form modes."
-msgstr ""
+msgstr "Hantera anpassade formulärslägen."
 
 msgid "Manage tagging, categorization, and classification of your content."
 msgstr ""
+"Hantera etikettering, kategorisering och klassificering av ditt innehåll."
 
 msgid "Administer blocks, content types, menus, etc."
-msgstr ""
+msgstr "Administrera block, innehållstyper, menyer, etcetera."
 
 msgid "Administer how and where CAPTCHA is used."
-msgstr ""
+msgstr "Administer how and where CAPTCHA is used."
 
 msgid ""
 "Allow for site emails to be sent through an SMTP server of your choice."
 msgstr ""
+"Allow for site emails to be sent through an SMTP server of your choice."
 
 msgid ""
 "Configure tracking behavior to get insights into your website traffic and "
 "marketing effectiveness."
 msgstr ""
+"Configure tracking behavior to get insights into your website traffic and "
+"marketing effectiveness."
 
 msgid "Manage automatic site maintenance tasks."
-msgstr ""
+msgstr "Hantera automatiska underhållsuppgifter för webbplatsen."
 
 msgid "Configure basic site settings, actions, and cron."
 msgstr ""
+"Konfigurera grundläggande inställningar för webbplats, åtgärder och "
+"schemalagda aktiviteter."
 
 msgid "Global settings for the display of Font Awesome icons."
-msgstr ""
+msgstr "Global settings for the display of Font Awesome icons."
 
 msgid ""
 "Configure Honeypot spam prevention and the forms on which Honeypot will be "
 "used."
 msgstr ""
+"Konfigurera spamförebyggande för Honeypot och de formulär som Honeypot "
+"kommer att användas på."
 
 msgid "Controls settings for the module Easy Breadcrumb"
-msgstr ""
+msgstr "Controls settings for the module Easy Breadcrumb"
 
 msgid ""
 "Choose which image toolkit to use if you have installed optional toolkits."
 msgstr ""
+"Välj vilket bildbehandlingsverktyg som skall användas om du har flera "
+"installerade."
 
 msgid "Configure Metatag defaults."
-msgstr ""
+msgstr "Configure Metatag defaults."
 
 msgid "Create and configure search indexes and servers."
-msgstr ""
+msgstr "Create and configure search indexes and servers."
 
 msgid "Provides configuration options for the Disqus comment system."
-msgstr ""
+msgstr "Provides configuration options for the Disqus comment system."
 
 msgid ""
 "Get a status report about available interface translations for your "
 "installed modules and themes."
 msgstr ""
+"Få en statusrapport om tillgängliga gränssnittsöversättningar för dina "
+"installerade moduler och teman."
 
 msgid "Overview of plugins used in all views."
-msgstr ""
+msgstr "Översikt av insticksprogram som används i alla vyer."
 
 msgid "Profile"
-msgstr ""
+msgstr "Profile"
 
 msgid "Logout"
-msgstr ""
+msgstr "Logout"
 
 msgid "CustomMessage: !customMessage"
-msgstr ""
+msgstr "Anpassat meddelande: !customMessage"
 
 msgid "Allows users to translate content entities."
-msgstr ""
+msgstr "Allows users to translate content entities."
 
 msgid "Tray @action."
-msgstr ""
+msgstr "Tray @action."
 
 msgid "!tour_item of !total"
-msgstr ""
+msgstr "!tour_item av !total"
 
 msgid "Random number generation"
-msgstr ""
+msgstr "Random number generation"
 
 msgid "Font Awesome 5"
-msgstr ""
+msgstr "Font Awesome 5"
 
 msgid "Trusted Host Settings"
-msgstr ""
+msgstr "Trusted Host Settings"
 
 msgid ""
 "External resources can be optimized automatically, which can reduce both the"
 " size and number of requests made to your website."
 msgstr ""
+"Externa resurser kan optimeras automatiskt, vilket kan minska både storlek "
+"och antal förfrågningar till din webbplats."
 
 msgid "Configure page caching strategy with APE."
-msgstr ""
+msgstr "Configure page caching strategy with APE."
 
 msgid ""
 "The CAPTCHA module will disable the caching of pages that contain a CAPTCHA "
 "element."
 msgstr ""
+"The CAPTCHA module will disable the caching of pages that contain a CAPTCHA "
+"element."
 
 msgid ""
 "Drupal provides an <a href=\":module_enable\">Internal Page Cache module</a>"
 " that is recommended for small to medium-sized websites."
 msgstr ""
+"Drupal provides an <a href=\":module_enable\">Internal Page Cache module</a>"
+" that is recommended for small to medium-sized websites."
 
 msgid "CAPTCHA"
-msgstr ""
+msgstr "CAPTCHA"
 
 msgid "Aggregate CSS files"
-msgstr ""
+msgstr "Aggregate CSS files"
 
 msgid "The website encountered an unexpected error. Please try again later."
-msgstr ""
+msgstr "Webbplatsen stötte på ett oväntat fel. Var vänlig försök igen senare."
 
 msgid ""
 "The toolbar cannot be set to a horizontal orientation when it is locked."
 msgstr ""
+"Verktygsraden kan inte vara inställd till en horisontell orientering när den"
+" är låst."
 
 msgid "@label"
-msgstr ""
+msgstr "@label"
 
 msgid "System maintenance"
-msgstr ""
+msgstr "System maintenance"
 
 msgid "System information"
-msgstr ""
+msgstr "System information"
 
 msgid ""
 "This page lists all configuration items on your site that have translatable "
 "text, like your site name, role names, etc."
 msgstr ""
+"This page lists all configuration items on your site that have translatable "
+"text, like your site name, role names, etc."
 
 msgid "Horizontal orientation"
-msgstr ""
+msgstr "Horisontell orientering"
 
 msgid "Tray \"@tray\" @action."
-msgstr ""
+msgstr "Tray \"@tray\" @action."
 
 msgid "Leave blank to show all strings. The search is case sensitive."
 msgstr ""
+"Lämna tomt för att visa alla textsträngar. Sökningen skiljer på stora och "
+"små bokstäver."
 
 msgid "Go to page @key"
-msgstr ""
+msgstr "Go to page @key"
 
 msgid "Provides Drush commands for language manipulation"
-msgstr ""
+msgstr "Provides Drush commands for language manipulation"
 
 msgid ""
 "This page allows a translator to search for specific translated and "
@@ -25694,12 +28326,19 @@ msgid ""
 " translation editor.) Searches may be limited to strings in a specific "
 "language."
 msgstr ""
+"This page allows a translator to search for specific translated and "
+"untranslated strings, and is used when creating or editing translations. "
+"(Note: Because translation tasks involve many strings, it may be more "
+"convenient to <a title=\"User interface translation export\" "
+"href=\":export\">export</a> strings for offline editing in a desktop Gettext"
+" translation editor.) Searches may be limited to strings in a specific "
+"language."
 
 msgid "Source text only, no translations"
-msgstr ""
+msgstr "Enbart källtext, inga översättningar"
 
 msgid "Interface translation export"
-msgstr ""
+msgstr "Interface translation export"
 
 msgid ""
 "This page exports the translated strings used by your site. An export file "
@@ -25709,224 +28348,272 @@ msgid ""
 "includes the original strings only (used to create new translations with a "
 "Gettext translation editor)."
 msgstr ""
+"Denna sida exporterar översatta strängar som används på din webbplats. En "
+"exporterad fil kan vara i formatet Gettext Portable Object (<em>.po</em>), "
+"vilken inkluderar både originalsträngen och den översatta (används för att "
+"dela översättningar med andra), eller i formatet Gettext Portable Object "
+"Template (<em>.pot</em>) vilket bara innehåller originalsträngarna (används "
+"för att skapa nya översättningar med ett Gettext-översättningsprogram)."
 
 msgid ""
 "There was a problem checking <a href=\":update-report\">available "
 "updates</a> for Drupal."
 msgstr ""
+"There was a problem checking <a href=\":update-report\">available "
+"updates</a> for Drupal."
 
 msgid "Tuottajat"
-msgstr ""
+msgstr "Tuottajat"
 
 msgid "Field storage"
-msgstr ""
+msgstr "Field storage"
 
 msgid "Performance and scalability"
-msgstr ""
+msgstr "Performance and scalability"
 
 msgid "Examples"
-msgstr ""
+msgstr "Examples"
 
 msgid "Chaos tool suite (Experimental)"
-msgstr ""
+msgstr "Chaos tool suite (Experimental)"
 
 msgid "Enter a part of the module name or description"
-msgstr ""
+msgstr "Ange en del av modulnamnet eller beskrivning"
 
 msgid ""
 "Machine name: <span dir=\"ltr\" class=\"table-filter-text-source\">@machine-"
 "name</span>"
 msgstr ""
+"Machine name: <span dir=\"ltr\" class=\"table-filter-text-source\">@machine-"
+"name</span>"
 
 msgid ""
 "Aggregates syndicated content (RSS, RDF, and Atom feeds) from external "
 "sources."
 msgstr ""
+"Aggregates syndicated content (RSS, RDF, and Atom feeds) from external "
+"sources."
 
 msgid ""
 "Provides an automated way to run cron jobs, by executing them at the end of "
 "a server response."
 msgstr ""
+"Provides an automated way to run cron jobs, by executing them at the end of "
+"a server response."
 
 msgid "Configure <span class=\"visually-hidden\">the @module module</span>"
-msgstr ""
+msgstr "Configure <span class=\"visually-hidden\">the @module module</span>"
 
 msgid ""
 "Sends pages using the BigPipe technique that allows browsers to show them "
 "much faster."
 msgstr ""
+"Sends pages using the BigPipe technique that allows browsers to show them "
+"much faster."
 
 msgid ""
 "Controls the visual building blocks a page is constructed with. Blocks are "
 "boxes of content rendered into an area, or region, of a web page."
 msgstr ""
+"Styr de visuella byggstenarna som en sida är uppbyggt av. Block är rutor med"
+" innehåll som återges på en plats, eller en region, på en webbsida."
 
 msgid "Manage breakpoints and breakpoint groups for responsive designs."
-msgstr ""
+msgstr "Manage breakpoints and breakpoint groups for responsive designs."
 
 msgid "Allows administrators to manage configuration changes."
-msgstr ""
+msgstr "Allows administrators to manage configuration changes."
 
 msgid "Provides moderation states for content."
-msgstr ""
+msgstr "Provides moderation states for content."
 
 msgid "Allows administrators to create custom menu links."
-msgstr ""
+msgstr "Allows administrators to create custom menu links."
 
 msgid "Records which user has read which content."
-msgstr ""
+msgstr "Records which user has read which content."
 
 msgid ""
 "Places error messages adjacent to form inputs, for improved usability and "
 "accessibility."
 msgstr ""
+"Places error messages adjacent to form inputs, for improved usability and "
+"accessibility."
 
 msgid "Caches pages for any user, handling dynamic content correctly."
-msgstr ""
+msgstr "Caches pages for any user, handling dynamic content correctly."
 
 msgid ""
 "Caches pages for anonymous users. Use when an external page cache is not "
 "available."
 msgstr ""
+"Caches pages for anonymous users. Use when an external page cache is not "
+"available."
 
 msgid ""
 "Allows users to add and arrange blocks and content fields directly on the "
 "content."
 msgstr ""
+"Allows users to add and arrange blocks and content fields directly on the "
+"content."
 
 msgid "Provides a way for modules or themes to register layouts."
-msgstr ""
+msgstr "Provides a way for modules or themes to register layouts."
 
 msgid "Manages the creation, configuration, and display of media items."
-msgstr ""
+msgstr "Manages the creation, configuration, and display of media items."
 
 msgid ""
 "Enriches your content with metadata to let other applications (e.g. search "
 "engines, aggregators) better understand its relationships and attributes."
 msgstr ""
+"Berikar ditt innehåll med metadata för att låta andra applikationer (till "
+"exempel sökmotorer och innehållssamlare) bättre förstå dess relation och "
+"attribut."
 
 msgid ""
 "Allows users to directly edit the configuration of blocks on the current "
 "page."
 msgstr ""
+"Allows users to directly edit the configuration of blocks on the current "
+"page."
 
 msgid "Logs content statistics for your site."
-msgstr ""
+msgstr "Logs content statistics for your site."
 
 msgid ""
 "Provides a means to associate text formats with text editor libraries such "
 "as WYSIWYGs or toolbars."
 msgstr ""
+"Provides a means to associate text formats with text editor libraries such "
+"as WYSIWYGs or toolbars."
 
 msgid ""
 "Provides a toolbar that shows the top-level administration menu items and "
 "links from other modules."
 msgstr ""
+"Tillhandahåller en verktygsrad som visar de översta menyvalen för "
+"administration och länkar från andra moduler."
 
 msgid "Create customized lists and queries from your database."
-msgstr ""
+msgstr "Skapa anpassade listor och frågor från din databas."
 
 msgid ""
 "Provides UI and API for managing workflows. This module can be used with the"
 " Content moderation module to add highly customizable workflows to content."
 msgstr ""
+"Provides UI and API for managing workflows. This module can be used with the"
+" Content moderation module to add highly customizable workflows to content."
 
 msgid ""
 "Provides a number of utility and helper APIs for Drupal developers and site "
 "builders."
 msgstr ""
+"Provides a number of utility and helper APIs for Drupal developers and site "
+"builders."
 
 msgid ""
 "Provides improvements to blocks that will one day be added to Drupal core."
 msgstr ""
+"Provides improvements to blocks that will one day be added to Drupal core."
 
 msgid ""
 "A set of improvements to the core Views code that allows for greater control"
 " over Blocks."
 msgstr ""
+"A set of improvements to the core Views code that allows for greater control"
+" over Blocks."
 
 msgid ""
 "Allows users to configure the display and form display by arranging fields "
 "in several columns."
 msgstr ""
+"Allows users to configure the display and form display by arranging fields "
+"in several columns."
 
 msgid ""
 "Enhances the media list with additional features to more easily find and use"
 " existing media items."
 msgstr ""
+"Enhances the media list with additional features to more easily find and use"
+" existing media items."
 
 msgid "Provides a requirement for multilingual migrations."
-msgstr ""
+msgstr "Provides a requirement for multilingual migrations."
 
 msgid ""
 "Allows users to stage content or preview a full site by using multiple "
 "workspaces on a single site."
 msgstr ""
+"Allows users to stage content or preview a full site by using multiple "
+"workspaces on a single site."
 
 msgid "Creates app feed component"
-msgstr ""
+msgstr "Creates app feed component"
 
 msgid "Shows Articles page"
-msgstr ""
+msgstr "Shows Articles page"
 
 msgid "Creates categories component"
-msgstr ""
+msgstr "Creates categories component"
 
 msgid "Creates dataset list component"
-msgstr ""
+msgstr "Creates dataset list component"
 
 msgid "Shows Events page"
-msgstr ""
+msgstr "Shows Events page"
 
 msgid "Creates footer component"
-msgstr ""
+msgstr "Creates footer component"
 
 msgid "Manages the guide and its menu"
-msgstr ""
+msgstr "Manages the guide and its menu"
 
 msgid "Creates a header"
-msgstr ""
+msgstr "Creates a header"
 
 msgid "Creates a hero component"
-msgstr ""
+msgstr "Creates a hero component"
 
 msgid "Creates infobox component"
-msgstr ""
+msgstr "Creates infobox component"
 
 msgid "Creates news feed component"
-msgstr ""
+msgstr "Creates news feed component"
 
 msgid "Creates servicemessage component"
-msgstr ""
+msgstr "Creates servicemessage component"
 
 msgid "Modifies user validation"
-msgstr ""
+msgstr "Modifies user validation"
 
 msgid "Examples of how Drupal 8 migration compares to previous versions."
-msgstr ""
+msgstr "Examples of how Drupal 8 migration compares to previous versions."
 
 msgid "Specialized examples of Drupal 8 migration."
-msgstr ""
+msgstr "Specialized examples of Drupal 8 migration."
 
 msgid "Simple JSON Migration example"
-msgstr ""
+msgstr "Simple JSON Migration example"
 
 msgid "Defines datetime form elements and a datetime field type."
-msgstr ""
+msgstr "Defines datetime form elements and a datetime field type."
 
 msgid "Provides the ability to store end dates."
-msgstr ""
+msgstr "Provides the ability to store end dates."
 
 msgid "Defines an image field type and provides image manipulation tools."
-msgstr ""
+msgstr "Defines an image field type and provides image manipulation tools."
 
 msgid "Provides a simple link field type."
-msgstr ""
+msgstr "Provides a simple link field type."
 
 msgid ""
 "Offers an implementation of the Search API that uses database tables for "
 "indexing content."
 msgstr ""
+"Offers an implementation of the Search API that uses database tables for "
+"indexing content."
 
 msgid ""
 "Enable this module for a best-practice default setup of Search API with the "
@@ -25934,82 +28621,91 @@ msgid ""
 "module again for performance reasons. The provided configuration will not be"
 " removed."
 msgstr ""
+"Enable this module for a best-practice default setup of Search API with the "
+"Database backend. After installation it is recommended to uninstall this "
+"module again for performance reasons. The provided configuration will not be"
+" removed."
 
 msgid "Provides a generic framework for modules offering search capabilities."
 msgstr ""
+"Provides a generic framework for modules offering search capabilities."
 
 msgid "Drush support for direct upgrades from older Drupal versions."
-msgstr ""
+msgstr "Drush support for direct upgrades from older Drupal versions."
 
 msgid "Handles migrations"
-msgstr ""
+msgstr "Handles migrations"
 
 msgid "Contains migrations from older Drupal versions."
-msgstr ""
+msgstr "Contains migrations from older Drupal versions."
 
 msgid "Provides a user interface for migrating from older Drupal versions."
-msgstr ""
+msgstr "Provides a user interface for migrating from older Drupal versions."
 
 msgid "Enhancements to core migration support"
-msgstr ""
+msgstr "Enhancements to core migration support"
 
 msgid "Tools to assist in developing and running migrations."
-msgstr ""
+msgstr "Tools to assist in developing and running migrations."
 
 msgid "Provides a translation interface for configuration."
-msgstr ""
+msgstr "Provides a translation interface for configuration."
 
 msgid "Uses the Disqus web service to enhance comments."
-msgstr ""
+msgstr "Uses the Disqus web service to enhance comments."
 
 msgid "Provides configurable path based breadcrumbs."
-msgstr ""
+msgstr "Provides configurable path based breadcrumbs."
 
 msgid ""
 "Allows an entity type to borrow the fields and display configuration of "
 "another entity type."
 msgstr ""
+"Allows an entity type to borrow the fields and display configuration of "
+"another entity type."
 
 msgid "The most popular icon set and toolkit on the web."
-msgstr ""
+msgstr "The most popular icon set and toolkit on the web."
 
 msgid "Adds a Font Awesome Media Entity Type."
-msgstr ""
+msgstr "Adds a Font Awesome Media Entity Type."
 
 msgid "Allows version-dependent and shared usage of external libraries."
-msgstr ""
+msgstr "Tillåter versionsberoende och delade användning av externa bibliotek."
 
 msgid "Allows users to redirect from old URLs to new URLs."
-msgstr ""
+msgstr "Allows users to redirect from old URLs to new URLs."
 
 msgid ""
 "Logs 404 errors and allows users to create redirects for often requested but"
 " missing pages."
 msgstr ""
+"Logs 404 errors and allows users to create redirects for often requested but"
+" missing pages."
 
 msgid "Allows users to redirect between domains."
-msgstr ""
+msgstr "Allows users to redirect between domains."
 
 msgid "Twig filters for value(s) and label."
-msgstr ""
+msgstr "Twig filters for value(s) and label."
 
 msgid "Provides some extra Twig functions and filters."
-msgstr ""
+msgstr "Provides some extra Twig functions and filters."
 
 msgid "Allows finer control of the Cache Control header."
-msgstr ""
+msgstr "Allows finer control of the Cache Control header."
 
 msgid "Adds endpoints and functionality for testing ape."
-msgstr ""
+msgstr "Adds endpoints and functionality for testing ape."
 
 msgid "Manage meta tags for all entities."
-msgstr ""
+msgstr "Manage meta tags for all entities."
 
 msgid "Provides metatag support for Page Manager variants."
-msgstr ""
+msgstr "Provides metatag support for Page Manager variants."
 
 msgid "Provides support for applinks.org meta tags."
-msgstr ""
+msgstr "Provides support for applinks.org meta tags."
 
 msgid ""
 "Provides the fifteen <a "
@@ -26017,130 +28713,157 @@ msgid ""
 "Set 1.1</a> meta tags from the <a href=\"http://dublincore.org/\">Dublin "
 "Core Metadata Institute</a>."
 msgstr ""
+"Provides the fifteen <a "
+"href=\"http://dublincore.org/documents/dces/\">Dublin Core Metadata Element "
+"Set 1.1</a> meta tags from the <a href=\"http://dublincore.org/\">Dublin "
+"Core Metadata Institute</a>."
 
 msgid ""
 "Provides forty additional meta tags from the <a "
 "href=\"http://dublincore.org/\">Dublin Core Metadata Institute</a>."
 msgstr ""
+"Provides forty additional meta tags from the <a "
+"href=\"http://dublincore.org/\">Dublin Core Metadata Institute</a>."
 
 msgid ""
 "A set of meta tags specially for controlling advanced functionality with "
 "Facebook."
 msgstr ""
+"A set of meta tags specially for controlling advanced functionality with "
+"Facebook."
 
 msgid "Provides support for many different favicons."
-msgstr ""
+msgstr "Provides support for many different favicons."
 
 msgid "Provides support for meta tags used for Google Custom Search Engine."
-msgstr ""
+msgstr "Provides support for meta tags used for Google Custom Search Engine."
 
 msgid "Provides support for Google's Plus meta tags."
-msgstr ""
+msgstr "Provides support for Google's Plus meta tags."
 
 msgid ""
 "Provides support for the hreflang meta tag with some extra logic to simplify"
 " it."
 msgstr ""
+"Provides support for the hreflang meta tag with some extra logic to simplify"
+" it."
 
 msgid ""
 "Provides support for meta tags used to control the mobile browser "
 "experience."
 msgstr ""
+"Provides support for meta tags used to control the mobile browser "
+"experience."
 
 msgid "Provides support for Open Graph Protocol meta tags."
-msgstr ""
+msgstr "Provides support for Open Graph Protocol meta tags."
 
 msgid ""
 "Provides additional Open Graph Protocol meta tags for describing products."
 msgstr ""
+"Provides additional Open Graph Protocol meta tags for describing products."
 
 msgid "Provides support for Pinterest's custom meta tags."
-msgstr ""
+msgstr "Provides support for Pinterest's custom meta tags."
 
 msgid "Provides support for Twitter's Card meta tags."
-msgstr ""
+msgstr "Provides support for Twitter's Card meta tags."
 
 msgid "Verifies ownership of a site for search engines and other services."
-msgstr ""
+msgstr "Verifies ownership of a site for search engines and other services."
 
 msgid "Provides views integration for metatags."
-msgstr ""
+msgstr "Provides views integration for metatags."
 
 msgid "Provides the CAPTCHA API for adding challenges to arbitrary forms."
-msgstr ""
+msgstr "Provides the CAPTCHA API for adding challenges to arbitrary forms."
 
 msgid "Mitigates spam form submissions using the honeypot method."
 msgstr ""
+"Minskar inskickande av skräppostformulär med hjälp av metoden honungsfälla."
 
 msgid "Provides an image based CAPTCHA."
-msgstr ""
+msgstr "Tillhandahåller en bildbaserad CAPTCHA."
 
 msgid ""
 "Protect your website from spam and abuse while letting real people pass "
 "through with ease."
 msgstr ""
+"Protect your website from spam and abuse while letting real people pass "
+"through with ease."
 
 msgid "FontAwesome Menu Icons"
-msgstr ""
+msgstr "FontAwesome Menu Icons"
 
 msgid "Serializes entities using Hypertext Application Language."
-msgstr ""
+msgstr "Serializes entities using Hypertext Application Language."
 
 msgid "Provides the HTTP Basic authentication provider"
-msgstr ""
+msgstr "Provides the HTTP Basic authentication provider"
 
 msgid "Exposes entities as a JSON:API-specification-compliant web API."
-msgstr ""
+msgstr "Exposes entities as a JSON:API-specification-compliant web API."
 
 msgid "Exposes entities and other resources as RESTful web API"
-msgstr ""
+msgstr "Exposes entities and other resources as RESTful web API"
 
 msgid ""
 "Provides a service for (de)serializing data to/from formats such as JSON and"
 " XML"
 msgstr ""
+"Provides a service for (de)serializing data to/from formats such as JSON and"
+" XML"
 
 msgid ""
 "Regularly review and install <a href=\":updates\">available updates</a> to "
 "maintain a secure and current site. Always run the <a href=\":update-"
 "php\">update script</a> each time a module is updated."
 msgstr ""
+"Regularly review and install <a href=\":updates\">available updates</a> to "
+"maintain a secure and current site. Always run the <a href=\":update-"
+"php\">update script</a> each time a module is updated."
 
 msgid "Disqus comment"
-msgstr ""
+msgstr "Disqus comment"
 
 msgid ""
 "Provides a filter plugin that is in use in the following filter formats: "
 "%formats"
 msgstr ""
+"Provides a filter plugin that is in use in the following filter formats: "
+"%formats"
 
 msgid "content items"
-msgstr ""
+msgstr "content items"
 
 msgid "shortcut links"
-msgstr ""
+msgstr "shortcut links"
 
 msgid ""
 "The following modules will be completely uninstalled from your site, and "
 "<em>all data from these modules will be lost</em>!"
 msgstr ""
+"Följande moduler kommer att avinstalleras helt och hållet från webbplatsen, "
+"och <em>all data från dessa moduler kommer att försvinna</em>!"
 
 msgid "!modules modules are available in the modified list."
-msgstr ""
+msgstr "!modules modules are available in the modified list."
 
 msgid "Applicationsasd"
-msgstr ""
+msgstr "Applicationsasd"
 
 msgid "News"
-msgstr ""
+msgstr "News"
 
 msgid "The callback URL is not local and not trusted: !url"
-msgstr ""
+msgstr "URL för återanrop är inte lokalt och ej betrott: !url"
 
 msgid "Show all columns"
-msgstr ""
+msgstr "Visa alla kolumner"
 
 msgid ""
 "Show table cells that were hidden to make the table fit within a small "
 "screen."
 msgstr ""
+"Visa tabellceller som var dolda för att anpassa tabellen inom en liten "
+"skärm."


### PR DESCRIPTION
Translation files now include all translations, as importing empty strings break some admin translations.

If translation does not exist it is the same as in the source string. 