### PR TITLE
Av 1745 apiset filtering fix

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -160,7 +160,6 @@ def action_package_search(original_action, context, data_dict):
 
     if sort_auto:
         result['sort'] = 'auto'
-
     return result
 
 
@@ -464,8 +463,8 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
             pkg_dict['update_frequency'] = ""
 
         update_frequency_list = {}
-        for resource in resources:
-            try:
+        try:
+            for resource in resources:
                 res_update_frequency = resource.get('update_frequency')
                 if res_update_frequency:
                     for key in res_update_frequency.keys():
@@ -473,8 +472,8 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
                             if not key in update_frequency_list:
                                 update_frequency_list[key] = []
                             update_frequency_list[key].append(value)
-            except Exception as e:
-                logging.error(e)
+        except Exception as e:
+            logging.error(f"Error while populating update frequencies: {e}")
         pkg_dict['update_frequency'] = json.dumps(update_frequency_list)
 
         # Map keywords to vocab_keywords_{lang}
@@ -501,9 +500,6 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
             org = toolkit.get_action('organization_show')({}, {'id': pkg_dict.get('organization')})
             if 'producer_type' in org:
                 pkg_dict['producer_type'] = org['producer_type']
-
-        # logging.warning(json.dumps(pkg_dict))
-
 
         return pkg_dict
 


### PR DESCRIPTION
There was a flaw in how the update frequencies were calculated for apisets that had more than one dataset. Now the filters for update frequency are updated correctly