### PR TITLE
AV-1351: Replace maps with OSM and fix CSP errors

### DIFF
--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -221,8 +221,8 @@ ckanext.matomo.script_domain = {{ ckan_matomo_analytics.script_domain }}
 ckanext.spatial.harvest.continue_on_validation_errors = true
 
 ckanext.spatial.common_map.type = custom
-ckanext.spatial.common_map.custom.url = https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
-ckanext.spatial.common_map.attribution = Maps &copy; <a href="http://www.wikimedia.org">Wikimedia Foundation</a>, Data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>
+ckanext.spatial.common_map.custom.url = https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+ckanext.spatial.common_map.attribution = &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors
 
 solr_url = http://{{ ckan_solr_host }}:{{ ckan_solr_port }}/{{ item.solr_path }}
 

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -14,3 +14,45 @@ nginx_service_state: started
 
 nginx_domain: ""
 nginx_secondary_domain: ""
+
+nginx_content_security_policy_script_domains:
+  - "platform.twitter.com"
+  - "syndication.twitter.com"
+  - "cdn.syndication.twimg.com"
+  - "*.disqus.com"
+  - "https://disqus.com"
+  - "*.disquscdn.com"
+  - "www.google-analytics.com"
+  - "https://www.google.com/recaptcha/"
+  - "https://www.gstatic.com/"
+  - "https://www.google.com"
+  - "cdn.matomo.cloud"
+  - "suomi.matomo.cloud"
+
+nginx_content_security_policy_style_domains:
+  - "https://fonts.googleapis.com"
+  - "https://platform.twitter.com"
+  - "https://ton.twimg.com"
+  - "*.disquscdn.com"
+  - "https://www.google.com"
+  - "https://ajax.googleapis.com"
+  - "https://www.gstatic.com"
+
+nginx_content_security_policy_frame_domains:
+  - "{% if nginx_domain is defined and nginx_domain != ''%}*.{{ nginx_domain }} {% endif %}"
+  - "{% if nginx_secondary_domain is defined and nginx_secondary_domain != '' %}*.{{ nginx_secondary_domain}} {% endif %}"
+  - "syndication.twitter.com"
+  - "https://platform.twitter.com"
+  - "https://disqus.com"
+  - "*.disqus.com"
+  - "https://www.google.com/recaptcha/"
+
+nginx_content_security_policy:
+  - "default-src 'self';"
+  - "script-src 'self' 'unsafe-inline' 'unsafe-eval' {{ nginx_content_security_policy_script_domains | join(' ') }};"
+  - "img-src 'self' https: gravatar.com data:;"
+  - "style-src 'self' 'unsafe-inline' {{ nginx_content_security_policy_style_domains | join(' ') }};"
+  - "font-src 'self' https://themes.googleusercontent.com https://fonts.gstatic.com;"
+  - "frame-src 'self' {{ nginx_content_security_policy_frame_domains | join(' ') }};"
+  - "object-src 'none';"
+  - "connect-src 'self' https://links.services.disqus.com wss://realtime.services.disqus.com https://epsg.io *;"

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -47,8 +47,12 @@ nginx_content_security_policy_frame_domains:
   - "*.disqus.com"
   - "https://www.google.com/recaptcha/"
 
+nginx_content_security_policy_default_domains:
+  - "*.disquscdn.com"
+  - "https://disqus.com"
+
 nginx_content_security_policy:
-  - "default-src 'self';"
+  - "default-src 'self' {{ nginx_content_security_policy_default_domains | join (' ') }};"
   - "script-src 'self' 'unsafe-inline' 'unsafe-eval' {{ nginx_content_security_policy_script_domains | join(' ') }};"
   - "img-src 'self' https: gravatar.com data:;"
   - "style-src 'self' 'unsafe-inline' {{ nginx_content_security_policy_style_domains | join(' ') }};"

--- a/ansible/roles/nginx/templates/nginx_security_headers.conf.j2
+++ b/ansible/roles/nginx/templates/nginx_security_headers.conf.j2
@@ -2,7 +2,7 @@
 add_header X-XSS-Protection "1; mode=block";
 
 # Content security policies allowing content to be loaded from specified addresses
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' platform.twitter.com syndication.twitter.com cdn.syndication.twimg.com *.disqus.com https://disqus.com *.disquscdn.com www.google-analytics.com https://www.google.com/recaptcha/ https://www.gstatic.com/ https://www.google.com cdn.matomo.cloud suomi.matomo.cloud; img-src 'self' https: gravatar.com data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://platform.twitter.com https://ton.twimg.com *.disquscdn.com https://www.google.com https://ajax.googleapis.com  https://www.gstatic.com; font-src 'self' https://themes.googleusercontent.com https://fonts.gstatic.com; frame-src 'self' {% if nginx_domain is defined%}*.{{ nginx_domain }} {% endif %} {% if nginx_secondary_domain is defined %}*.{{ nginx_secondary_domain}} {% endif %}syndication.twitter.com https://platform.twitter.com https://disqus.com *.disqus.com https://www.google.com/recaptcha/; object-src 'none'; connect-src 'self' https://links.services.disqus.com wss://realtime.services.disqus.com https://epsg.io *";
+add_header Content-Security-Policy "{{ nginx_content_security_policy | join(' ') }}";
 
 # Strict Transport Security (use only https)
 add_header Strict-Transport-Security "max-age=31536000; preload";


### PR DESCRIPTION
* Replaces wikimedia maps with OpenStreetMaps.
* Constructs CSP header from variables for easier diffs.
* Add disqus domains to default-src as the implementation has changed.