### PR TITLE
AV-1397: Downloading initial virus definitions is not allowed anymore

### DIFF
--- a/clamav/clamav-docker/Dockerfile
+++ b/clamav/clamav-docker/Dockerfile
@@ -14,11 +14,6 @@ RUN echo "deb http://http.debian.net/debian/ $DEBIAN_VERSION main contrib non-fr
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
-    wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
-    wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
-    chown clamav:clamav /var/lib/clamav/*.cvd
-
 RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
     chmod 750 /var/run/clamav


### PR DESCRIPTION
This might need adjustments to builds after it is deployed.