### PR TITLE
AV-1151: added quick scripts for combining/updating po-csv CSVs

### DIFF
--- a/scripts/combine_translation_csv.py
+++ b/scripts/combine_translation_csv.py
@@ -1,0 +1,42 @@
+import csv
+import sys
+
+if len(sys.argv) < 4:
+    print("Usage: %s <csv_fi> <csv_sv> <csv_en>" % sys.argv[0])
+    sys.exit()
+
+csv_file_fi = sys.argv[1]
+csv_file_sv = sys.argv[2]
+csv_file_en = sys.argv[3]
+
+def extract_from_csv(filename):
+    reader = csv.DictReader(open(filename, 'r'))
+    return {row['msgid']: row for row in reader}
+
+fi_data = extract_from_csv(csv_file_fi)
+sv_data = extract_from_csv(csv_file_sv)
+en_data = extract_from_csv(csv_file_en)
+
+keys = set(fi_data.keys()).union(set(sv_data.keys())).union(set(en_data.keys()))
+
+fields = ['msgid', 'msgid_plural', 'references', 'fi', 'fi_plural', 'en', 'en_plural', 'sv', 'sv_plural']
+writer = csv.DictWriter(sys.stdout, fields, quoting=csv.QUOTE_ALL)
+writer.writeheader()
+
+for key in keys:
+    fi_values = fi_data[key]
+    sv_values = sv_data[key]
+    en_values = en_data[key]
+    values = {
+            'msgid': key,
+            'msgid_plural': fi_values['msgid_plural'],
+            'references': fi_values['references'],
+            'fi': fi_values['msgstr[0]'],
+            'fi_plural': fi_values['msgstr[1]'],
+            'sv': sv_values['msgstr[0]'],
+            'sv_plural': sv_values['msgstr[1]'],
+            'en': en_values['msgstr[0]'],
+            'en_plural': en_values['msgstr[1]'],
+            }
+    writer.writerow(values)
+

--- a/scripts/update_translation_csv.py
+++ b/scripts/update_translation_csv.py
@@ -1,0 +1,23 @@
+import csv
+import sys
+
+if len(sys.argv) < 4:
+    print("Usage: %s <combined_csv> <lang_csv> <lang>" % sys.argv[0])
+    sys.exit()
+
+csv_file_combined = sys.argv[1]
+csv_file = sys.argv[2]
+csv_lang = sys.argv[3]
+
+combined_data = {row['msgid']: row for row in csv.DictReader(open(csv_file_combined, 'r'))}
+
+rows = list(csv.DictReader(open(csv_file, 'r')))
+fields = ['msgid','msgid_plural','flags','references','extractedComments','comments','msgstr[0]','msgstr[1]']
+writer = csv.DictWriter(sys.stdout, fields, quoting=csv.QUOTE_ALL)
+writer.writeheader()
+
+for row in rows:
+    combined_values = combined_data[row['msgid']]
+    row['msgstr[0]'] = combined_values['%s' % csv_lang]
+    row['msgstr[1]'] = combined_values['%s_plural' % csv_lang]
+    writer.writerow(row)


### PR DESCRIPTION
- `combine_translation_csv.py` creates a new CSV based on three language specific CSVs created using the `po-csv` tool.
- `update-translation_csv.py` creates a new CSV based on a combined CSV, a language specific CSV and a language code
- Together these can be used to get a translatable CSV to translators, then to merge the result back into `.po` files 