### PR TITLE
AV-1793: Remove update frequency from apisets

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -454,7 +454,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
                 pkg_dict['vocab_%s' % field] = [tag for tag in json.loads(pkg_dict[field])]
 
         # Map keywords to vocab_keywords_{lang}
-        translated_vocabs = ['keywords', 'content_type']
+        translated_vocabs = ['keywords', 'content_type', 'update_frequency']
         languages = ['fi', 'sv', 'en']
         ignored_tags = ["avoindata.fi"]
         for prop_key in translated_vocabs:

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -274,7 +274,6 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
             facets_dict['vocab_keywords_' + lang] = _('Tags')
             facets_dict['organization'] = _('Organization')
             facets_dict['res_format'] = _('Formats')
-            facets_dict['vocab_update_frequency_' + lang] = _('Update frequency')
             facets_dict['license_id'] = _('Licenses')
             facets_dict['groups'] = _('Category')
             facets_dict['producer_type'] = _('Producer type')
@@ -454,30 +453,8 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
             if pkg_dict.get(field):
                 pkg_dict['vocab_%s' % field] = [tag for tag in json.loads(pkg_dict[field])]
 
-        # Populate update frequencies for apisets from validated data_dict
-        validated_data_dict = pkg_dict.get('validated_data_dict')
-        converted_validated_data_dict = json.loads(validated_data_dict)
-        resources = converted_validated_data_dict.get('resources')
-        
-        if not 'update_frequency' in pkg_dict:
-            pkg_dict['update_frequency'] = ""
-
-        update_frequency_list = {}
-        try:
-            for resource in resources:
-                res_update_frequency = resource.get('update_frequency')
-                if res_update_frequency:
-                    for key in res_update_frequency.keys():
-                        for value in res_update_frequency[key]:
-                            if not key in update_frequency_list:
-                                update_frequency_list[key] = []
-                            update_frequency_list[key].append(value)
-        except Exception as e:
-            logging.error(f"Error while populating update frequencies: {e}")
-        pkg_dict['update_frequency'] = json.dumps(update_frequency_list)
-
         # Map keywords to vocab_keywords_{lang}
