### PR TITLE
AV-1770: Add missing env var to allow robots for prod

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -61,7 +61,7 @@ const clusterStackInfratest = new ClusterStack(app, 'ClusterStack-infratest', {
   secondaryDomainName: infratestProps.secondaryDomainName,
 });
 
-const backupStackInfratest = new BackupStack(app,'BackupStack-infratest', {
+const backupStackInfratest = new BackupStack(app, 'BackupStack-infratest', {
   envProps: envProps,
   env: {
     account: infratestProps.account,
@@ -262,6 +262,7 @@ const webStackInfratest = new WebStack(app, 'WebStack-infratest', {
   },
   drupalService: drupalStackInfratest.drupalService,
   ckanService: ckanStackInfratest.ckanService,
+  allowRobots: 'false',
 });
 
 //
@@ -291,7 +292,7 @@ const clusterStackBeta = new ClusterStack(app, 'ClusterStack-beta', {
   secondaryDomainName: betaProps.secondaryDomainName,
 });
 
-const backupStackBeta = new BackupStack(app,'BackupStack-beta', {
+const backupStackBeta = new BackupStack(app, 'BackupStack-beta', {
   envProps: envProps,
   env: {
     account: betaProps.account,
@@ -501,6 +502,7 @@ const webStackBeta = new WebStack(app, 'WebStack-beta', {
   },
   drupalService: drupalStackBeta.drupalService,
   ckanService: ckanStackBeta.ckanService,
+  allowRobots: 'false',
 });
 
 //
@@ -530,7 +532,7 @@ const clusterStackProd = new ClusterStack(app, 'ClusterStack-prod', {
   secondaryDomainName: prodProps.secondaryDomainName,
 });
 
-const backupStackProd = new BackupStack(app,'BackupStack-prod', {
+const backupStackProd = new BackupStack(app, 'BackupStack-prod', {
   envProps: envProps,
   env: {
     account: prodProps.account,
@@ -739,4 +741,5 @@ const webStackProd = new WebStack(app, 'WebStack-prod', {
   },
   drupalService: drupalStackProd.drupalService,
   ckanService: ckanStackProd.ckanService,
+  allowRobots: 'true',
 });

--- a/cdk/lib/web-stack-props.ts
+++ b/cdk/lib/web-stack-props.ts
@@ -10,4 +10,5 @@ export interface WebStackProps extends EcsStackProps {
   nginxTaskDef: EcsStackPropsTaskDef,
   drupalService: ecs.FargateService;
   ckanService: ecs.FargateService;
+  allowRobots: string
 }

--- a/cdk/lib/web-stack.ts
+++ b/cdk/lib/web-stack.ts
@@ -95,6 +95,7 @@ export class WebStack extends Stack {
         DRUPAL_PORT: '80',
         // dynatrace oneagent
         DT_CUSTOM_PROP: `Environment=${props.environment}`,
+        NGINX_ROBOTS_ALLOW: props.allowRobots,
       },
       logging: ecs.LogDrivers.awsLogs({
         logGroup: nginxLogGroup,


### PR DESCRIPTION
Nginx container was using env var NGINX_ROBOTS_ALLOW [(opendata-nginx/nginx/jinja2-templates/robots.txt.j2)](https://github.com/vrk-kpa/opendata-nginx/blob/30f257142084c6d1afb9d0ad9f71c38b6ae65f72/nginx/jinja2-templates/robots.txt.j2#L3) to determine whether robots should be allowed (in prod) or not. The only issue being that env var was never set.