### PR TITLE
Remove drupal migration tools from use

### DIFF
--- a/ansible/roles/drupal/defaults/main.yml
+++ b/ansible/roles/drupal/defaults/main.yml
@@ -73,6 +73,9 @@ drupal_removed_extensions:
   - search
   - contextual
   - page_cache
+  - migrate_tools
+  - migrate_plus
+  - migrate_upgrade
 
 drupal_modules_path: "../modules"
 drupal_admin_email: admin@localhost


### PR DESCRIPTION
Migration was done years ago, this disables the tools so that we can remove them from composer after all environments have been updated.