### PR TITLE
AV-1827: hide empty associated resources

### DIFF
--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/ckanext-sixodp_showcase.pot
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/ckanext-sixodp_showcase.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-sixodp_showcase 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-02 11:57+0000\n"
+"POT-Creation-Date: 2022-10-06 09:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -529,7 +529,7 @@ msgstr ""
 
 #: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:73
 #: ckanext/sixodp_showcase/templates/showcase/search.html:12
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:16
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:13
 msgid "Relevance"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 
 #: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:77
 #: ckanext/sixodp_showcase/templates/showcase/search.html:16
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:15
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:16
 msgid "Popular"
 msgstr ""
 
@@ -585,7 +585,7 @@ msgid "Launch website"
 msgstr ""
 
 #: ckanext/sixodp_showcase/templates/showcase/search.html:19
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:23
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:22
 msgid "Search showcases..."
 msgstr ""
 
@@ -677,12 +677,12 @@ msgid ""
 "License</a>."
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:92
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:95
 msgid "Used datasets"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:97
-msgid "There are no Datasets in this Showcase"
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:102
+msgid "Used apisets"
 msgstr ""
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:20
@@ -747,16 +747,12 @@ msgstr ""
 msgid "Remove dataset from this showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:13
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:14
 msgid "Newest first"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:14
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:15
 msgid "Oldest first"
-msgstr ""
-
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:20
-msgid "Top rating"
 msgstr ""
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_result_text.html:7

--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/en_GB/LC_MESSAGES/ckanext-sixodp_showcase.po
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/en_GB/LC_MESSAGES/ckanext-sixodp_showcase.po
@@ -8,75 +8,37 @@
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2018
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2019
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-sixodp_showcase 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-02-22 11:44+0000\n"
+"POT-Creation-Date: 2022-10-06 09:27+0000\n"
 "PO-Revision-Date: 2018-03-14 11:02+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2022\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.7.0\n"
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/sixodp_showcase/controller.py:60
-#: ckanext/sixodp_showcase/controller.py:62
-#: ckanext/sixodp_showcase/controller.py:309
-msgid "Showcase not found"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:101
-msgid "Not authorized to see this page"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:196
-msgid "Organizations"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:197
-#: ckanext/sixodp_showcase/plugin.py:96
+#: ckanext/sixodp_showcase/plugin.py:86 ckanext/sixodp_showcase/utils.py:182
+#: ckanext/sixodp_showcase/utils.py:332
 msgid "Groups"
 msgstr "Categories"
 
-#: ckanext/sixodp_showcase/controller.py:198
-#: ckanext/sixodp_showcase/plugin.py:97
+#: ckanext/sixodp_showcase/plugin.py:87
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new_package_form.html:33
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_info.html:5
+#: ckanext/sixodp_showcase/utils.py:183 ckanext/sixodp_showcase/utils.py:333
 msgid "Tags"
 msgstr ""
 
-#: ckanext/sixodp_showcase/controller.py:199
-msgid "Formats"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:200
-msgid "Licenses"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:250
-msgid "Invalid search query: {error_message}"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:267
-msgid "Parameter \"{parameter_name}\" is not an integer"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:296
-#: ckanext/sixodp_showcase/controller.py:307
-msgid "Unauthorized to delete showcase"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:301
-msgid "Showcase has been deleted."
-msgstr ""
-
-#: ckanext/sixodp_showcase/plugin.py:99
+#: ckanext/sixodp_showcase/plugin.py:89
 msgid "Platforms"
 msgstr ""
 
@@ -323,7 +285,7 @@ msgstr ""
 msgid ""
 "Add max. 3 images of your showcase. Good images are for example those that "
 "show the user interface and features of the showcase."
-msgstr ""
+msgstr "Add images that show the user interface and features of the showcase."
 
 #: ckanext/sixodp_showcase/translations.py:62
 msgid ""
@@ -332,6 +294,8 @@ msgid ""
 "app logo to show as the featured image, upload the app logo (and possible "
 "other images), but do not upload a featured image."
 msgstr ""
+"Images will be shown on the Showcases page and showcase's own page. You can "
+"upload images from your computer or link to an URL."
 
 #: ckanext/sixodp_showcase/translations.py:63
 msgid "Logo"
