### PR TITLE
AV-1320: Added SHACL validation files for DCAT-AP output

### DIFF
--- a/ansible/roles/dcatap/files/FOAF.ttl
+++ b/ansible/roles/dcatap/files/FOAF.ttl
@@ -1,0 +1,637 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix wot:   <http://xmlns.com/wot/0.1/> .
+@prefix vs:    <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+
+foaf:knows  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A person known by this person (indicating some level of reciprocated interaction between the parties)." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "knows" ;
+        rdfs:range        foaf:Person ;
+        vs:term_status    "stable" .
+
+foaf:firstName  a         owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The first name of a person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "firstName" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:icqChatID  a           owl:InverseFunctionalProperty , rdf:Property , owl:DatatypeProperty ;
+        rdfs:comment        "An ICQ chat ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "ICQ chat ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:birthday  a          owl:DatatypeProperty , owl:FunctionalProperty , rdf:Property ;
+        rdfs:comment      "The birthday of this Agent, represented in mm-dd string form, eg. '12-31'." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "birthday" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "unstable" .
+
+foaf:givenname  a         owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The given name of some person." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Given name" ;
+        vs:term_status    "archaic" .
+
+foaf:focus  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "The underlying or 'focal' entity associated with some SKOS-described concept." ;
+        rdfs:domain       <http://www.w3.org/2004/02/skos/core#Concept> ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "focus" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:accountServiceHomepage
+        a                 owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Indicates a homepage of the service provide for this online account." ;
+        rdfs:domain       foaf:OnlineAccount ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "account service homepage" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+foaf:isPrimaryTopicOf
+        a                   owl:InverseFunctionalProperty , rdf:Property ;
+        rdfs:comment        "A document that this thing is the primary topic of." ;
+        rdfs:domain         owl:Thing ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "is primary topic of" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:page ;
+        owl:inverseOf       foaf:primaryTopic ;
+        vs:term_status      "stable" .
+
+foaf:depicts  a           owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A thing depicted in this representation." ;
+        rdfs:domain       foaf:Image ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "depicts" ;
+        rdfs:range        owl:Thing ;
+        owl:inverseOf     foaf:depiction ;
+        vs:term_status    "testing" .
+
+foaf:phone  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A phone,  specified using fully qualified tel: URI scheme (refs: http://www.w3.org/Addressing/schemes.html#tel)." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "phone" ;
+        vs:term_status    "testing" .
+
+foaf:openid  a              owl:ObjectProperty , rdf:Property , owl:InverseFunctionalProperty ;
+        rdfs:comment        "An OpenID for an Agent." ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "openid" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:isPrimaryTopicOf ;
+        vs:term_status      "testing" .
+
+foaf:givenName  a         owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The given name of some person." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Given name" ;
+        vs:term_status    "testing" .
+
+foaf:Project  a           owl:Class , rdfs:Class ;
+        rdfs:comment      "A project (a collective endeavour of some kind)." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Project" ;
+        owl:disjointWith  foaf:Document , foaf:Person ;
+        vs:term_status    "testing" .
+
+foaf:account  a           owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Indicates an account held by this agent." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "account" ;
+        rdfs:range        foaf:OnlineAccount ;
+        vs:term_status    "testing" .
+
+foaf:skypeID  a             owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment        "A Skype ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "Skype ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:Image  a                owl:Class , rdfs:Class ;
+        rdfs:comment         "An image." ;
+        rdfs:isDefinedBy     foaf: ;
+        rdfs:label           "Image" ;
+        rdfs:subClassOf      foaf:Document ;
+        owl:equivalentClass  <http://schema.org/ImageObject> ;
+        vs:term_status       "stable" .
+
+foaf:page  a              owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A page or document about this thing." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "page" ;
+        rdfs:range        foaf:Document ;
+        owl:inverseOf     foaf:topic ;
+        vs:term_status    "stable" .
+
+foaf:OnlineEcommerceAccount
+        a                 owl:Class , rdfs:Class ;
+        rdfs:comment      "An online e-commerce account." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Online E-commerce Account" ;
+        rdfs:subClassOf   foaf:OnlineAccount ;
+        vs:term_status    "unstable" .
+
+foaf:lastName  a          owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The last name of a person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "lastName" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:membershipClass  a   owl:AnnotationProperty , rdf:Property ;
+        rdfs:comment      "Indicates the class of individuals that are a member of a Group" ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "membershipClass" ;
+        vs:term_status    "unstable" .
+
+foaf:yahooChatID  a         owl:DatatypeProperty , rdf:Property , owl:InverseFunctionalProperty ;
+        rdfs:comment        "A Yahoo chat ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "Yahoo chat ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:homepage  a            rdf:Property , owl:ObjectProperty , owl:InverseFunctionalProperty ;
+        rdfs:comment        "A homepage for some thing." ;
+        rdfs:domain         owl:Thing ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "homepage" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:page , foaf:isPrimaryTopicOf ;
+        vs:term_status      "stable" .
+
+wot:assurance  a  owl:AnnotationProperty .
+
+foaf:topic_interest  a    owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A thing of interest to this person." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "topic_interest" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:dnaChecksum  a       owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A checksum for the DNA of some thing. Joke." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "DNA checksum" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "archaic" .
+
+foaf:gender  a            owl:DatatypeProperty , owl:FunctionalProperty , rdf:Property ;
+        rdfs:comment      "The gender of this Agent (typically but not necessarily 'male' or 'female')." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "gender" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:mbox_sha1sum  a      owl:DatatypeProperty , owl:InverseFunctionalProperty , rdf:Property ;
+        rdfs:comment      "The sha1sum of the URI of an Internet mailbox associated with exactly one owner, the  first owner of the mailbox." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "sha1sum of a personal mailbox URI name" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:logo  a              owl:InverseFunctionalProperty , owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A logo representing some thing." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "logo" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+dc:description  a  owl:AnnotationProperty .
+
+foaf:img  a                 owl:ObjectProperty , rdf:Property ;
+        rdfs:comment        "An image that can be used to represent some thing (ie. those depictions which are particularly representative of something, eg. one's photo on a homepage)." ;
+        rdfs:domain         foaf:Person ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "image" ;
+        rdfs:range          foaf:Image ;
+        rdfs:subPropertyOf  foaf:depiction ;
+        vs:term_status      "testing" .
+
+foaf:fundedBy  a          owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "An organization funding a project or person." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "funded by" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "archaic" .
+
+foaf:interest  a          owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A page about a topic of interest to this person." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "interest" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+<http://www.w3.org/2004/02/skos/core#Concept>
+        rdfs:label  "Concept" .
+
+foaf:familyName  a        owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The family name of some person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "familyName" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:status  a            owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A string expressing what the user is happy for the general public (normally) to know about their current activity." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "status" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "unstable" .
+
+foaf:msnChatID  a           owl:InverseFunctionalProperty , owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment        "An MSN chat ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "MSN chat ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:sha1  a              owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A sha1sum hash, in hex." ;
+        rdfs:domain       foaf:Document ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "sha1sum (hex)" ;
+        vs:term_status    "unstable" .
+
+foaf:PersonalProfileDocument
+        a                owl:Class , rdfs:Class ;
+        rdfs:comment     "A personal profile RDF document." ;
+        rdfs:label       "PersonalProfileDocument" ;
+        rdfs:subClassOf  foaf:Document ;
+        vs:term_status   "testing" .
+
+foaf:workInfoHomepage
+        a                 owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A work info homepage of some person; a page about their work for some organization." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "work info homepage" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+foaf:currentProject  a    owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A current project this person works on." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "current project" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:mbox  a              owl:ObjectProperty , owl:InverseFunctionalProperty , rdf:Property ;
+        rdfs:comment      "A  personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox. This is a 'static inverse functional property', in that  there is (across time and change) at most one individual that ever has any particular value for foaf:mbox." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "personal mailbox" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "stable" .
+
+vs:term_status  a  owl:AnnotationProperty .
+
+foaf:schoolHomepage  a    owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A homepage of a school attended by the person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "schoolHomepage" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+foaf:   a               owl:Ontology ;
+        dc:description  "The Friend of a Friend (FOAF) RDF vocabulary, described using W3C RDF Schema and the Web Ontology Language." ;
+        dc:title        "Friend of a Friend (FOAF) vocabulary" .
+
+owl:Thing  rdfs:label  "Thing" .
+
+foaf:Organization  a      owl:Class , rdfs:Class ;
+        rdfs:comment      "An organization." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Organization" ;
+        rdfs:subClassOf   foaf:Agent ;
+        owl:disjointWith  foaf:Document , foaf:Person ;
+        vs:term_status    "stable" .
+
+foaf:holdsAccount  a      owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Indicates an account held by this agent." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "account" ;
+        rdfs:range        foaf:OnlineAccount ;
+        vs:term_status    "archaic" .
+
+foaf:maker  a                   rdf:Property , owl:ObjectProperty ;
+        rdfs:comment            "An agent that  made this thing." ;
+        rdfs:domain             owl:Thing ;
+        rdfs:isDefinedBy        foaf: ;
+        rdfs:label              "maker" ;
+        rdfs:range              foaf:Agent ;
+        owl:equivalentProperty  <http://purl.org/dc/terms/creator> ;
+        owl:inverseOf           foaf:made ;
+        vs:term_status          "stable" .
+
+foaf:pastProject  a       owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A project this person has previously worked on." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "past project" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:OnlineChatAccount
+        a                 owl:Class , rdfs:Class ;
+        rdfs:comment      "An online chat account." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Online Chat Account" ;
+        rdfs:subClassOf   foaf:OnlineAccount ;
+        vs:term_status    "unstable" .
+
+foaf:jabberID  a          owl:InverseFunctionalProperty , owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A jabber ID for something." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "jabber ID" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:accountName  a       owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "Indicates the name (identifier) associated with this online account." ;
+        rdfs:domain       foaf:OnlineAccount ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "account name" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:name  a                owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment        "A name for some thing." ;
+        rdfs:domain         owl:Thing ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "name" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  rdfs:label ;
+        vs:term_status      "testing" .
+
+foaf:OnlineAccount  a     owl:Class , rdfs:Class ;
+        rdfs:comment      "An online account." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Online Account" ;
+        rdfs:subClassOf   owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:tipjar  a              owl:ObjectProperty , rdf:Property ;
+        rdfs:comment        "A tipjar document for this agent, describing means for payment and reward." ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "tipjar" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:page ;
+        vs:term_status      "testing" .
+
+wot:src_assurance  a  owl:AnnotationProperty .
+
+<http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing>
+        a           owl:Class ;
+        rdfs:label  "Spatial Thing" .
+
+foaf:age  a               owl:DatatypeProperty , owl:FunctionalProperty , rdf:Property ;
+        rdfs:comment      "The age in years of some agent." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "age" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "unstable" .
+
+foaf:primaryTopic  a      owl:FunctionalProperty , rdf:Property , owl:ObjectProperty ;
+        rdfs:comment      "The primary topic of some page or document." ;
+        rdfs:domain       foaf:Document ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "primary topic" ;
+        rdfs:range        owl:Thing ;
+        owl:inverseOf     foaf:isPrimaryTopicOf ;
+        vs:term_status    "stable" .
+
+foaf:myersBriggs  a       owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A Myers Briggs (MBTI) personality classification." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "myersBriggs" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+rdfs:Class  a   owl:Class .
+
+foaf:Agent  a                rdfs:Class , owl:Class ;
+        rdfs:comment         "An agent (eg. person, group, software or physical artifact)." ;
+        rdfs:label           "Agent" ;
+        owl:equivalentClass  <http://purl.org/dc/terms/Agent> ;
+        vs:term_status       "stable" .
+
+dc:date  a      owl:AnnotationProperty .
+
+foaf:OnlineGamingAccount
+        a                 owl:Class , rdfs:Class ;
+        rdfs:comment      "An online gaming account." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Online Gaming Account" ;
+        rdfs:subClassOf   foaf:OnlineAccount ;
+        vs:term_status    "unstable" .
+
+foaf:depiction  a         owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A depiction of some thing." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "depiction" ;
+        rdfs:range        foaf:Image ;
+        owl:inverseOf     foaf:depicts ;
+        vs:term_status    "testing" .
+
+foaf:workplaceHomepage
+        a                 owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A workplace homepage of some person; the homepage of an organization they work for." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "workplace homepage" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+foaf:weblog  a              rdf:Property , owl:InverseFunctionalProperty , owl:ObjectProperty ;
+        rdfs:comment        "A weblog of some thing (whether person, group, company etc.)." ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "weblog" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:page ;
+        vs:term_status      "stable" .
+
+foaf:title  a             owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "Title (Mr, Mrs, Ms, Dr. etc)" ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "title" ;
+        vs:term_status    "testing" .
+
+foaf:thumbnail  a         owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A derived thumbnail image." ;
+        rdfs:domain       foaf:Image ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "thumbnail" ;
+        rdfs:range        foaf:Image ;
+        vs:term_status    "testing" .
+
+foaf:Person  a               rdfs:Class , owl:Class ;
+        rdfs:comment         "A person." ;
+        rdfs:isDefinedBy     foaf: ;
+        rdfs:label           "Person" ;
+        rdfs:subClassOf      <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> , foaf:Agent ;
+        owl:disjointWith     foaf:Project , foaf:Organization ;
+        owl:equivalentClass  <http://schema.org/Person> , <http://www.w3.org/2000/10/swap/pim/contact#Person> ;
+        vs:term_status       "stable" .
+
+foaf:made  a              owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Something that was made by this agent." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "made" ;
+        rdfs:range        owl:Thing ;
+        owl:inverseOf     foaf:maker ;
+        vs:term_status    "stable" .
+
+foaf:LabelProperty  a     owl:Class , rdfs:Class ;
+        rdfs:comment      "A foaf:LabelProperty is any RDF property with texual values that serve as labels." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Label Property" ;
+        vs:term_status    "unstable" .
+
+foaf:nick  a              owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames)." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "nickname" ;
+        vs:term_status    "testing" .
+
+foaf:based_near  a        owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A location that something is based near, for some broadly human notion of near." ;
+        rdfs:domain       <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "based near" ;
+        rdfs:range        <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> ;
+        vs:term_status    "testing" .
+
+foaf:surname  a           owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The surname of some person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Surname" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "archaic" .
+
+foaf:plan  a              owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A .plan comment, in the tradition of finger and '.plan' files." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "plan" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:aimChatID  a           rdf:Property , owl:DatatypeProperty , owl:InverseFunctionalProperty ;
+        rdfs:comment        "An AIM chat ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "AIM chat ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:Group  a            owl:Class , rdfs:Class ;
+        rdfs:comment     "A class of Agents." ;
+        rdfs:label       "Group" ;
+        rdfs:subClassOf  foaf:Agent ;
+        vs:term_status   "stable" .
+
+foaf:geekcode  a          owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A textual geekcode for this person, see http://www.geekcode.com/geek.html" ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "geekcode" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "archaic" .
+
+dc:title  a     owl:AnnotationProperty .
+
+foaf:Document  a             owl:Class , rdfs:Class ;
+        rdfs:comment         "A document." ;
+        rdfs:isDefinedBy     foaf: ;
+        rdfs:label           "Document" ;
+        owl:disjointWith     foaf:Project , foaf:Organization ;
+        owl:equivalentClass  <http://schema.org/CreativeWork> ;
+        vs:term_status       "stable" .
+
+foaf:topic  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A topic of some page or document." ;
+        rdfs:domain       foaf:Document ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "topic" ;
+        rdfs:range        owl:Thing ;
+        owl:inverseOf     foaf:page ;
+        vs:term_status    "testing" .
+
+foaf:family_name  a       owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The family name of some person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "family_name" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "archaic" .
+
+foaf:member  a            owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Indicates a member of a Group" ;
+        rdfs:domain       foaf:Group ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "member" ;
+        rdfs:range        foaf:Agent ;
+        vs:term_status    "stable" .
+
+foaf:theme  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A theme." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "theme" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "archaic" .
+
+foaf:publications  a      owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A link to the publications of this person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "publications" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .

