### PR TITLE
AV 1529: Frontpage Accessibility Fixes

### DIFF
--- a/modules/avoindata-drupal-hero/templates/avoindata_hero_form.html.twig
+++ b/modules/avoindata-drupal-hero/templates/avoindata_hero_form.html.twig
@@ -61,8 +61,32 @@
             {% endfor %}
         </div>
         <div class="bg-highlight-base d-flex p-3 mt-4">
+            <div class="flex-1">
+                <div class="ytp-input-with-icon-frontpage">
+                    {% set placeholder %}
+                        {%- trans -%}
+                        Type what are you searching for
+                        {%- endtrans -%}
+                    {% endset %}
+                    <input
+                        id="edit-search"
+                        name="search"
+                        type="text"
+                        class="ytp-input-element-frontpage color-depth-dark27"
+                        placeholder="{{ placeholder }}"
+                    >
+                  <button type="submit">
+                    <span>
+                      {% trans %}
+                      Submit
+                    {% endtrans %}
+                    </span>
+                    <i class="fa fa-2x fa-search color-depth-base"></i>
+                  </button>
+                </div>
+            </div>
             <div class="position-relative">
-                <button id="type-dropdown" type="button" class="suomi-button suomi-button-custom mr-2" data-toggle="dropdown" value="1" aria-haspopup="true" aria-expanded="false">
+                <button id="type-dropdown" type="button" class="suomifi-button-secondary" data-toggle="dropdown" value="1" aria-haspopup="true" aria-expanded="false">
                     <span class="mr-3">
                         {% trans %}
                             Datasets
@@ -93,32 +117,6 @@
                         </a>
                     </li>
                 </ul>
-            </div>
-            <div class="flex-1">
-                <div class="ytp-input-with-icon">
-                    {% set placeholder %}
-                        {%- trans -%}
-                        Type what are you searching for
-                        {%- endtrans -%}
-                    {% endset %}
-                    <input
-                        id="edit-search"
-                        name="search"
-                        type="text"
-                        class="ytp-input-element color-depth-dark27"
-                        placeholder="{{ placeholder }}"
-                    >
-
-                  <button type="submit">
-                    <span>
-                      {% trans %}
-                      Submit
-                    {% endtrans %}
-                    </span>
-                    <i class="fa fa-2x fa-search color-depth-base"></i>
-                  </button>
-                </div>
-
             </div>
         </div>
         {{ form.searchfilter }}

--- a/modules/avoindata-drupal-hero/templates/avoindata_hero_form.html.twig
+++ b/modules/avoindata-drupal-hero/templates/avoindata_hero_form.html.twig
@@ -13,18 +13,10 @@
     {{ form.form_id }}
     <div class="avoindata-hero-search-container">
         <div>
-            <div class="d-inline-block mr-4">
-                <h1>
-                    <img class="avoindata-hero-logo mr-2" src="/resources/images/logo/opendata.svg"/>
-                    {% trans %}
-                    Avoindata.fi
-                    {% endtrans %}
-                </h1>
-            </div>
-            <div class="d-inline-block">
+            <div class="d-inline-block avoindata-frontpage-header-text-container">
                 <h2>
                     {% trans %}
-                        All Finnish open data from one place.
+                        All Finnish open data from one place
                     {% endtrans %}
                 </h2>
             </div>

--- a/modules/avoindata-drupal-hero/templates/avoindata_hero_form.html.twig
+++ b/modules/avoindata-drupal-hero/templates/avoindata_hero_form.html.twig
@@ -86,7 +86,7 @@
                 </div>
             </div>
             <div class="position-relative">
-                <button id="type-dropdown" type="button" class="suomifi-button-secondary" data-toggle="dropdown" value="1" aria-haspopup="true" aria-expanded="false">
+                <button id="type-dropdown" type="button" class="suomifi-button-secondary-black-text" data-toggle="dropdown" value="1" aria-haspopup="true" aria-expanded="false">
                     <span class="mr-3">
                         {% trans %}
                             Datasets

