### PR TITLE
AV-1337: Send notification on stuck harvesters

### DIFF
--- a/ansible/inventories/group_vars/beta/ckan.yml
+++ b/ansible/inventories/group_vars/beta/ckan.yml
@@ -53,4 +53,5 @@ ckan_sentry_dsn: "{{ secret_ckan_sentry_dsn }}"
 ckan_harvester_status_email_recipients: "{{ secret_ckan_harvester_status_email_recipients }}"
 ckan_fault_recipients: "{{ secret_ckan_fault_recipients }}"
 ckan_matomo_analytics: "{{ matomo_analytics }}"
+ckan_harvester_instruction_url: "{{ secret_ckan_harvester_instruction_url }}"
 

--- a/ansible/inventories/group_vars/beta/ckan.yml
+++ b/ansible/inventories/group_vars/beta/ckan.yml
@@ -51,6 +51,6 @@ ckan_deployment_environment_id: 'beta'
 ckan_sentry_dsn: "{{ secret_ckan_sentry_dsn }}"
 
 ckan_harvester_status_email_recipients: "{{ secret_ckan_harvester_status_email_recipients }}"
-
+ckan_fault_recipients: "{{ secret_ckan_fault_recipients }}"
 ckan_matomo_analytics: "{{ matomo_analytics }}"
 

--- a/ansible/inventories/group_vars/prod/ckan.yml
+++ b/ansible/inventories/group_vars/prod/ckan.yml
@@ -54,3 +54,4 @@ ckan_exempt_domains_from_broken_link_notifications:
   - fmi.fi
 
 ckan_matomo_analytics: "{{ matomo_analytics }}"
+ckan_harvester_instruction_url: "{{ secret_ckan_harvester_instruction_url }}"

--- a/ansible/inventories/group_vars/prod/ckan.yml
+++ b/ansible/inventories/group_vars/prod/ckan.yml
@@ -48,6 +48,7 @@ ckan_deployment_environment_id: 'prod'
 ckan_sentry_dsn: "{{ secret_ckan_sentry_dsn }}"
 
 ckan_harvester_status_email_recipients: "{{ secret_ckan_harvester_status_email_recipients }}"
+ckan_fault_recipients: "{{ secret_ckan_fault_recipients }}"
 ckan_notifications_to_maintainers_enabled: true
 ckan_exempt_domains_from_broken_link_notifications:
   - fmi.fi

--- a/ansible/roles/ckan/defaults/main.yml
+++ b/ansible/roles/ckan/defaults/main.yml
@@ -224,6 +224,7 @@ ckan_admins:
 # user who should run supervisord
 ckan_harvester_user: "{{ ckan_www_user }}"
 ckan_harvester_status_email_recipients: ""
+ckan_fault_recipients: ""
 ckan_sql_files_to_execute:
   - datastore_permissions.sql.j2
 

--- a/ansible/roles/ckan/defaults/main.yml
+++ b/ansible/roles/ckan/defaults/main.yml
@@ -322,3 +322,4 @@ ckan_dynatrace_pip_packages:
 
 ckan_notifications_to_maintainers_enabled: false
 ckan_exempt_domains_from_broken_link_notifications: []
+ckan_harvester_instruction_url: ""

--- a/ansible/roles/ckan/tasks/cron.yml
+++ b/ansible/roles/ckan/tasks/cron.yml
@@ -109,6 +109,14 @@
     hour: "11"
     job: "{{ ckan_virtual_environment }}/bin/paster --plugin=ckanext-ytp_main opendata-harvest send-status-emails --config={{ ckan_ini }}"
 
+- name: Send stuck harvester report emails as a cron job
+  cron:
+    name: "Send stuck harvester report emails"
+    minute: "0"
+    hour: "11"
+    job: "{{ ckan_virtual_environment }}/bin/paster --plugin=ckanext-ytp_main opendata-harvest send-stuck-runs-report --config={{ ckan_ini }}"
+
+
 - name: Remove old beaker sessions from beaker_cache table
   cron:
     name: "Remove old beaker sessions"

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -154,6 +154,7 @@ target_group_options_url = file://{{ ckan_files_path }}/target_groups.json
 ckanext.ytp.default_organization_name = yksityishenkilo
 ckanext.ytp.default_organization_title = Yksityishenkil\u00f6
 ckanext.ytp.harvester_status_recipients = {{ ckan_harvester_status_email_recipients|join(' ') }}
+ckanext.ytp.fault_recipients = {{ ckan_fault_recipients|join(' ') }}
 
 ckanext.prh_tools.mail_recipients = {{ ckan_harvester_status_email_recipients|join(' ') }}
 

--- a/ansible/roles/ckan/templates/ckan.ini.j2
+++ b/ansible/roles/ckan/templates/ckan.ini.j2
@@ -155,6 +155,7 @@ ckanext.ytp.default_organization_name = yksityishenkilo
 ckanext.ytp.default_organization_title = Yksityishenkil\u00f6
 ckanext.ytp.harvester_status_recipients = {{ ckan_harvester_status_email_recipients|join(' ') }}
 ckanext.ytp.fault_recipients = {{ ckan_fault_recipients|join(' ') }}
+ckanext.ytp.harvester_instruction_url = {{ ckan_harvester_instruction_url }}
 
 ckanext.prh_tools.mail_recipients = {{ ckan_harvester_status_email_recipients|join(' ') }}
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/commands.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/commands.py
@@ -647,22 +647,23 @@ def send_stuck_runs_report(ctx, config, dryrun, force, all_harvesters):
         print('No recipients configured')
         return
 
