### PR TITLE
Av-1509: Update facet filter texts and translations

### DIFF
--- a/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/plugin.py
+++ b/modules/ckanext-sixodp_showcase/ckanext/sixodp_showcase/plugin.py
@@ -96,7 +96,7 @@ class Sixodp_ShowcasePlugin(ShowcasePlugin):
             facets_dict.update({'groups': _('Groups')})
             facets_dict['vocab_keywords_' + lang] = _('Tags')
 
-            facets_dict.update({'vocab_platform': _('Platform')})
+            facets_dict.update({'vocab_platform': _('Platforms')})
 
         return facets_dict
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-09-16 13:19+0000\n"
+"POT-Creation-Date: 2021-11-24 17:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -325,7 +325,8 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: ckanext/ytp/menu.py:155 ckanext/ytp/templates/organization/admin_list.html:31
+#: ckanext/ytp/menu.py:155 ckanext/ytp/plugin.py:272
+#: ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/index.html:10
 #: ckanext/ytp/templates/organization/organization_not_found.html:6
 #: ckanext/ytp/templates/organization/user_list.html:31
@@ -354,28 +355,20 @@ msgstr ""
 msgid "Publish Data"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:268 ckanext/ytp/translations.py:40
-msgid "International benchmarks"
+#: ckanext/ytp/plugin.py:268
+msgid "International Benchmarks"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:269 ckanext/ytp/plugin.py:283
-msgid "Collection Type"
+msgid "Collection Types"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:270
-msgid "Popular tags"
+msgid "Popular Tags"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:271 ckanext/ytp/plugin.py:285
-msgid "Content Type"
-msgstr ""
-
-#: ckanext/ytp/plugin.py:272
-#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
-#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
-#: ckanext/ytp/templates/snippets/organization.html:21
-#: ckanext/ytp/translations.py:36
-msgid "Organization"
+msgid "Content Types"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:273 ckanext/ytp/plugin.py:286
@@ -383,15 +376,12 @@ msgstr ""
 msgid "Formats"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:275 ckanext/ytp/templates/package/search.html:58
-#: ckanext/ytp/templates/package/snippets/additional_info.html:12
-msgid "Source"
+#: ckanext/ytp/plugin.py:275
+msgid "Sources"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:276 ckanext/ytp/templates/package/resource_read.html:168
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
-#: ckanext/ytp/templates/snippets/license.html:21
-msgid "License"
+#: ckanext/ytp/plugin.py:276
+msgid "Licenses"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:284
@@ -492,12 +482,23 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
+#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
+#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
+#: ckanext/ytp/templates/snippets/organization.html:21
+#: ckanext/ytp/translations.py:36
+msgid "Organization"
+msgstr ""
+
 #: ckanext/ytp/translations.py:37
 msgid "Key"
 msgstr ""
 
 #: ckanext/ytp/translations.py:39
 msgid "Fullname"
+msgstr ""
+
+#: ckanext/ytp/translations.py:40
+msgid "International benchmarks"
 msgstr ""
 
 #: ckanext/ytp/translations.py:41
@@ -1348,6 +1349,98 @@ msgstr ""
 msgid "uk-ogl"
 msgstr ""
 
+#: ckanext/ytp/translations.py:268
+msgid "Platforms"
+msgstr ""
+
+#: ckanext/ytp/translations.py:271
+msgid "Show more collection_type"
+msgstr ""
+
+#: ckanext/ytp/translations.py:272
+msgid "Show more vocab_international_benchmarks"
+msgstr ""
+
+#: ckanext/ytp/translations.py:273
+msgid "Show more vocab_keywords_en"
+msgstr ""
+
+#: ckanext/ytp/translations.py:274
+msgid "Show more vocab_keywords_fi"
+msgstr ""
+
+#: ckanext/ytp/translations.py:275
+msgid "Show more vocab_keywords_sv"
+msgstr ""
+
+#: ckanext/ytp/translations.py:276
+msgid "Show more organization"
+msgstr ""
+
+#: ckanext/ytp/translations.py:277
+msgid "Show more res_format"
+msgstr ""
+
+#: ckanext/ytp/translations.py:278
+msgid "Show more source"
+msgstr ""
+
+#: ckanext/ytp/translations.py:279
+msgid "Show more license_id"
+msgstr ""
+
+#: ckanext/ytp/translations.py:280
+msgid "Show more groups"
+msgstr ""
+
+#: ckanext/ytp/translations.py:281
+msgid "Show more vocab_platform"
+msgstr ""
+
+#: ckanext/ytp/translations.py:284
+msgid "Show less collection_type"
+msgstr ""
+
+#: ckanext/ytp/translations.py:285
+msgid "Show less vocab_international_benchmarks"
+msgstr ""
+
+#: ckanext/ytp/translations.py:286
+msgid "Show less vocab_keywords_en"
+msgstr ""
+
+#: ckanext/ytp/translations.py:287
+msgid "Show less vocab_keywords_fi"
+msgstr ""
+
+#: ckanext/ytp/translations.py:288
+msgid "Show less vocab_keywords_sv"
+msgstr ""
+
+#: ckanext/ytp/translations.py:289
+msgid "Show less organization"
+msgstr ""
+
+#: ckanext/ytp/translations.py:290
+msgid "Show less res_format"
+msgstr ""
+
+#: ckanext/ytp/translations.py:291
+msgid "Show less source"
+msgstr ""
+
+#: ckanext/ytp/translations.py:292
+msgid "Show less license_id"
+msgstr ""
+
+#: ckanext/ytp/translations.py:293
+msgid "Show less groups"
+msgstr ""
+
+#: ckanext/ytp/translations.py:294
+msgid "Show less vocab_platform"
+msgstr ""
+
 #: ckanext/ytp/validators.py:81
 msgid "Missing value"
 msgstr ""