--- a/ansible/roles/dcatap/files/avoindata_dcat-ap_shacl.ttl
+++ b/ansible/roles/dcatap/files/avoindata_dcat-ap_shacl.ttl
@@ -1,0 +1,753 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://data.europa.eu/r5r#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix lcon: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix cc: <http://creativecommons.org/ns#> .
+
+<http://data.europa.eu/r5r/shacl_shapes>
+    dcat:accessURL <https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/distribution/dcat-ap-200-shacl-shapes>;
+    dcat:downloadURL <https://github.com/SEMICeu/DCAT-AP/raw/cea5a96bb4a6f120c20b7a2b3fb4d86bcd725952/releases/2.0.0/Draft/dcat-ap_2.0.0_shacl_shapes.ttl> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:creator [
+        rdfs:seeAlso <https://www.linkedin.com/in/bert-van-nuffelen-a349634/> ;
+        org:memberOf <https://tenforce.com> ;
+        foaf:homepage <https://www.linkedin.com/in/bert-van-nuffelen-a349634/> ;
+        foaf:name "Bert Van Nuffelen"
+    ], [
+        rdfs:seeAlso <https://www.ails.ece.ntua.gr/people/natasa> ;
+        org:memberOf <https://www.ails.ece.ntua.gr/> ;
+        foaf:homepage <https://www.ails.ece.ntua.gr/people/natasa> ;
+        foaf:name "Natasa Sofou"
+    ], [
+        rdfs:seeAlso <http://eugeniu.costezki.ro#me> ;
+        org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/PUBL> ;
+        foaf:homepage <http://costezki.ro> ;
+        foaf:name "Eugeniu Costetchi"
+    ], [
+        rdfs:seeAlso <http://makxdekkers.com/#me> ;
+        org:memberOf <http://ami-consult.com/#id> ;
+        foaf:homepage <http://makxdekkers.com/> ;
+        foaf:name "Makx Dekkers"
+    ], [
+        rdfs:seeAlso <http://nikosloutas.com/> ;
+        org:memberOf <http://www.pwc.com/gx/en/eu-institutions-services> ;
+        foaf:homepage <http://nikosloutas.com/> ;
+        foaf:name "Nikolaos Loutas"
+    ], [
+        rdfs:seeAlso <http://www.deri.ie/users/vassilios-peristeras/> ;
+        org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/COM> ;
+        foaf:homepage <http://www.deri.ie/users/vassilios-peristeras/> ;
+        foaf:name "Vassilios Peristeras"
+    ] ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    cc:attributionURL <http://ec.europa.eu/> ;
+    dct:modified "2019-11-15"^^xsd:date ;
+    dct:publisher <http://publications.europa.eu/resource/authority/corporate-body/DIGIT> ;
+    dct:relation <https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/release/200> ;
+    dct:description "This document specifies the constraints on properties and classes expressed by DCAT-AP in SHACL."@en ;
+    dct:title "The constraints of DCAT Application Profile for Data Portals in Europe"@en ;
+    owl:versionInfo "2.0.0" ;
+    foaf:homepage <https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/release/200> ;
+    foaf:maker [
+        foaf:mbox <mailto:contact@semic.eu> ;
+        foaf:name "DCAT-AP Working Group" ;
+        foaf:page <https://github.com/SEMICeu/DCAT-AP>, <https://joinup.ec.europa.eu/node/64331>
+    ] .
+
+
+
+#-------------------------------------------------------------------------
+# The shapes in this file cover all classes in DCAT-AP 2.0.0.
+#
+# 
+#-------------------------------------------------------------------------
+
+:Agent_Shape
+    a sh:NodeShape ;
+    sh:name "Agent"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path foaf:name ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass foaf:Agent ;
+    sh:or ([
+            sh:class foaf:Agent
+        ]
+        [
+            sh:class foaf:Organization
+        ]
+        [
+            sh:class foaf:Group
+        ]
+        [
+            sh:class foaf:Person
+        ]
+    ) .
+
+:CatalogRecord_Shape
+    a sh:NodeShape ;
+    sh:name "Catalog Record"@en ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:node :DcatResource_Shape ;
+        sh:path foaf:primaryTopic ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class dct:Standard ;
+        sh:maxCount 1 ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:CatalogRecord ;
+        sh:maxCount 1 ;
+        sh:path dct:source ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:CatalogRecord .
+
+:Catalog_Shape
+    a sh:NodeShape ;
+    sh:name "Catalog"@en ;
+    sh:property [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LicenseDocument ;
+        sh:maxCount 1 ;
+        sh:path dct:license ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Location ;
+        sh:path dct:spatial ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Catalog ;
+        sh:path dct:hasPart ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Catalog ;
+        sh:maxCount 1 ;
+        sh:path dct:isPartOf ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:rights ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:CatalogRecord ;
+        sh:path dcat:record ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:ConceptScheme ;
+        sh:path dcat:themeTaxonomy ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:DataService ;
+        sh:path dcat:service ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Catalog ;
+        sh:path dcat:catalog ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:path dct:creator ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:minCount 1 ;
+        sh:path dcat:dataset ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path dct:publisher ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:maxCount 1 ;
+        sh:path foaf:homepage ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Catalog .
+
+:CategoryScheme_Shape
+    a sh:NodeShape ;
+    sh:name "Category Scheme"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass skos:ConceptScheme .
+
+:Category_Shape
+    a sh:NodeShape ;
+    sh:name "Category"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path skos:prefLabel ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass skos:Concept .
+
+:Checksum_Shape
+    a sh:NodeShape ;
+    sh:name "Category"@en ;
+    sh:property [
+        sh:hasValue spdx:checksumAlgorithm_sha1 ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path spdx:algorithm ;
+        sh:severity sh:Violation
+    ], [
+        sh:dateTime xsd:hexBinary ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path spdx:checksumValue ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass spdx:Checksum .
+
+:DataService_Shape
+    a sh:NodeShape ;
+    sh:name "Data Service"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:endpointURL ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dcat:servesDataset ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:endPointDescription ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LicenseDocument ;
+        sh:maxCount 1 ;
+        sh:path dct:licence ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:accessRights ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:DataService .
+
+:Dataset_Shape
+    a sh:NodeShape ;
+    sh:name "Dataset"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:shape :VcardKind_Shape ;
+        sh:path dcat:contactPoint ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Distribution ;
+        sh:path dcat:distribution ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:keyword ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:path dct:publisher ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Location ;
+        sh:path dct:spatial ;
+        sh:severity sh:Violation
+    ], [
+	sh:class dct:PeriodOfTime ;
+        sh:path dct:temporal ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:path dcat:theme ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:accessRights ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Frequency ;
+        sh:maxCount 1 ;
+        sh:path dct:accrualPeriodicity ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Standard ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:hasVersion ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:isVersionOf ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class dct:ProvenanceStatement ;
+        sh:path dct:provenance ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:relation ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:source ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path owl:versionInfo ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path adms:versionNotes ;
+        sh:severity sh:Violation
+    ], [
+        sh:class adms:Identifier ;
+        sh:path adms:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Distribution ;
+        sh:path adms:sample ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:path dcat:landingPage ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:path foaf:page ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Relationship ;
+        sh:path dcat:qualifiedRelation ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dc:isReferencedBy ;
+        sh:severity sh:Violation
+    ], [
+        sh:class prov:Attribution ;
+        sh:path prov:qualifiedAttribution ;
+        sh:severity sh:Violation
+    ], [
+        sh:class prov:Activity ;
+        sh:path prov:wasGeneratedBy ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:duration ;
+        sh:path dcat:temporalResolution ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:decimal ;
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:path dct:creator ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Dataset .
+
+:DateOrDateTimeDataType_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Date time date disjunction shape checks that a datatype property receives a date or a dateTime literal" ;
+    rdfs:label "Date time date disjunction" ;
+    sh:message "The values must be data typed as either xsd:date or xsd:dateTime" ;
+    sh:or ([
+            sh:datatype xsd:date
+        ]
+        [
+            sh:datatype xsd:dateTime
+        ]
+    ) .
+
+:DcatResource_Shape
+    a sh:NodeShape ;
+    rdfs:comment "the union of Catalog, Dataset and DataService" ;
+    rdfs:label "dcat:Resource" ;
+    sh:message "The node is either a Catalog, Dataset or a DataService" ;
+    sh:or ([
+            sh:class dcat:Catalog
+        ]
+        [
+            sh:class dcat:Dataset
+        ]
+        [
+            sh:class dcat:DataService
+        ]
+    ) .
+
+:Distribution_Shape
+    a sh:NodeShape ;
+    sh:name "Distribution"@en ;
+    sh:property [
+        sh:class dct:Standard ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:rights ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:class spdx:Checksum ;
+        sh:maxCount 1 ;
+        sh:path spdx:checksum ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:decimal ;
+        sh:maxCount 1 ;
+        sh:path dcat:byteSize ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:downloadURL ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ;
+        sh:maxCount 1 ;
+        sh:path dcat:mediaType ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:path foaf:page ;
+        sh:severity sh:Violation
+    ], [
+        sh:class odrl:Policy ;
+        sh:maxCount 1 ;
+        sh:path odrl:hasPolicy ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:DataService ;
+        sh:path dcat:accessService ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ;
+        sh:maxCount 1 ;
+        sh:path dcat:compressFormat ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ;
+        sh:maxCount 1 ;
+        sh:path dcat:packageFormat ;
+        sh:severity sh:Violation
+    ], [
+	sh:class dct:PeriodOfTime ;
+        sh:path dct:temporal ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:duration ;
+        sh:path dcat:temporalResolution ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:decimal ;
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:accessURL ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path dcatap:availability ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaTypeOrExtent ;
+        sh:maxCount 1 ;
+        sh:path dct:format ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LicenseDocument ;
+        sh:maxCount 1 ;
+        sh:path dct:license ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Distribution .
+
+:Identifier_Shape
+    a sh:NodeShape ;
+    sh:name "Identifier"@en ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:path skos:notation ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass adms:Identifier .
+
+:LicenceDocument_Shape
+    a sh:NodeShape ;
+    sh:name "Licence Document"@en ;
+    sh:property [
+        sh:class skos:Concept ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:LicenseDocument .
+
+:Location_Shape
+    a sh:NodeShape ;
+    sh:name "Location"@en ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:bbox ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:centroid ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path lcon:geometry ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:Location .
+
+:PeriodOfTime_Shape
+    a sh:NodeShape ;
+    sh:name "PeriodOfTime"@en ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:path dcat:endDate ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class time:Instant ;
+        sh:maxCount 1 ;
+        sh:path time:hasBeginning ;
+        sh:severity sh:Violation
+    ], [
+        sh:class time:Instant ;
+        sh:maxCount 1 ;
+        sh:path time:hasEnd ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:path dcat:startDate ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ] ;
+    sh:targetClass dct:PeriodOfTime .
+
+:Relationship_Shape
+    a sh:NodeShape ;
+    sh:name "Relationship"@en ;
+    sh:property [
+        sh:class dcat:Role ;
+        sh:minCount 1 ;
+        sh:path dct:relation ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:node :DcatResource_Shape ;
+        sh:path dcat:hadRole ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Relationship .
+
+
+:VcardKind_Shape
+    a sh:NodeShape ;
+    rdfs:comment "the union of Individual, Organization, Group and Location" ;
+    rdfs:label "vcard:Kind" ;
+    sh:message "The node is either a Individual, Organization, Group or Location" ;
+    sh:or ([
+            sh:class vcard:Individual
+        ]
+        [
+            sh:class vcard:Organization
+        ]
+        [
+            sh:class vcard:Group
+        ]
+        [
+            sh:class vcard:Location
+        ]
+    ) .
+
+:FoafAgent_Shape
+    a sh:NodeShape ;
+    rdfs:comment "the union of Agent, Organization, Group and Person" ;
+    rdfs:label "foaf:Agent" ;
+    sh:message "The node is either a Agent, Organization, Group or Person" ;
+    sh:or ([
+            sh:class foaf:Agent
+        ]
+        [
+            sh:class foaf:Organization
+        ]
+        [
+            sh:class foaf:Group
+        ]
+        [
+            sh:class foaf:Person
+        ]
+    ) .

--- a/ansible/roles/dcatap/files/index.html
+++ b/ansible/roles/dcatap/files/index.html
@@ -8,6 +8,17 @@
   <body class="container">
     <h1>Avoindata.fi DCAT-AP extension</h1>
 
+    <h2>Validation</h2>
+    <p>Documents can be validated against this specification with a <a href="https://www.w3.org/TR/shacl/">SHACL</a> processor using these schema files:
+      <ul>
+        <li><a href="avoindata_dcat-ap_shacl.ttl">avoindata_dcat-ap_shacl.ttl</a></li>
+        <li><a href="FOAF.ttl">FOAF.ttl</a></li>
+      </ul>
+    </p>
+    <p>For example, using <a href="https://pypi.org/project/pyshacl/">pyshacl</a>:
+    <code>pyshacl -s avoindata_dcat-ap_shacl.ttl -e FOAF.ttl --imports -i rdfs catalog.xml</code>
+    </p>
+
     <h2>Vocabularies</h2>
 
     <table class="table table-striped">

--- a/ansible/roles/dcatap/tasks/main.yml
+++ b/ansible/roles/dcatap/tasks/main.yml
@@ -12,3 +12,12 @@
   synchronize:
     src: "files/index.html"
     dest: "/var/www/ns"
+
+- name: Copy namespace documentation
+  synchronize:
+    src: "{{ item }}"
+    dest: "/var/www/ns"
+  with_items:
+    - files/index.html
+    - files/avoindata_dcat-ap_shacl.ttl
+    - files/FOAF.ttl

--- a/doc/dcat-ap/FOAF.ttl
+++ b/doc/dcat-ap/FOAF.ttl
@@ -1,0 +1,637 @@
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix wot:   <http://xmlns.com/wot/0.1/> .
+@prefix vs:    <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix dc:    <http://purl.org/dc/elements/1.1/> .
+
+foaf:knows  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A person known by this person (indicating some level of reciprocated interaction between the parties)." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "knows" ;
+        rdfs:range        foaf:Person ;
+        vs:term_status    "stable" .
+
+foaf:firstName  a         owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The first name of a person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "firstName" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:icqChatID  a           owl:InverseFunctionalProperty , rdf:Property , owl:DatatypeProperty ;
+        rdfs:comment        "An ICQ chat ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "ICQ chat ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:birthday  a          owl:DatatypeProperty , owl:FunctionalProperty , rdf:Property ;
+        rdfs:comment      "The birthday of this Agent, represented in mm-dd string form, eg. '12-31'." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "birthday" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "unstable" .
+
+foaf:givenname  a         owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The given name of some person." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Given name" ;
+        vs:term_status    "archaic" .
+
+foaf:focus  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "The underlying or 'focal' entity associated with some SKOS-described concept." ;
+        rdfs:domain       <http://www.w3.org/2004/02/skos/core#Concept> ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "focus" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:accountServiceHomepage
+        a                 owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Indicates a homepage of the service provide for this online account." ;
+        rdfs:domain       foaf:OnlineAccount ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "account service homepage" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+foaf:isPrimaryTopicOf
+        a                   owl:InverseFunctionalProperty , rdf:Property ;
+        rdfs:comment        "A document that this thing is the primary topic of." ;
+        rdfs:domain         owl:Thing ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "is primary topic of" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:page ;
+        owl:inverseOf       foaf:primaryTopic ;
+        vs:term_status      "stable" .
+
+foaf:depicts  a           owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A thing depicted in this representation." ;
+        rdfs:domain       foaf:Image ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "depicts" ;
+        rdfs:range        owl:Thing ;
+        owl:inverseOf     foaf:depiction ;
+        vs:term_status    "testing" .
+
+foaf:phone  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A phone,  specified using fully qualified tel: URI scheme (refs: http://www.w3.org/Addressing/schemes.html#tel)." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "phone" ;
+        vs:term_status    "testing" .
+
+foaf:openid  a              owl:ObjectProperty , rdf:Property , owl:InverseFunctionalProperty ;
+        rdfs:comment        "An OpenID for an Agent." ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "openid" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:isPrimaryTopicOf ;
+        vs:term_status      "testing" .
+
+foaf:givenName  a         owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The given name of some person." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Given name" ;
+        vs:term_status    "testing" .
+
+foaf:Project  a           owl:Class , rdfs:Class ;
+        rdfs:comment      "A project (a collective endeavour of some kind)." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Project" ;
+        owl:disjointWith  foaf:Document , foaf:Person ;
+        vs:term_status    "testing" .
+
+foaf:account  a           owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Indicates an account held by this agent." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "account" ;
+        rdfs:range        foaf:OnlineAccount ;
+        vs:term_status    "testing" .
+
+foaf:skypeID  a             owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment        "A Skype ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "Skype ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:Image  a                owl:Class , rdfs:Class ;
+        rdfs:comment         "An image." ;
+        rdfs:isDefinedBy     foaf: ;
+        rdfs:label           "Image" ;
+        rdfs:subClassOf      foaf:Document ;
+        owl:equivalentClass  <http://schema.org/ImageObject> ;
+        vs:term_status       "stable" .
+
+foaf:page  a              owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A page or document about this thing." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "page" ;
+        rdfs:range        foaf:Document ;
+        owl:inverseOf     foaf:topic ;
+        vs:term_status    "stable" .
+
+foaf:OnlineEcommerceAccount
+        a                 owl:Class , rdfs:Class ;
+        rdfs:comment      "An online e-commerce account." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Online E-commerce Account" ;
+        rdfs:subClassOf   foaf:OnlineAccount ;
+        vs:term_status    "unstable" .
+
+foaf:lastName  a          owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The last name of a person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "lastName" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:membershipClass  a   owl:AnnotationProperty , rdf:Property ;
+        rdfs:comment      "Indicates the class of individuals that are a member of a Group" ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "membershipClass" ;
+        vs:term_status    "unstable" .
+
+foaf:yahooChatID  a         owl:DatatypeProperty , rdf:Property , owl:InverseFunctionalProperty ;
+        rdfs:comment        "A Yahoo chat ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "Yahoo chat ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:homepage  a            rdf:Property , owl:ObjectProperty , owl:InverseFunctionalProperty ;
+        rdfs:comment        "A homepage for some thing." ;
+        rdfs:domain         owl:Thing ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "homepage" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:page , foaf:isPrimaryTopicOf ;
+        vs:term_status      "stable" .
+
+wot:assurance  a  owl:AnnotationProperty .
+
+foaf:topic_interest  a    owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A thing of interest to this person." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "topic_interest" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:dnaChecksum  a       owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A checksum for the DNA of some thing. Joke." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "DNA checksum" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "archaic" .
+
+foaf:gender  a            owl:DatatypeProperty , owl:FunctionalProperty , rdf:Property ;
+        rdfs:comment      "The gender of this Agent (typically but not necessarily 'male' or 'female')." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "gender" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:mbox_sha1sum  a      owl:DatatypeProperty , owl:InverseFunctionalProperty , rdf:Property ;
+        rdfs:comment      "The sha1sum of the URI of an Internet mailbox associated with exactly one owner, the  first owner of the mailbox." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "sha1sum of a personal mailbox URI name" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:logo  a              owl:InverseFunctionalProperty , owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A logo representing some thing." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "logo" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+dc:description  a  owl:AnnotationProperty .
+
+foaf:img  a                 owl:ObjectProperty , rdf:Property ;
+        rdfs:comment        "An image that can be used to represent some thing (ie. those depictions which are particularly representative of something, eg. one's photo on a homepage)." ;
+        rdfs:domain         foaf:Person ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "image" ;
+        rdfs:range          foaf:Image ;
+        rdfs:subPropertyOf  foaf:depiction ;
+        vs:term_status      "testing" .
+
+foaf:fundedBy  a          owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "An organization funding a project or person." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "funded by" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "archaic" .
+
+foaf:interest  a          owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A page about a topic of interest to this person." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "interest" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+<http://www.w3.org/2004/02/skos/core#Concept>
+        rdfs:label  "Concept" .
+
+foaf:familyName  a        owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The family name of some person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "familyName" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:status  a            owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A string expressing what the user is happy for the general public (normally) to know about their current activity." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "status" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "unstable" .
+
+foaf:msnChatID  a           owl:InverseFunctionalProperty , owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment        "An MSN chat ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "MSN chat ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:sha1  a              owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A sha1sum hash, in hex." ;
+        rdfs:domain       foaf:Document ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "sha1sum (hex)" ;
+        vs:term_status    "unstable" .
+
+foaf:PersonalProfileDocument
+        a                owl:Class , rdfs:Class ;
+        rdfs:comment     "A personal profile RDF document." ;
+        rdfs:label       "PersonalProfileDocument" ;
+        rdfs:subClassOf  foaf:Document ;
+        vs:term_status   "testing" .
+
+foaf:workInfoHomepage
+        a                 owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A work info homepage of some person; a page about their work for some organization." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "work info homepage" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+foaf:currentProject  a    owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A current project this person works on." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "current project" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:mbox  a              owl:ObjectProperty , owl:InverseFunctionalProperty , rdf:Property ;
+        rdfs:comment      "A  personal mailbox, ie. an Internet mailbox associated with exactly one owner, the first owner of this mailbox. This is a 'static inverse functional property', in that  there is (across time and change) at most one individual that ever has any particular value for foaf:mbox." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "personal mailbox" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "stable" .
+
+vs:term_status  a  owl:AnnotationProperty .
+
+foaf:schoolHomepage  a    owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A homepage of a school attended by the person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "schoolHomepage" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+foaf:   a               owl:Ontology ;
+        dc:description  "The Friend of a Friend (FOAF) RDF vocabulary, described using W3C RDF Schema and the Web Ontology Language." ;
+        dc:title        "Friend of a Friend (FOAF) vocabulary" .
+
+owl:Thing  rdfs:label  "Thing" .
+
+foaf:Organization  a      owl:Class , rdfs:Class ;
+        rdfs:comment      "An organization." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Organization" ;
+        rdfs:subClassOf   foaf:Agent ;
+        owl:disjointWith  foaf:Document , foaf:Person ;
+        vs:term_status    "stable" .
+
+foaf:holdsAccount  a      owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Indicates an account held by this agent." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "account" ;
+        rdfs:range        foaf:OnlineAccount ;
+        vs:term_status    "archaic" .
+
+foaf:maker  a                   rdf:Property , owl:ObjectProperty ;
+        rdfs:comment            "An agent that  made this thing." ;
+        rdfs:domain             owl:Thing ;
+        rdfs:isDefinedBy        foaf: ;
+        rdfs:label              "maker" ;
+        rdfs:range              foaf:Agent ;
+        owl:equivalentProperty  <http://purl.org/dc/terms/creator> ;
+        owl:inverseOf           foaf:made ;
+        vs:term_status          "stable" .
+
+foaf:pastProject  a       owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A project this person has previously worked on." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "past project" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:OnlineChatAccount
+        a                 owl:Class , rdfs:Class ;
+        rdfs:comment      "An online chat account." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Online Chat Account" ;
+        rdfs:subClassOf   foaf:OnlineAccount ;
+        vs:term_status    "unstable" .
+
+foaf:jabberID  a          owl:InverseFunctionalProperty , owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A jabber ID for something." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "jabber ID" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:accountName  a       owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "Indicates the name (identifier) associated with this online account." ;
+        rdfs:domain       foaf:OnlineAccount ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "account name" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:name  a                owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment        "A name for some thing." ;
+        rdfs:domain         owl:Thing ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "name" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  rdfs:label ;
+        vs:term_status      "testing" .
+
+foaf:OnlineAccount  a     owl:Class , rdfs:Class ;
+        rdfs:comment      "An online account." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Online Account" ;
+        rdfs:subClassOf   owl:Thing ;
+        vs:term_status    "testing" .
+
+foaf:tipjar  a              owl:ObjectProperty , rdf:Property ;
+        rdfs:comment        "A tipjar document for this agent, describing means for payment and reward." ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "tipjar" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:page ;
+        vs:term_status      "testing" .
+
+wot:src_assurance  a  owl:AnnotationProperty .
+
+<http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing>
+        a           owl:Class ;
+        rdfs:label  "Spatial Thing" .
+
+foaf:age  a               owl:DatatypeProperty , owl:FunctionalProperty , rdf:Property ;
+        rdfs:comment      "The age in years of some agent." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "age" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "unstable" .
+
+foaf:primaryTopic  a      owl:FunctionalProperty , rdf:Property , owl:ObjectProperty ;
+        rdfs:comment      "The primary topic of some page or document." ;
+        rdfs:domain       foaf:Document ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "primary topic" ;
+        rdfs:range        owl:Thing ;
+        owl:inverseOf     foaf:isPrimaryTopicOf ;
+        vs:term_status    "stable" .
+
+foaf:myersBriggs  a       owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A Myers Briggs (MBTI) personality classification." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "myersBriggs" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+rdfs:Class  a   owl:Class .
+
+foaf:Agent  a                rdfs:Class , owl:Class ;
+        rdfs:comment         "An agent (eg. person, group, software or physical artifact)." ;
+        rdfs:label           "Agent" ;
+        owl:equivalentClass  <http://purl.org/dc/terms/Agent> ;
+        vs:term_status       "stable" .
+
+dc:date  a      owl:AnnotationProperty .
+
+foaf:OnlineGamingAccount
+        a                 owl:Class , rdfs:Class ;
+        rdfs:comment      "An online gaming account." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Online Gaming Account" ;
+        rdfs:subClassOf   foaf:OnlineAccount ;
+        vs:term_status    "unstable" .
+
+foaf:depiction  a         owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A depiction of some thing." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "depiction" ;
+        rdfs:range        foaf:Image ;
+        owl:inverseOf     foaf:depicts ;
+        vs:term_status    "testing" .
+
+foaf:workplaceHomepage
+        a                 owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A workplace homepage of some person; the homepage of an organization they work for." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "workplace homepage" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .
+
+foaf:weblog  a              rdf:Property , owl:InverseFunctionalProperty , owl:ObjectProperty ;
+        rdfs:comment        "A weblog of some thing (whether person, group, company etc.)." ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "weblog" ;
+        rdfs:range          foaf:Document ;
+        rdfs:subPropertyOf  foaf:page ;
+        vs:term_status      "stable" .
+
+foaf:title  a             owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "Title (Mr, Mrs, Ms, Dr. etc)" ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "title" ;
+        vs:term_status    "testing" .
+
+foaf:thumbnail  a         owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A derived thumbnail image." ;
+        rdfs:domain       foaf:Image ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "thumbnail" ;
+        rdfs:range        foaf:Image ;
+        vs:term_status    "testing" .
+
+foaf:Person  a               rdfs:Class , owl:Class ;
+        rdfs:comment         "A person." ;
+        rdfs:isDefinedBy     foaf: ;
+        rdfs:label           "Person" ;
+        rdfs:subClassOf      <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> , foaf:Agent ;
+        owl:disjointWith     foaf:Project , foaf:Organization ;
+        owl:equivalentClass  <http://schema.org/Person> , <http://www.w3.org/2000/10/swap/pim/contact#Person> ;
+        vs:term_status       "stable" .
+
+foaf:made  a              owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Something that was made by this agent." ;
+        rdfs:domain       foaf:Agent ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "made" ;
+        rdfs:range        owl:Thing ;
+        owl:inverseOf     foaf:maker ;
+        vs:term_status    "stable" .
+
+foaf:LabelProperty  a     owl:Class , rdfs:Class ;
+        rdfs:comment      "A foaf:LabelProperty is any RDF property with texual values that serve as labels." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Label Property" ;
+        vs:term_status    "unstable" .
+
+foaf:nick  a              owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A short informal nickname characterising an agent (includes login identifiers, IRC and other chat nicknames)." ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "nickname" ;
+        vs:term_status    "testing" .
+
+foaf:based_near  a        owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A location that something is based near, for some broadly human notion of near." ;
+        rdfs:domain       <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "based near" ;
+        rdfs:range        <http://www.w3.org/2003/01/geo/wgs84_pos#SpatialThing> ;
+        vs:term_status    "testing" .
+
+foaf:surname  a           owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The surname of some person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "Surname" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "archaic" .
+
+foaf:plan  a              owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A .plan comment, in the tradition of finger and '.plan' files." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "plan" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "testing" .
+
+foaf:aimChatID  a           rdf:Property , owl:DatatypeProperty , owl:InverseFunctionalProperty ;
+        rdfs:comment        "An AIM chat ID" ;
+        rdfs:domain         foaf:Agent ;
+        rdfs:isDefinedBy    foaf: ;
+        rdfs:label          "AIM chat ID" ;
+        rdfs:range          rdfs:Literal ;
+        rdfs:subPropertyOf  foaf:nick ;
+        vs:term_status      "testing" .
+
+foaf:Group  a            owl:Class , rdfs:Class ;
+        rdfs:comment     "A class of Agents." ;
+        rdfs:label       "Group" ;
+        rdfs:subClassOf  foaf:Agent ;
+        vs:term_status   "stable" .
+
+foaf:geekcode  a          owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "A textual geekcode for this person, see http://www.geekcode.com/geek.html" ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "geekcode" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "archaic" .
+
+dc:title  a     owl:AnnotationProperty .
+
+foaf:Document  a             owl:Class , rdfs:Class ;
+        rdfs:comment         "A document." ;
+        rdfs:isDefinedBy     foaf: ;
+        rdfs:label           "Document" ;
+        owl:disjointWith     foaf:Project , foaf:Organization ;
+        owl:equivalentClass  <http://schema.org/CreativeWork> ;
+        vs:term_status       "stable" .
+
+foaf:topic  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A topic of some page or document." ;
+        rdfs:domain       foaf:Document ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "topic" ;
+        rdfs:range        owl:Thing ;
+        owl:inverseOf     foaf:page ;
+        vs:term_status    "testing" .
+
+foaf:family_name  a       owl:DatatypeProperty , rdf:Property ;
+        rdfs:comment      "The family name of some person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "family_name" ;
+        rdfs:range        rdfs:Literal ;
+        vs:term_status    "archaic" .
+
+foaf:member  a            owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "Indicates a member of a Group" ;
+        rdfs:domain       foaf:Group ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "member" ;
+        rdfs:range        foaf:Agent ;
+        vs:term_status    "stable" .
+
+foaf:theme  a             owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A theme." ;
+        rdfs:domain       owl:Thing ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "theme" ;
+        rdfs:range        owl:Thing ;
+        vs:term_status    "archaic" .
+
+foaf:publications  a      owl:ObjectProperty , rdf:Property ;
+        rdfs:comment      "A link to the publications of this person." ;
+        rdfs:domain       foaf:Person ;
+        rdfs:isDefinedBy  foaf: ;
+        rdfs:label        "publications" ;
+        rdfs:range        foaf:Document ;
+        vs:term_status    "testing" .

--- a/doc/dcat-ap/README.md
+++ b/doc/dcat-ap/README.md
@@ -1,5 +1,16 @@
 # Avoindata.fi DCAT-AP extension
 
+## Validation
+
+Documents can be validated against this specification with a [https://www.w3.org/TR/shacl/](SHACL) processor using these schema files:
+
+- [avoindata_dcat-ap_shacl.ttl](avoindata_dcat-ap_shacl.ttl)
+- [FOAF.ttl](FOAF.ttl)
+
+For example, using [https://pypi.org/project/pyshacl](pyshacl):
+
+    pyshacl -s avoindata_dcat-ap_shacl.ttl -e FOAF.ttl --imports -i rdfs catalog.xml</code>
+
 ## Vocabularies
 
 Prefix | URI

--- a/doc/dcat-ap/README.md
+++ b/doc/dcat-ap/README.md
@@ -9,7 +9,7 @@ Documents can be validated against this specification with a [SHACL](https://www
 
 For example, using [pyshacl](https://pypi.org/project/pyshacl):
 
-    pyshacl -s avoindata_dcat-ap_shacl.ttl -e FOAF.ttl --imports -i rdfs catalog.xml</code>
+    pyshacl -s avoindata_dcat-ap_shacl.ttl -e FOAF.ttl --imports -i rdfs catalog.xml
 
 ## Vocabularies
 

--- a/doc/dcat-ap/README.md
+++ b/doc/dcat-ap/README.md
@@ -2,12 +2,12 @@
 
 ## Validation
 
-Documents can be validated against this specification with a [https://www.w3.org/TR/shacl/](SHACL) processor using these schema files:
+Documents can be validated against this specification with a [SHACL](https://www.w3.org/TR/shacl/) processor using these schema files:
 
 - [avoindata_dcat-ap_shacl.ttl](avoindata_dcat-ap_shacl.ttl)
 - [FOAF.ttl](FOAF.ttl)
 
-For example, using [https://pypi.org/project/pyshacl](pyshacl):
+For example, using [pyshacl](https://pypi.org/project/pyshacl):
 
     pyshacl -s avoindata_dcat-ap_shacl.ttl -e FOAF.ttl --imports -i rdfs catalog.xml</code>
 

--- a/doc/dcat-ap/avoindata_dcat-ap_shacl.ttl
+++ b/doc/dcat-ap/avoindata_dcat-ap_shacl.ttl
@@ -1,0 +1,753 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix : <http://data.europa.eu/r5r#> .
+@prefix adms: <http://www.w3.org/ns/adms#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix lcon: <http://www.w3.org/ns/locn#> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix spdx: <http://spdx.org/rdf/terms#> .
+@prefix time: <http://www.w3.org/2006/time#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcatap: <http://data.europa.eu/r5r> .
+@prefix cc: <http://creativecommons.org/ns#> .
+
+<http://data.europa.eu/r5r/shacl_shapes>
+    dcat:accessURL <https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/distribution/dcat-ap-200-shacl-shapes>;
+    dcat:downloadURL <https://github.com/SEMICeu/DCAT-AP/raw/cea5a96bb4a6f120c20b7a2b3fb4d86bcd725952/releases/2.0.0/Draft/dcat-ap_2.0.0_shacl_shapes.ttl> ;
+    dcatap:availability <http://data.europa.eu/r5r/stable> ;
+    dct:format <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+    dct:conformsTo <https://www.w3.org/TR/shacl> ;
+    dct:creator [
+        rdfs:seeAlso <https://www.linkedin.com/in/bert-van-nuffelen-a349634/> ;
+        org:memberOf <https://tenforce.com> ;
+        foaf:homepage <https://www.linkedin.com/in/bert-van-nuffelen-a349634/> ;
+        foaf:name "Bert Van Nuffelen"
+    ], [
+        rdfs:seeAlso <https://www.ails.ece.ntua.gr/people/natasa> ;
+        org:memberOf <https://www.ails.ece.ntua.gr/> ;
+        foaf:homepage <https://www.ails.ece.ntua.gr/people/natasa> ;
+        foaf:name "Natasa Sofou"
+    ], [
+        rdfs:seeAlso <http://eugeniu.costezki.ro#me> ;
+        org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/PUBL> ;
+        foaf:homepage <http://costezki.ro> ;
+        foaf:name "Eugeniu Costetchi"
+    ], [
+        rdfs:seeAlso <http://makxdekkers.com/#me> ;
+        org:memberOf <http://ami-consult.com/#id> ;
+        foaf:homepage <http://makxdekkers.com/> ;
+        foaf:name "Makx Dekkers"
+    ], [
+        rdfs:seeAlso <http://nikosloutas.com/> ;
+        org:memberOf <http://www.pwc.com/gx/en/eu-institutions-services> ;
+        foaf:homepage <http://nikosloutas.com/> ;
+        foaf:name "Nikolaos Loutas"
+    ], [
+        rdfs:seeAlso <http://www.deri.ie/users/vassilios-peristeras/> ;
+        org:memberOf <http://publications.europa.eu/resource/authority/corporate-body/COM> ;
+        foaf:homepage <http://www.deri.ie/users/vassilios-peristeras/> ;
+        foaf:name "Vassilios Peristeras"
+    ] ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    cc:attributionURL <http://ec.europa.eu/> ;
+    dct:modified "2019-11-15"^^xsd:date ;
+    dct:publisher <http://publications.europa.eu/resource/authority/corporate-body/DIGIT> ;
+    dct:relation <https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/release/200> ;
+    dct:description "This document specifies the constraints on properties and classes expressed by DCAT-AP in SHACL."@en ;
+    dct:title "The constraints of DCAT Application Profile for Data Portals in Europe"@en ;
+    owl:versionInfo "2.0.0" ;
+    foaf:homepage <https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/release/200> ;
+    foaf:maker [
+        foaf:mbox <mailto:contact@semic.eu> ;
+        foaf:name "DCAT-AP Working Group" ;
+        foaf:page <https://github.com/SEMICeu/DCAT-AP>, <https://joinup.ec.europa.eu/node/64331>
+    ] .
+
+
+
+#-------------------------------------------------------------------------
+# The shapes in this file cover all classes in DCAT-AP 2.0.0.
+#
+# 
+#-------------------------------------------------------------------------
+
+:Agent_Shape
+    a sh:NodeShape ;
+    sh:name "Agent"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path foaf:name ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass foaf:Agent ;
+    sh:or ([
+            sh:class foaf:Agent
+        ]
+        [
+            sh:class foaf:Organization
+        ]
+        [
+            sh:class foaf:Group
+        ]
+        [
+            sh:class foaf:Person
+        ]
+    ) .
+
+:CatalogRecord_Shape
+    a sh:NodeShape ;
+    sh:name "Catalog Record"@en ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:node :DcatResource_Shape ;
+        sh:path foaf:primaryTopic ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class dct:Standard ;
+        sh:maxCount 1 ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:CatalogRecord ;
+        sh:maxCount 1 ;
+        sh:path dct:source ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:CatalogRecord .
+
+:Catalog_Shape
+    a sh:NodeShape ;
+    sh:name "Catalog"@en ;
+    sh:property [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LicenseDocument ;
+        sh:maxCount 1 ;
+        sh:path dct:license ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Location ;
+        sh:path dct:spatial ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Catalog ;
+        sh:path dct:hasPart ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Catalog ;
+        sh:maxCount 1 ;
+        sh:path dct:isPartOf ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:rights ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:CatalogRecord ;
+        sh:path dcat:record ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:ConceptScheme ;
+        sh:path dcat:themeTaxonomy ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:DataService ;
+        sh:path dcat:service ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Catalog ;
+        sh:path dcat:catalog ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:path dct:creator ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:minCount 1 ;
+        sh:path dcat:dataset ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path dct:publisher ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:maxCount 1 ;
+        sh:path foaf:homepage ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Catalog .
+
+:CategoryScheme_Shape
+    a sh:NodeShape ;
+    sh:name "Category Scheme"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass skos:ConceptScheme .
+
+:Category_Shape
+    a sh:NodeShape ;
+    sh:name "Category"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path skos:prefLabel ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass skos:Concept .
+
+:Checksum_Shape
+    a sh:NodeShape ;
+    sh:name "Category"@en ;
+    sh:property [
+        sh:hasValue spdx:checksumAlgorithm_sha1 ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path spdx:algorithm ;
+        sh:severity sh:Violation
+    ], [
+        sh:dateTime xsd:hexBinary ;
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:path spdx:checksumValue ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass spdx:Checksum .
+
+:DataService_Shape
+    a sh:NodeShape ;
+    sh:name "Data Service"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:endpointURL ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dcat:servesDataset ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:endPointDescription ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LicenseDocument ;
+        sh:maxCount 1 ;
+        sh:path dct:licence ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:accessRights ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:DataService .
+
+:Dataset_Shape
+    a sh:NodeShape ;
+    sh:name "Dataset"@en ;
+    sh:property [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:shape :VcardKind_Shape ;
+        sh:path dcat:contactPoint ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Distribution ;
+        sh:path dcat:distribution ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:keyword ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:path dct:publisher ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Location ;
+        sh:path dct:spatial ;
+        sh:severity sh:Violation
+    ], [
+	sh:class dct:PeriodOfTime ;
+        sh:path dct:temporal ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:path dcat:theme ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:accessRights ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Frequency ;
+        sh:maxCount 1 ;
+        sh:path dct:accrualPeriodicity ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:Standard ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:hasVersion ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:isVersionOf ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class dct:ProvenanceStatement ;
+        sh:path dct:provenance ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dct:relation ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Dataset ;
+        sh:path dct:source ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path owl:versionInfo ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path adms:versionNotes ;
+        sh:severity sh:Violation
+    ], [
+        sh:class adms:Identifier ;
+        sh:path adms:identifier ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Distribution ;
+        sh:path adms:sample ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:path dcat:landingPage ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:path foaf:page ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:Relationship ;
+        sh:path dcat:qualifiedRelation ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dc:isReferencedBy ;
+        sh:severity sh:Violation
+    ], [
+        sh:class prov:Attribution ;
+        sh:path prov:qualifiedAttribution ;
+        sh:severity sh:Violation
+    ], [
+        sh:class prov:Activity ;
+        sh:path prov:wasGeneratedBy ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:duration ;
+        sh:path dcat:temporalResolution ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:decimal ;
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Agent ;
+        sh:maxCount 1 ;
+        sh:path dct:creator ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Dataset .
+
+:DateOrDateTimeDataType_Shape
+    a sh:NodeShape ;
+    rdfs:comment "Date time date disjunction shape checks that a datatype property receives a date or a dateTime literal" ;
+    rdfs:label "Date time date disjunction" ;
+    sh:message "The values must be data typed as either xsd:date or xsd:dateTime" ;
+    sh:or ([
+            sh:datatype xsd:date
+        ]
+        [
+            sh:datatype xsd:dateTime
+        ]
+    ) .
+
+:DcatResource_Shape
+    a sh:NodeShape ;
+    rdfs:comment "the union of Catalog, Dataset and DataService" ;
+    rdfs:label "dcat:Resource" ;
+    sh:message "The node is either a Catalog, Dataset or a DataService" ;
+    sh:or ([
+            sh:class dcat:Catalog
+        ]
+        [
+            sh:class dcat:Dataset
+        ]
+        [
+            sh:class dcat:DataService
+        ]
+    ) .
+
+:Distribution_Shape
+    a sh:NodeShape ;
+    sh:name "Distribution"@en ;
+    sh:property [
+        sh:class dct:Standard ;
+        sh:path dct:conformsTo ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:issued ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LinguisticSystem ;
+        sh:path dct:language ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:node :DateOrDateTimeDataType_Shape ;
+        sh:path dct:modified ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:RightsStatement ;
+        sh:maxCount 1 ;
+        sh:path dct:rights ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:title ;
+        sh:severity sh:Violation
+    ], [
+        sh:class spdx:Checksum ;
+        sh:maxCount 1 ;
+        sh:path spdx:checksum ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path adms:status ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:decimal ;
+        sh:maxCount 1 ;
+        sh:path dcat:byteSize ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:downloadURL ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ;
+        sh:maxCount 1 ;
+        sh:path dcat:mediaType ;
+        sh:severity sh:Violation
+    ], [
+        sh:class foaf:Document ;
+        sh:path foaf:page ;
+        sh:severity sh:Violation
+    ], [
+        sh:class odrl:Policy ;
+        sh:maxCount 1 ;
+        sh:path odrl:hasPolicy ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dcat:DataService ;
+        sh:path dcat:accessService ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ;
+        sh:maxCount 1 ;
+        sh:path dcat:compressFormat ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaType ;
+        sh:maxCount 1 ;
+        sh:path dcat:packageFormat ;
+        sh:severity sh:Violation
+    ], [
+	sh:class dct:PeriodOfTime ;
+        sh:path dct:temporal ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:duration ;
+        sh:path dcat:temporalResolution ;
+        sh:severity sh:Violation
+    ], [
+        sh:datatype xsd:decimal ;
+        sh:path dcat:spatialResolutionInMeters ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:path dcat:accessURL ;
+        sh:severity sh:Violation
+    ], [
+        sh:nodeKind sh:Literal ;
+        sh:path dct:description ;
+        sh:severity sh:Violation
+    ], [
+        sh:class skos:Concept ;
+        sh:maxCount 1 ;
+        sh:path dcatap:availability ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:MediaTypeOrExtent ;
+        sh:maxCount 1 ;
+        sh:path dct:format ;
+        sh:severity sh:Violation
+    ], [
+        sh:class dct:LicenseDocument ;
+        sh:maxCount 1 ;
+        sh:path dct:license ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Distribution .
+
+:Identifier_Shape
+    a sh:NodeShape ;
+    sh:name "Identifier"@en ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:path skos:notation ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass adms:Identifier .
+
+:LicenceDocument_Shape
+    a sh:NodeShape ;
+    sh:name "Licence Document"@en ;
+    sh:property [
+        sh:class skos:Concept ;
+        sh:path dct:type ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:LicenseDocument .
+
+:Location_Shape
+    a sh:NodeShape ;
+    sh:name "Location"@en ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:bbox ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path dcat:centroid ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:nodeKind sh:Literal ;
+        sh:path lcon:geometry ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dct:Location .
+
+:PeriodOfTime_Shape
+    a sh:NodeShape ;
+    sh:name "PeriodOfTime"@en ;
+    sh:property [
+        sh:maxCount 1 ;
+        sh:path dcat:endDate ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ], [
+        sh:class time:Instant ;
+        sh:maxCount 1 ;
+        sh:path time:hasBeginning ;
+        sh:severity sh:Violation
+    ], [
+        sh:class time:Instant ;
+        sh:maxCount 1 ;
+        sh:path time:hasEnd ;
+        sh:severity sh:Violation
+    ], [
+        sh:maxCount 1 ;
+        sh:path dcat:startDate ;
+        sh:severity sh:Violation ;
+        sh:shape :DateOrDateTimeDataType_Shape
+    ] ;
+    sh:targetClass dct:PeriodOfTime .
+
+:Relationship_Shape
+    a sh:NodeShape ;
+    sh:name "Relationship"@en ;
+    sh:property [
+        sh:class dcat:Role ;
+        sh:minCount 1 ;
+        sh:path dct:relation ;
+        sh:severity sh:Violation
+    ], [
+        sh:minCount 1 ;
+        sh:node :DcatResource_Shape ;
+        sh:path dcat:hadRole ;
+        sh:severity sh:Violation
+    ] ;
+    sh:targetClass dcat:Relationship .
+
+
+:VcardKind_Shape
+    a sh:NodeShape ;
+    rdfs:comment "the union of Individual, Organization, Group and Location" ;
+    rdfs:label "vcard:Kind" ;
+    sh:message "The node is either a Individual, Organization, Group or Location" ;
+    sh:or ([
+            sh:class vcard:Individual
+        ]
+        [
+            sh:class vcard:Organization
+        ]
+        [
+            sh:class vcard:Group
+        ]
+        [
+            sh:class vcard:Location
+        ]
+    ) .
+
+:FoafAgent_Shape
+    a sh:NodeShape ;
+    rdfs:comment "the union of Agent, Organization, Group and Person" ;
+    rdfs:label "foaf:Agent" ;
+    sh:message "The node is either a Agent, Organization, Group or Person" ;
+    sh:or ([
+            sh:class foaf:Agent
+        ]
+        [
+            sh:class foaf:Organization
+        ]
+        [
+            sh:class foaf:Group
+        ]
+        [
+            sh:class foaf:Person
+        ]
+    ) .

--- a/doc/dcat-ap/template.html.j2
+++ b/doc/dcat-ap/template.html.j2
@@ -8,6 +8,17 @@
   <body class="container">
     <h1>Avoindata.fi DCAT-AP extension</h1>
 
+    <h2>Validation</h2>
+    <p>Documents can be validated against this specification with a <a href="https://www.w3.org/TR/shacl/">SHACL</a> processor using these schema files:
+      <ul>
+        <li><a href="avoindata_dcat-ap_shacl.ttl">avoindata_dcat-ap_shacl.ttl</a></li>
+        <li><a href="FOAF.ttl">FOAF.ttl</a></li>
+      </ul>
+    </p>
+    <p>For example, using <a href="https://pypi.org/project/pyshacl/">pyshacl</a>:
+    <code>pyshacl -s avoindata_dcat-ap_shacl.ttl -e FOAF.ttl --imports -i rdfs catalog.xml</code>
+    </p>
+
     <h2>Vocabularies</h2>
 
     <table class="table table-striped">

--- a/doc/dcat-ap/template.md.j2
+++ b/doc/dcat-ap/template.md.j2
@@ -1,5 +1,16 @@
 # Avoindata.fi DCAT-AP extension
 
+## Validation
+
+Documents can be validated against this specification with a [https://www.w3.org/TR/shacl/](SHACL) processor using these schema files:
+
+- [avoindata_dcat-ap_shacl.ttl](avoindata_dcat-ap_shacl.ttl)
+- [FOAF.ttl](FOAF.ttl)
+
+For example, using [https://pypi.org/project/pyshacl](pyshacl):
+
+    pyshacl -s avoindata_dcat-ap_shacl.ttl -e FOAF.ttl --imports -i rdfs catalog.xml</code>
+
 ## Vocabularies
 
 Prefix | URI

--- a/doc/dcat-ap/template.md.j2
+++ b/doc/dcat-ap/template.md.j2
@@ -2,14 +2,14 @@
 
 ## Validation
 
-Documents can be validated against this specification with a [https://www.w3.org/TR/shacl/](SHACL) processor using these schema files:
+Documents can be validated against this specification with a [SHACL](https://www.w3.org/TR/shacl/) processor using these schema files:
 
 - [avoindata_dcat-ap_shacl.ttl](avoindata_dcat-ap_shacl.ttl)
 - [FOAF.ttl](FOAF.ttl)
 
-For example, using [https://pypi.org/project/pyshacl](pyshacl):
+For example, using [pyshacl](https://pypi.org/project/pyshacl):
 
-    pyshacl -s avoindata_dcat-ap_shacl.ttl -e FOAF.ttl --imports -i rdfs catalog.xml</code>
+    pyshacl -s avoindata_dcat-ap_shacl.ttl -e FOAF.ttl --imports -i rdfs catalog.xml
 
 ## Vocabularies
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/dcat.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/dcat.py
@@ -364,9 +364,12 @@ class AvoindataDCATAPProfile(RDFProfile):
 
         language = p.config.get('ckan.locale_default', 'en')
         linguistic_system = URIRef('http://id.loc.gov/vocabulary/iso639-1/%s' % language)
+        g.add((linguistic_system, RDF.type, DCT.LinguisticSystem))
         g.add((catalog_ref, DCT.language, linguistic_system))
 
-        publisher = URIRef(p.config.get('ckan.site_url', ''))
+        publisher = BNode()
+        g.add((publisher, RDF.type, FOAF.Organization))
+        g.add((publisher, FOAF.hasSite, URIRef(p.config.get('ckan.site_url', ''))))
         g.add((publisher, FOAF.name, Literal(p.config.get('ckan.site_title'))))
         g.add((catalog_ref, DCT.publisher, publisher))
 


### PR DESCRIPTION
- Added FOAF and avoindata_dcat-ap SHACL schema files to doc
- Added documentation to dcat-ap namespace documentation templates
- Modified Ansible to include SHACL files in the documentation
- Modified DCAT-AP output to match the new validation