@@ -353,7 +317,68 @@ msgstr ""
 msgid "Visualisation"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/admin/base.html:6
+#: ckanext/sixodp_showcase/utils.py:181 ckanext/sixodp_showcase/utils.py:331
+msgid "Organizations"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:184 ckanext/sixodp_showcase/utils.py:334
+msgid "Formats"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:185 ckanext/sixodp_showcase/utils.py:335
+msgid "Licenses"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:245
+msgid "Parameter '{parameter_name}' is not an integer"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:261
+msgid "Not authorized to see this page"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:385
+msgid "Invalid search query: {error_message}"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:410
+msgid "Parameter u\"{parameter_name}\" is not an integer"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:438 ckanext/sixodp_showcase/utils.py:474
+msgid "Showcase not found"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:440 ckanext/sixodp_showcase/utils.py:476
+msgid "Unauthorized to read showcase"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:467
+msgid "User not authorized to edit {showcase_id}"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:502
+msgid "The apiset has been removed from the showcase."
+msgid_plural "The apisets have been removed from the showcase."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ckanext/sixodp_showcase/utils.py:534
+msgid "The apiset has been added to the showcase."
+msgid_plural "The apisets have been added to the showcase."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ckanext/sixodp_showcase/views.py:150
+msgid "Dataset not found"
+msgstr ""
+
+#: ckanext/sixodp_showcase/views.py:171
+#, python-format
+msgid "User %r not authorized to edit %s"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/admin/base.html:5
 #: ckanext/sixodp_showcase/templates/admin/manage_showcase_admins.html:38
 msgid "Showcase Admins"
 msgstr ""
@@ -415,8 +440,8 @@ msgstr ""
 
 #: ckanext/sixodp_showcase/templates/admin/manage_showcase_admins.html:69
 msgid ""
-" <p><strong>Showcase Admin:</strong> Can create and remove showcases. Can "
-"add and remove datasets from showcases.</p> "
+"<p><strong>Showcase Admin:</strong> Can create and remove showcases. Can add"
+" and remove datasets from showcases.</p>"
 msgstr ""
 
 #: ckanext/sixodp_showcase/templates/package/dataset_showcase_list.html:3
@@ -428,8 +453,8 @@ msgstr ""
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/edit_base.html:21
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:6
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:28
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:4
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:7
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:9
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:12
 msgid "Showcases"
 msgstr ""
 
@@ -481,61 +506,77 @@ msgstr ""
 msgid "Manage datasets"
 msgstr ""
 
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:4
+msgid "apisets in this showcase"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:8
+msgid "This showcase has no apisets associated to it"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:12
+msgid "Search and add apisets to a showcase"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:16
+msgid "No apisets could be found"
+msgstr ""
+
 #: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:3
 msgid "Showcases - Manage datasets"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:16
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:18
 msgid "Datasets in this showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:41
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:45
 msgid "Remove from Showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:47
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:52
 msgid "This showcase has no datasets associated to it"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:53
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:61
 msgid "Search and add datasets to a showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:63
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:73
 #: ckanext/sixodp_showcase/templates/showcase/search.html:12
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:16
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:13
 msgid "Relevance"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:64
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:74
 #: ckanext/sixodp_showcase/templates/showcase/search.html:13
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:17
 msgid "Name Ascending"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:65
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:75
 #: ckanext/sixodp_showcase/templates/showcase/search.html:14
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:18
 msgid "Name Descending"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:66
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:76
 #: ckanext/sixodp_showcase/templates/showcase/search.html:15
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:19
 msgid "Last Modified"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:67
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:77
 #: ckanext/sixodp_showcase/templates/showcase/search.html:16
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:15
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:16
 msgid "Popular"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:76
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:86
 msgid "Add to Showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:108
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:120
 msgid "No datasets could be found"
 msgstr ""
 
@@ -559,8 +600,12 @@ msgid "Launch website"
 msgstr "View website"
 
 #: ckanext/sixodp_showcase/templates/showcase/search.html:19
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:23
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:22
 msgid "Search showcases..."
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/edit_base.html:44
+msgid "Manage apisets"
 msgstr ""
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new.html:5
@@ -651,27 +696,27 @@ msgstr ""
 "href=\"https://creativecommons.org/publicdomain/zero/1.0/deed.en\">Creative "
 "Commons CC0 1.0 license</a>."
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:92
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:95
 msgid "Used datasets"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:97
