### PR TITLE
Fix production deployment trigger to published release

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,9 +1,9 @@
 name: Deploy Production
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Releases do not push tag anymore so the prod deployment didn't trigger.