### PR TITLE
AV-932: Disallow creating datasets in non-approved organizations

### DIFF
--- a/cypress/integration/showcase_spec.js
+++ b/cypress/integration/showcase_spec.js
@@ -88,6 +88,14 @@ describe('Showcase tests', function() {
     // Organization
     const organization_name = 'testi_organisaatio';
     cy.create_new_organization(organization_name);
+    cy.logout();
+    cy.login_post_request('admin', 'administrator');
+    cy.visit('/');
+    cy.approve_organization(organization_name);
+    cy.logout();
+    cy.login_post_request('test-publisher', 'test-publisher');
+    
+    cy.visit(`/data/fi/organization/${organization_name}`)
 
     // Dataset linked to organization
     const dataset_form_data = {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -118,7 +118,19 @@ Cypress.Commands.add('create_new_organization', (organization_name, organization
   cy.url().should('include', `/data/fi/organization/${organization_name}`);
 })
 
-// Creates a new dataset filling both dataset and resource forms
+Cypress.Commands.add('approve_organization', (organization_id) => {
+  // Approves a previously created organization
+  cy.request({
+    method: 'POST',
+    url: "/data/fi/ckan-admin/organization_management",
+    form: true,
+    body: {
+      'org_id': organization_id,
+      'approval_status': 'approved'
+    }
+  });
+})
+
 Cypress.Commands.add('create_new_dataset', (dataset_name, dataset_form_data, resource_form_data, parent_organization) => {
 
   // Default values for dataset and resource forms
@@ -254,7 +266,11 @@ Cypress.Commands.add('edit_showcase', (showcase_name, showcase_form_data) => {
 // Deletes a showcase and verifies that it is not found in the search anymore
 Cypress.Commands.add('delete_showcase', (showcase_name) => {
   cy.get(`a[href='/data/fi/showcase/edit/${showcase_name}']`).click();
-  cy.get('.form-actions').contains('Poista').click();
+  cy.get('.form-actions').contains('Poista')
+    .should('have.attr', 'href')
+    .then((href) => {
+         cy.visit(href)
+    });
   cy.contains('Haluatko varmasti poistaa sovelluksen');
   cy.get('body').find('.btn').contains('Vahvista').click();
   cy.visit('/data/showcase');

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/group/read_base.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/group/read_base.html
@@ -3,6 +3,6 @@
 {% block breadcrumb_content %}
     <li>{% link_for _('Groups'), named_route=group_type+'_index' %}</li>
     <li class="active">
-        {% link_for h.get_translated(c.group_dict, 'title')|truncate(35), named_route=group_type+'_read', id=c.group_dict.name %}
+        {% link_for (h.get_translated(c.group_dict, 'title') or c.group_dict.name)|truncate(35), named_route=group_type+'_read', id=c.group_dict.name %}
     </li>
 {% endblock %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/read.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/organization/read.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{% block page_primary_action %}
+  {% if c.group_dict.approval_status == 'approved' %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/organization_ex.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/organization_ex.html
@@ -26,12 +26,14 @@
          <option value="" {% if not selected_org and data.id %} selected="selected" {% endif %}>{{ _('No organization') }}</option>
       {% endif %}
       {% for organization in organizations_available %}
-        {# get out first org from users list only if there is not an existing org #}
-        {% set selected_org = (existing_org and existing_org == organization.id) or (
-          not existing_org and not data.id and organization.id == organizations_available[0].id) %}
-        {% block organization_option scoped %}
-          <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.display_name }}</option>
-        {% endblock %}
+        {% if organization.approval_status == 'approved' %}
+          {# get out first org from users list only if there is not an existing org #}
+          {% set selected_org = (existing_org and existing_org == organization.id) or (
+            not existing_org and not data.id and organization.id == organizations_available[0].id) %}
+          {% block organization_option scoped %}
+            <option value="{{ organization.id }}" {% if selected_org %} selected="selected" {% endif %}>{{ organization.display_name }}</option>
+          {% endblock %}
+        {% endif %}
       {% endfor %}
     </select>
     </div>


### PR DESCRIPTION
- Add auth function to disallow creating datasets in non-approved organizations
- Hide non-approved organizations from organization list in dataset creation
- Hide create dataset button for non-approved organizations
- Fix tests to approve organizations where needed