@@ -1907,6 +2000,12 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
+#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
+#: ckanext/ytp/templates/snippets/license.html:21
+msgid "License"
+msgstr ""
+
 #: ckanext/ytp/templates/package/resource_read.html:171
 msgid "Temporal Granularity"
 msgstr ""
@@ -1988,6 +2087,11 @@ msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:57
 msgid "Date Created Descending"
+msgstr ""
+
+#: ckanext/ytp/templates/package/search.html:58
+#: ckanext/ytp/templates/package/snippets/additional_info.html:12
+msgid "Source"
 msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:59
@@ -2488,15 +2592,15 @@ msgstr ""
 msgid "Save Organization"
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:27
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:26
 msgid "Last modified"
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:30
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:29
 msgid "Show change log"
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:34
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:33
 msgid "Created on"
 msgstr ""
 
@@ -2672,15 +2776,7 @@ msgstr ""
 msgid "Height:"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/facet_list.html:80
-msgid "Show More"
-msgstr ""
-
-#: ckanext/ytp/templates/snippets/facet_list.html:83
-msgid "Show Less"
-msgstr ""
-
-#: ckanext/ytp/templates/snippets/facet_list.html:87
+#: ckanext/ytp/templates/snippets/facet_list.html:90
 msgid "There are no {facet_type} that match this search"
 msgstr ""
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
@@ -10,15 +10,16 @@
 # Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2020
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2020
+# Daniel Vainio, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-09-16 13:19+0000\n"
+"POT-Creation-Date: 2021-11-24 17:34+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2020\n"
+"Last-Translator: Daniel Vainio, 2021\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -335,7 +336,7 @@ msgstr ""
 msgid "Users"
 msgstr ""
 
-#: ckanext/ytp/menu.py:155
+#: ckanext/ytp/menu.py:155 ckanext/ytp/plugin.py:272
 #: ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/index.html:10
 #: ckanext/ytp/templates/organization/organization_not_found.html:6
@@ -365,45 +366,33 @@ msgstr ""
 msgid "Publish Data"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:268 ckanext/ytp/translations.py:40
-msgid "International benchmarks"
+#: ckanext/ytp/plugin.py:268
+msgid "International Benchmarks"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:269 ckanext/ytp/plugin.py:283
-msgid "Collection Type"
+msgid "Collection Types"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:270
-msgid "Popular tags"
+msgid "Popular Tags"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:271 ckanext/ytp/plugin.py:285
-msgid "Content Type"
+msgid "Content Types"
 msgstr ""
-
-#: ckanext/ytp/plugin.py:272
-#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
-#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
-#: ckanext/ytp/templates/snippets/organization.html:21
-#: ckanext/ytp/translations.py:36
-msgid "Organization"
-msgstr "Publisher"
 
 #: ckanext/ytp/plugin.py:273 ckanext/ytp/plugin.py:286
 #: ckanext/ytp/translations.py:35
 msgid "Formats"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:275 ckanext/ytp/templates/package/search.html:58
-#: ckanext/ytp/templates/package/snippets/additional_info.html:12
-msgid "Source"
+#: ckanext/ytp/plugin.py:275
+msgid "Sources"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:276
-#: ckanext/ytp/templates/package/resource_read.html:168
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
-#: ckanext/ytp/templates/snippets/license.html:21
-msgid "License"
+msgid "Licenses"
 msgstr ""
 
 #: ckanext/ytp/plugin.py:284
@@ -506,12 +495,23 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
+#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
+#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
+#: ckanext/ytp/templates/snippets/organization.html:21
+#: ckanext/ytp/translations.py:36
+msgid "Organization"
+msgstr "Publisher"
+
 #: ckanext/ytp/translations.py:37
 msgid "Key"
 msgstr ""
 
 #: ckanext/ytp/translations.py:39
 msgid "Fullname"
+msgstr ""
+
+#: ckanext/ytp/translations.py:40
+msgid "International benchmarks"
 msgstr ""
 
 #: ckanext/ytp/translations.py:41
