### PR TITLE
AV-1576: Remove breadcrumbs from guide page

### DIFF
--- a/ansible/roles/drupal/files/site_config/block.block.breadcrumbs.yml
+++ b/ansible/roles/drupal/files/site_config/block.block.breadcrumbs.yml
@@ -1,0 +1,24 @@
+uuid: 14907830-26c5-426d-bf69-b42aa5bc9666
+langcode: fi
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - avoindata
+id: breadcrumbs
+theme: avoindata
+region: header
+weight: 0
+provider: null
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  provider: system
+  label_display: visible
+visibility:
+  request_path:
+    id: request_path
+    pages: /guide
+    negate: true


### PR DESCRIPTION
Add configuration file for omitting the breadcrumbs from the /guide pages.

Done in this PR:

- Generated .yml config and added it to the correct folder where it will be automatically installed.

Refs AV-1576