-
     status_opts = {} if not all_harvesters else {'include_manual': True, 'include_never_run': True}
     status = get_action('harvester_status')({}, status_opts)
 
-    stuck_runs = [(title, status) for title, status in six.iteritems(status)
-                  if status.get('status') == 'running' and _elapsed_since(status.get('started')).days > 1]
+    stuck_runs = [(title, job_status) for title, job_status in six.iteritems(status)
+                  if job_status.get('status') == 'running' and _elapsed_since(job_status.get('started')).days > 1]
 
     if stuck_runs:
         site_title = t.config.get('ckan.site_title', '')
 
         msg = '%(site_title)s - Following harvesters have been running more than 24 hours: \n\n%(status)s\n\n' \
-              'Instructions to fix this can be found from here %(instructions)s' % {
-            'site_title': site_title,
-            'status': '\n'.join('%s has been stuck since %s' % (title, status.get('started')) for title, status in stuck_runs),
-            'instructions': t.config.get('ckanext.ytp.harvester_instruction_url', 'url not configured')
-        }
+              'Instructions to fix this can be found from here %(instructions)s' % \
+              {
+                  'site_title': site_title,
+                  'status': '\n'.join('%s has been stuck since %s' %
+                                      (title, status.get('started')) for title, status in stuck_runs),
+                  'instructions': t.config.get('ckanext.ytp.harvester_instruction_url', 'url not configured')
+              }
 
         subject = '%s - There are stuck harvester runs that need to have a look at' % site_title
         _send_harvester_notification(subject, msg, email_notification_recipients, dryrun)

--- a/modules/ckanext-ytp_main/ckanext/ytp/commands.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/commands.py
@@ -13,6 +13,7 @@ import polib
 import os
 import re
 import glob
+import six
 from tools import check_package_deprecation
 from logic import send_package_deprecation_emails
 
@@ -621,22 +622,72 @@ def send_harvester_status_emails(ctx, config, dryrun, force, all_harvesters):
             'status': '\n'.join(status_string(title, values) for title, values in status.items())
             }
 
-    for recipient in email_notification_recipients:
+    subject = '%s - Harvester summary %s' % (site_title, today)
+    _send_harvester_notification(subject, msg, email_notification_recipients, dryrun)
+
+    if dryrun:
+        print msg
+
+
+@opendata_harvest_group.command(
+    u'send-stuck-runs-report',
+    help='Sends stuck runs report to configured recipients'
+)
+@click_config_option
+@click.option(u'--dryrun', is_flag=True)
+@click.option(u'--force', is_flag=True)
+@click.option(u'--all-harvesters', is_flag=True)
+@click.pass_context
+def send_stuck_runs_report(ctx, config, dryrun, force, all_harvesters):
+    load_config(config or ctx.obj['config'])
+
+    email_notification_recipients = t.aslist(t.config.get('ckanext.ytp.fault_recipients', ''))
+
+    if not email_notification_recipients and not dryrun:
+        print('No recipients configured')
+        return
+
+
+    status_opts = {} if not all_harvesters else {'include_manual': True, 'include_never_run': True}
+    status = get_action('harvester_status')({}, status_opts)
+
+    stuck_runs = [(title, status) for title, status in six.iteritems(status)
+                  if status.get('status') == 'running' and _elapsed_since(status.get('started')).days > 1]
+
+    if stuck_runs:
+        site_title = t.config.get('ckan.site_title', '')
+
+        msg = '%(site_title)s - Following harvesters have been running more than 24 hours: \n\n%(status)s\n\n' \
+              'Instructions to fix this can be found from here %(instructions)s' % {
+            'site_title': site_title,
+            'status': '\n'.join('%s has been stuck since %s' % (title, status.get('started')) for title, status in stuck_runs),
+            'instructions': t.config.get('ckanext.ytp.harvester_instruction_url', 'url not configured')
+        }
+
+        subject = '%s - There are stuck harvester runs that need to have a look at' % site_title
+        _send_harvester_notification(subject, msg, email_notification_recipients, dryrun)
+
+        if dryrun:
+            print(msg)
+    else:
+        print('Nothing to report')
+
+
+def _send_harvester_notification(subject, msg, recipients, dryrun):
+
+    for recipient in recipients:
         email = {'recipient_name': recipient,
                  'recipient_email': recipient,
-                 'subject': '%s - Harvester summary %s' % (site_title, today),
+                 'subject': subject,
                  'body': msg}
 
         if dryrun:
-            print 'to: %s' % recipient
+            print('to: %s' % recipient)
         else:
             try:
                 mailer.mail_recipient(**email)
             except mailer.MailerException as e:
-                print 'Sending harvester summary to %s failed: %s' % (recipient, e)
-
-    if dryrun:
-        print msg
+                print('Sending harvester notification to %s failed: %s' % (recipient, e))
 
 
 def _elapsed_since(t):

--- a/modules/ckanext-ytp_main/ckanext/ytp/harvesterstatusplugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/harvesterstatusplugin.py
@@ -24,7 +24,7 @@ def harvester_status(context=None, data_dict=None):
         finished = j.get('finished')
         errors = j.get('stats', {}).get('errored', 0)
 
-        if finished is not None:
+        if j.get('status') == u'Finished' or finished is not None:
             status = 'finished'
         elif started is not None:
             status = 'running'


### PR DESCRIPTION
* Adds new configuration options: URL for instructions and fault recipients as not everything is sent to them.
* Adds new command to send notification only if some harvester has been running more than 24 hours.
* Modifies harvester status action as stopped harvester does not have finished timestamp but its status in finished.