### PR TITLE
Fix node source repository installation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         ytp.vm.synced_folder ".", "/vagrant", type:"virtualbox", :mount_options => ["dmode=755","fmode=644"]
     end
 
+    ytp.vm.provision "shell",
+      inline: "apt-get update && apt-get install -y --only-upgrade ca-certificates"
+
     ytp.vm.provision "ansible_local" do |ansible|
       ansible.playbook = "ansible/single-server.yml"
       ansible.verbose = "v"

--- a/ansible/roles/opendata_frontend/tasks/main.yml
+++ b/ansible/roles/opendata_frontend/tasks/main.yml
@@ -5,11 +5,6 @@
   apt_key:
     data: "{{ lookup('file', 'nodesource.gpg.key') }}"
 
-- name: Update ca-certificates
-  apt:
-    name: ca-certificates=20210119~18.04.2
-    state: present
-
 - name: Add NodeSource APT repository
   apt_repository:
     repo: 'deb https://deb.nodesource.com/node_12.x {{ ansible_distribution_release }} main'


### PR DESCRIPTION
Ansible does not update packages in vagrant as it breaks the guest additions. Updating single package with state: latest is a violation of linting rules. This PR updates CA certificates in Vagrantfile instead as the problem is only with vagrant environments.