### PR TITLE
AV-1024: Add drupal module to enable blacklisting domains

### DIFF
--- a/ansible/roles/drupal/files/drupal8/composer.json
+++ b/ansible/roles/drupal/files/drupal8/composer.json
@@ -37,6 +37,7 @@
         "drupal/twig_tweak": "^2.0",
         "drupal/pathauto": "^1.2",
         "drupal/recaptcha": "^2.3",
+        "drupal/registration_validation": "^1.2",
         "drupal/easy_breadcrumb": "^1.8",
         "drupal/twig_field_value":"^1.1",
         "drupal/metatag": "^1.7",

--- a/ansible/roles/drupal/tasks/configure_drupal.yml
+++ b/ansible/roles/drupal/tasks/configure_drupal.yml
@@ -129,6 +129,7 @@
     - metatag_open_graph
     - ape
     - honeypot
+    - registration_validation
   when: item not in drupal_enabled_modules.stdout
   tags:
     - skip_ansible_lint
@@ -239,6 +240,7 @@
     - { src: captcha.settings.yml.j2, dest: captcha.settings.yml }
     - { src: captcha.captcha_point.user_register_form.yml.j2, dest: captcha.captcha_point.user_register_form.yml }
     - { src: recaptcha.settings.yml.j2, dest: recaptcha.settings.yml }
+    - { src: registration_validation.settings.yml.j2, dest: registration_validation.settings.yml }
     - { src: fontawesome.settings.yml.j2, dest: fontawesome.settings.yml }
     - { src: search_api.server.default_server.yml.j2, dest: search_api.server.default_server.yml }
     - { src: google_analytics.settings.yml.j2, dest: google_analytics.settings.yml }

--- a/ansible/roles/drupal/templates/drupal_site_config/registration_validation.settings.yml.j2
+++ b/ansible/roles/drupal/templates/drupal_site_config/registration_validation.settings.yml.j2
@@ -1,0 +1,6 @@
+domains: "sina.com\r\n*.xyz\r\nbaridasari.ru\r\ntwilightparadox.com\r\nhostmailmonster.com\r\n*.top\r\n.idea.frienced.com\r\nkopqi.com\r\nhillproductions.com\r\nweb2mail.com"
+usernames: ''
+domains_message: 'Your account was not created. You are trying to register from a domain we have blocked due to multiple spam accounts.'
+usernames_message: 'The username contains %username, which has been blacklisted from being used when registering. Please enter a different username.'
+validation_counter: 3
+langcode: en


### PR DESCRIPTION
* Added drupal module [registration validation](https://www.drupal.org/project/registration_validation) to enable the possibility to blacklist email domains from registering accounts
* Configured to blacklist the specified domains by default and to give the suggested error message instead