### PR TITLE
AV-1055: Reduce FOUT by separating fonts to their own css and testing…

### DIFF
--- a/modules/avoindata-drupal-theme/avoindata.info.yml
+++ b/modules/avoindata-drupal-theme/avoindata.info.yml
@@ -28,3 +28,4 @@ libraries:
   - 'avoindata/bootstrap-scripts'
   - 'avoindata/fonts'
   - 'avoindata/avoindata-custom-elements'
+  - 'avoindata/webfonts'

--- a/modules/avoindata-drupal-theme/avoindata.libraries.yml
+++ b/modules/avoindata-drupal-theme/avoindata.libraries.yml
@@ -24,3 +24,8 @@ avoindata-custom-elements:
     - core/drupal
     - core/jquery
     - core/jquery.once
+webfonts:
+  css:
+    header: true
+    base:
+      '/resources/styles/fonts.css': {preprocess: false}

--- a/modules/ytp-assets-common/gulpfile.js
+++ b/modules/ytp-assets-common/gulpfile.js
@@ -30,6 +30,7 @@ var paths = {
     static_pages: "src/static_pages",
     font: "src/font/**/*",
     fonts: "src/fonts/**/*",
+    fontsCss: "src/less/fonts.less",
     scripts: "src/scripts/**/*",
     bootstrap_styles: "node_modules/bootstrap/less",
     bootstrap_scripts: "node_modules/bootstrap/js/*",
@@ -115,6 +116,21 @@ gulp.task("drupal_copy_custom_element_styles_to_plugin", (done) => {
     concat("style.css"),
     sourcemaps.write("./maps"),
     gulp.dest("../avoindata-drupal-ckeditor-plugins/css"),
+  ], done)
+});
+
+// Separate fonts to their own css to optimize their loading
+gulp.task("fontsCss", (done) => {
+  pump([
+    gulp.src(paths.src.fontsCss),
+    sourcemaps.init(),
+    less({paths: [paths.src.fontsCss]}),
+    prefixer({browsers: ['last 2 versions']}),
+    template({ timestamp: timestamp }),
+    cleancss({ keepBreaks: false }),
+    concat("fonts.css"),
+    sourcemaps.write("./maps"),
+    gulp.dest(paths.dist + "/styles"),
   ], done)
 });
 
@@ -272,6 +288,7 @@ gulp.task(
       "drupal_copy_custom_element_styles_to_plugin",
       "fonts",
       "font",
+      "fontsCss",
       "scripts")
   )
 );
@@ -298,7 +315,8 @@ gulp.task("watch_styles", () => {
       "vendor",
       "static_pages",
       "ckan",
-      "drupal"
+      "drupal",
+      "fontsCss"
     )
   );
 
