### PR TITLE
AV-1843: Removed the show all links from hero

### DIFF
--- a/drupal/modules/avoindata-hero/templates/avoindata_hero_form.html.twig
+++ b/drupal/modules/avoindata-hero/templates/avoindata_hero_form.html.twig
@@ -55,14 +55,10 @@
                 <div class="text-center">
                     <h2>{{ count.count }}</h2>
                     <h4>
-                        <strong>{{ count.text }}</strong>
+                        <a href="/data/{{ form.language }}/{{ count.url }}">
+                            <strong>{{ count.text }}</strong>
+                        </a>
                     </h4>
-                    <a href="/data/{{ form.language }}/{{ count.url }}">
-                        {% trans %}
-                        Show all
-                        {% endtrans %}
-                        →
-                    </a>
                 </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
Removed the show all from each link in the hero and moved the link to the title of the resource
![image](https://user-images.githubusercontent.com/24498487/200803153-484e6974-d9c2-46b1-9545-4fc010cda222.png)
