### PR TITLE
AV-1330: Set dcat_base_uri to url which contain root path

### DIFF
--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -163,6 +163,7 @@ ckanext.forcetranslation.domain = ckanext-ytp_main
 
 ckanext.dcat.rdf.profiles = avoindata_dcat_ap
 ckanext.dcat.translate_keys = False
+ckanext.dcat.base_uri = {{ ckan_site_protocol }}://{{ item.hostname }}/data
 
 ckanext.geoview.ol_viewer.formats = wms wfs geojson
 


### PR DESCRIPTION
By default ckanext-dcat will use site_url if base_uri is not set. site_url does not contain root_path and generated URL are missing /data/