### PR TITLE
AV-1747: Add format field to apiset apis

### DIFF
--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -352,7 +352,6 @@ describe('Apiset tests', function() {
       '#field-name_translated-en': 'test api',
       '#field-name_translated-sv': 'test api',
       '#field-image-url': 'http://example.com',
-      '[name="format"]': {type: 'text', value: 'CSV', force: true},
       '#field-description_translated-fi': 'test kuvaus',
       '#field-description_translated-en': 'test description',
       '#field-description_translated-sv': 'test beskrivning',

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -6,8 +6,7 @@ describe('Apiset filtering', function(){
   const apiset1_form_data = {
     '#field-title_translated-fi': apiset1_name,
     '#field-notes_translated-fi': 'test kuvaus',
-     '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
-    '#s2id_autogen2': {type: 'select2', values: ['keyword one']},
+    '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
     '#field-license_id':{type: 'select', value: 'cc-nc'},
     '#field-api_provider': 'Api Provider',
     '#field-api_provider_email': 'test.provider@example.com',
@@ -16,8 +15,7 @@ describe('Apiset filtering', function(){
   const apiset2_form_data = {
     '#field-title_translated-fi': apiset2_name,
     '#field-notes_translated-fi': 'test kuvaus',
-    '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
-    '#s2id_autogen2': {type: 'select2', values: ['keyword two']},
+    '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
     '#field-license_id':{type: 'select', value: 'cc-by'},
     '#field-api_provider': 'Api Provider',
     '#field-api_provider_email': 'test.provider@example.com',
@@ -27,13 +25,16 @@ describe('Apiset filtering', function(){
   const api1_form_data = {
     '#field-name_translated-fi': 'test api',
     '#field-description_translated-fi': 'test kuvaus',
-    '#s2id_autogen1': {type: 'select2', values: ['Kuukausittain']},
+    '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
+    '#s2id_autogen2': {type: 'select2', values: ['Kuukausittain']},
   }
 
   const api2_form_data = {
     '#field-name_translated-fi': 'test api',
     '#field-description_translated-fi': 'test kuvaus',
-    '#s2id_autogen1': {type: 'select2', values: ['Päivittäin']},
+    '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
+    '#s2id_autogen2': {type: 'select2', values: ['Päivittäin']},
+
   }
 
   beforeEach(function () {

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -352,7 +352,7 @@ describe('Apiset tests', function() {
       '#field-name_translated-en': 'test api',
       '#field-name_translated-sv': 'test api',
       '#field-image-url': 'http://example.com',
-      '[name="field_format"]': {type: 'text', value: 'CSV', force: true},
+      '[name="format"]': {type: 'text', value: 'CSV', force: true},
       '#field-description_translated-fi': 'test kuvaus',
       '#field-description_translated-en': 'test description',
       '#field-description_translated-sv': 'test beskrivning',

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -6,7 +6,8 @@ describe('Apiset filtering', function(){
   const apiset1_form_data = {
     '#field-title_translated-fi': apiset1_name,
     '#field-notes_translated-fi': 'test kuvaus',
-    '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
+     '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
+    '#s2id_autogen2': {type: 'select2', values: ['keyword one']},
     '#field-license_id':{type: 'select', value: 'cc-nc'},
     '#field-api_provider': 'Api Provider',
     '#field-api_provider_email': 'test.provider@example.com',
@@ -15,7 +16,8 @@ describe('Apiset filtering', function(){
   const apiset2_form_data = {
     '#field-title_translated-fi': apiset2_name,
     '#field-notes_translated-fi': 'test kuvaus',
-    '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
+    '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
+    '#s2id_autogen2': {type: 'select2', values: ['keyword two']},
     '#field-license_id':{type: 'select', value: 'cc-by'},
     '#field-api_provider': 'Api Provider',
     '#field-api_provider_email': 'test.provider@example.com',

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -352,7 +352,7 @@ describe('Apiset tests', function() {
       '#field-name_translated-en': 'test api',
       '#field-name_translated-sv': 'test api',
       '#field-image-url': 'http://example.com',
-      '#field-format': 'CSV',
+      '[name="field_format"]': {type: 'text', value: 'CSV', force: true},
       '#field-description_translated-fi': 'test kuvaus',
       '#field-description_translated-en': 'test description',
       '#field-description_translated-sv': 'test beskrivning',

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -351,7 +351,6 @@ describe('Apiset tests', function() {
       '#field-name_translated-fi': 'test api',
       '#field-name_translated-en': 'test api',
       '#field-name_translated-sv': 'test api',
-      '#s2id_field-format': {type: 'select2', values: ['CSV']},
       '#field-image-url': 'http://example.com',
       '#field-description_translated-fi': 'test kuvaus',
       '#field-description_translated-en': 'test description',
@@ -361,6 +360,7 @@ describe('Apiset tests', function() {
       '#field-documentation_translated-sv': 'test dokumentaatio',
       '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
       // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
+      '#s2id_autogen1': {type: 'select2', values: ['CSV']},
       '#s2id_autogen1': {type: 'select2', values: ['Päivittäin']},
       '#s2id_autogen2': {type: 'select2', values: ['Päivittäin']},
       '#s2id_autogen3': {type: 'select2', values: ['Päivittäin']}

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -359,6 +359,7 @@ describe('Apiset tests', function() {
       '#field-documentation_translated-en': 'test dokumentaatio',
       '#field-documentation_translated-sv': 'test dokumentaatio',
       '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
+      '#field-format': 'CSV',
       // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
       '#s2id_autogen1': {type: 'select2', values: ['Päivittäin']},
       '#s2id_autogen2': {type: 'select2', values: ['Päivittäin']},

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -6,7 +6,7 @@ describe('Apiset filtering', function(){
   const apiset1_form_data = {
     '#field-title_translated-fi': apiset1_name,
     '#field-notes_translated-fi': 'test kuvaus',
-    '#s2id_autogen1': {type: 'select2', values: ['keyword one'], force: true},
+    '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
     '#field-license_id':{type: 'select', value: 'cc-nc'},
     '#field-api_provider': 'Api Provider',
     '#field-api_provider_email': 'test.provider@example.com',
@@ -15,7 +15,7 @@ describe('Apiset filtering', function(){
   const apiset2_form_data = {
     '#field-title_translated-fi': apiset2_name,
     '#field-notes_translated-fi': 'test kuvaus',
-    '#s2id_autogen1': {type: 'select2', values: ['keyword two'], force: true},
+    '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
     '#field-license_id':{type: 'select', value: 'cc-by'},
     '#field-api_provider': 'Api Provider',
     '#field-api_provider_email': 'test.provider@example.com',

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -6,7 +6,7 @@ describe('Apiset filtering', function(){
   const apiset1_form_data = {
     '#field-title_translated-fi': apiset1_name,
     '#field-notes_translated-fi': 'test kuvaus',
-    '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
+    '#s2id_autogen1': {type: 'select2', values: ['keyword one'], force: true},
     '#field-license_id':{type: 'select', value: 'cc-nc'},
     '#field-api_provider': 'Api Provider',
     '#field-api_provider_email': 'test.provider@example.com',
@@ -15,7 +15,7 @@ describe('Apiset filtering', function(){
   const apiset2_form_data = {
     '#field-title_translated-fi': apiset2_name,
     '#field-notes_translated-fi': 'test kuvaus',
-    '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
+    '#s2id_autogen1': {type: 'select2', values: ['keyword two'], force: true},
     '#field-license_id':{type: 'select', value: 'cc-by'},
     '#field-api_provider': 'Api Provider',
     '#field-api_provider_email': 'test.provider@example.com',

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -360,7 +360,7 @@ describe('Apiset tests', function() {
       '#field-documentation_translated-sv': 'test dokumentaatio',
       '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
       // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
-      '#s2id_autogen1': {type: 'select2', values: ['CSV']},
+      '#s2id_autogen1_search': {type: 'select2', values: ['CSV']},
       '#s2id_autogen2': {type: 'select2', values: ['Päivittäin']},
       '#s2id_autogen3': {type: 'select2', values: ['Päivittäin']},
       '#s2id_autogen4': {type: 'select2', values: ['Päivittäin']}

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -361,9 +361,9 @@ describe('Apiset tests', function() {
       '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
       // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
       '#s2id_autogen1': {type: 'select2', values: ['CSV']},
-      '#s2id_autogen1': {type: 'select2', values: ['Päivittäin']},
       '#s2id_autogen2': {type: 'select2', values: ['Päivittäin']},
-      '#s2id_autogen3': {type: 'select2', values: ['Päivittäin']}
+      '#s2id_autogen3': {type: 'select2', values: ['Päivittäin']},
+      '#s2id_autogen4': {type: 'select2', values: ['Päivittäin']}
     };
     cy.create_new_apiset(apiset_name, apiset_form_data, api_form_data);
   });

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -360,7 +360,7 @@ describe('Apiset tests', function() {
       '#field-documentation_translated-sv': 'test dokumentaatio',
       '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
       // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
-      '#s2id_autogen1_search': {type: 'select2', values: ['CSV']},
+      '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
       '#s2id_autogen2': {type: 'select2', values: ['Päivittäin']},
       '#s2id_autogen3': {type: 'select2', values: ['Päivittäin']},
       '#s2id_autogen4': {type: 'select2', values: ['Päivittäin']}

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -352,6 +352,7 @@ describe('Apiset tests', function() {
       '#field-name_translated-en': 'test api',
       '#field-name_translated-sv': 'test api',
       '#field-image-url': 'http://example.com',
+      '#field-format': 'CSV',
       '#field-description_translated-fi': 'test kuvaus',
       '#field-description_translated-en': 'test description',
       '#field-description_translated-sv': 'test beskrivning',
@@ -359,7 +360,6 @@ describe('Apiset tests', function() {
       '#field-documentation_translated-en': 'test dokumentaatio',
       '#field-documentation_translated-sv': 'test dokumentaatio',
       '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
-      '#field-format': 'CSV',
       // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
       '#s2id_autogen1': {type: 'select2', values: ['Päivittäin']},
       '#s2id_autogen2': {type: 'select2', values: ['Päivittäin']},

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -351,7 +351,7 @@ describe('Apiset tests', function() {
       '#field-name_translated-fi': 'test api',
       '#field-name_translated-en': 'test api',
       '#field-name_translated-sv': 'test api',
-      '#field-format': 'CSV',
+      '#s2id_field-format': {type: 'select2', values: ['CSV']},
       '#field-image-url': 'http://example.com',
       '#field-description_translated-fi': 'test kuvaus',
       '#field-description_translated-en': 'test description',

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -351,6 +351,7 @@ describe('Apiset tests', function() {
       '#field-name_translated-fi': 'test api',
       '#field-name_translated-en': 'test api',
       '#field-name_translated-sv': 'test api',
+      '#field-format': 'CSV',
       '#field-image-url': 'http://example.com',
       '#field-description_translated-fi': 'test kuvaus',
       '#field-description_translated-en': 'test description',

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -145,7 +145,7 @@ Cypress.Commands.add('fill_form_fields', (form_data) => {
                 // immediately after typing in ajax-populated instances
                 case 'select2':
                     field_value.values.forEach((v) => {
-                      field.type(v, options).wait(1000)
+                      field.type(v, options).wait(2000)
                       cy.get(field_selector).type('{enter}', {'force': true})
                     })
                     break;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -145,7 +145,7 @@ Cypress.Commands.add('fill_form_fields', (form_data) => {
                 // immediately after typing in ajax-populated instances
                 case 'select2':
                     field_value.values.forEach((v) => {
-                      field.type(v, options).wait(2000)
+                      field.type(v, options).wait(1000)
                       cy.get(field_selector).type('{enter}', {'force': true})
                     })
                     break;


### PR DESCRIPTION
This PR updates the checkout version of ckanext-apis module, where a new "format" fields was added to the apiset schema. In addition, some updates to relevant cypress tests.