-msgid "There are no Datasets in this Showcase"
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:102
+msgid "Used apisets"
+msgstr "Used apis"
+
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:20
+msgid "Applications"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:15
-msgid " Applications "
-msgstr " Showcases"
-
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:23
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:28
 msgid "Add Showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:38
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:43
 msgid "Search applications..."
 msgstr "Search showcases..."
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:54
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:63
 msgid "Filter list"
 msgstr ""
 
@@ -721,16 +766,12 @@ msgstr ""
 msgid "Remove dataset from this showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:13
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:14
 msgid "Newest first"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:14
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:15
 msgid "Oldest first"
-msgstr ""
-
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:20
-msgid "Top rating"
 msgstr ""
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_result_text.html:7

--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/fi/LC_MESSAGES/ckanext-sixodp_showcase.po
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/fi/LC_MESSAGES/ckanext-sixodp_showcase.po
@@ -5,81 +5,42 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 # 
 # Translators:
-# Pentti Laitinen, 2018
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2018
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2019
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2020
 # Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2020
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-sixodp_showcase 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-02-22 11:44+0000\n"
+"POT-Creation-Date: 2022-10-06 09:27+0000\n"
 "PO-Revision-Date: 2018-03-14 11:02+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2022\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.7.0\n"
 "Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/sixodp_showcase/controller.py:60
-#: ckanext/sixodp_showcase/controller.py:62
-#: ckanext/sixodp_showcase/controller.py:309
-msgid "Showcase not found"
-msgstr "Sovellusta ei löytynyt"
-
-#: ckanext/sixodp_showcase/controller.py:101
-msgid "Not authorized to see this page"
-msgstr "Ei oikeuksia nähdä tätä sivua"
-
-#: ckanext/sixodp_showcase/controller.py:196
-msgid "Organizations"
-msgstr "Organisaatiot"
-
-#: ckanext/sixodp_showcase/controller.py:197
-#: ckanext/sixodp_showcase/plugin.py:96
+#: ckanext/sixodp_showcase/plugin.py:86 ckanext/sixodp_showcase/utils.py:182
+#: ckanext/sixodp_showcase/utils.py:332
 msgid "Groups"
 msgstr "Kategoriat"
 
-#: ckanext/sixodp_showcase/controller.py:198
-#: ckanext/sixodp_showcase/plugin.py:97
+#: ckanext/sixodp_showcase/plugin.py:87
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new_package_form.html:33
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_info.html:5
+#: ckanext/sixodp_showcase/utils.py:183 ckanext/sixodp_showcase/utils.py:333
 msgid "Tags"
 msgstr "Avainsanat"
 
-#: ckanext/sixodp_showcase/controller.py:199
-msgid "Formats"
-msgstr "Tiedostomuodot"
-
-#: ckanext/sixodp_showcase/controller.py:200
-msgid "Licenses"
-msgstr "Lisenssit"
-
-#: ckanext/sixodp_showcase/controller.py:250
-msgid "Invalid search query: {error_message}"
-msgstr "Virheellinen haku: {error_message}"
-
-#: ckanext/sixodp_showcase/controller.py:267
-msgid "Parameter \"{parameter_name}\" is not an integer"
-msgstr "Parametri \"{parameter_name}\" ei ole kokonaisluku"
-
-#: ckanext/sixodp_showcase/controller.py:296
-#: ckanext/sixodp_showcase/controller.py:307
-msgid "Unauthorized to delete showcase"
-msgstr "Ei oikeuksia poistaa sovellusta"
-
-#: ckanext/sixodp_showcase/controller.py:301
-msgid "Showcase has been deleted."
-msgstr "Sovellus on poistettu."
-
-#: ckanext/sixodp_showcase/plugin.py:99
+#: ckanext/sixodp_showcase/plugin.py:89
 msgid "Platforms"
 msgstr "Käyttöympäristöt (alustat)"
 
@@ -254,7 +215,7 @@ msgstr "Valitse listasta yksi tai useampi sovellusta kuvaava tyyppi."
 
 #: ckanext/sixodp_showcase/translations.py:42
 msgid "Select at least one category."
