### PR TITLE
AV-1818: Apisets to advanced search

### DIFF
--- a/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
+++ b/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/controller.py
@@ -85,6 +85,10 @@ def search():
         'mm': 0,
     }
 
+    # set default filters to datasets and apisets if none given
+    if not search_query_filters:
+        search_query_filters = ['dataset_type:dataset OR dataset_type:apiset']
+
     if search_query_filters:
         # Outputs: (filter:value) AND (another_filter:another_value)
         data_dict['fq'] = '(' + ') AND ('.join(search_query_filters) + ')'

--- a/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/helpers.py
+++ b/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/helpers.py
@@ -117,7 +117,9 @@ def advanced_license_options(field=None):
 
 
 def advanced_dataset_types_options(field=None):
-    dataset_types = [{"value": "dataset", "label": _("Datasets")}, {"value": "showcase", "label": _("Showcases")}]
+    dataset_types = [{"value": "dataset", "label": _("Datasets")}, 
+    {"value": "showcase", "label": _("Showcases")},
+    {"value": "apiset", "label": _("Apisets")}]
 
     return make_options(dataset_types, value="value", label="label")
 

--- a/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/i18n/ckanext-advancedsearch.pot
+++ b/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/i18n/ckanext-advancedsearch.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-advancedsearch 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-09 09:59+0000\n"
+"POT-Creation-Date: 2022-10-11 07:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,12 +18,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.7.0\n"
 
-#: ckanext/advancedsearch/helpers.py:118 ckanext/advancedsearch/translations.py:29
+#: ckanext/advancedsearch/helpers.py:120 ckanext/advancedsearch/translations.py:29
 msgid "Datasets"
 msgstr ""
 
-#: ckanext/advancedsearch/helpers.py:118 ckanext/advancedsearch/translations.py:30
+#: ckanext/advancedsearch/helpers.py:121 ckanext/advancedsearch/translations.py:30
 msgid "Showcases"
+msgstr ""
+
+#: ckanext/advancedsearch/helpers.py:122
+msgid "Apisets"
 msgstr ""
 
 #: ckanext/advancedsearch/translations.py:8
@@ -38,10 +42,10 @@ msgstr ""
 msgid "Search target"
 msgstr ""
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:17
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:36
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:70
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:24
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:42
 #: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:76
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:83
 #: ckanext/advancedsearch/translations.py:11
 msgid "All"
 msgstr ""
@@ -106,13 +110,13 @@ msgstr ""
 
 #: ckanext/advancedsearch/fanstatic/javascript/avoindata-utils.js:33
 #: ckanext/advancedsearch/fanstatic/javascript/avoindata-utils.js:38
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:45
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:40
 #: ckanext/advancedsearch/translations.py:26
 msgid "Show less options"
 msgstr ""
 
 #: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker.html:8
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:41
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:47
 #: ckanext/advancedsearch/translations.py:27
 msgid "Not selected"
 msgstr ""
@@ -122,7 +126,7 @@ msgstr ""
 msgid "Are you sure you want to clear all filters?"
 msgstr ""
 
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:24
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:23
 #: ckanext/advancedsearch/translations.py:31
 msgid "Release interval"
 msgstr ""
@@ -175,15 +179,11 @@ msgid "Date Created Descending"
 msgstr ""
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:103
-msgid "Source"
-msgstr ""
-
-#: ckanext/advancedsearch/templates/advanced_search/index.html:104
 msgid "Popular"
 msgstr ""
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:108
-msgid "Found {count} datasets"
+msgid "Found {count} results"
 msgstr ""
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:111
@@ -194,20 +194,20 @@ msgstr ""
 msgid "Filter search"
 msgstr ""
 
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:34
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:32
 msgid "Update interval"
 msgstr ""
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:6
-msgid "before"
-msgstr ""
-
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:7
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:8
 msgid "after"
 msgstr ""
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:18
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:33
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:9
+msgid "before"
+msgstr ""
+
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:25
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:39
 msgid "selected"
 msgstr ""
 

