### PR TITLE
AV-1815: Fixed broken image link for draft and deleted datasets

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/dataset_state_banner.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/dataset_state_banner.html
@@ -1,7 +1,7 @@
 {% if pkg.get('state', '').startswith('deleted') %}
   <div class="well admin-banner private-or-draft-dataset deleted-dataset">
     <div>
-      <img src="/resources/images/avoindata-closed-eye.svg">
+      <img src="/themes/avoindata/images/avoindata-closed-eye.svg">
       <span>{{ _('Deleted. The ' + dataset_type + ' is only visible to logged in users of the producer organization.') }}</span>
     </div>
     {% if h.check_access('package_update', {'id':pkg.id }) %}
@@ -11,7 +11,7 @@
 {% elif pkg.state.startswith('draft') %}
   <div class="well admin-banner private-or-draft-dataset">
     <div>
-      <img src="/resources/images/avoindata-closed-eye.svg">
+      <img src="/themes/avoindata/images/avoindata-closed-eye.svg">
       <span>{{ _('In draft state. The ' + dataset_type + ' is only visible to logged in users of the producer organization.') }}</span>
     </div>
     {% if h.check_access('package_update', {'id':pkg.id }) %}
@@ -21,7 +21,7 @@
 {% elif pkg.private %}
   <div class="well admin-banner private-or-draft-dataset">
     <div>
-      <img src="/resources/images/avoindata-closed-eye.svg">
+      <img src="/themes/avoindata/images/avoindata-closed-eye.svg">
       <span>{{ _('Private mode. The ' + dataset_type + ' is only visible to logged in users of the producer organization.') }}</span>
     </div>
     {% if h.check_access('package_update', {'id':pkg.id }) %}


### PR DESCRIPTION
Fixed draft and deleted datasets having a broken image link for the notification banner.
![image](https://user-images.githubusercontent.com/24498487/195561740-221a34fd-5fc4-4406-b077-a0a51af3f532.png)