@@ -315,6 +333,7 @@ gulp.task("watch_drupal_styles", () => {
     gulp.series(
       "drupal",
       "drupal_copy_custom_element_styles_to_plugin",
+      "fontsCss",
       "lint"
     )
   );

--- a/modules/ytp-assets-common/src/less/ckan/ckan.less
+++ b/modules/ytp-assets-common/src/less/ckan/ckan.less
@@ -4,8 +4,6 @@
 @common-path: '../..';
 @common-less: '@{common-path}/less';
 
-// Open Sans
-@import "@{common-less}/fonts.less";
 @import "@{common-less}/variables.less";
 @import "@{common-less}/mixins/mixins.less";
 @import "@{common-less}/navbars";

--- a/modules/ytp-assets-common/src/less/drupal/overrides.less
+++ b/modules/ytp-assets-common/src/less/drupal/overrides.less
@@ -21,9 +21,6 @@
 @common-path: "../../../src/";
 @common-less: "@{common-path}/less";
 
-// Open Sans
-@import "@{common-less}/fonts.less";
-
 // FontAwesome
 @import "@{common-path}/vendor/@fortawesome/fontawesome/less/fontawesome";
 @import "@{common-path}/vendor/@fortawesome/fontawesome/less/solid.less";

--- a/modules/ytp-assets-common/src/less/fonts.less
+++ b/modules/ytp-assets-common/src/less/fonts.less
@@ -5,6 +5,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 300;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-300.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans Light'),
@@ -21,6 +22,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 300;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-300italic.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans Light Italic'), local('OpenSans-LightItalic'),
@@ -36,6 +38,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-regular.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans Regular'), local('OpenSans-Regular'),
@@ -51,6 +54,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 400;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-italic.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans Italic'), local('OpenSans-Italic'),
@@ -66,6 +70,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 600;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-600.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans SemiBold'), local('OpenSans-SemiBold'),
@@ -81,6 +86,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 600;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-600italic.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans SemiBold Italic'), local('OpenSans-SemiBoldItalic'),
@@ -96,6 +102,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 700;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-700.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans Bold'), local('OpenSans-Bold'),
@@ -111,6 +118,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 700;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-700italic.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans Bold Italic'), local('OpenSans-BoldItalic'),
@@ -126,6 +134,7 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 800;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-800.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans ExtraBold'), local('OpenSans-ExtraBold'),
@@ -141,6 +150,7 @@
   font-family: 'Open Sans';
   font-style: italic;
   font-weight: 800;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/open-sans-v15-latin-800italic.eot'); /* IE9 Compat Modes */
   src:
     local('Open Sans ExtraBold Italic'), local('OpenSans-ExtraBoldItalic'),
@@ -156,6 +166,7 @@
   font-family: 'Source Sans Pro';
   font-style: normal;
   font-weight: 400;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/source-sans-pro-v13-latin-regular.eot'); /* IE9 Compat Modes */
   src:
     local('Source Sans Pro Regular'), local('SourceSansPro-Regular'),
@@ -171,6 +182,7 @@
   font-family: 'Source Sans Pro Light';
   font-style: normal;
   font-weight: 300;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/source-sans-pro-v13-latin-300.eot'); /* IE9 Compat Modes */
   src:
     local('Source Sans Pro Light'), local('SourceSansPro-Light'),
@@ -186,6 +198,7 @@
   font-family: 'Source Sans Pro SemiBold';
   font-style: normal;
   font-weight: 600;
+  font-display: block; /* or auto, swap, fallback, optional */
   src: url('/resources/fonts/source-sans-pro-v13-latin-600.eot'); /* IE9 Compat Modes */
   src:
     local('Source Sans Pro SemiBold'), local('SourceSansPro-SemiBold'),

--- a/modules/ytp-assets-common/src/resource.config
+++ b/modules/ytp-assets-common/src/resource.config
@@ -6,6 +6,7 @@ vendor/@fortawesome/fontawesome/css/all.css = 10
 vendor/@fortawesome/fontawesome/css/v4-shims.css = 9
 vendor/bootstrap/dist/css/bootstrap.css = 8
 vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css = 9
+styles/fonts.css = 8
 styles/ckan.css = 9
 vendor/moment/min/moment-with-locales.js = 5
 vendor/bootstrap/dist/js/bootstrap.js = 3

--- a/modules/ytp-assets-common/src/templates/head-styles-ckan.html
+++ b/modules/ytp-assets-common/src/templates/head-styles-ckan.html
@@ -1,4 +1,7 @@
-<link rel="preload" href="/resources/styles/fonts.css">
+<link rel="preload" href="/resources/fonts/source-sans-pro-v13-latin-regular.woff2" as="font">
+<link rel="preload" href="/resources/fonts/source-sans-pro-v13-latin-300.woff2" as="font">
+<link rel="preload" href="/resources/fonts/source-sans-pro-v13-latin-600.woff2" as="font">
+<link rel="preload" href="/resources/styles/fonts.css" as="style">
 {% resource "ytp_resources/styles/ckan.css" %}
 {% resource "ytp_resources/vendor/bootstrap/dist/css/bootstrap.css" %}
 {% resource "ytp_resources/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css" %}

--- a/modules/ytp-assets-common/src/templates/head-styles-ckan.html
+++ b/modules/ytp-assets-common/src/templates/head-styles-ckan.html
@@ -1,3 +1,4 @@
+<link rel="preload" href="/resources/styles/fonts.css">
 {% resource "ytp_resources/styles/ckan.css" %}
 {% resource "ytp_resources/vendor/bootstrap/dist/css/bootstrap.css" %}
 {% resource "ytp_resources/vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css" %}


### PR DESCRIPTION
… font-display block

Note: This is not an ideal fix for Drupal. Drupal doesn't give us a nice way to preload assets such as .css or fonts and instead always seems to reload assets after dom is rendered even if they were already preloaded elsewhere.