--- a/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/i18n/en_GB/LC_MESSAGES/ckanext-advancedsearch.po
+++ b/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/i18n/en_GB/LC_MESSAGES/ckanext-advancedsearch.po
@@ -5,7 +5,7 @@
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
 # 
 # Translators:
-# Jonna Jantunen <jonna.jantunen@vrk.fi>, 2019
+# Meeri Hakala <meeri.hakala@dvv.fi>, 2022
 # Ville Teräväinen, 2022
 # 
 #, fuzzy
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-advancedsearch 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-09 09:59+0000\n"
+"POT-Creation-Date: 2022-10-11 07:58+0000\n"
 "PO-Revision-Date: 2019-07-16 07:12+0000\n"
 "Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -24,14 +24,18 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/advancedsearch/helpers.py:118
+#: ckanext/advancedsearch/helpers.py:120
 #: ckanext/advancedsearch/translations.py:29
 msgid "Datasets"
 msgstr ""
 
-#: ckanext/advancedsearch/helpers.py:118
+#: ckanext/advancedsearch/helpers.py:121
 #: ckanext/advancedsearch/translations.py:30
 msgid "Showcases"
+msgstr ""
+
+#: ckanext/advancedsearch/helpers.py:122
+msgid "Apisets"
 msgstr ""
 
 #: ckanext/advancedsearch/translations.py:8
@@ -46,10 +50,10 @@ msgstr ""
 msgid "Search target"
 msgstr ""
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:17
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:36
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:70
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:24
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:42
 #: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:76
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:83
 #: ckanext/advancedsearch/translations.py:11
 msgid "All"
 msgstr ""
@@ -68,7 +72,7 @@ msgstr ""
 
 #: ckanext/advancedsearch/translations.py:15
 msgid "Publisher"
-msgstr "Producer"
+msgstr "Publisher"
 
 #: ckanext/advancedsearch/translations.py:16
 msgid "License"
@@ -114,13 +118,13 @@ msgstr ""
 
 #: ckanext/advancedsearch/fanstatic/javascript/avoindata-utils.js:33
 #: ckanext/advancedsearch/fanstatic/javascript/avoindata-utils.js:38
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:45
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:40
 #: ckanext/advancedsearch/translations.py:26
 msgid "Show less options"
 msgstr ""
 
 #: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker.html:8
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:41
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:47
 #: ckanext/advancedsearch/translations.py:27
 msgid "Not selected"
 msgstr ""
@@ -130,7 +134,7 @@ msgstr ""
 msgid "Are you sure you want to clear all filters?"
 msgstr ""
 
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:24
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:23
 #: ckanext/advancedsearch/translations.py:31
 msgid "Release interval"
 msgstr "published between"
@@ -183,16 +187,12 @@ msgid "Date Created Descending"
 msgstr ""
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:103
-msgid "Source"
-msgstr ""
-
-#: ckanext/advancedsearch/templates/advanced_search/index.html:104
 msgid "Popular"
 msgstr ""
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:108
-msgid "Found {count} datasets"
-msgstr ""
+msgid "Found {count} results"
+msgstr "Found {count} results"
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:111
 msgid "Sorting"
@@ -202,20 +202,20 @@ msgstr ""
 msgid "Filter search"
 msgstr ""
 
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:34
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:32
 msgid "Update interval"
 msgstr "updated between"
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:6
-msgid "before"
-msgstr "before"
-
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:7
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:8
 msgid "after"
 msgstr "after"
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:18
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:33
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:9
+msgid "before"
+msgstr "before"
+
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:25
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:39
 msgid "selected"
 msgstr ""
 

