### PR TITLE
AV-1091: Added support for apisets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,6 @@
 [submodule "modules/ckanext-forcetranslation"]
 	path = modules/ckanext-forcetranslation
 	url = https://github.com/vrk-kpa/ckanext-forcetranslation
+[submodule "modules/ckanext-apis"]
+	path = modules/ckanext-apis
+	url = https://github.com/vrk-kpa/ckanext-apis.git

--- a/ansible/roles/ckan/defaults/main.yml
+++ b/ansible/roles/ckan/defaults/main.yml
@@ -27,6 +27,7 @@ ckan_plugin_order:
   - ytp_drupal
   - ytp_tasks
   - ytp_dataset
+  - apis
   - ytp_spatial
   - ytp_user
   - datastore
@@ -98,6 +99,7 @@ ckan_extensions:
   - ckanext-advancedsearch
   - ckanext-rating
   - ckanext-forcetranslation
+  - ckanext-apis
 
 ckan_extensions_with_translations:
   - ckanext-ytp_request

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -85,6 +85,7 @@ ckan.feeds.authority_name =
 ckan.feeds.date = 2019-01-01
 ckan.feeds.author_name =
 ckan.feeds.author_link =
+ckan.search.show_all_types = False
 
 ckan.cors.origin_allow_all = True
 


### PR DESCRIPTION
- Added `ckanext-apis` to support API datasets
- Set `ckan.search.show_all_types` to `False` to exclude *apisets* from dataset search