@@ -1385,6 +1385,98 @@ msgstr "Other (Public Domain)"
 msgid "uk-ogl"
 msgstr "UK Open Government Licence (OGL)"
 
+#: ckanext/ytp/translations.py:268
+msgid "Platforms"
+msgstr ""
+
+#: ckanext/ytp/translations.py:271
+msgid "Show more collection_type"
+msgstr "Show more Collection Types"
+
+#: ckanext/ytp/translations.py:272
+msgid "Show more vocab_international_benchmarks"
+msgstr "Show more International Benchmarks"
+
+#: ckanext/ytp/translations.py:273
+msgid "Show more vocab_keywords_en"
+msgstr "Show more Keywords"
+
+#: ckanext/ytp/translations.py:274
+msgid "Show more vocab_keywords_fi"
+msgstr ""
+
+#: ckanext/ytp/translations.py:275
+msgid "Show more vocab_keywords_sv"
+msgstr ""
+
+#: ckanext/ytp/translations.py:276
+msgid "Show more organization"
+msgstr "Show more Publishers"
+
+#: ckanext/ytp/translations.py:277
+msgid "Show more res_format"
+msgstr "Show more Formats"
+
+#: ckanext/ytp/translations.py:278
+msgid "Show more source"
+msgstr "Show more Sources"
+
+#: ckanext/ytp/translations.py:279
+msgid "Show more license_id"
+msgstr "Show more Licenses"
+
+#: ckanext/ytp/translations.py:280
+msgid "Show more groups"
+msgstr "Show more Groups"
+
+#: ckanext/ytp/translations.py:281
+msgid "Show more vocab_platform"
+msgstr "Show more Platforms"
+
+#: ckanext/ytp/translations.py:284
+msgid "Show less collection_type"
+msgstr "Show less Collection Types"
+
+#: ckanext/ytp/translations.py:285
+msgid "Show less vocab_international_benchmarks"
+msgstr "Show less International Benchmarks"
+
+#: ckanext/ytp/translations.py:286
+msgid "Show less vocab_keywords_en"
+msgstr "Show less Keywords"
+
+#: ckanext/ytp/translations.py:287
+msgid "Show less vocab_keywords_fi"
+msgstr ""
+
+#: ckanext/ytp/translations.py:288
+msgid "Show less vocab_keywords_sv"
+msgstr ""
+
+#: ckanext/ytp/translations.py:289
+msgid "Show less organization"
+msgstr "Show less Publishers"
+
+#: ckanext/ytp/translations.py:290
+msgid "Show less res_format"
+msgstr "Show less Formats"
+
+#: ckanext/ytp/translations.py:291
+msgid "Show less source"
+msgstr "Show less Sources"
+
+#: ckanext/ytp/translations.py:292
+msgid "Show less license_id"
+msgstr "Show less Licenses"
+
+#: ckanext/ytp/translations.py:293
+msgid "Show less groups"
+msgstr "Show less Groups"
+
+#: ckanext/ytp/translations.py:294
+msgid "Show less vocab_platform"
+msgstr "Show less Platforms"
+
 #: ckanext/ytp/validators.py:81
 msgid "Missing value"
 msgstr ""
@@ -1947,6 +2039,12 @@ msgstr ""
 msgid "Format"
 msgstr ""
 
+#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
+#: ckanext/ytp/templates/snippets/license.html:21
+msgid "License"
+msgstr ""
+
 #: ckanext/ytp/templates/package/resource_read.html:171
 msgid "Temporal Granularity"
 msgstr ""
@@ -2030,6 +2128,11 @@ msgstr ""
 msgid "Date Created Descending"
 msgstr ""
 
+#: ckanext/ytp/templates/package/search.html:58
+#: ckanext/ytp/templates/package/snippets/additional_info.html:12
+msgid "Source"
+msgstr ""
+
 #: ckanext/ytp/templates/package/search.html:59
 #: ckanext/ytp/templates/snippets/package_item.html:43
 #: ckanext/ytp/templates/snippets/popular.html:3
@@ -2085,11 +2188,11 @@ msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/categories.html:31
 msgid "Show more categories"
-msgstr ""
+msgstr "Show more Categories"
 
 #: ckanext/ytp/templates/package/snippets/categories.html:34
 msgid "Show more"
-msgstr ""
+msgstr "Show more"
 
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:61
 msgid "License Not Specified"
@@ -2534,15 +2637,15 @@ msgstr ""
 msgid "Save Organization"
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:27
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:26
 msgid "Last modified"
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:30
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:29
 msgid "Show change log"
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:34
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:33
 msgid "Created on"
 msgstr ""
 
@@ -2721,15 +2824,7 @@ msgstr ""
 msgid "Height:"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/facet_list.html:80