--- a/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/i18n/fi/LC_MESSAGES/ckanext-advancedsearch.po
+++ b/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/i18n/fi/LC_MESSAGES/ckanext-advancedsearch.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-advancedsearch 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-09 09:59+0000\n"
+"POT-Creation-Date: 2022-10-11 07:58+0000\n"
 "PO-Revision-Date: 2019-07-16 07:12+0000\n"
 "Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
@@ -27,15 +27,19 @@ msgstr ""
 "Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/advancedsearch/helpers.py:118
+#: ckanext/advancedsearch/helpers.py:120
 #: ckanext/advancedsearch/translations.py:29
 msgid "Datasets"
 msgstr "Tietoaineistot"
 
-#: ckanext/advancedsearch/helpers.py:118
+#: ckanext/advancedsearch/helpers.py:121
 #: ckanext/advancedsearch/translations.py:30
 msgid "Showcases"
 msgstr "Sovellukset"
+
+#: ckanext/advancedsearch/helpers.py:122
+msgid "Apisets"
+msgstr ""
 
 #: ckanext/advancedsearch/translations.py:8
 msgid "Search terms"
@@ -49,10 +53,10 @@ msgstr "Kirjoita mitä olet etsimässä"
 msgid "Search target"
 msgstr "Haun kohdistuminen"
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:17
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:36
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:70
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:24
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:42
 #: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:76
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:83
 #: ckanext/advancedsearch/translations.py:11
 msgid "All"
 msgstr "Kaikki"
@@ -117,13 +121,13 @@ msgstr "Näytä lisää hakuehtoja"
 
 #: ckanext/advancedsearch/fanstatic/javascript/avoindata-utils.js:33
 #: ckanext/advancedsearch/fanstatic/javascript/avoindata-utils.js:38
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:45
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:40
 #: ckanext/advancedsearch/translations.py:26
 msgid "Show less options"
 msgstr "Näytä vähemmän hakuehtoja"
 
 #: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker.html:8
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:41
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:47
 #: ckanext/advancedsearch/translations.py:27
 msgid "Not selected"
 msgstr "Ei valittu"
@@ -133,7 +137,7 @@ msgstr "Ei valittu"
 msgid "Are you sure you want to clear all filters?"
 msgstr "Haluatko varmasti tyhjentää kaikki rajaukset?"
 
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:24
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:23
 #: ckanext/advancedsearch/translations.py:31
 msgid "Release interval"
 msgstr "julkaistu välillä"
@@ -186,16 +190,12 @@ msgid "Date Created Descending"
 msgstr "Luomispäivän mukaan laskevasti"
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:103
-msgid "Source"
-msgstr "Lähde"
-
-#: ckanext/advancedsearch/templates/advanced_search/index.html:104
 msgid "Popular"
 msgstr "Suosittu"
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:108
-msgid "Found {count} datasets"
-msgstr "Löytyi {count} tietoaineistoa"
+msgid "Found {count} results"
+msgstr "Löytyi {count} tulosta"
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:111
 msgid "Sorting"
@@ -205,20 +205,20 @@ msgstr "Lajittelu"
 msgid "Filter search"
 msgstr "Rajaa hakua"
 
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:34
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:32
 msgid "Update interval"
 msgstr "päivitetty välillä"
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:6
-msgid "before"
-msgstr "päättyen"
-
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:7
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:8
 msgid "after"
 msgstr "alkaen"
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:18
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:33
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:9
+msgid "before"
+msgstr "päättyen"
+
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:25
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:39
 msgid "selected"
 msgstr "valittu"
 

--- a/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/i18n/sv/LC_MESSAGES/ckanext-advancedsearch.po
+++ b/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/i18n/sv/LC_MESSAGES/ckanext-advancedsearch.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-advancedsearch 0.0.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-06-09 09:59+0000\n"
+"POT-Creation-Date: 2022-10-11 07:58+0000\n"
 "PO-Revision-Date: 2019-07-16 07:12+0000\n"
 "Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
@@ -25,15 +25,19 @@ msgstr ""
 "Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ckanext/advancedsearch/helpers.py:118
