### PR TITLE
AV-1461: Single apiset fails with internal server error

### DIFF
--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/package/snippets/additional_info.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/scheming/package/snippets/additional_info.html
@@ -14,14 +14,13 @@
 
   {%- for field_key in ordered_dataset_fields -%}
     {%- set field = schema.dataset_fields | selectattr('field_name', 'equalto', field_key) | list -%}
-      <tr>
-        <th scope="row" class="dataset-label">{{
-          h.scheming_language_text(field[0].label) }}</th>
-        <td class="dataset-details"{%
-          if field[0].display_property %} property="{{ field[0].display_property
-          }}"{% endif %}>{%- snippet 'scheming/snippets/display_field.html',
-          field=field[0], data=pkg_dict, schema=schema -%}</td>
-      </tr>
+      {% if field[0] %}
+        <tr>
+          <th scope="row" class="dataset-label">{{ h.scheming_language_text(field[0].label) }}</th>
+          <td class="dataset-details"{% if field[0].display_property %} property="{{ field[0].display_property }}" {% endif %}>
+          {%- snippet 'scheming/snippets/display_field.html', field=field[0], data=pkg_dict, schema=schema -%}</td>
+        </tr>
+      {% endif %}
   {%- endfor -%}
   <tr>
     <th scope="row" class="dataset-label">{{ _("Last modified") }}</th>


### PR DESCRIPTION
The data provided to the template is trying to access an index
from a list which might or might not be empty. Add a sanity check
to ensure that we only display the additional data section in the
apiset view if and only if the section contains any information.

Refs. AV-1461