-msgid "Show More"
-msgstr ""
-
-#: ckanext/ytp/templates/snippets/facet_list.html:83
-msgid "Show Less"
-msgstr ""
-
-#: ckanext/ytp/templates/snippets/facet_list.html:87
+#: ckanext/ytp/templates/snippets/facet_list.html:90
 msgid "There are no {facet_type} that match this search"
 msgstr ""
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -14,15 +14,16 @@
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2020
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2021
 # Pasi Laakso <pasi.laakso@gofore.com>, 2021
+# Daniel Vainio, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-09-16 13:19+0000\n"
+"POT-Creation-Date: 2021-11-24 17:34+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Pasi Laakso <pasi.laakso@gofore.com>, 2021\n"
+"Last-Translator: Daniel Vainio, 2021\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -341,7 +342,7 @@ msgstr "Poista käyttäjätili"
 msgid "Users"
 msgstr "Käyttäjät"
 
-#: ckanext/ytp/menu.py:155
+#: ckanext/ytp/menu.py:155 ckanext/ytp/plugin.py:272
 #: ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/index.html:10
 #: ckanext/ytp/templates/organization/organization_not_found.html:6
@@ -371,45 +372,33 @@ msgstr "Julkaise avointa dataa"
 msgid "Publish Data"
 msgstr "Julkaise dataa"
 
-#: ckanext/ytp/plugin.py:268 ckanext/ytp/translations.py:40
-msgid "International benchmarks"
+#: ckanext/ytp/plugin.py:268
+msgid "International Benchmarks"
 msgstr "Kansainväliset vertailut"
 
 #: ckanext/ytp/plugin.py:269 ckanext/ytp/plugin.py:283
-msgid "Collection Type"
+msgid "Collection Types"
 msgstr "Tietoaineisto"
 
 #: ckanext/ytp/plugin.py:270
-msgid "Popular tags"
+msgid "Popular Tags"
 msgstr "Suositut avainsanat"
 
 #: ckanext/ytp/plugin.py:271 ckanext/ytp/plugin.py:285
-msgid "Content Type"
+msgid "Content Types"
 msgstr "Sisältötyyppi"
-
-#: ckanext/ytp/plugin.py:272
-#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
-#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
-#: ckanext/ytp/templates/snippets/organization.html:21
-#: ckanext/ytp/translations.py:36
-msgid "Organization"
-msgstr "Tuottaja"
 
 #: ckanext/ytp/plugin.py:273 ckanext/ytp/plugin.py:286
 #: ckanext/ytp/translations.py:35
 msgid "Formats"
 msgstr "Tiedostomuoto"
 
-#: ckanext/ytp/plugin.py:275 ckanext/ytp/templates/package/search.html:58
-#: ckanext/ytp/templates/package/snippets/additional_info.html:12
-msgid "Source"
+#: ckanext/ytp/plugin.py:275
+msgid "Sources"
 msgstr "Lähde"
 
 #: ckanext/ytp/plugin.py:276
-#: ckanext/ytp/templates/package/resource_read.html:168
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
-#: ckanext/ytp/templates/snippets/license.html:21
-msgid "License"
+msgid "Licenses"
 msgstr "Lisenssi"
 
 #: ckanext/ytp/plugin.py:284
@@ -512,6 +501,13 @@ msgstr "Logo tai kuvituskuva"
 msgid "Size"
 msgstr "Tiedostokoko"
 
+#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
+#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
+#: ckanext/ytp/templates/snippets/organization.html:21
+#: ckanext/ytp/translations.py:36
+msgid "Organization"
+msgstr "Tuottaja"
+
 #: ckanext/ytp/translations.py:37
 msgid "Key"
 msgstr ""
@@ -519,6 +515,10 @@ msgstr ""
 #: ckanext/ytp/translations.py:39
 msgid "Fullname"
 msgstr "Koko nimi"
+
+#: ckanext/ytp/translations.py:40
+msgid "International benchmarks"
+msgstr "Kansainväliset vertailut"
 
 #: ckanext/ytp/translations.py:41
 msgid "eg. Maps"
@@ -1438,6 +1438,98 @@ msgstr " Muu (Public Domain)"
 msgid "uk-ogl"
 msgstr "UK Open Government Licence OGL"
 
