### PR TITLE
AV-1366: Dataset schema support for multiple emails

### DIFF
--- a/cypress/integration/advancedsearch_spec.js
+++ b/cypress/integration/advancedsearch_spec.js
@@ -25,7 +25,7 @@ describe('Advanced search tests', () => {
                     '#field-notes_translated-fi': 'First dataset description',
                     '#s2id_autogen1': 'test_keyword {enter}',
                     '#field-maintainer': 'test maintainer',
-                    '#field-maintainer_email': 'test.maintainer@example.com',
+                    '#field-maintainer_email-1': 'test.maintainer@example.com',
                     '#field-valid_from': '2019-02-04',
                     '#field-valid_till': '2020-02-04',
                     '#field-license_id': {
@@ -50,7 +50,7 @@ describe('Advanced search tests', () => {
                     '#field-notes_translated-fi': 'second dataset description with unicorns',
                     '#s2id_autogen1': 'another_keyword {enter} test_keyword {enter}',
                     '#field-maintainer': 'test maintainer',
-                    '#field-maintainer_email': 'test.maintainer@example.com',
+                    '#field-maintainer_email-1': 'test.maintainer@example.com',
                     '#field-valid_from': '2019-02-04',
                     '#field-valid_till': '2020-02-04'
                 },

--- a/cypress/integration/category_spec.js
+++ b/cypress/integration/category_spec.js
@@ -21,7 +21,7 @@ describe('Category tests', function () {
       '#field-notes_translated-fi': 'Dataset test description',
       '#s2id_autogen1': 'test_keyword {enter}',
       '#field-maintainer': 'test maintainer',
-      '#field-maintainer_email': 'test.maintainer@example.com'
+      '#field-maintainer_email-1': 'test.maintainer@example.com'
     };
 
     cy.get('nav a[href="/data/fi/dataset"]').click();

--- a/cypress/integration/dataset_spec.js
+++ b/cypress/integration/dataset_spec.js
@@ -25,7 +25,7 @@ describe('Dataset tests', function() {
       '#field-notes_translated-fi': 'Dataset test description',
       '#s2id_autogen1': 'test_keyword {enter}',
       '#field-maintainer': 'test maintainer',
-      '#field-maintainer_email': 'test.maintainer@example.com'
+      '#field-maintainer_email-1': 'test.maintainer@example.com'
     };
 
     cy.get('a[href="/data/fi/dataset/new"]').click();
@@ -89,7 +89,7 @@ describe('Dataset tests', function() {
       '#s2id_autogen3': 'test {enter}',
       '#s2id_autogen4': 'test {enter}',
       '#field-maintainer': 'test maintainer',
-      '#field-maintainer_email': 'example@example.com',
+      '#field-maintainer_email-1': 'example@example.com',
       '#field-maintainer_website': 'www.example.com',
       '#field-copyright_notice_translated-fi': 'lisenssi test',
       '#field-copyright_notice_translated-en': 'lisenssi test',

--- a/cypress/integration/showcase_spec.js
+++ b/cypress/integration/showcase_spec.js
@@ -87,7 +87,7 @@ describe('Showcase tests', function() {
       '#field-notes_translated-fi': 'Dataset test description',
       '#s2id_autogen1': 'test_keyword {enter}',
       '#field-maintainer': 'test maintainer',
-      '#field-maintainer_email': 'test.maintainer@example.com',
+      '#field-maintainer_email-1': 'test.maintainer@example.com',
     }
     cy.get('nav a[href="/data/fi/dataset"]').click();
     // Dataset will be created with default resource_form_data

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -147,7 +147,7 @@ Cypress.Commands.add('create_new_dataset', (dataset_name, dataset_form_data, res
       '#field-notes_translated-fi': 'Dataset test description',
       '#s2id_autogen1': 'test_keyword {enter}',
       '#field-maintainer': 'test maintainer',
-      '#field-maintainer_email': 'test.maintainer@example.com'
+      '#field-maintainer_email-1': 'test.maintainer@example.com'
     }
   }
   if (!resource_form_data) {

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -475,6 +475,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
             'override_field': validators.override_field,
             'repeating_text_output': validators.repeating_text_output,
             'repeating_text': validators.repeating_text,
+            'repeating_email': validators.repeating_email,
             'set_private_if_not_admin_or_showcase_admin': validators.set_private_if_not_admin_or_showcase_admin,
             'tag_list_output': validators.tag_list_output,
             'tag_string_or_tags_required': validators.tag_string_or_tags_required,

--- a/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
+++ b/modules/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
@@ -240,13 +240,14 @@
     {
       "field_name": "maintainer_email",
       "label": "Maintainer email",
+      "preset": "repeating_text",
       "form_placeholder": "e.g. avoindata@dvv.fi",
       "form_attrs": {
         "class": "form-control"
       },
       "display_property": "dc:contributor",
-      "display_snippet": "email.html",
-      "validators": "not_empty email_validator",
+      "display_snippet": "repeating_email.html",
+      "validators": "repeating_text repeating_email not_empty",
       "required": true
     },
     {

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/display_snippets/repeating_email.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/display_snippets/repeating_email.html
@@ -1,0 +1,6 @@
+{%- set values = data[field.field_name] -%}
+<ol>
+{%- for element in values -%}
+  <li>{{ h.mail_to(email_address=element, name=element) }}</li>
+{%- endfor -%}
+</ol>

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/repeating_text.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/repeating_text.html
@@ -12,7 +12,7 @@
     error=errors[field.field_name],
     classes=['control-full'],
     attrs=field.form_attrs if 'form_attrs' in field else {},
-    is_required=h.scheming_field_required(field),
+    is_required=(h.scheming_field_required(field) and loop.index == 1),
     description=field.description
     ) }}
 {%- endfor -%}

--- a/modules/ckanext-ytp_main/ckanext/ytp/validators.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/validators.py
@@ -248,6 +248,22 @@ def repeating_text_output(value):
         return [value]
 
 
+def repeating_email(key, data, errors, context):
+    if errors[key]:
+        return
+
+    value_json = data[key]
+    value = json.loads(value_json)
+
+    if not isinstance(value, list):
+        errors[key].append(_('expecting a list'))
+        return
+
+    email_validator = toolkit.get_validator('email_validator')
+    for item in value:
+        email_validator(item, context)
+
+
 @scheming_validator
 def only_default_lang_required(field, schema):
     default_lang = ''


### PR DESCRIPTION
- Add template for showing multiple email addresses in dataset page
- Add a validator for validating multiple email addresses
- Fix repeating_text form_snippet requiring all fields to be filled if the field is required
- Modify dataset.json schema to use repeating_text for maintainer email address input