+#: ckanext/advancedsearch/helpers.py:120
 #: ckanext/advancedsearch/translations.py:29
 msgid "Datasets"
 msgstr "Datamängder"
 
-#: ckanext/advancedsearch/helpers.py:118
+#: ckanext/advancedsearch/helpers.py:121
 #: ckanext/advancedsearch/translations.py:30
 msgid "Showcases"
 msgstr "Applikationer"
+
+#: ckanext/advancedsearch/helpers.py:122
+msgid "Apisets"
+msgstr ""
 
 #: ckanext/advancedsearch/translations.py:8
 msgid "Search terms"
@@ -47,10 +51,10 @@ msgstr "Sök efter..."
 msgid "Search target"
 msgstr "Sökobjekt"
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:17
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:36
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:70
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:24
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:42
 #: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:76
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:83
 #: ckanext/advancedsearch/translations.py:11
 msgid "All"
 msgstr "Alla"
@@ -115,13 +119,13 @@ msgstr "Visa fler sökvillkor"
 
 #: ckanext/advancedsearch/fanstatic/javascript/avoindata-utils.js:33
 #: ckanext/advancedsearch/fanstatic/javascript/avoindata-utils.js:38
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:45
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:40
 #: ckanext/advancedsearch/translations.py:26
 msgid "Show less options"
 msgstr "Visa färre sökvillkor"
 
 #: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker.html:8
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:41
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:47
 #: ckanext/advancedsearch/translations.py:27
 msgid "Not selected"
 msgstr "Inte markerat"
@@ -131,7 +135,7 @@ msgstr "Inte markerat"
 msgid "Are you sure you want to clear all filters?"
 msgstr "Vill du verkligen tömma alla filter?"
 
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:24
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:23
 #: ckanext/advancedsearch/translations.py:31
 msgid "Release interval"
 msgstr "publicerad mellan"
@@ -184,15 +188,11 @@ msgid "Date Created Descending"
 msgstr "Fallande enligt skapandedatum"
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:103
-msgid "Source"
-msgstr "Källa"
-
-#: ckanext/advancedsearch/templates/advanced_search/index.html:104
 msgid "Popular"
 msgstr "Populärt"
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:108
-msgid "Found {count} datasets"
+msgid "Found {count} results"
 msgstr ""
 
 #: ckanext/advancedsearch/templates/advanced_search/index.html:111
@@ -203,20 +203,20 @@ msgstr "Sortering"
 msgid "Filter search"
 msgstr "Filtrera sökning"
 
-#: ckanext/advancedsearch/templates/advanced_search/search_form.html:34
+#: ckanext/advancedsearch/templates/advanced_search/search_form.html:32
 msgid "Update interval"
 msgstr "uppdaterad mellan"
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:6
-msgid "before"
-msgstr "till"
-
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:7
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:8
 msgid "after"
 msgstr "från"
 
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:18
-#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:33
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/datepicker-range.html:9
+msgid "before"
+msgstr "till"
+
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:25
+#: ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html:39
 msgid "selected"
 msgstr "valt"
 

--- a/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html
+++ b/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/display_snippets/multiselect.html
@@ -3,8 +3,15 @@
 {% set allow_select_all = field.display_options.allow_select_all %}
 {% set prev_selected = h.value_or_blank(prev_query, name) %}
 
+
 {% if prev_selected %}
     {% set stats_prev = h.selected_indexes_checkboxes(options, prev_selected) %}
+{% else %}
+    <!-- Set the default options for dataset type if no previous filters have been given -->
+    {% if field.field_name == 'dataset_type' %}
+        {% set prev_selected = ['dataset', 'apiset'] %}
+        {% set stats_prev = h.selected_indexes_checkboxes(options, prev_selected) %}
+    {% endif %}
 {% endif %}
 
 {% asset 'advancedsearch/ytp_multiselect_js' %}