-msgstr "Valitse listasta yksi tai useampi sovellusta kuvaava kategoria."
+msgstr "Valitse yksi tai useampi sovellusta kuvaava kategoria."
 
 #: ckanext/sixodp_showcase/translations.py:43
 msgid "Additional showcase information"
@@ -351,12 +312,8 @@ msgid ""
 "app logo to show as the featured image, upload the app logo (and possible "
 "other images), but do not upload a featured image."
 msgstr ""
-"Kuvat näkyvät sovelluksen esittelysivulla ja Käyttösovellukset-sivulla "
-"sovelluksen korttinäkymässä. Voit ladata tiedostot tietokoneelta tai lisätä "
-"linkin kuvaan. Oletko ilmoittamassa mobiilisovellusta? Jos haluat "
-"sovelluksesi kuvakkeen näkyvän sovelluksesi esittelykuvana, lataa "
-"sovelluksen kuvake ja muita sovelluksen kuvia, mutta älä lataa sovellukselle"
-" esittelykuvaa."
+"Kuvat näkyvät Sovellusten etusivulla esittelykuvana sekä sovelluksen omalla "
+"sivulla. Voit ladata kuvat tietokoneeltasi tai lisätä linkin kuvaan. "
 
 #: ckanext/sixodp_showcase/translations.py:63
 msgid "Logo"
@@ -378,7 +335,68 @@ msgstr "Työkalut"
 msgid "Visualisation"
 msgstr "Visualisaatio"
 
-#: ckanext/sixodp_showcase/templates/admin/base.html:6
+#: ckanext/sixodp_showcase/utils.py:181 ckanext/sixodp_showcase/utils.py:331
+msgid "Organizations"
+msgstr "Organisaatiot"
+
+#: ckanext/sixodp_showcase/utils.py:184 ckanext/sixodp_showcase/utils.py:334
+msgid "Formats"
+msgstr "Tiedostomuodot"
+
+#: ckanext/sixodp_showcase/utils.py:185 ckanext/sixodp_showcase/utils.py:335
+msgid "Licenses"
+msgstr "Lisenssit"
+
+#: ckanext/sixodp_showcase/utils.py:245
+msgid "Parameter '{parameter_name}' is not an integer"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:261
+msgid "Not authorized to see this page"
+msgstr "Ei oikeuksia nähdä tätä sivua"
+
+#: ckanext/sixodp_showcase/utils.py:385
+msgid "Invalid search query: {error_message}"
+msgstr "Virheellinen haku: {error_message}"
+
+#: ckanext/sixodp_showcase/utils.py:410
+msgid "Parameter u\"{parameter_name}\" is not an integer"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:438 ckanext/sixodp_showcase/utils.py:474
+msgid "Showcase not found"
+msgstr "Sovellusta ei löytynyt"
+
+#: ckanext/sixodp_showcase/utils.py:440 ckanext/sixodp_showcase/utils.py:476
+msgid "Unauthorized to read showcase"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:467
+msgid "User not authorized to edit {showcase_id}"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:502
+msgid "The apiset has been removed from the showcase."
+msgid_plural "The apisets have been removed from the showcase."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ckanext/sixodp_showcase/utils.py:534
+msgid "The apiset has been added to the showcase."
+msgid_plural "The apisets have been added to the showcase."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ckanext/sixodp_showcase/views.py:150
+msgid "Dataset not found"
+msgstr ""
+
+#: ckanext/sixodp_showcase/views.py:171
+#, python-format
+msgid "User %r not authorized to edit %s"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/admin/base.html:5
 #: ckanext/sixodp_showcase/templates/admin/manage_showcase_admins.html:38
 msgid "Showcase Admins"
 msgstr "Sovellusten ylläpitäjät"
@@ -444,11 +462,9 @@ msgstr "Sivustolla ei ole tällä hetkellä sovellusten ylläpitäjiä."
 
 #: ckanext/sixodp_showcase/templates/admin/manage_showcase_admins.html:69
 msgid ""