+#: ckanext/ytp/translations.py:268
+msgid "Platforms"
+msgstr "Käyttöympäristö (alusta)"
+
+#: ckanext/ytp/translations.py:271
+msgid "Show more collection_type"
+msgstr "Näytä enemmän Tietoaineistoja"
+
+#: ckanext/ytp/translations.py:272
+msgid "Show more vocab_international_benchmarks"
+msgstr "Näytä enemmän Kansainvälisiä Vertailuja"
+
+#: ckanext/ytp/translations.py:273
+msgid "Show more vocab_keywords_en"
+msgstr ""
+
+#: ckanext/ytp/translations.py:274
+msgid "Show more vocab_keywords_fi"
+msgstr "Näytä enemmän Avainsanoja"
+
+#: ckanext/ytp/translations.py:275
+msgid "Show more vocab_keywords_sv"
+msgstr ""
+
+#: ckanext/ytp/translations.py:276
+msgid "Show more organization"
+msgstr "Näytä enemmän Tuottajia"
+
+#: ckanext/ytp/translations.py:277
+msgid "Show more res_format"
+msgstr "Näytä enemmän Tiedostomuotoja"
+
+#: ckanext/ytp/translations.py:278
+msgid "Show more source"
+msgstr "Näytä enemmän Lähteitä"
+
+#: ckanext/ytp/translations.py:279
+msgid "Show more license_id"
+msgstr "Näytä enemmän Lisenssejä"
+
+#: ckanext/ytp/translations.py:280
+msgid "Show more groups"
+msgstr "Näytä enemmän Kategorioita"
+
+#: ckanext/ytp/translations.py:281
+msgid "Show more vocab_platform"
+msgstr "Näytä enemmän Käyttöympäristöjä"
+
+#: ckanext/ytp/translations.py:284
+msgid "Show less collection_type"
+msgstr "Näytä vähemmän Tietoaineistoja"
+
+#: ckanext/ytp/translations.py:285
+msgid "Show less vocab_international_benchmarks"
+msgstr "Näytä vähemmän Kansainvälisiä Vertailuja"
+
+#: ckanext/ytp/translations.py:286
+msgid "Show less vocab_keywords_en"
+msgstr ""
+
+#: ckanext/ytp/translations.py:287
+msgid "Show less vocab_keywords_fi"
+msgstr "Näytä vähemmän Avainsanoja"
+
+#: ckanext/ytp/translations.py:288
+msgid "Show less vocab_keywords_sv"
+msgstr ""
+
+#: ckanext/ytp/translations.py:289
+msgid "Show less organization"
+msgstr "Näytä vähemmän Tuottajia"
+
+#: ckanext/ytp/translations.py:290
+msgid "Show less res_format"
+msgstr "Näytä vähemmän Tiedostomuotoja"
+
+#: ckanext/ytp/translations.py:291
+msgid "Show less source"
+msgstr "Näytä vähemmän Lähteitä"
+
+#: ckanext/ytp/translations.py:292
+msgid "Show less license_id"
+msgstr "Näytä vähemmän Lisenssejä"
+
+#: ckanext/ytp/translations.py:293
+msgid "Show less groups"
+msgstr "Näytä vähemmän Kategorioita"
+
+#: ckanext/ytp/translations.py:294
+msgid "Show less vocab_platform"
+msgstr "Näytä vähemmän Käyttöympäristöjä"
+
 #: ckanext/ytp/validators.py:81
 msgid "Missing value"
 msgstr "Puuttuva arvo"
@@ -2009,6 +2101,12 @@ msgstr "tuntematon"
 msgid "Format"
 msgstr "Muoto"
 
+#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
+#: ckanext/ytp/templates/snippets/license.html:21
+msgid "License"
+msgstr "Lisenssi"
+
 #: ckanext/ytp/templates/package/resource_read.html:171
 msgid "Temporal Granularity"
 msgstr "Ajallinen mittausväli"
@@ -2097,6 +2195,11 @@ msgstr "Luomispäivän mukaan nousevasti"
 #: ckanext/ytp/templates/package/search.html:57
 msgid "Date Created Descending"
 msgstr "Luomispäivän mukaan laskevasti"
+
+#: ckanext/ytp/templates/package/search.html:58
+#: ckanext/ytp/templates/package/snippets/additional_info.html:12
+msgid "Source"
+msgstr "Lähde"
 
 #: ckanext/ytp/templates/package/search.html:59
 #: ckanext/ytp/templates/snippets/package_item.html:43
@@ -2631,15 +2734,15 @@ msgstr ""
 msgid "Save Organization"
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:27
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:26
 msgid "Last modified"
 msgstr "Viimeksi muokattu"
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:30
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:29
 msgid "Show change log"
 msgstr "Näytä muutoshistoria"
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:34
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:33
 msgid "Created on"
 msgstr "Luotu"
 
@@ -2831,15 +2934,7 @@ msgstr "Leveys:"
 msgid "Height:"
 msgstr "Korkeus:"
 
-#: ckanext/ytp/templates/snippets/facet_list.html:80
-msgid "Show More"
-msgstr "Näytä enemmän"
-
-#: ckanext/ytp/templates/snippets/facet_list.html:83
-msgid "Show Less"
-msgstr "Näytä vähemmän"
-
-#: ckanext/ytp/templates/snippets/facet_list.html:87
+#: ckanext/ytp/templates/snippets/facet_list.html:90
 msgid "There are no {facet_type} that match this search"
 msgstr "Hakutulokset eivät sisällä \"{facet_type}\"-kenttiä"
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
+++ b/modules/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
@@ -9,15 +9,16 @@
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2020
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2021
+# Daniel Vainio, 2021
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-09-16 13:19+0000\n"
+"POT-Creation-Date: 2021-11-24 17:34+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Zharktas <jari-pekka.voutilainen@gofore.com>, 2021\n"
+"Last-Translator: Daniel Vainio, 2021\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -338,7 +339,7 @@ msgstr "Radera användarkonto"
 msgid "Users"
 msgstr "Användare"
 
