### PR TITLE
AV-1117: Hide international benchmarks search facet from non-admins

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
@@ -98,12 +98,16 @@
 {% block secondary_content %}
   {% for facet in c.facet_titles %}
     {% set title = c.facet_titles[facet] or h.get_facet_title(name) %}
-    {% if (title == 'Sisältötyyppi' or title == "Content Type") %}
+    {% if facet.startswith('vocab_content_type_')  %}
       {% for item in items or h.get_facet_items_dict('collection_type') %}
         {% if (item.name == 'Interoperability Tools' and item.active == True) %}
           {{ h.snippet('snippets/facet_list.html', title=title, name=facet) }}
         {% endif %}
       {% endfor %}
+    {% elif facet == 'vocab_international_benchmarks' %}
+      {% if h.check_access('sysadmin') %}
+        {{ h.snippet('snippets/facet_list.html', title=title, name=facet) }}
+      {% endif %}
     {% else %}
       {{ h.snippet('snippets/facet_list.html', title=title, name=facet) }}
     {% endif %}


### PR DESCRIPTION
- Only show international benchmarks facet for sysadmins
- Fix Interoperability tools content type hiding to be language-agnostic