-        translated_vocabs = ['keywords', 'content_type', 'update_frequency']
+        translated_vocabs = ['keywords', 'content_type']
         languages = ['fi', 'sv', 'en']
         ignored_tags = ["avoindata.fi"]
         for prop_key in translated_vocabs:

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
@@ -155,6 +155,20 @@
       "description": "Select which municipalities/cities the data covers."
     },
     {
+      "field_name": "update_frequency",
+      "label": "Update frequency",
+      "form_placeholder": "e.g. monthly",
+      "form_languages": ["fi", "en", "sv"],
+      "preset": "fluent_vocabulary_with_autocomplete",
+      "validators": "fluent_tags create_fluent_tags(update_frequency)",
+      "form_attrs": {
+        "data-module": "autocomplete",
+        "data-module-tags": "",
+        "data-module-source": "/api/2/util/tag/autocomplete?incomplete=?&vocabulary_id=update_frequency"
+      },
+      "description": "Describe how often your data is updated"
+    },
+    {
       "field_name": "valid_from",
       "label": "Valid from",
       "preset": "date_opendata_with_icon",

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
@@ -155,20 +155,6 @@
       "description": "Select which municipalities/cities the data covers."
     },
     {
-      "field_name": "update_frequency",
-      "label": "Update frequency",
-      "form_placeholder": "e.g. monthly",
-      "form_languages": ["fi", "en", "sv"],
-      "preset": "fluent_vocabulary_with_autocomplete",
-      "validators": "fluent_tags create_fluent_tags(update_frequency)",
-      "form_attrs": {
-        "data-module": "autocomplete",
-        "data-module-tags": "",
-        "data-module-source": "/api/2/util/tag/autocomplete?incomplete=?&vocabulary_id=update_frequency"
-      },
-      "description": "Describe how often your data is updated"
-    },
-    {
       "field_name": "valid_from",
       "label": "Valid from",
       "preset": "date_opendata_with_icon",

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -26,15 +26,12 @@ describe('Apiset filtering', function(){
     '#field-name_translated-fi': 'test api',
     '#field-description_translated-fi': 'test kuvaus',
     '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
-    '#s2id_autogen2': {type: 'select2', values: ['Kuukausittain']},
   }
 
   const api2_form_data = {
     '#field-name_translated-fi': 'test api',
     '#field-description_translated-fi': 'test kuvaus',
     '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
-    '#s2id_autogen2': {type: 'select2', values: ['Päivittäin']},
-
   }
 
   beforeEach(function () {
@@ -115,7 +112,6 @@ describe('Apiset filtering', function(){
     cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
     cy.get('.container-search-result').should('contain.text', apiset1_name);
     cy.get('.container-search-result').should('contain.text', apiset2_name);
-
   })
 
   it('Organization filters are working', function(){
@@ -182,85 +178,45 @@ describe('Apiset filtering', function(){
     cy.get('.container-search-result').should('contain.text', apiset2_name);
   });
 
-  it('Update frequency filters are working', function(){
-    cy.get('.secondary > :nth-child(5)').should('contain.text', 'kuukausittain');
-    cy.get('.secondary > :nth-child(5)').should('contain.text', 'päivittäin');
-    cy.get('.container-search-result').should('contain.text', apiset1_name);
-    cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-    //filter by monthly
-    cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-    cy.get('.secondary > :nth-child(5)').should('contain.text', 'kuukausittain');
-    cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'päivittäin');
-    cy.get('.container-search-result').should('contain.text', apiset1_name);
-    cy.get('.container-search-result').should('not.contain.text', apiset2_name);
-
-    //release the filter
-    cy.get('.remove > .fal').click();
-
-    cy.get('.secondary > :nth-child(5)').should('contain.text', 'kuukausittain');
-    cy.get('.secondary > :nth-child(5)').should('contain.text', 'päivittäin');
-    cy.get('.container-search-result').should('contain.text', apiset1_name);
-    cy.get('.container-search-result').should('contain.text', apiset2_name);
-   
-    //filter by daily
-    cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-    cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'kuukausittain');
-    cy.get('.secondary > :nth-child(5)').should('contain.text', 'päivittäin');
-    cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-    cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-    //release the filter
-    cy.get('.remove > .fal').click();
-
-    cy.get('.secondary > :nth-child(5)').should('contain.text', 'kuukausittain');
-    cy.get('.secondary > :nth-child(5)').should('contain.text', 'päivittäin');
-    cy.get('.container-search-result').should('contain.text', apiset1_name);
-    cy.get('.container-search-result').should('contain.text', apiset2_name);
-  })
-
   it('Licence filters are working', function(){
-    cy.get('.secondary > :nth-child(6)').should('contain.text', 'Creative Commons Attribution');
-    cy.get('.secondary > :nth-child(6)').should('contain.text', 'Creative Commons Non-Commercial');
+    cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Attribution');
+    cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
     cy.get('.container-search-result').should('contain.text', apiset1_name);
     cy.get('.container-search-result').should('contain.text', apiset2_name);
 
     //filter by Creative Commons Attribution
-    cy.get(':nth-child(6) > nav > .list-unstyled > :nth-child(1) > a > span').click();
+    cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(1) > a > span').click();
 
-    cy.get('.secondary > :nth-child(6)').should('contain.text', 'Creative Commons Attribution');
-    cy.get('.secondary > :nth-child(6)').should('not.contain.text', 'Creative Commons Non-Commercial');
+    cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Attribution');
+    cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Non-Commercial');
     cy.get('.container-search-result').should('not.contain.text', apiset1_name);
     cy.get('.container-search-result').should('contain.text', apiset2_name);
 
     //release the filter
     cy.get('.remove > .fal').click();
 
-    cy.get('.secondary > :nth-child(6)').should('contain.text', 'Creative Commons Attribution');
-    cy.get('.secondary > :nth-child(6)').should('contain.text', 'Creative Commons Non-Commercial');
+    cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Attribution');
+    cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
     cy.get('.container-search-result').should('contain.text', apiset1_name);
     cy.get('.container-search-result').should('contain.text', apiset2_name);
    
     //filter by Creative Commons Non-Commercial
-    cy.get(':nth-child(6) > nav > .list-unstyled > :nth-child(2) > a > span').click();
+    cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(2) > a > span').click();
 
-    cy.get('.secondary > :nth-child(6)').should('not.contain.text', 'Creative Commons Attribution');
-    cy.get('.secondary > :nth-child(6)').should('contain.text', 'Creative Commons Non-Commercial');
+    cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Attribution');
+    cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
     cy.get('.container-search-result').should('contain.text', apiset1_name);
     cy.get('.container-search-result').should('not.contain.text', apiset2_name);
 
     //release the filter
     cy.get('.remove > .fal').click();
 
-    cy.get('.secondary > :nth-child(6)').should('contain.text', 'Creative Commons Attribution');
-    cy.get('.secondary > :nth-child(6)').should('contain.text', 'Creative Commons Non-Commercial');
+    cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Attribution');
+    cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
     cy.get('.container-search-result').should('contain.text', apiset1_name);
     cy.get('.container-search-result').should('contain.text', apiset2_name);
   })
 })
-
 
 describe('Apiset tests', function() {
 
@@ -364,9 +320,6 @@ describe('Apiset tests', function() {
       '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
       // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
       '#s2id_autogen1_search': {type: 'select2', values: ['CSV'], force:true},
-      '#s2id_autogen2': {type: 'select2', values: ['Päivittäin']},
-      '#s2id_autogen3': {type: 'select2', values: ['Päivittäin']},
-      '#s2id_autogen4': {type: 'select2', values: ['Päivittäin']}
     };
     cy.create_new_apiset(apiset_name, apiset_form_data, api_form_data);
   });


### PR DESCRIPTION
Removed update frequency from apisets, will no longer appear as a filter term or in the form. Update frequency still exists for datasets.