-#: ckanext/ytp/menu.py:155
+#: ckanext/ytp/menu.py:155 ckanext/ytp/plugin.py:272
 #: ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/index.html:10
 #: ckanext/ytp/templates/organization/organization_not_found.html:6
@@ -369,51 +370,39 @@ msgstr "Publicera öppna data"
 msgid "Publish Data"
 msgstr "Publicera data"
 
-#: ckanext/ytp/plugin.py:268 ckanext/ytp/translations.py:40
-msgid "International benchmarks"
+#: ckanext/ytp/plugin.py:268
+msgid "International Benchmarks"
 msgstr "Internationella jämförelser"
 
 #: ckanext/ytp/plugin.py:269 ckanext/ytp/plugin.py:283
-msgid "Collection Type"
-msgstr "Datamängd"
+msgid "Collection Types"
+msgstr "Typer av datamängder"
 
 #: ckanext/ytp/plugin.py:270
-msgid "Popular tags"
-msgstr "Populära taggar"
+msgid "Popular Tags"
+msgstr "Populära Nyckelord"
 
 #: ckanext/ytp/plugin.py:271 ckanext/ytp/plugin.py:285
-msgid "Content Type"
-msgstr "Innehållstyp"
-
-#: ckanext/ytp/plugin.py:272
-#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
-#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
-#: ckanext/ytp/templates/snippets/organization.html:21
-#: ckanext/ytp/translations.py:36
-msgid "Organization"
-msgstr "Producent"
+msgid "Content Types"
+msgstr "Innehållstyper"
 
 #: ckanext/ytp/plugin.py:273 ckanext/ytp/plugin.py:286
 #: ckanext/ytp/translations.py:35
 msgid "Formats"
 msgstr "Filformat"
 
-#: ckanext/ytp/plugin.py:275 ckanext/ytp/templates/package/search.html:58
-#: ckanext/ytp/templates/package/snippets/additional_info.html:12
-msgid "Source"
-msgstr "Källa"
+#: ckanext/ytp/plugin.py:275
+msgid "Sources"
+msgstr ""
 
 #: ckanext/ytp/plugin.py:276
-#: ckanext/ytp/templates/package/resource_read.html:168
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
-#: ckanext/ytp/templates/snippets/license.html:21
-msgid "License"
-msgstr "Licens"
+msgid "Licenses"
+msgstr ""
 
 #: ckanext/ytp/plugin.py:284
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:14
 msgid "Tags"
-msgstr "Taggar"
+msgstr "Nyckelord"
 
 #: ckanext/ytp/plugin.py:324
 #: ckanext/ytp/templates/package/snippets/additional_info.html:2
@@ -510,6 +499,13 @@ msgstr "Logotyp eller illustrationsbild"
 msgid "Size"
 msgstr "Filstorlek"
 
+#: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
+#: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
+#: ckanext/ytp/templates/snippets/organization.html:21
+#: ckanext/ytp/translations.py:36
+msgid "Organization"
+msgstr "Producent"
+
 #: ckanext/ytp/translations.py:37
 msgid "Key"
 msgstr ""
@@ -517,6 +513,10 @@ msgstr ""
 #: ckanext/ytp/translations.py:39
 msgid "Fullname"
 msgstr "Fullständigt namn"
+
+#: ckanext/ytp/translations.py:40
+msgid "International benchmarks"
+msgstr "Internationella jämförelser"
 
 #: ckanext/ytp/translations.py:41
 msgid "eg. Maps"
@@ -1426,6 +1426,98 @@ msgstr ""
 msgid "uk-ogl"
 msgstr ""
 