--- a/modules/ytp-assets-common/generate_test_categories.py
+++ b/modules/ytp-assets-common/generate_test_categories.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+Script for adding categories. These categories are intended for use when working with front-end tasks.
+
+This script is still WIP.
+
+How to run: python generate_test_categories.py <db_username> <db_password>
+"""
+import sys
+
+import ckan.model as model
+from sqlalchemy import create_engine
+
+
+def _generate_image_urls():
+    base_url = u'https://www.betaavoindata.fi/data/uploads/group'
+    return [
+        u'{}/2019-09-14-125225.580409Ikonit-AvoinData-Regions.svg'.format(base_url),
+        u'{}/2019-07-01-102212.846599energia.svg'.format(base_url),
+        u'{}/2019-09-14-125054.290257Ikonit-AvoinData-Government.svg'.format(base_url),
+        u'{}/2019-07-01-102343.243986Kansainvalistyminen.svg'.format(base_url),
+        u'{}/2019-09-14-124019.900929Kulttuuri-liikunta-ulkoilu-ja-matkailu.svg'.format(base_url),
+        u'{}/2019-09-14-124758.525007kulttuurijavapaaaika.svg'.format(base_url),
+        u'{}/2019-09-14-123833.880147Ikonit--Kuvitukset--Juna.svg'.format(base_url),
+        u'{}/2019-07-01-102740.5558642018-07-13-104602.335155Ikonit-AvoinData-Agriculture.svg'.format(base_url),
+        u'{}/2019-09-14-124219.193737Liikennejamatkailu.svg'.format(base_url),
+        u'{}/2019-07-01-103050.1219632018-03-19-090141.983568hallintojapaatoksenteko.svg'.format(base_url),
+        u'{}/2019-09-14-124612.287327Asuminen-ja-muttaminen.svg'.format(base_url),
+        u'{}/2018-03-22-162901.594613talous.svg'.format(base_url),
+        u'{}/2018-03-22-162934.287485terveysjasosiaalipalvelut.svg'.format(base_url),
+        u'{}/2019-09-14-124655.983665Yritystoiminnan-aloittaminen.svg'.format(base_url),
+        u'{}/2019-09-14-123926.932875Parisuhde-ja-perhe.svg'.format(base_url),
+        u'{}/2018-03-22-163027.730610ymparisto.svg'.format(base_url),
+    ]
+
+
+def _generate_category_data():
+    image_urls = _generate_image_urls()
+    categories = []
+
+    for i in range(len(image_urls)):
+        categories.append(
+            {
+                'name': u'cat{}'.format(i+1),
+                'title': u'Category{}'.format(i+1),
+                'image_url': image_urls[i]
+            }
+        )
+
+    return categories
+
+
+def _create_group_models():
+    data = _generate_category_data()
+
+    return [
+        model.Group(
+            name=x.get('name'),
+            title=x.get('title'),
+            image_url=x.get('image_url'),
+        ) for x in data
+    ]
+
+
+def create_categories(db_username, db_password):
+    engine = create_engine('postgresql://{}:{}@localhost/ckan_default'.format(db_username, db_password))
+    session = model.meta.Session
+    session.bind = engine
+
+    groups = _create_group_models()
+
+    session.bulk_save_objects(groups)
+    session.commit()
+
+
+if __name__ == '__main__':
+    db_username = sys.argv[1]
+    db_password = sys.argv[2]
+
+    create_categories(db_username, db_password)
+    print('Done...')

--- a/modules/ytp-assets-common/src/less/components/forms.less
+++ b/modules/ytp-assets-common/src/less/components/forms.less
@@ -372,6 +372,12 @@ fieldset.checkboxes {
 .ytp-input-element-frontpage {
   .ytp-input-element;
 
+  &::placeholder {
+    color: rgb(109, 120, 126);
+    font-style: italic;
+    opacity: 1;
+  }
+
   height: 40px;
   border-radius: 1px;
 }

--- a/modules/ytp-assets-common/src/less/components/forms.less
+++ b/modules/ytp-assets-common/src/less/components/forms.less
@@ -368,6 +368,14 @@ fieldset.checkboxes {
   }
 }
 
+// Frontpage search bar input.
+.ytp-input-element-frontpage {
+  .ytp-input-element;
+
+  height: 40px;
+  border-radius: 1px;
+}
+
 .ytp-search-bar {
   &::before {
     content: "\f002";
@@ -457,6 +465,14 @@ fieldset.checkboxes {
       display: none;
     }
   }
+}
+
+// Frontpage search bar.
+.ytp-input-with-icon-frontpage {
+  .ytp-input-with-icon;
+
+  height: 40px;
+  margin-right: 10px;
 }
 
 .ytp-group-title {

--- a/modules/ytp-assets-common/src/less/components/layout.less
+++ b/modules/ytp-assets-common/src/less/components/layout.less
@@ -203,6 +203,16 @@ body {
   }
 }
 
+.suomifi-button-secondary-black-text {
+  .suomifi-button-secondary;
+
+  color: rgb(41, 41, 41);
+
+  i {
+    margin-left: 8px;
+  }
+}
+
 .suomifi-button-secondary-noborder {
   .suomifi-button-secondary();
 

--- a/modules/ytp-assets-common/src/less/drupal/overrides.less
+++ b/modules/ytp-assets-common/src/less/drupal/overrides.less
@@ -558,8 +558,7 @@ p:last-child,
 
     .avoindata-datasetlist-offer-data {
       .login-link {
-        width: 120px;
-        height: 40px;
+        width: 160px;
         margin: 44px 50px 16px auto;
         background: #2a6ebb;
         line-height: 20px;

--- a/modules/ytp-assets-common/src/less/drupal/overrides.less
+++ b/modules/ytp-assets-common/src/less/drupal/overrides.less
@@ -240,10 +240,11 @@ p:last-child,
   }
 
   .avoindata-categories-container {
-    max-width: @opendata-container-max-width;
+    max-width: @opendata-categories-container-max-width;
     float: none;
     display: block;
     margin: 0 auto;
+    flex: 2;
 
     .avoindata-categories-items {
       .flex-display(flex);
@@ -252,7 +253,7 @@ p:last-child,
     }
 
     .avoindata-category-box {
-      height: 13em;
+      height: 10em;
       width: 10em;
       text-align: center;
       justify-content: center;

--- a/modules/ytp-assets-common/src/less/drupal/overrides.less
+++ b/modules/ytp-assets-common/src/less/drupal/overrides.less
@@ -1478,3 +1478,8 @@ p:last-child,
   margin: 0 auto;
   padding: 25px;
 }
+
+.avoindata-frontpage-header-text-container {
+  text-align: center;
+  width: 100%;
+}

--- a/modules/ytp-assets-common/src/less/variables.less
+++ b/modules/ytp-assets-common/src/less/variables.less
@@ -14,6 +14,7 @@
 @brand-info: @opendata-brand-decorative;
 
 @opendata-container-max-width: 1110px;
+@opendata-categories-container-max-width: 1500px;
 @background-hero-image: url("/resources/images/logo/opendata.svg");
 
 // Bootstrap: Alerts


### PR DESCRIPTION
This PR takes care of some layout fixes and updates to the frontpage of avoindata.fi.

What has been done:

- Create a script for generating categories which can be used for local front-end development.
- Display the categories in the categories section in two rows instead of three in full screen.
- Remove the logo and the avoindata.fi text from the header.
- Update the layout of the search bar. Move drop down to the right side and modify small layout details.
- Fix the broken log in button at the bottom of the frontpage.