### PR TITLE
AV-1343: AWS WAF Bot Control

### DIFF
--- a/ansible/opendata_cloudfront.yml
+++ b/ansible/opendata_cloudfront.yml
@@ -8,16 +8,14 @@
   hosts: "localhost"
   connection: "local"
   gather_facts: no
-  environment:
-    AWS_PROFILE: "{{ aws_profile }}"
 
   tasks:
-  - name: Configure web stack
+  - name: Configure CloudFront stack
     cloudformation:
       stack_name: "{{ deployment_environment_id }}-cloudfront"
-      state: "{{ lookup('aws_ssm', '/{{ deployment_environment_id }}/cloudfront/status', aws_profile=aws_profile ) }}"
-      region: "{{ lookup('aws_ssm', '/{{ deployment_environment_id }}/cloudfront/region', aws_profile=aws_profile ) }}"
-      create_changeset: "{{ lookup('aws_ssm', '/{{ deployment_environment_id }}/cloudfront/changeset', aws_profile=aws_profile ) }}"
+      state: present
+      region: "{{ lookup('aws_ssm', '/{{ deployment_environment_id }}/cloudfront/region') }}"
+      create_changeset: true
       template: ../cloudformation/cloudfront.yml
       template_parameters:
         Aliases: "/{{ deployment_environment_id }}/cloudfront/aliases"
@@ -26,6 +24,8 @@
         DefaultTTL: "/{{ deployment_environment_id }}/cloudfront/default_ttl"
         EnvironmentName: "/{{ deployment_environment_id }}/cloudfront/environment_name"
         DNSHostName: "/{{ deployment_environment_id }}/cloudfront/dns_hostname"
+        DNSDomainName: "/{{ deployment_environment_id }}/cloudfront/domain"
+        AlternateDNSDomainName: "/{{ deployment_environment_id }}/cloudfront/alternate_domain"
         HostedZoneId: "/{{ deployment_environment_id }}/web/hosted_zone_id"
         HostedZoneIdAlternate: "/{{ deployment_environment_id }}/web/hosted_zone_id_alternate"
         LogIncludeCookies: "/{{ deployment_environment_id }}/cloudfront/log_include_cookies"

--- a/cloudformation/instances.yml
+++ b/cloudformation/instances.yml
@@ -401,6 +401,18 @@ Resources:
             CloudWatchMetricsEnabled: True
             MetricName: allowed-ips
             SampledRequestsEnabled: !Ref WafAllowedIpsRequestSampling
+        - Name: AWS-AWSManagedRulesAmazonIpReputationList
+          Priority: 5
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesAmazonIpReputationList
+          OverrideAction:
+            Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: True
+            CloudWatchMetricsEnabled: True
+            MetricName: AWS-AWSManagedRulesAmazonIpReputationList
         - Name: rate-limit-finland
           Priority: 10
           Action:
@@ -444,6 +456,34 @@ Resources:
             CloudWatchMetricsEnabled: True
             MetricName: banned-ips
             SampledRequestsEnabled: !Ref WafBannedIpsRequestSampling
+        - Name: AWS-AWSManagedRulesBotControlRuleSet
+          Priority: 40
+          Statement:
+            ManagedRuleGroupStatement:
+              VendorName: AWS
+              Name: AWSManagedRulesBotControlRuleSet
+              ExcludedRules:
+              - Name: CategoryAdvertising
+              - Name: CategoryArchiver
+              - Name: CategoryContentFetcher
+              - Name: CategoryHttpLibrary
+              - Name: CategoryLinkChecker
+              - Name: CategoryMiscellaneous
+              - Name: CategoryMonitoring
+              - Name: CategoryScrapingFramework
+              - Name: CategorySearchEngine
+              - Name: CategorySecurity
+              - Name: CategorySeo
+              - Name: CategorySocialMedia
+              - Name: SignalAutomatedBrowser
+              - Name: SignalKnownBotDataCenter
+              - Name: SignalNonBrowserUserAgent
+          OverrideAction:
+            Count: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: True
+            CloudWatchMetricsEnabled: True
+            MetricName: AWS-AWSManagedRulesBotControlRuleSet
       VisibilityConfig:
         CloudWatchMetricsEnabled: True
         MetricName: DVVWAF


### PR DESCRIPTION
add AWS managed rules in counting state to be able to evaluate if the rules could be used to better manage bot traffic