### PR TITLE
AV-1794: fixed organizations with deleted datasets 

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -746,7 +746,7 @@ def action_organization_tree_list(context, data_dict):
                 ids_and_titles
                 .outerjoin(model.Package, and_(model.Package.type == 'dataset',
                                                model.Package.private == false(),
-                                               model.Package.state != 'deleted',
+                                               model.Package.state == 'active',
                                                or_(model.Package.owner_org == model.Group.name,
                                                    model.Package.owner_org == model.Group.id)))
                 .group_by(model.Group.id, model.Group.title, model.GroupExtra.value)

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -740,11 +740,13 @@ def action_organization_tree_list(context, data_dict):
                       .order_by(model.Group.title))
 
     # Optionally handle getting only organizations with datasets
+    # Note! Check if state is deleted for the results or else it will return all dataset collections that have had a dataset at some point
     if with_datasets:
         ids_and_titles = (
                 ids_and_titles
                 .outerjoin(model.Package, and_(model.Package.type == 'dataset',
                                                model.Package.private == false(),
+                                               model.Package.state != 'deleted',
                                                or_(model.Package.owner_org == model.Group.name,
                                                    model.Package.owner_org == model.Group.id)))
                 .group_by(model.Group.id, model.Group.title, model.GroupExtra.value)


### PR DESCRIPTION
Organizations with only deleted datasets will no longer appear with the filter "_Näytä vain dataa julkaisseet tuottajat_"