### PR TITLE
Fix clamav lambda build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -578,7 +578,7 @@ jobs:
 
   clamav-build:
     docker:
-      - image: circleci/python
+      - image: circleci/python:3.7
     steps:
       - checkout
 
@@ -601,7 +601,7 @@ jobs:
 
   clamav-deploy:
     docker:
-      - image: circleci/python:3.7
+      - image: circleci/python
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -584,7 +584,7 @@ jobs:
 
       - setup_remote_docker
 
-      - run: sudo pip install boto awscli aws-sam-cli
+      - run: sudo pip install boto awscli aws-sam-cli pip==19.2.3
 
       - run:
           name: Build and tag ClamAV container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,7 +601,7 @@ jobs:
 
   clamav-deploy:
     docker:
-      - image: circleci/python
+      - image: circleci/python:3.7
     steps:
       - checkout
 


### PR DESCRIPTION
Python 3.8 was released so our image was newer and pip 19.3 was released which does not work with aws sam.