### PR TITLE
AV-1497: Apiset related datasets page implementation

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -587,6 +587,9 @@ def get_package_showcase_list(package_id):
     context = {'model': model, 'session': model.Session, 'user': c.user}
     return get_action('ckanext_package_showcase_list')(context, {'package_id': package_id})
 
+def get_apiset_package_list(package_id):
+    context = {'model': model, 'session': model.Session, 'user': c.user}
+    return get_action('apiset_package_list')(context, {'apiset_id': package_id})
 
 def get_groups_where_user_is_admin():
     context = {'model': model, 'session': model.Session, 'user': c.user}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -42,7 +42,7 @@ from .helpers import extra_translation, render_date, service_database_enabled, g
     scheming_language_text_or_empty, get_lang_prefix, call_toolkit_function, get_translation, get_translated, \
     dataset_display_name, resource_display_name, get_current_date, get_label_for_producer, scheming_category_list, \
     check_group_selected, group_title_by_id, group_list_with_selected, \
-    get_last_harvested_date, get_resource_sha256, get_package_showcase_list, get_groups_where_user_is_admin, \
+    get_last_harvested_date, get_resource_sha256, get_package_showcase_list, get_apiset_package_list, get_groups_where_user_is_admin, \
     get_value_from_extras_by_key, get_field_from_dataset_schema, get_field_from_resource_schema, is_boolean_selected, \
     site_url_with_root_path, get_organization_filters_count
 
@@ -405,6 +405,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
                 'group_list_with_selected': group_list_with_selected,
                 'get_resource_sha256': get_resource_sha256,
                 'get_package_showcase_list': get_package_showcase_list,
+                'get_apiset_package_list': get_apiset_package_list,
                 'get_groups_where_user_is_admin': get_groups_where_user_is_admin,
                 'get_value_from_extras_by_key': get_value_from_extras_by_key,
                 'get_field_from_dataset_schema': get_field_from_dataset_schema,

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/read.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/read.html
@@ -54,6 +54,16 @@
           {% endblock %}
         {% endblock %}
 
+        {% if dataset_type=='apiset' %}
+        <h3 class="showcase-packages-title">{{ _('Used datasets') }}</h3>
+        {% set pkgs = h.get_apiset_package_list(pkg.id) %}
+        {% if pkgs %}
+            {% snippet "sixodp_showcase/snippets/showcase_package_list.html", packages=pkgs, list_class='showcase-packages' %}
+        {% else %}
+            <p class="module-content empty">{{_('There are no Datasets in this Apiset')}}</p>
+        {% endif %}
+      {% endif %}
+
         {{h.disqus_comments()}}
       </section>
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -11,7 +11,7 @@ module.exports = defineConfig({
   },
   videoCompression: 20,
   videoUploadOnPasses: false,
-
+  defaultCommandTimeout: 30000,
   e2e: {
     baseUrl: 'http://localhost',
     specPattern: 'cypress/e2e/**/*.{js,jsx,ts,tsx}',

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -529,6 +529,8 @@ Cypress.Commands.add('edit_apiset', (apiset_name, apiset_form_data) => {
   cy.visit(`/data/fi/apiset/edit/${apiset_name}`);
   cy.fill_form_fields(apiset_form_data)
   cy.get('button[name=save]').click();
+  // Check if the url has changed in order to determine when the form has been properly submitted
+  cy.url().should('include', `/data/fi/apiset/${apiset_name}`); 
   cy.get('.dataset-title').contains(apiset_name+'edit');
 })
 


### PR DESCRIPTION
Datasets can now be associated with datasets. Most of the functionality is implemented in the ckanext-apis submodule from AV-1694 and this PR contains the implementation of the submodule for the Apiset page along with e2e tests. Also adjusted the default timeout for cypress tests from 4 seconds (default) to 30 seconds in order to reduce timeout based failures.

Create apiset-dataset associations on the manage_datasets page:
![image](https://user-images.githubusercontent.com/24498487/191586707-4a10cf46-027e-4961-bbc8-32610ba2c7c8.png)

Associated datasets will appear on the apiset's page:
![image](https://user-images.githubusercontent.com/24498487/191586929-77aec6e2-d7b9-4823-a985-7230fec55790.png)
