### PR TITLE
Use smaller page_size in package generation

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/commands.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/commands.py
@@ -105,7 +105,7 @@ def migrate_author_email(ctx, config, dryrun):
     load_config(config or ctx.obj['config'])
     package_patches = []
 
-    for old_package_dict in package_generator('*:*', 1000):
+    for old_package_dict in package_generator('*:*', 10):
         if old_package_dict.get('author_email') is None:
             patch = {'id': old_package_dict['id'], 'author_email': ''}
             package_patches.append(patch)
@@ -132,7 +132,7 @@ def migrate(ctx, config, dryrun):
     package_patches = []
     resource_patches = []
 
-    for old_package_dict in package_generator('*:*', 1000):
+    for old_package_dict in package_generator('*:*', 10):
 
         if 'title_translated' in old_package_dict:
             continue
@@ -221,7 +221,7 @@ def migrate_temporal_granularity(ctx, config, dryrun):
 
     package_patches = []
 
-    for old_package_dict in package_generator('*:*', 1000):
+    for old_package_dict in package_generator('*:*', 10):
         resource_patches = []
         changes = False
         for resource in old_package_dict.get('resources', []):
@@ -258,7 +258,7 @@ def migrate_high_value_datasets(ctx, config, dryrun):
     load_config(config or ctx.obj['config'])
     package_patches = []
 
-    for old_package_dict in package_generator('*:*', 1000):
+    for old_package_dict in package_generator('*:*', 10):
         if old_package_dict.get('high_value_dataset_category'):
             patch = {'id': old_package_dict['id'], 'international_benchmarks': old_package_dict['high_value_dataset_category']}
             package_patches.append(patch)
@@ -345,7 +345,7 @@ def batch_edit(ctx, config, search_string, dryrun, group):
     if group:
         group_assigns[group] = []
 
-    for package_dict in package_generator(search_string, 1000):
+    for package_dict in package_generator(search_string, 10):
         if group:
             group_assigns[group].append(package_dict['name'])
 
@@ -370,7 +370,7 @@ def update_package_deprecation(ctx, config, dryrun):
     package_patches = []
 
     # Get only packages with a valid_till field and some value in the valid_till field
-    for old_package_dict in package_generator('valid_till:* AND -valid_till:""', 1000):
+    for old_package_dict in package_generator('valid_till:* AND -valid_till:""', 10):
         valid_till = old_package_dict.get('valid_till')
 
         # For packages that have a valid_till date set depracated field to true or false
@@ -407,7 +407,7 @@ def validate(ctx, config, verbose):
     no_errors = True
     user = t.get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
     context = {'model': model, 'session': model.Session, 'user': user['name'], 'ignore_auth': True}
-    for package_dict in package_generator('*:*', 1000):
+    for package_dict in package_generator('*:*', 10):
         if verbose:
             print "Validating %s" % package_dict['name']
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/reports.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/reports.py
@@ -56,7 +56,7 @@ def administrative_branch_summary_report():
 
     # Optimization opportunity: Prefetch datasets for all related orgs in one go
     root_datasets_pairs = (
-        (k, list(package_generator('owner_org:(%s)' % ' OR '.join(v), 1000, context)))
+        (k, list(package_generator('owner_org:(%s)' % ' OR '.join(v), 10, context)))
         for k, v in root_tree_ids_pairs)
 
     try:
@@ -102,7 +102,7 @@ administrative_branch_summary_report_info = {
 
 def deprecated_datasets_report():
     # Get packages that are deprecated
-    all_deprecated = package_generator('deprecated:true AND private:false', 1000, {})
+    all_deprecated = package_generator('deprecated:true AND private:false', 10, {})
 
     # Function to loop packages through
     # Get package visit and download data

--- a/modules/ckanext-ytp_main/ckanext/ytp/reports.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/reports.py
@@ -56,7 +56,7 @@ def administrative_branch_summary_report():
 
     # Optimization opportunity: Prefetch datasets for all related orgs in one go
     root_datasets_pairs = (
-        (k, list(package_generator('owner_org:(%s)' % ' OR '.join(v), 10, context)))
+        (k, list(package_generator('owner_org:(%s)' % ' OR '.join(v), 1000, context)))
         for k, v in root_tree_ids_pairs)
 
     try:


### PR DESCRIPTION
to reduce memory footprint of batch commands.

Our batch running instance is running out of memory due to daily cron commands. This should help as python code wont fetch 1000 datasets at once, although this multiplis calls to package_search.