-" <p><strong>Showcase Admin:</strong> Can create and remove showcases. Can "
-"add and remove datasets from showcases.</p> "
+"<p><strong>Showcase Admin:</strong> Can create and remove showcases. Can add"
+" and remove datasets from showcases.</p>"
 msgstr ""
-"<p><strong>Sovellusten ylläpitäjä:</strong> Voi luoda ja poistaa "
-"sovelluksia. Voi lisätä ja poistaa tietoaineistoja sovelluksesta</p>"
 
 #: ckanext/sixodp_showcase/templates/package/dataset_showcase_list.html:3
 #: ckanext/sixodp_showcase/templates/showcase/edit_base.html:5
@@ -459,8 +475,8 @@ msgstr ""
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/edit_base.html:21
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:6
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:28
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:4
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:7
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:9
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:12
 msgid "Showcases"
 msgstr "Sovellukset"
 
@@ -512,61 +528,77 @@ msgstr "Muokkaa sovellusta"
 msgid "Manage datasets"
 msgstr "Hallitse tietoaineistoja"
 
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:4
+msgid "apisets in this showcase"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:8
+msgid "This showcase has no apisets associated to it"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:12
+msgid "Search and add apisets to a showcase"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:16
+msgid "No apisets could be found"
+msgstr ""
+
 #: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:3
 msgid "Showcases - Manage datasets"
 msgstr "Sovellukset - Hallitse tietoaineistoja"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:16
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:18
 msgid "Datasets in this showcase"
 msgstr "Tämän sovelluksen tietoaineistot"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:41
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:45
 msgid "Remove from Showcase"
 msgstr "Poista sovelluksesta"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:47
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:52
 msgid "This showcase has no datasets associated to it"
 msgstr "Tähän sovellukseen ei ole liitetty tietoaineistoja"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:53
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:61
 msgid "Search and add datasets to a showcase"
 msgstr "Hae ja lisää tietoaineistoja sovellukselle"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:63
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:73
 #: ckanext/sixodp_showcase/templates/showcase/search.html:12
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:16
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:13
 msgid "Relevance"
 msgstr "Osuvin ensin"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:64
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:74
 #: ckanext/sixodp_showcase/templates/showcase/search.html:13
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:17
 msgid "Name Ascending"
 msgstr "Nimen mukaan nousevasti"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:65
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:75
 #: ckanext/sixodp_showcase/templates/showcase/search.html:14
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:18
 msgid "Name Descending"
 msgstr "Nimen mukaan laskevasti"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:66
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:76
 #: ckanext/sixodp_showcase/templates/showcase/search.html:15
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:19
 msgid "Last Modified"
 msgstr "Viimeksi muokattu"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:67
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:77
 #: ckanext/sixodp_showcase/templates/showcase/search.html:16
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:15
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:16
 msgid "Popular"
 msgstr "Suositut"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:76
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:86
 msgid "Add to Showcase"
 msgstr "Lisää sovellukseen"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:108
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:120
 msgid "No datasets could be found"
 msgstr "Tietoaineistoja ei löytynyt"
 
@@ -590,9 +622,13 @@ msgid "Launch website"
 msgstr "Näytä sivu"
 
 #: ckanext/sixodp_showcase/templates/showcase/search.html:19
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:23
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:22
 msgid "Search showcases..."
 msgstr "Etsi käyttösovelluksia..."
+
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/edit_base.html:44
+msgid "Manage apisets"
+msgstr ""
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new.html:5
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new.html:10
@@ -681,27 +717,27 @@ msgstr ""
 "href=\"https://creativecommons.org/publicdomain/zero/1.0/deed.fi\">Creative "
 "Commons CC0 1.0 -lisenssin</a> mukaisesti."
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:92
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:95
 msgid "Used datasets"
 msgstr "Käytetyt tietoaineistot"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:97
-msgid "There are no Datasets in this Showcase"
-msgstr "Sovellukseen ei ole liitetty tietoaineistoja"
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:102
+msgid "Used apisets"
+msgstr "Käytetyt rajapinnat"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:15
-msgid " Applications "
-msgstr "Sovellukset"
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:20
+msgid "Applications"
+msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:23
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:28
 msgid "Add Showcase"
 msgstr "Lisää sovellus"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:38
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:43
 msgid "Search applications..."
 msgstr "Etsi käyttösovelluksia..."
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:54
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:63
 msgid "Filter list"
 msgstr "Rajaa listaa"
 
