### PR TITLE
AV-1211: Update prh script

### DIFF
--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -152,6 +152,8 @@ ckanext.ytp.default_organization_name = yksityishenkilo
 ckanext.ytp.default_organization_title = Yksityishenkil\u00f6
 ckanext.ytp.harvester_status_recipients = {{ ckan_harvester_status_email_recipients|join(' ') }}
 
+ckanext.prh_tools.mail_recipients = {{ ckan_harvester_status_email_recipients|join(' ') }}
+
 ckanext.forcetranslation.module = ckanext.ytp
 ckanext.forcetranslation.path = i18n
 ckanext.forcetranslation.domain = ckanext-ytp_main

--- a/ansible/roles/prh_tools/files/prh_clear.service
+++ b/ansible/roles/prh_tools/files/prh_clear.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Clears PRH data
+
+[Service]
+ExecStart=/usr/lib/ckan/default/bin/paster --plugin=ckanext-prh prh-tools clear /srv/ytp/files/prh --config=/etc/ckan/default/production.ini
+

--- a/ansible/roles/prh_tools/files/prh_clear.timer
+++ b/ansible/roles/prh_tools/files/prh_clear.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run prh clear service at last of day month
+
+[Timer]
+OnCalendar=*-*~01 0:22:00
+Persistent=True
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/prh_tools/tasks/configure_prh_tools.yml
+++ b/ansible/roles/prh_tools/tasks/configure_prh_tools.yml
@@ -1,16 +1,21 @@
 - block:
-    - name: Copy prh systemd configuration
+    - name: Copy prh systemd configurations
       copy:
         src: "{{ item }}"
         dest: "/etc/systemd/system/{{ item }}"
       with_items:
         - prh.service
         - prh.timer
+        - prh_clear.service
+        - prh_clear.timer
       notify: Reload systemd
 
-    - name: Enable prh timer
+    - name: Enable prh timers
       systemd:
-        name: prh.timer
+        name: "{{ item }}"
         enabled: yes
         state: started
+      with_items:
+        - prh.timer
+        - prh_clear.timer
   when: prh_crawler_enabled


### PR DESCRIPTION
The recipients are the same as in ckan_harvester_status_email_recipients, so that we don't need to create new secret variable.

Add clear command which is run on last day of month, and email notification when data is uploaded.