### PR TITLE
AV-1449: Main navigation styling

### DIFF
--- a/modules/ytp-assets-common/src/less/navbars.less
+++ b/modules/ytp-assets-common/src/less/navbars.less
@@ -328,7 +328,12 @@ End of dropdown CSS
   a:hover {
     color: @navbar-color-links;
     background-color: @navbar-background;
-    text-decoration: underline;
+    border-bottom: 4px solid @main-nav-hover-border-bottom;
+    text-decoration: none;
+
+    &.is-active {
+      background-color: #e7e7e7;
+    }
   }
 
   li.active {
@@ -342,17 +347,15 @@ End of dropdown CSS
 
   li {
     a {
+      margin-right: 5px;
+
       &.is-active {
         position: relative;
+        border-bottom: 4px solid @main-nav-hover-border-bottom;
 
         &::after {
           position: absolute;
-          content: ' ';
-          bottom: 4px;
-          height: 4px;
-          left: 10px;
-          right: 10px;
-          background-color: @suomi-highlightBase;
+          border-bottom: 4px solid @main-nav-hover-border-bottom;
         }
       }
     }
@@ -366,7 +369,17 @@ End of dropdown CSS
     &:active {
       color: @navbar-color-links;
       background-color: @navbar-background;
-      text-decoration: underline;
+      text-decoration: none;
+    }
+  }
+
+  // Bit of a hack to not make the nav go crazy on resize.
+  @media (max-width: 1155px) {
+    li {
+      a {
+        margin: 5px 5px 5px 5px;
+        padding: 5px 5px 5px 5px;
+      }
     }
   }
 
@@ -411,6 +424,7 @@ End of dropdown CSS
 
       &:hover {
         border-left: 10px solid @menu-hover-border-color;
+        border-bottom: none;
         text-decoration: none;
       }
     }

--- a/modules/ytp-assets-common/src/less/variables.less
+++ b/modules/ytp-assets-common/src/less/variables.less
@@ -156,3 +156,5 @@
 @new-layout-nonimportant-text-color: rgb(95, 104, 109);
 
 @nav-link-selected-color: #EEEEEE;
+
+@main-nav-hover-border-bottom: rgb(42, 110, 187);


### PR DESCRIPTION
Fix the styling in the main navigation menu so it follows the suomi.fi
design standards.

* Change hover for nav items to a 4px border
* Show active page with gray background and a border-bottom
* Modify how the nav menu changes when resizing window
* Make sure dropdowns only have a left border when hovering

Refs. AV-1449