@@ -753,17 +789,13 @@ msgstr "Kategoriat"
 msgid "Remove dataset from this showcase"
 msgstr "Poista tietoaineisto tästä sovelluksesta"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:13
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:14
 msgid "Newest first"
 msgstr "Uusin ensin"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:14
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:15
 msgid "Oldest first"
 msgstr "Vanhin ensin"
-
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:20
-msgid "Top rating"
-msgstr "Paras arvosana"
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_result_text.html:7
 msgid "{number} showcase found for '{query}'"

--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/sv/LC_MESSAGES/ckanext-sixodp_showcase.po
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/sv/LC_MESSAGES/ckanext-sixodp_showcase.po
@@ -9,75 +9,37 @@
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2020
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-sixodp_showcase 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-02-22 11:44+0000\n"
+"POT-Creation-Date: 2022-10-06 09:27+0000\n"
 "PO-Revision-Date: 2018-03-14 11:02+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2022\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.7.0\n"
 "Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/sixodp_showcase/controller.py:60
-#: ckanext/sixodp_showcase/controller.py:62
-#: ckanext/sixodp_showcase/controller.py:309
-msgid "Showcase not found"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:101
-msgid "Not authorized to see this page"
-msgstr "Behörighet krävs för att visa sidan"
-
-#: ckanext/sixodp_showcase/controller.py:196
-msgid "Organizations"
-msgstr "Organisationer"
-
-#: ckanext/sixodp_showcase/controller.py:197
-#: ckanext/sixodp_showcase/plugin.py:96
+#: ckanext/sixodp_showcase/plugin.py:86 ckanext/sixodp_showcase/utils.py:182
+#: ckanext/sixodp_showcase/utils.py:332
 msgid "Groups"
 msgstr "Grupper"
 
-#: ckanext/sixodp_showcase/controller.py:198
-#: ckanext/sixodp_showcase/plugin.py:97
+#: ckanext/sixodp_showcase/plugin.py:87
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new_package_form.html:33
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_info.html:5
+#: ckanext/sixodp_showcase/utils.py:183 ckanext/sixodp_showcase/utils.py:333
 msgid "Tags"
 msgstr "Nyckelord"
 
-#: ckanext/sixodp_showcase/controller.py:199
-msgid "Formats"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:200
-msgid "Licenses"
-msgstr "Licenser"
-
-#: ckanext/sixodp_showcase/controller.py:250
-msgid "Invalid search query: {error_message}"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:267
-msgid "Parameter \"{parameter_name}\" is not an integer"
-msgstr "Parametern \"{parameter_name}\" är inte ett heltal"
-
-#: ckanext/sixodp_showcase/controller.py:296
-#: ckanext/sixodp_showcase/controller.py:307
-msgid "Unauthorized to delete showcase"
-msgstr ""
-
-#: ckanext/sixodp_showcase/controller.py:301
-msgid "Showcase has been deleted."
-msgstr ""
-
-#: ckanext/sixodp_showcase/plugin.py:99
+#: ckanext/sixodp_showcase/plugin.py:89
 msgid "Platforms"
 msgstr ""
 
@@ -375,7 +337,68 @@ msgstr ""
 msgid "Visualisation"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/admin/base.html:6
