### PR TITLE
Fix build ssh key use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
 
       - run:
           name: Copy private key for ec2 usage
-          command: aws s3 cp --quiet s3://$AWS_PRIVATE_KEY_S3_PATH ~/.ssh/id_rsa
+          command: aws s3 cp --quiet s3://$AWS_PRIVATE_KEY_S3_PATH ~/.ssh/opendata-buildtest-key.pem
           working_directory: ~/project/
 
       - run: |

--- a/ansible/circleci_build_test.yml
+++ b/ansible/circleci_build_test.yml
@@ -31,7 +31,7 @@
 
     - name: Configure AWS private key permissions
       file:
-        path: ~/.ssh/id_rsa
+        path: ~/.ssh/opendata-buildtest-key.pem
         mode: 0600
 
     - name: Disable host key checking
@@ -40,7 +40,7 @@
         content: |
           Host *
               StrictHostKeyChecking no
-              IdentityFile ~/.ssh/id_rsa
+              IdentityFile ~/.ssh/opendata-buildtest-key.pem
 
     - name: Launch EC2 instance
       ec2:


### PR DESCRIPTION
Circle CI has id_rsa.pub now for some reason, which breaks using id_rsa, this renames the key which is used with ansible.