+#: ckanext/ytp/translations.py:268
+msgid "Platforms"
+msgstr ""
+
+#: ckanext/ytp/translations.py:271
+msgid "Show more collection_type"
+msgstr "Vias flera Datamängder"
+
+#: ckanext/ytp/translations.py:272
+msgid "Show more vocab_international_benchmarks"
+msgstr "Visa flera Internationella Jämförelser"
+
+#: ckanext/ytp/translations.py:273
+msgid "Show more vocab_keywords_en"
+msgstr ""
+
+#: ckanext/ytp/translations.py:274
+msgid "Show more vocab_keywords_fi"
+msgstr ""
+
+#: ckanext/ytp/translations.py:275
+msgid "Show more vocab_keywords_sv"
+msgstr "Visa flera Nyckelord"
+
+#: ckanext/ytp/translations.py:276
+msgid "Show more organization"
+msgstr "Visa flera Producenter"
+
+#: ckanext/ytp/translations.py:277
+msgid "Show more res_format"
+msgstr "Visa flera Format"
+
+#: ckanext/ytp/translations.py:278
+msgid "Show more source"
+msgstr "Visa flera Källor"
+
+#: ckanext/ytp/translations.py:279
+msgid "Show more license_id"
+msgstr "Visa flera Licenser"
+
+#: ckanext/ytp/translations.py:280
+msgid "Show more groups"
+msgstr "Visa flera Grupper"
+
+#: ckanext/ytp/translations.py:281
+msgid "Show more vocab_platform"
+msgstr "Visa flera Plattformar"
+
+#: ckanext/ytp/translations.py:284
+msgid "Show less collection_type"
+msgstr "Vias färre Datamängder"
+
+#: ckanext/ytp/translations.py:285
+msgid "Show less vocab_international_benchmarks"
+msgstr "Visa färre Internationella Jämförelser"
+
+#: ckanext/ytp/translations.py:286
+msgid "Show less vocab_keywords_en"
+msgstr ""
+
+#: ckanext/ytp/translations.py:287
+msgid "Show less vocab_keywords_fi"
+msgstr ""
+
+#: ckanext/ytp/translations.py:288
+msgid "Show less vocab_keywords_sv"
+msgstr "Visa färre Nyckelord"
+
+#: ckanext/ytp/translations.py:289
+msgid "Show less organization"
+msgstr "Visa färre Producenter"
+
+#: ckanext/ytp/translations.py:290
+msgid "Show less res_format"
+msgstr "Visa färre Format"
+
+#: ckanext/ytp/translations.py:291
+msgid "Show less source"
+msgstr "Visa färre Källor"
+
+#: ckanext/ytp/translations.py:292
+msgid "Show less license_id"
+msgstr "Visa färre Licenser"
+
+#: ckanext/ytp/translations.py:293
+msgid "Show less groups"
+msgstr "Visa färre Grupper"
+
+#: ckanext/ytp/translations.py:294
+msgid "Show less vocab_platform"
+msgstr "Visa färre Plattformar"
+
 #: ckanext/ytp/validators.py:81
 msgid "Missing value"
 msgstr "Saknat värde"
@@ -1998,6 +2090,12 @@ msgstr "okänd"
 msgid "Format"
 msgstr "Format"
 
+#: ckanext/ytp/templates/package/resource_read.html:168
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
+#: ckanext/ytp/templates/snippets/license.html:21
+msgid "License"
+msgstr "Licens"
+
 #: ckanext/ytp/templates/package/resource_read.html:171
 msgid "Temporal Granularity"
 msgstr "Tidsmässigt mätintervall"
@@ -2086,6 +2184,11 @@ msgstr "Stigande efter datumet för skapande"
 msgid "Date Created Descending"
 msgstr "Fallande efter datumet för skapande"
 
+#: ckanext/ytp/templates/package/search.html:58
+#: ckanext/ytp/templates/package/snippets/additional_info.html:12
+msgid "Source"
+msgstr "Källa"
+
 #: ckanext/ytp/templates/package/search.html:59
 #: ckanext/ytp/templates/snippets/package_item.html:43
 #: ckanext/ytp/templates/snippets/popular.html:3
@@ -2145,11 +2248,11 @@ msgstr "Senast uppdaterat"
 
 #: ckanext/ytp/templates/package/snippets/categories.html:31
 msgid "Show more categories"
-msgstr ""
+msgstr "Visa flera Kategorier"
 
 #: ckanext/ytp/templates/package/snippets/categories.html:34
 msgid "Show more"
-msgstr ""
+msgstr "Visa flera"
 
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:61
 msgid "License Not Specified"
@@ -2620,15 +2723,15 @@ msgstr ""
 msgid "Save Organization"
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:27
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:26
 msgid "Last modified"
 msgstr ""
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:30
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:29
 msgid "Show change log"
 msgstr "Visa ändringslogg"
 
-#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:34
+#: ckanext/ytp/templates/scheming/package/snippets/additional_info.html:33
 msgid "Created on"
 msgstr ""
 
@@ -2819,15 +2922,7 @@ msgstr "Bredd:"
 msgid "Height:"
 msgstr "Höjd:"
 
-#: ckanext/ytp/templates/snippets/facet_list.html:80
-msgid "Show More"
-msgstr "Visa fler"
-
-#: ckanext/ytp/templates/snippets/facet_list.html:83
-msgid "Show Less"
-msgstr "Visa färre"
-
-#: ckanext/ytp/templates/snippets/facet_list.html:87
+#: ckanext/ytp/templates/snippets/facet_list.html:90
 msgid "There are no {facet_type} that match this search"
 msgstr "Sökresultaten innehåller inga fält med {facet_type}"
 

--- a/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -265,24 +265,24 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
     def dataset_facets(self, facets_dict, package_type):
         lang = get_lang_prefix()
         facets_dict = OrderedDict()