+#: ckanext/sixodp_showcase/utils.py:181 ckanext/sixodp_showcase/utils.py:331
+msgid "Organizations"
+msgstr "Organisationer"
+
+#: ckanext/sixodp_showcase/utils.py:184 ckanext/sixodp_showcase/utils.py:334
+msgid "Formats"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:185 ckanext/sixodp_showcase/utils.py:335
+msgid "Licenses"
+msgstr "Licenser"
+
+#: ckanext/sixodp_showcase/utils.py:245
+msgid "Parameter '{parameter_name}' is not an integer"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:261
+msgid "Not authorized to see this page"
+msgstr "Behörighet krävs för att visa sidan"
+
+#: ckanext/sixodp_showcase/utils.py:385
+msgid "Invalid search query: {error_message}"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:410
+msgid "Parameter u\"{parameter_name}\" is not an integer"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:438 ckanext/sixodp_showcase/utils.py:474
+msgid "Showcase not found"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:440 ckanext/sixodp_showcase/utils.py:476
+msgid "Unauthorized to read showcase"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:467
+msgid "User not authorized to edit {showcase_id}"
+msgstr ""
+
+#: ckanext/sixodp_showcase/utils.py:502
+msgid "The apiset has been removed from the showcase."
+msgid_plural "The apisets have been removed from the showcase."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ckanext/sixodp_showcase/utils.py:534
+msgid "The apiset has been added to the showcase."
+msgid_plural "The apisets have been added to the showcase."
+msgstr[0] ""
+msgstr[1] ""
+
+#: ckanext/sixodp_showcase/views.py:150
+msgid "Dataset not found"
+msgstr ""
+
+#: ckanext/sixodp_showcase/views.py:171
+#, python-format
+msgid "User %r not authorized to edit %s"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/admin/base.html:5
 #: ckanext/sixodp_showcase/templates/admin/manage_showcase_admins.html:38
 msgid "Showcase Admins"
 msgstr ""
@@ -437,8 +460,8 @@ msgstr ""
 
 #: ckanext/sixodp_showcase/templates/admin/manage_showcase_admins.html:69
 msgid ""
-" <p><strong>Showcase Admin:</strong> Can create and remove showcases. Can "
-"add and remove datasets from showcases.</p> "
+"<p><strong>Showcase Admin:</strong> Can create and remove showcases. Can add"
+" and remove datasets from showcases.</p>"
 msgstr ""
 
 #: ckanext/sixodp_showcase/templates/package/dataset_showcase_list.html:3
@@ -450,8 +473,8 @@ msgstr ""
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/edit_base.html:21
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:6
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:28
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:4
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:7
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:9
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:12
 msgid "Showcases"
 msgstr "Applikationer"
 
@@ -503,61 +526,77 @@ msgstr ""
 msgid "Manage datasets"
 msgstr ""
 
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:4
+msgid "apisets in this showcase"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:8
+msgid "This showcase has no apisets associated to it"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:12
+msgid "Search and add apisets to a showcase"
+msgstr ""
+
+#: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:16
+msgid "No apisets could be found"
+msgstr ""
+
 #: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:3
 msgid "Showcases - Manage datasets"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:16
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:18
 msgid "Datasets in this showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:41
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:45
 msgid "Remove from Showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:47
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:52
 msgid "This showcase has no datasets associated to it"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:53
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:61
 msgid "Search and add datasets to a showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:63
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:73
 #: ckanext/sixodp_showcase/templates/showcase/search.html:12
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:16
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:13
 msgid "Relevance"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:64
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:74
 #: ckanext/sixodp_showcase/templates/showcase/search.html:13
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:17
 msgid "Name Ascending"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:65
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:75
 #: ckanext/sixodp_showcase/templates/showcase/search.html:14
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:18
 msgid "Name Descending"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:66
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:76
 #: ckanext/sixodp_showcase/templates/showcase/search.html:15
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:19
 msgid "Last Modified"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:67
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:77
 #: ckanext/sixodp_showcase/templates/showcase/search.html:16
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:15
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:16
 msgid "Popular"
 msgstr "Populärt"
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:76
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:86
 msgid "Add to Showcase"
 msgstr ""
 
-#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:108
+#: ckanext/sixodp_showcase/templates/showcase/manage_datasets.html:120
 msgid "No datasets could be found"
 msgstr ""
 
@@ -581,9 +620,13 @@ msgid "Launch website"
 msgstr ""
 
 #: ckanext/sixodp_showcase/templates/showcase/search.html:19
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:23
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:22
 msgid "Search showcases..."
 msgstr "Sök applikationer..."
+
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/edit_base.html:44
+msgid "Manage apisets"
+msgstr ""
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new.html:5
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new.html:10
@@ -673,27 +716,27 @@ msgstr ""
 "href=\"http://opendatacommons.org/licenses/odbl/1-0/\">Open Database-"
 "licensen</a>."
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:92
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:95
 msgid "Used datasets"
 msgstr "Använda datamängder"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:97
