### PR TITLE
AV-762: Fix fuseki container admin password environment variable name

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -743,7 +743,7 @@ export class CkanStack extends Stack {
     });
 
     const fusekiContainerSecrets: { [key: string]: ecs.Secret; } = {
-      ADMIN_PASS: ecs.Secret.fromSecretsManager(sCommonSecrets, 'fuseki_admin_pass'),
+      ADMIN_PASSWORD: ecs.Secret.fromSecretsManager(sCommonSecrets, 'fuseki_admin_pass'),
     };
 
     const fusekiContainer = fusekiTaskDef.addContainer('fuseki', {

--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -743,7 +743,7 @@ export class CkanStack extends Stack {
     });
 
     const fusekiContainerSecrets: { [key: string]: ecs.Secret; } = {
-      FUSEKI_ADMIN_PASS: ecs.Secret.fromSecretsManager(sCommonSecrets, 'fuseki_admin_pass'),
+      ADMIN_PASS: ecs.Secret.fromSecretsManager(sCommonSecrets, 'fuseki_admin_pass'),
     };
 
     const fusekiContainer = fusekiTaskDef.addContainer('fuseki', {


### PR DESCRIPTION
- Fuseki container should receive `ADMIN_PASSWORD` environment variable instead of `FUSEKI_ADMIN_PASS`