### PR TITLE
AV-1435: Fix internal server error on the new dataset page

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/categories.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/categories.html
@@ -13,9 +13,9 @@
         class="categories__list__item__icon"
         src="{{ category.get('image_display_url') }}"
       />
-      {% if category.get('title_translated').get(lang) %}
+      {% if category.get('title_translated', {}).get(lang) %}
       <h5 class="categories__list__item__title">
-        {{ category.get('title_translated').get(lang) }}
+        {{ category.get('title_translated', {}).get(lang) }}
       </h5>
       {% else %}
       <h5 class="categories__list__item__title">


### PR DESCRIPTION
For some reason sometimes categories do not have translations and it causes an error as you can't get from None.