### PR TITLE
AV-1061: Layout fixes for dataset additional info table

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/additional_info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/additional_info.html
@@ -2,6 +2,10 @@
   <h3>{{ _('Additional Info') }}</h3>
   <div class="p-3 bg-depth-light30">
     <table class="table table-condensed mb-0">
+      <colgroup>
+        <col class="dataset-label">
+        <col class="dataset-details">
+      </colgroup>
       <thead>
         <tr>
           <th scope="col">{{ _('Field') }}</th>

--- a/modules/ytp-assets-common/src/less/ckan/upstream-overrides.less
+++ b/modules/ytp-assets-common/src/less/ckan/upstream-overrides.less
@@ -5,3 +5,17 @@
     color: #fff;
   }
 }
+
+.additional-info {
+  table.table {
+    table-layout: fixed;
+
+    .dataset-label {
+      width: 30%;
+    }
+
+    .dataset-details {
+      word-break: break-all;
+    }
+  }
+}


### PR DESCRIPTION
Using word-break: break-all due to IE not supporting smarter solutions.