@@ -24,8 +31,7 @@
         for="advanced-search-dropdown-toggle-{{name}}"
         class="ytp-multiselect-toggle ytp-input-element"
         type="button"
-        aria-expanded="false"
-    >
+        aria-expanded="false">
         {% if prev_selected %}
             {% if stats_prev %}
                 {% if not stats_prev.all_selected %}
@@ -68,8 +74,9 @@
                         id="{{name}}-checkbox-all"
                         data-option-value="all"
                         data-option-label="{{ _('All') }}"
-                        {% if checked %}checked{% endif %}
-                    >
+                        {% if checked %}
+                            checked
+                        {% endif %}>
                     <span class="custom-checkbox">
                     </span>
                     <span class="m-0 ml-2">

--- a/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/index.html
+++ b/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/index.html
@@ -105,7 +105,7 @@
                     {% set sorting_selected = c.advanced_search.sort_string %}
                     {% set sorting_selection = c.advanced_search["sorting_selection"] %}
                     <div id="search-results">
-                      <div id="search-results-header" class="d-flex flex-wrap justify-content-between align-items-center mt-3">{{_('Found {count} datasets').format(count=c.advanced_search.item_count)}}
+                      <div id="search-results-header" class="d-flex flex-wrap justify-content-between align-items-center mt-3">{{_('Found {count} results').format(count=c.advanced_search.item_count)}}
                         <div class="form-inline">
                           <div class="form-select form-group control-order-by">
                             <label for="field-order-by">{{ _('Sorting') }}</label>

--- a/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/search_form.html
+++ b/ckan/ckanext/ckanext-advancedsearch/ckanext/advancedsearch/templates/advanced_search/search_form.html
@@ -19,7 +19,6 @@
     </div>
 
     <div>
-        <!-- testing -->
       <div class="md-12">
         <label class="ytp-input-label" id="release-interval-label">{{_("Release interval")|capitalize}}</label>
       </div>
@@ -29,7 +28,6 @@
     </div>
 
     <div>
-            <!-- testing -->
       <div class="md-12">
         <label class="ytp-input-label" id="update-interval-label">{{_("Update interval")|capitalize}}</label>
       </div>
@@ -37,9 +35,6 @@
         {% snippet 'advanced_search/display_field.html', field=input_fields.updated, prev_query=prev_query, options=field_options['updated'] %}
       </div>
     </div>
-
-
-      
     
     <hr class="avoindata-divider">
     <a class="more-options-link" data-expanded="true" data-target="#search-options-extras" data-module="avoindata-utils"><span id="more-options-link-text">{{_("Show less options")}}</span>

--- a/cypress/e2e/advancedsearch_spec.js
+++ b/cypress/e2e/advancedsearch_spec.js
@@ -149,7 +149,7 @@ describe('Advanced search tests', () => {
             cy.get('[data-module-name="dataset_type"]').find('label[for="advanced-search-dropdown-toggle-dataset_type"]').contains('Search target');
             cy.get('[data-module-name="dataset_type"]').find('button[for="advanced-search-dropdown-toggle-dataset_type"]');
     
-            cy.get('[data-module-name="publisher"]').find('label[for="advanced-search-dropdown-toggle-publisher"]').contains('Producer');
+            cy.get('[data-module-name="publisher"]').find('label[for="advanced-search-dropdown-toggle-publisher"]').contains('Publisher');
             cy.get('[data-module-name="publisher"]').find('button[for="advanced-search-dropdown-toggle-publisher"]');
     
             cy.get('[data-module-name="category"]').find('label[for="advanced-search-dropdown-toggle-category"]').contains('Category');


### PR DESCRIPTION
Apisets have been added to the advanced search and it now defaults to showing datasets and apisets. 

![image](https://user-images.githubusercontent.com/24498487/195035756-631cf73b-fdd6-40b1-aaf8-c424a5d73f5d.png)
