### PR TITLE
AV-1474: Add active class on nav subpages

### DIFF
--- a/modules/avoindata-drupal-theme/avoindata.theme
+++ b/modules/avoindata-drupal-theme/avoindata.theme
@@ -70,22 +70,33 @@ function avoindata_preprocess_html(array &$variables){
   $variables['base_url'] = $base_url;
 }
 
+function get_language_code($hook) {
+  $languageCodeMapping = array(
+    "menu__main_fi" => "fi",
+    "menu__main_en" => "en",
+    "menu__main_sv" => "sv"
+  );
+
+  return $languageCodeMapping[$hook];
+}
+
 /**
  * Implements hook_preprocess_menu().
  */
 function avoindata_preprocess_menu(&$variables, $hook){
   if ($hook === 'menu__main_fi' || $hook === 'menu__main_sv' || $hook === 'menu__main_en') {
     $variables['#cache']['max-age'] = 0;
-    $currentPath = preg_replace("/\//", "\\/", \Drupal::service('path.current')->getPath());
     $items = $variables['items'];
-    $pattern = "/\/data\/(fi|sv|en)$currentPath/";
-    
+
+    $languageCode = get_language_code($hook);
+    $path = Drupal::service('path.current')->getPath();
+    $pathAlias = Drupal::service('path_alias.manager')->getAliasByPath($path);
+    $fullPath = "/data/$languageCode$pathAlias";
+
     foreach($items as $key => $item) {
-      if (preg_match($pattern, $item['url']->toString()) === 1) {
-        $variables['items'][$key]['is_active'] = true;
-      } else {
-        $variables['items'][$key]['is_active'] = false;
-      }
+      $navUrl = $item['url']->toString();
+      $navUrlInPath = strpos($fullPath, $navUrl) !== false;
+      $variables['items'][$key]['is_active'] = $navUrlInPath;
     }
   }
 }


### PR DESCRIPTION
The navigation element should have the "is_active" css class on the element
if a user navigates to a page and its subpages.

Accomplish this by getting the base path used for the view, build a
full path by getting the alias of the base path and the language code.
Check if the url in the nav element exists in the full path, this will
essentially include subpages if they are under the same baseurl and the
is_active class will be set on the corresponding "parent" element.

Implement a helper function for getting the language code from the
$hook variable.

Refs. AV-1474