-msgid "There are no Datasets in this Showcase"
-msgstr "Denna applikation saknar datamängder"
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/read.html:102
+msgid "Used apisets"
+msgstr "Använda gränssnitts"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:15
-msgid " Applications "
-msgstr "Applikationer "
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:20
+msgid "Applications"
+msgstr ""
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:23
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:28
 msgid "Add Showcase"
 msgstr "Lägg till applikation"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:38
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:43
 msgid "Search applications..."
 msgstr "Sök applikationer ..."
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:54
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/search.html:63
 msgid "Filter list"
 msgstr ""
 
@@ -745,17 +788,13 @@ msgstr ""
 msgid "Remove dataset from this showcase"
 msgstr "Ta bort datamängden från denna applikation"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:13
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:14
 msgid "Newest first"
 msgstr "Nyast först"
 
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:14
+#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:15
 msgid "Oldest first"
 msgstr "Äldst först"
-
-#: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_input.html:20
-msgid "Top rating"
-msgstr "Bästa betyg"
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/snippets/showcase_search_result_text.html:7
 msgid "{number} showcase found for '{query}'"

--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/read.html
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/read.html
@@ -98,7 +98,6 @@
 
             {% set showcase_apisets = h.get_showcase_apisets(pkg.id) %}
             {% if showcase_apisets %}
-            <!-- VAATII KÄÄNNÖKSEN -->
               <h3 class="showcase-packages-title">{{ _('Used apisets') }}</h3>
               {{ h.snippet('sixodp_showcase/snippets/showcase_package_list.html', packages=showcase_apisets, list_class='showcase-packages') }}
             {% endif %}

--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/read.html
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/read.html
@@ -89,13 +89,21 @@
             {% endif %}
 
 
-            <h3 class="showcase-packages-title">{{ _('Used datasets') }}</h3>
+            
             {% set showcase_pkgs = h.get_showcase_pkgs(pkg.id) %}
             {% if showcase_pkgs %}
+              <h3 class="showcase-packages-title">{{ _('Used datasets') }}</h3>
               {{ h.snippet('sixodp_showcase/snippets/showcase_package_list.html', packages=showcase_pkgs, list_class='showcase-packages') }}
-            {% else %}
-              <p class="module-content empty">{{_('There are no Datasets in this Showcase')}}</p>
             {% endif %}
+
+            {% set showcase_apisets = h.get_showcase_apisets(pkg.id) %}
+            {% if showcase_apisets %}
+            <!-- VAATII KÄÄNNÖKSEN -->
+              <h3 class="showcase-packages-title">{{ _('Used apisets') }}</h3>
+              {{ h.snippet('sixodp_showcase/snippets/showcase_package_list.html', packages=showcase_apisets, list_class='showcase-packages') }}
+            {% endif %}
+
+
 
             {% snippet "sixodp_showcase/snippets/showcase_additional_info.html", pkg_dict=pkg %}
           {% endblock %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/read.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/read.html
@@ -55,12 +55,10 @@
         {% endblock %}
 
         {% if dataset_type=='apiset' %}
-        <h3 class="showcase-packages-title">{{ _('Used datasets') }}</h3>
         {% set pkgs = h.get_apiset_package_list(pkg.id) %}
         {% if pkgs %}
+            <h3 class="showcase-packages-title">{{ _('Used datasets') }}</h3>
             {% snippet "sixodp_showcase/snippets/showcase_package_list.html", packages=pkgs, list_class='showcase-packages' %}
-        {% else %}
-            <p class="module-content empty">{{_('There are no Datasets in this Apiset')}}</p>
         {% endif %}
       {% endif %}
 

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -366,7 +366,7 @@ describe('Apiset tests', function(){
       // Wait for page to load
       cy.url().should('include', `/apiset/${apiset_name}`); 
       // No datasets should be associated
-      cy.get('.empty').should('exist');
+      cy.get('.apiset-datasets-block').should('not.exist');
   
       cy.get('.admin-banner > a').click();
       cy.url().should('include', `/apiset/edit/${apiset_name}`); 


### PR DESCRIPTION
Associated datasets/apis are now hidden by default if none have been added to a showcase or an apiset. Apis can now be associated with showcases.

![image](https://user-images.githubusercontent.com/24498487/194286468-69f72924-d67f-4222-bf3b-d025d55ff5e3.png)
