### PR TITLE
AV-1787: Only build required images during tests

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -15,6 +15,9 @@ on:
       solr:
         description: "Change in solr container"
         value: ${{ jobs.changes_in_containers.outputs.solr }}
+      assets:
+        description: "Change in assets"
+        value: ${{ jobs.changes_in_containers.outputs.assets }}
 
 jobs:
   changes_in_containers:
@@ -37,3 +40,4 @@ jobs:
             drupal: drupal/**
             solr: docker/solr/**
             nginx: docker/nginx/**
+            assets: opendata-assets/**

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -3,7 +3,9 @@ name: Changes
 on:
   workflow_call:
     outputs:
-      ckan: ${{ jobs.changes_in_containers.outputs.ckan }}
+      ckan:
+        description: "Change in ckan container"
+        value: ${{ jobs.changes_in_containers.outputs.ckan }}
       drupal: ${{ jobs.changes_in_containers.outputs.drupal }}
       nginx: ${{ jobs.changes_in_containers.outputs.nginx }}
       solr: ${{ jobs.changes_in_containers.outputs.solr }}

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -1,0 +1,26 @@
+name: Changes
+
+on:
+  workflow_call:
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      ckan: ${{ steps.filter.outputs.ckan }}
+      drupal: ${{ steps.filter.outputs.drupal }}
+      nginx: ${{ steps.filter.outputs.nginx }}
+      solr: ${{ steps.filter.outputs.solr }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          initial-fetch-depth: '10'
+          filters: |
+            ckan: ckan/**
+            drupal: drupal/**
+            solr: docker/solr/**
+            nginx: docker/nginx/**

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -2,6 +2,11 @@ name: Changes
 
 on:
   workflow_call:
+    outputs:
+      ckan: ${{ jobs.changes.outputs.ckan }}
+      drupal: ${{ jobs.changes.outputs.drupal }}
+      nginx: ${{ jobs.changes.outputs.nginx }}
+      solr: ${{ jobs.changes.outputs.solr }}
 
 jobs:
   changes:

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -3,13 +3,13 @@ name: Changes
 on:
   workflow_call:
     outputs:
-      ckan: ${{ jobs.changes.outputs.ckan }}
-      drupal: ${{ jobs.changes.outputs.drupal }}
-      nginx: ${{ jobs.changes.outputs.nginx }}
-      solr: ${{ jobs.changes.outputs.solr }}
+      ckan: ${{ jobs.changes_in_containers.outputs.ckan }}
+      drupal: ${{ jobs.changes_in_containers.outputs.drupal }}
+      nginx: ${{ jobs.changes_in_containers.outputs.nginx }}
+      solr: ${{ jobs.changes_in_containers.outputs.solr }}
 
 jobs:
-  changes:
+  changes_in_containers:
     runs-on: ubuntu-latest
     outputs:
       ckan: ${{ steps.filter.outputs.ckan }}

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -6,9 +6,15 @@ on:
       ckan:
         description: "Change in ckan container"
         value: ${{ jobs.changes_in_containers.outputs.ckan }}
-      drupal: ${{ jobs.changes_in_containers.outputs.drupal }}
-      nginx: ${{ jobs.changes_in_containers.outputs.nginx }}
-      solr: ${{ jobs.changes_in_containers.outputs.solr }}
+      drupal:
+        description: "Change in drupal container"
+        value: ${{ jobs.changes_in_containers.outputs.drupal }}
+      nginx:
+        description: "Change in nginx container"
+        value: ${{ jobs.changes_in_containers.outputs.nginx }}
+      solr:
+        description: "Change in solr container"
+        value: ${{ jobs.changes_in_containers.outputs.solr }}
 
 jobs:
   changes_in_containers:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -55,7 +55,7 @@ jobs:
             name: drupal
             image_tag: DRUPAL_IMAGE_TAG
             dynatrace: true
-            build-container: ${{ needs.changes.outputs.drupal }}
+            build-container: ${{ needs.changes.outputs.drupal || needs.detect-changes.outputs.assets }}
           - dockerfile: ./ckan/Dockerfile
             context: ./ckan
             submodules: recursive
@@ -63,7 +63,7 @@ jobs:
             name: ckan
             image_tag: CKAN_IMAGE_TAG
             dynatrace: true
-            build-container: ${{ needs.changes.outputs.ckan }}
+            build-container: ${{ needs.changes.outputs.ckan || needs.detect-changes.outputs.assets }}
 
     steps:
       - name: checkout

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,7 +39,7 @@ jobs:
             name: solr
             image_tag: SOLR_IMAGE_TAG
             dynatrace: false
-            build-container: ${{ needs.changes.outputs.solr }}
+            build-container: ${{ needs.detect-changes.changes.outputs.solr }}
           - dockerfile: ./docker/nginx/Dockerfile
             context: ./docker/nginx
             submodules: ""
@@ -47,7 +47,7 @@ jobs:
             name: nginx
             image_tag: NGINX_IMAGE_TAG
             dynatrace: true
-            build-container: ${{ needs.changes.outputs.nginx }}
+            build-container: ${{ needs.detect-changes.changes.outputs.nginx }}
           - dockerfile: ./drupal/Dockerfile
             context: ./drupal
             submodules: ""
@@ -55,7 +55,7 @@ jobs:
             name: drupal
             image_tag: DRUPAL_IMAGE_TAG
             dynatrace: true
-            build-container: ${{ needs.changes.outputs.drupal }}
+            build-container: ${{ needs.detect-changes.changes.outputs.drupal }}
           - dockerfile: ./ckan/Dockerfile
             context: ./ckan
             submodules: recursive
@@ -63,7 +63,7 @@ jobs:
             name: ckan
             image_tag: CKAN_IMAGE_TAG
             dynatrace: true
-            build-container: ${{ needs.changes.outputs.ckan }}
+            build-container: ${{ needs.detect-changes.changes.outputs.ckan }}
 
     steps:
       - name: checkout

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,34 +12,15 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-        ckan: ${{ steps.filter.outputs.ckan }}
-        drupal: ${{ steps.filter.outputs.drupal }}
-        nginx: ${{ steps.filter.outputs.nginx }}
-        solr: ${{ steps.filter.outputs.solr }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          initial-fetch-depth: '10'
-          filters: |
-            ckan: ckan/**
-            drupal: drupal/**
-            solr: docker/solr/**
-            nginx: docker/nginx/**
-
+  detect-changes:
+    uses: ./.github/workflows/changes.yml
 
   build-and-push:
     name: Build and push containers
     runs-on: ubuntu-latest
     needs:
       - build-and-test-containers
-      - changes
+      - detect-changes
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -39,7 +39,7 @@ jobs:
             name: solr
             image_tag: SOLR_IMAGE_TAG
             dynatrace: false
-            build-container: ${{ needs.detect-changes.changes.outputs.solr }}
+            build-container: ${{ needs.changes.changes.outputs.solr }}
           - dockerfile: ./docker/nginx/Dockerfile
             context: ./docker/nginx
             submodules: ""
@@ -47,7 +47,7 @@ jobs:
             name: nginx
             image_tag: NGINX_IMAGE_TAG
             dynatrace: true
-            build-container: ${{ needs.detect-changes.changes.outputs.nginx }}
+            build-container: ${{ needs.changes.outputs.nginx }}
           - dockerfile: ./drupal/Dockerfile
             context: ./drupal
             submodules: ""
@@ -55,7 +55,7 @@ jobs:
             name: drupal
             image_tag: DRUPAL_IMAGE_TAG
             dynatrace: true
-            build-container: ${{ needs.detect-changes.changes.outputs.drupal }}
+            build-container: ${{ needs.changes.outputs.drupal }}
           - dockerfile: ./ckan/Dockerfile
             context: ./ckan
             submodules: recursive
@@ -63,7 +63,7 @@ jobs:
             name: ckan
             image_tag: CKAN_IMAGE_TAG
             dynatrace: true
-            build-container: ${{ needs.detect-changes.changes.outputs.ckan }}
+            build-container: ${{ needs.changes.outputs.ckan }}
 
     steps:
       - name: checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar
-          tags: ${REGISTRY}/${REPOSITORY}/${{ matrix.name }}:latest
+          tags: ${{ REGISTRY }}/${{ REPOSITORY }}/${{ matrix.name }}:latest
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           REPOSITORY: ${{ secrets.REPOSITORY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,8 +127,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-        with:
-          submodules: recursive
 
       - name: setup docker buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,9 @@ jobs:
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar
           tags: ${REGISTRY}/${REPOSITORY}/${{ matrix.name }}:latest
+        env:
+          REGISTRY: ${{ secrets.REGISTRY }}
+          REPOSITORY: ${{ secrets.REPOSITORY }}
 
       - name: upload images
         if: ${{ matrix.build-container == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,12 @@ jobs:
             name: ckan
             build-container: ${{ needs.detect-changes.outputs.ckan || needs.detect-changes.outputs.assets }}
 
+    outputs:
+      ckan-container-built: 'false'
+      drupal-container-built: 'false'
+      nginx-container-built: 'false'
+      solr-container-built: 'false'
+
     steps:
       - name: checkout
         if: ${{ matrix.build-container == 'true' }}
@@ -114,6 +120,10 @@ jobs:
         with:
           name: ${{ matrix.name }}
           path: /tmp/${{ matrix.name }}.tar
+
+      - name: Set built-container output to true
+        if: ${{ matrix.build-container == 'true' }}
+        run: echo '::set-output name=${{ matrix.name }}-container-built::true'
 
   test-e2e:
     name: test-e2e
@@ -228,23 +238,23 @@ jobs:
           path: /tmp
 
       - name: load built ckan image
-        if: ${{ needs.detect-changes.outputs.ckan == 'true' }}
+        if: ${{ needs.build-containers.outputs.ckan-container-built == 'true' }}
         run: |
           docker load --input /tmp/ckan/ckan.tar
 
       - name: load built drupal image
-        if: ${{ needs.detect-changes.outputs.drupal == 'true' }}
+        if: ${{ needs.build-containers.outputs.drupal-container-built == 'true' }}
         run: |
           docker load --input /tmp/drupal/drupal.tar
 
 
       - name: load built solr image
-        if: ${{ needs.detect-changes.outputs.solr == 'true' }}
+        if: ${{ needs.build-containers.outputs.solr-container-built == 'true' }}
         run: |
           docker load --input /tmp/solr/solr.tar
 
       - name: load built nginx image
-        if: ${{ needs.detect-changes.outputs.nginx == 'true' }}
+        if: ${{ needs.build-containers.outputs.nginx-container-built == 'true' }}
         run: |
           docker load --input /tmp/nginx/nginx.tar
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar
-          tags: ${{ REGISTRY }}/${{ REPOSITORY }}/${{ matrix.name }}:latest
+          tags: $REGISTRY/$REPOSITORY/${{ matrix.name }}:latest
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           REPOSITORY: ${{ secrets.REPOSITORY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,13 +46,13 @@ jobs:
             submodules: ""
             build-frontend: true
             name: drupal
-            build-container: ${{ needs.detect-changes.outputs.drupal }}
+            build-container: ${{ needs.detect-changes.outputs.drupal || needs.detect-changes.outputs.assets}}
           - dockerfile: ./ckan/Dockerfile
             context: ./ckan
             submodules: recursive
             build-frontend: true
             name: ckan
-            build-container: ${{ needs.detect-changes.outputs.ckan }}
+            build-container: ${{ needs.detect-changes.outputs.ckan || needs.detect-changes.outputs.assets }}
 
     steps:
       - name: checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,11 +93,6 @@ jobs:
         run: npx gulp
         working-directory: ./opendata-assets
 
-      - run: env
-        env:
-          REGISTRY: ${{ secrets.REGISTRY }}
-          REPOSITORY: ${{ secrets.REPOSITORY }}
-          
       - name: build images
         if: ${{ matrix.build-container == 'true' }}
         uses: docker/build-push-action@v3
@@ -108,7 +103,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar
-          tags: ${REGISTRY}/${REPOSITORY}/${{ matrix.name }}:latest
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.name }}:latest
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           REPOSITORY: ${{ secrets.REPOSITORY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,6 +93,11 @@ jobs:
         run: npx gulp
         working-directory: ./opendata-assets
 
+      - run: env
+        env:
+          REGISTRY: ${{ secrets.REGISTRY }}
+          REPOSITORY: ${{ secrets.REPOSITORY }}
+          
       - name: build images
         if: ${{ matrix.build-container == 'true' }}
         uses: docker/build-push-action@v3
@@ -103,7 +108,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar
-          tags: $REGISTRY/$REPOSITORY/${{ matrix.name }}:latest
+          tags: ${REGISTRY}/${REPOSITORY}/${{ matrix.name }}:latest
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           REPOSITORY: ${{ secrets.REPOSITORY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,7 +251,7 @@ jobs:
       - name: bring services up
         working-directory: docker
         run: |
-          docker-compose -p opendata up --build -d
+          docker-compose -f docker-compose.yml -f docker-compose.build.yml -p opendata up -d
 
       - name: wait until services have started
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
             submodules: ""
             build-frontend: true
             name: drupal
-            build-container: ${{ needs.detect-changes.outputs.drupal || needs.detect-changes.outputs.assets}}
+            build-container: ${{ needs.detect-changes.outputs.drupal || needs.detect-changes.outputs.assets }}
           - dockerfile: ./ckan/Dockerfile
             context: ./ckan
             submodules: recursive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,12 +54,6 @@ jobs:
             name: ckan
             build-container: ${{ needs.detect-changes.outputs.ckan || needs.detect-changes.outputs.assets }}
 
-    outputs:
-      ckan-container-built: 'false'
-      drupal-container-built: 'false'
-      nginx-container-built: 'false'
-      solr-container-built: 'false'
-
     steps:
       - name: checkout
         if: ${{ matrix.build-container == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar
-          tags: opendata/${{ matrix.name }}:latest
+          tags: ${REGISTRY}/${REPOSITORY}/opendata/${{ matrix.name }}:latest
 
       - name: upload images
         if: ${{ matrix.build-container == 'true' }}
@@ -239,7 +239,6 @@ jobs:
         if: ${{ needs.detect-changes.outputs.solr == 'true' }}
         run: |
           docker load --input /tmp/solr/solr.tar
-          docker load --input /tmp/nginx/nginx.tar
 
       - name: load built nginx image
         if: ${{ needs.detect-changes.outputs.nginx == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,13 +115,10 @@ jobs:
           name: ${{ matrix.name }}
           path: /tmp/${{ matrix.name }}.tar
 
-      - name: Set built-container output to true
-        if: ${{ matrix.build-container == 'true' }}
-        run: echo '::set-output name=${{ matrix.name }}-container-built::true'
-
   test-e2e:
     name: test-e2e
     needs:
+      - detect-changes
       - build-containers
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -232,23 +229,23 @@ jobs:
           path: /tmp
 
       - name: load built ckan image
-        if: ${{ needs.build-containers.outputs.ckan-container-built == 'true' }}
+        if: ${{ needs.detect-changes.outputs.ckan == 'true' || needs.detect-changes.outputs.assets == 'true'}}
         run: |
           docker load --input /tmp/ckan/ckan.tar
 
       - name: load built drupal image
-        if: ${{ needs.build-containers.outputs.drupal-container-built == 'true' }}
+        if: ${{ needs.detect-changes.outputs.drupal == 'true' || needs.detect-changes.outputs.assets == 'true' }}
         run: |
           docker load --input /tmp/drupal/drupal.tar
 
 
       - name: load built solr image
-        if: ${{ needs.build-containers.outputs.solr-container-built == 'true' }}
+        if: ${{ needs.detect-changes.outputs.solr == 'true' }}
         run: |
           docker load --input /tmp/solr/solr.tar
 
       - name: load built nginx image
-        if: ${{ needs.build-containers.outputs.nginx-container-built == 'true' }}
+        if: ${{ needs.detect-changes.outputs.nginx == 'true' }}
         run: |
           docker load --input /tmp/nginx/nginx.tar
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,25 +34,25 @@ jobs:
             submodules: ""
             build-frontend: false
             name: solr
-            build-container: ${{ needs.detect-changes.changes.outputs.solr }}
+            build-container: ${{ needs.detect-changes.outputs.solr }}
           - dockerfile: ./docker/nginx/Dockerfile
             context: ./docker/nginx
             submodules: ""
             build-frontend: false
             name: nginx
-            build-container: ${{ needs.detect-changes.changes.outputs.nginx }}
+            build-container: ${{ needs.detect-changes.outputs.nginx }}
           - dockerfile: ./drupal/Dockerfile
             context: ./drupal
             submodules: ""
             build-frontend: true
             name: drupal
-            build-container: ${{ needs.detect-changes.changes.outputs.drupal }}
+            build-container: ${{ needs.detect-changes.outputs.drupal }}
           - dockerfile: ./ckan/Dockerfile
             context: ./ckan
             submodules: recursive
             build-frontend: true
             name: ckan
-            build-container: ${{ needs.detect-changes.changes.outputs.ckan }}
+            build-container: ${{ needs.detect-changes.outputs.ckan }}
 
     steps:
       - name: checkout
@@ -225,23 +225,23 @@ jobs:
           path: /tmp
 
       - name: load built ckan image
-        if: ${{ needs.detect-changes.changes.outputs.ckan == 'true' }}
+        if: ${{ needs.detect-changes.outputs.ckan == 'true' }}
         run: |
           docker load --input /tmp/ckan/ckan.tar
 
       - name: load built drupal image
-        if: ${{ needs.detect-changes.changes.outputs.drupal == 'true' }}
+        if: ${{ needs.detect-changes.outputs.drupal == 'true' }}
         run: |
           docker load --input /tmp/drupal/drupal.tar
 
 
       - name: load built solr image
-        if: ${{ needs.detect-changes.changes.outputs.solr == 'true' }}
+        if: ${{ needs.detect-changes.outputs.solr == 'true' }}
         run: |
           docker load --input /tmp/solr/solr.tar
 
       - name: load built nginx image
-        if: ${{ needs.detect-changes.changes.outputs.nginx == 'true' }}
+        if: ${{ needs.detect-changes.outputs.nginx == 'true' }}
         run: |
           docker load --input /tmp/nginx/nginx.tar
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,25 +34,25 @@ jobs:
             submodules: ""
             build-frontend: false
             name: solr
-            build-container: ${{ needs.detect-changes.outputs.solr }}
+            build-container: ${{ needs.detect-changes.changes.outputs.solr }}
           - dockerfile: ./docker/nginx/Dockerfile
             context: ./docker/nginx
             submodules: ""
             build-frontend: false
             name: nginx
-            build-container: ${{ needs.detect-changes.outputs.nginx }}
+            build-container: ${{ needs.detect-changes.changes.outputs.nginx }}
           - dockerfile: ./drupal/Dockerfile
             context: ./drupal
             submodules: ""
             build-frontend: true
             name: drupal
-            build-container: ${{ needs.detect-changes.outputs.drupal }}
+            build-container: ${{ needs.detect-changes.changes.outputs.drupal }}
           - dockerfile: ./ckan/Dockerfile
             context: ./ckan
             submodules: recursive
             build-frontend: true
             name: ckan
-            build-container: ${{ needs.detect-changes.outputs.ckan }}
+            build-container: ${{ needs.detect-changes.changes.outputs.ckan }}
 
     steps:
       - name: checkout
@@ -225,23 +225,23 @@ jobs:
           path: /tmp
 
       - name: load built ckan image
-        if: ${{ needs.detect-changes.outputs.ckan == 'true' }}
+        if: ${{ needs.detect-changes.changes.outputs.ckan == 'true' }}
         run: |
           docker load --input /tmp/ckan/ckan.tar
 
       - name: load built drupal image
-        if: ${{ needs.detect-changes.outputs.drupal == 'true' }}
+        if: ${{ needs.detect-changes.changes.outputs.drupal == 'true' }}
         run: |
           docker load --input /tmp/drupal/drupal.tar
 
 
       - name: load built solr image
-        if: ${{ needs.detect-changes.outputs.solr == 'true' }}
+        if: ${{ needs.detect-changes.changes.outputs.solr == 'true' }}
         run: |
           docker load --input /tmp/solr/solr.tar
 
       - name: load built nginx image
-        if: ${{ needs.detect-changes.outputs.nginx == 'true' }}
+        if: ${{ needs.detect-changes.changes.outputs.nginx == 'true' }}
         run: |
           docker load --input /tmp/nginx/nginx.tar
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar
-          tags: ${REGISTRY}/${REPOSITORY}/opendata/${{ matrix.name }}:latest
+          tags: ${REGISTRY}/${REPOSITORY}/${{ matrix.name }}:latest
 
       - name: upload images
         if: ${{ matrix.build-container == 'true' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/changes.yml
+
   build-containers:
+    needs:
+      - detect-changes
     name: Build Containers
     runs-on: ubuntu-latest
     permissions:
@@ -29,33 +34,39 @@ jobs:
             submodules: ""
             build-frontend: false
             name: solr
+            build-container: ${{ needs.detect-changes.outputs.solr }}
           - dockerfile: ./docker/nginx/Dockerfile
             context: ./docker/nginx
             submodules: ""
             build-frontend: false
             name: nginx
+            build-container: ${{ needs.detect-changes.outputs.nginx }}
           - dockerfile: ./drupal/Dockerfile
             context: ./drupal
             submodules: ""
             build-frontend: true
             name: drupal
+            build-container: ${{ needs.detect-changes.outputs.drupal }}
           - dockerfile: ./ckan/Dockerfile
             context: ./ckan
             submodules: recursive
             build-frontend: true
             name: ckan
+            build-container: ${{ needs.detect-changes.outputs.ckan }}
 
     steps:
       - name: checkout
+        if: ${{ matrix.build-container == 'true' }}
         uses: actions/checkout@v3
         with:
           submodules: ${{ matrix.submodules }}
 
       - name: setup docker buildx
+        if: ${{ matrix.build-container == 'true' }}
         uses: docker/setup-buildx-action@v2
 
       - name: configure NPM credentials
-        if: ${{ matrix.build-frontend == true}}
+        if: ${{ matrix.build-frontend == true && matrix.build-container == 'true' }}
         run: |
           cat <<EOT >> ./opendata-assets/.npmrc
           @fortawesome:registry=https://npm.fontawesome.com/
@@ -65,7 +76,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: install nodejs v16
-        if: ${{ matrix.build-frontend == true }}
+        if: ${{ matrix.build-frontend == true && matrix.build-container == 'true' }}
         uses: actions/setup-node@v2
         with:
           node-version: 16
@@ -73,16 +84,17 @@ jobs:
           cache-dependency-path: opendata-assets/package-lock.json
 
       - name: install npm packages
-        if: ${{ matrix.build-frontend == true }}
+        if: ${{ matrix.build-frontend == true && matrix.build-container == 'true' }}
         run: npm ci
         working-directory: ./opendata-assets
 
       - name: build frontend with gulp
-        if: ${{ matrix.build-frontend == true }}
+        if: ${{ matrix.build-frontend == true && matrix.build-container == 'true' }}
         run: npx gulp
         working-directory: ./opendata-assets
 
       - name: build images
+        if: ${{ matrix.build-container == 'true' }}
         uses: docker/build-push-action@v3
         with:
           context: ${{ matrix.context }}
@@ -94,6 +106,7 @@ jobs:
           tags: opendata/${{ matrix.name }}:latest
 
       - name: upload images
+        if: ${{ matrix.build-container == 'true' }}
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.name }}
@@ -213,17 +226,32 @@ jobs:
         with:
           path: /tmp
 
-      - name: load built images
+      - name: load built ckan image
+        if: ${{ needs.detect-changes.outputs.ckan == 'true' }}
         run: |
           docker load --input /tmp/ckan/ckan.tar
+
+      - name: load built drupal image
+        if: ${{ needs.detect-changes.outputs.drupal == 'true' }}
+        run: |
           docker load --input /tmp/drupal/drupal.tar
+
+
+      - name: load built solr image
+        if: ${{ needs.detect-changes.outputs.solr == 'true' }}
+        run: |
           docker load --input /tmp/solr/solr.tar
+          docker load --input /tmp/nginx/nginx.tar
+
+      - name: load built nginx image
+        if: ${{ needs.detect-changes.outputs.nginx == 'true' }}
+        run: |
           docker load --input /tmp/nginx/nginx.tar
 
       - name: bring services up
         working-directory: docker
         run: |
-          docker-compose -f docker-compose.yml -f docker-compose.build.yml -p opendata up -d
+          docker-compose -p opendata up --build -d
 
       - name: wait until services have started
         shell: bash

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -1,12 +1,12 @@
 version: "3.8"
 services:
   ckan:
-    image: opendata/ckan:latest
+    image: ${REGISTRY}/${REPOSITORY}/opendata/ckan:latest
   ckan_cron:
-    image: opendata/ckan:latest
+    image: ${REGISTRY}/${REPOSITORY}/opendata/ckan:latest
   drupal:
-    image: opendata/drupal:latest
+    image: ${REGISTRY}/${REPOSITORY}/opendata/drupal:latest
   nginx:
-    image: opendata/nginx:latest
+    image: ${REGISTRY}/${REPOSITORY}/opendata/nginx:latest
   solr:
-    image: opendata/solr:latest
+    image: ${REGISTRY}/${REPOSITORY}/opendata/solr:latest

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -1,12 +1,12 @@
 version: "3.8"
 services:
   ckan:
-    image: ${REGISTRY}/${REPOSITORY}/opendata/ckan:latest
+    image: ${REGISTRY}/${REPOSITORY}/ckan:latest
   ckan_cron:
-    image: ${REGISTRY}/${REPOSITORY}/opendata/ckan:latest
+    image: ${REGISTRY}/${REPOSITORY}/ckan:latest
   drupal:
-    image: ${REGISTRY}/${REPOSITORY}/opendata/drupal:latest
+    image: ${REGISTRY}/${REPOSITORY}/drupal:latest
   nginx:
-    image: ${REGISTRY}/${REPOSITORY}/opendata/nginx:latest
+    image: ${REGISTRY}/${REPOSITORY}/nginx:latest
   solr:
-    image: ${REGISTRY}/${REPOSITORY}/opendata/solr:latest
+    image: ${REGISTRY}/${REPOSITORY}/solr:latest

--- a/drupal/modules/avoindata-theme/README.md
+++ b/drupal/modules/avoindata-theme/README.md
@@ -9,16 +9,15 @@ The Drupal 8 theme used at avoindata.fi is built on [Drupal Bootstrap](https://w
 
 Avoindata.fi uses Ansible to move this repository in Drupal's theme folder, and Drush to enable the subtheme and set it as default theme. The code can be found at [Opendata repository](https://github.com/vrk-kpa/opendata).
 
-## ytp-assets-common
+## opendata-assets
 
-This theme should be used together with [ytp-assets-common](https://github.com/vrk-kpa/opendata/tree/master/modules/ytp-assets-common).
+This theme should be used together with [opendata-assets](https://github.com/vrk-kpa/opendata/tree/master/opendata-assets).
 
-* Theme requires ytp-assets-common/src/less/variables.less to set variables used in both Drupal and CKAN
-* Theme Less files are compiled to CSS using ytp-assets-common's Gulpfile
+* Theme requires opendata-assets/src/less/variables.less to set variables used in both Drupal and CKAN
+* Theme Less files are compiled to CSS using opendata-assets's Gulpfile
 
 ## Developing the theme
 
-1. Edit Less files in this repo or ytp-assets-common/src/less/variables.less. Changes in other files shouldn't change this theme.
-2. In your local environment, cd to ytp-assets-common and run `gulp` or `gulp drupal`. This compiles Less to CSS.
-3. In your virtual environment, run `sudo python /vagrant/scripts/ytp-develop.py avoindata-drupal-theme`. You only need to run it once to link your local files.
-4. You usually need to empty Drupal theme cache at https://10.10.10.10/fi/admin/config/development/performance before you see any changes.
+1. Edit Less files in this repo or opendata-assets/src/less/variables.less. Changes in other files shouldn't change this theme.
+2. In your local environment, cd to opendata-assets and run `gulp` or `gulp drupal`. This compiles Less to CSS.
+3. You usually need to empty Drupal theme cache at http://localhost/fi/admin/config/development/performance before you see any changes.


### PR DESCRIPTION
Extend change detection to test workflows, now images are pulled from registry if there is no need to rebuild them, might make workflows slightly faster.