### PR TITLE
Only upload cypress artifacts on failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,16 +131,17 @@ jobs:
       - name: run cypress e2e tests
         run: |
           npx cypress run --browser chrome:stable --record --key ${{ secrets.CYPRESS_RECORD_KEY }}
-        continue-on-error: true
 
       - name: upload cypress screenshot artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: screenshots
           path: cypress/screenshots
 
       - name: upload cypress video artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: videos
           path: cypress/videos


### PR DESCRIPTION
`continue-on-error` marks the step as success even on failure, this should fix that.