-        facets_dict.update({'vocab_international_benchmarks': _('International benchmarks')})
-        facets_dict.update({'collection_type': _('Collection Type')})
-        facets_dict['vocab_keywords_' + lang] = _('Popular tags')
-        facets_dict.update({'vocab_content_type_' + lang: _('Content Type')})
-        facets_dict.update({'organization': _('Organization')})
+        facets_dict.update({'vocab_international_benchmarks': _('International Benchmarks')})
+        facets_dict.update({'collection_type': _('Collection Types')})
+        facets_dict['vocab_keywords_' + lang] = _('Popular Tags')
+        facets_dict.update({'vocab_content_type_' + lang: _('Content Types')})
+        facets_dict.update({'organization': _('Organizations')})
         facets_dict.update({'res_format': _('Formats')})
         # BFW: source is not part of the schema. created artificially at before_index function
-        facets_dict.update({'source': _('Source')})
-        facets_dict.update({'license_id': _('License')})
+        facets_dict.update({'source': _('Sources')})
+        facets_dict.update({'license_id': _('Licenses')})
         # add more dataset facets here
         return facets_dict
 
     def organization_facets(self, facets_dict, organization_type, package_type):
         lang = get_lang_prefix()
         facets_dict = OrderedDict()
-        facets_dict.update({'collection_type': _('Collection Type')})
+        facets_dict.update({'collection_type': _('Collection Types')})
         facets_dict['vocab_keywords_' + lang] = _('Tags')
-        facets_dict.update({'vocab_content_type': _('Content Type')})
+        facets_dict.update({'vocab_content_type': _('Content Types')})
         facets_dict.update({'res_format': _('Formats')})
 
         return facets_dict

--- a/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/facet_list.html
+++ b/modules/ckanext-ytp_main/ckanext/ytp/templates/snippets/facet_list.html
@@ -37,6 +37,10 @@ within_tertiary
   page and not the left column.
 
 #}
+
+{% set show_more_text = 'Show more {}'.format(name) %}
+{% set show_less_text = 'Show less {}'.format(name) %}
+
 {% block facet_list %}
   {% set hide_empty = hide_empty or false %}
   {% with items = items or h.get_facet_items_dict(name) %}
@@ -51,7 +55,6 @@ within_tertiary
           {% block facet_list_heading %}
             <h2 class="module-heading">
               {# No icon <i class="fa fa-filter"></i> #}
-              {% set title = title or h.get_facet_title(name) %}
               {{ title }}
             </h2>
           {% endblock %}
@@ -77,10 +80,10 @@ within_tertiary
               <p class="module-footer">
                 {% if h.get_param_int('_%s_limit' % name) %}
                   {% if h.has_more_facets(name) %}
-                    <a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show More') }}</a>
+                    <a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _(show_more_text) }}</a>
                   {% endif %}
                 {% else %}
-                  <a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show Less') }}</a>
+                  <a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _(show_less_text) }}</a>
                 {% endif %}
               </p>
             {% else %}

--- a/modules/ckanext-ytp_main/ckanext/ytp/translations.py
+++ b/modules/ckanext-ytp_main/ckanext/ytp/translations.py
@@ -264,6 +264,35 @@ def _translations():
     _('other-pd')
     _('uk-ogl')
 
+    # Showcase
+    _('Platforms')
+
+    # Facet filter "Show more ..." texts
+    _('Show more collection_type')
+    _('Show more vocab_international_benchmarks')
+    _('Show more vocab_keywords_en')
+    _('Show more vocab_keywords_fi')
+    _('Show more vocab_keywords_sv')
+    _('Show more organization')
+    _('Show more res_format')
+    _('Show more source')
+    _('Show more license_id')
+    _('Show more groups')
+    _('Show more vocab_platform')
+
+    # Facet filter "Show less ..." texts
+    _('Show less collection_type')
+    _('Show less vocab_international_benchmarks')
+    _('Show less vocab_keywords_en')
+    _('Show less vocab_keywords_fi')
+    _('Show less vocab_keywords_sv')
+    _('Show less organization')
+    _('Show less res_format')
+    _('Show less source')
+    _('Show less license_id')
+    _('Show less groups')
+    _('Show less vocab_platform')
+
 
 def facet_translations():
     return ["Open Data", "Interoperability Tools", "External", "Internal"]


### PR DESCRIPTION
The facet filter's "show more" and "show less" texts are updated to add the facet filter's title to the string instead of just displaying "Show More" and "Show Less" as it did in the previous version.

Some of the titles were updated to plural since singular and plural for were mixed for the titles. Dynamic string building was added to the template in order to build these strings. The strings are built with each facet's name instead of the title in order to create a unique string which can be translated into all three languages used.


Done in this PR:
- Template code for building strings
- Updated facet filter titles in Python code
- Added translations for Swedish, English and Finnish
- Slight update of Swedish translations since they were missing in some places