### PR TITLE
AV-1107: Show current page in user profile navigation

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/ytp/menu.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/ytp/menu.html
@@ -8,7 +8,7 @@
             <ul class="menu nav">
                 {%- for _item, attribs in menu.tree.items() recursive -%}
                     <li class="ytp-menulink">
-                        <a href="{{ attribs['link']['href'] }}" {% if attribs['selected'] -%}class="selected"{%- endif -%}>
+                        <a href="{{ attribs['link']['href'] }}" {% if attribs['selected'] -%}class="selected nav-link-selected"{%- endif -%}>
                             {{ attribs['link']['title'] }}
                         </a>
                         {%- if attribs['children'] -%}

--- a/modules/ytp-assets-common/src/less/navbars.less
+++ b/modules/ytp-assets-common/src/less/navbars.less
@@ -573,3 +573,7 @@ End of dropdown CSS
     border-radius: 0 !important;
   }
 }
+
+.nav-link-selected {
+  background-color: @nav-link-selected-color;
+}

--- a/modules/ytp-assets-common/src/less/variables.less
+++ b/modules/ytp-assets-common/src/less/variables.less
@@ -154,3 +154,5 @@
 @new-layout-secondary-text-color-dark: rgb(0, 52, 121);
 @new-layout-primary-text-color: rgb(41, 41, 41);
 @new-layout-nonimportant-text-color: rgb(95, 104, 109);
+
+@nav-link-selected-color: #EEEEEE;


### PR DESCRIPTION
Highlight the current page in the navigation menu in the user's profile page.

Done in this commit:
* Add new class to navbars.less
* Add new color variable to .less file for easier re-use
* Utilize the the less class if the current menu entry has the
selected attribute in the html template

Refs AV-1107