### PR TITLE
AV-1254: Fix duplicate tags in showcase search

### DIFF
--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html
@@ -8,11 +8,6 @@
             <i class="fa fa-search"></i>
             <span>{{ _('Submit') }}</span>
         </button>
-        {% for param in query_params %}
-            {% for value in query_params[param] %}
-                <input class="search-input" type="hidden" name="{{ param }}" value="{{value}}">
-            {% endfor %}
-        {% endfor %}
 
         <input class="search-input" type="hidden" name="sort" value="{{ sorting }}">
     </div>


### PR DESCRIPTION
Showcase search had filtered pills and hidden params in the form. This PR removes the hidden ones.