### PR TITLE
fix(AV-1752): Include website in showcases platform options

### DIFF
--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/schemas/showcase.json
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/schemas/showcase.json
@@ -51,15 +51,6 @@
       "group_description": "Keywords help users to find your showcase. Select at least one keyword in Finnish."
     },
     {
-      "field_name": "showcase_type",
-      "label": "Showcase type",
-      "validators": "empty_string_if_value_missing list_to_string",
-      "output_validators": "string_to_list",
-      "description": "Select one or more type that describes your showcase.",
-      "form_snippet": "select_preset_options.html",
-      "vocabulary": "showcase_type"
-    },
-    {
       "field_name": "category",
       "label": "Categories",
       "preset": "multiple_checkbox",

--- a/ckan/scripts/init_ckan.sh
+++ b/ckan/scripts/init_ckan.sh
@@ -27,7 +27,6 @@ cat ${SCRIPT_DIR}/datastore_permissions.sql | PGPASSWORD="${DB_CKAN_PASS}" psql 
 echo "init ckan extensions ..."
 #ckan -c ${APP_DIR}/production.ini opendata add-facet-translations ${EXT_DIR}/ckanext-ytp_main/ckanext/ytp/i18n
 ckan -c ${APP_DIR}/production.ini sixodp-showcase create_platform_vocabulary
-ckan -c ${APP_DIR}/production.ini sixodp-showcase create_showcase_type_vocabulary
 
 # init ckan extension databases
 echo "init ckan extension databases ..."

--- a/cypress/e2e/showcase_spec.js
+++ b/cypress/e2e/showcase_spec.js
@@ -25,7 +25,6 @@ describe('Showcase tests', function() {
       '#s2id_autogen1': {type: 'select2', values: ['test']},
       '#s2id_autogen2': {type: 'select2', values: ['test']},
       '#s2id_autogen3': {type: 'select2', values: ['test']},
-      '#s2id_field-showcase_type': 'Mobi{enter}',
       '#s2id_autogen5': {type: 'select2', values: ['Android']},
       '#field-author': {type: 'select2', values: ['test']},
       '#field-author_website': 'www.example.com',

--- a/cypress/e2e/showcase_spec.js
+++ b/cypress/e2e/showcase_spec.js
@@ -25,7 +25,6 @@ describe('Showcase tests', function() {
       '#s2id_autogen1': {type: 'select2', values: ['test']},
       '#s2id_autogen2': {type: 'select2', values: ['test']},
       '#s2id_autogen3': {type: 'select2', values: ['test']},
-      '#s2id_autogen5': {type: 'select2', values: ['Android']},
       '#field-author': {type: 'select2', values: ['test']},
       '#field-author_website': 'www.example.com',
       '#field-application_website': 'www.example.com',

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -355,7 +355,6 @@ Cypress.Commands.add('reset_db', () => {
         cy.exec("vagrant ssh -c  \'sudo /usr/lib/ckan/default/bin/ckan --config /etc/ckan/default/test.ini search-index clear\'", {timeout: 120*1000});
         // Init vocaularies
         cy.exec("vagrant ssh -c  \'sudo /usr/lib/ckan/default/bin/ckan --config /etc/ckan/default/test.ini sixodp-showcase create_platform_vocabulary\'", {timeout: 120*1000});
-        cy.exec("vagrant ssh -c  \'sudo /usr/lib/ckan/default/bin/ckan --config /etc/ckan/default/test.ini sixodp-showcase create_showcase_type_vocabulary\'", {timeout: 120*1000});
       } else {
         cy.exec('npm run reset:db', {
           env: {
@@ -370,7 +369,6 @@ Cypress.Commands.add('reset_db', () => {
         cy.exec(`docker exec -i ${containerName} sh -c "ckan --config /srv/app/production.ini search-index clear"`);
         // Init vocaularies
         cy.exec(`docker exec -i ${containerName} sh -c "ckan --config /srv/app/production.ini sixodp-showcase create_platform_vocabulary"`);
-        cy.exec(`docker exec -i ${containerName} sh -c "ckan --config /srv/app/production.ini sixodp-showcase create_showcase_type_vocabulary"`);
       }
     }
 });


### PR DESCRIPTION
- Add website as an platform-vocabulary-option.
- Remove showcase_type property.
- Add migration script to migrate website-values from old type-field to platform

Replaces [pull request](https://github.com/vrk-kpa/opendata-ckan/pull/113)