### PR TITLE
AV-1844 & AV-1845: apiset text updates and link urls

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-09 12:02+0000\n"
+"POT-Creation-Date: 2022-11-11 10:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -830,7 +830,8 @@ msgstr ""
 #: ckanext/ytp/templates/group/index.html:4
 #: ckanext/ytp/templates/group/read_base.html:4
 #: ckanext/ytp/templates/package/group_list.html:9
-#: ckanext/ytp/templates/package/group_list.html:14 ckanext/ytp/translations.py:132
+#: ckanext/ytp/templates/package/group_list.html:14
+#: ckanext/ytp/templates/package/read_base.html:26 ckanext/ytp/translations.py:132
 msgid "Groups"
 msgstr ""
 
@@ -1560,6 +1561,46 @@ msgstr ""
 msgid "Not authorized to see this page"
 msgstr ""
 
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:54
+#: ckanext/ytp/resources/opendata/scripts/translations.js:20
+msgid "Reorder apiset"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:55
+#: ckanext/ytp/resources/opendata/scripts/translations.js:21
+msgid ""
+"You can rearrange the apiset resources by dragging them using the arrow icon."
+" Drag the resource to the right and place it to the desired location on the "
+"list. When you are done, click the \"Save order\" -button."
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:59
+#: ckanext/ytp/resources/opendata/scripts/translations.js:16
+msgid "Reorder resources"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:60
+#: ckanext/ytp/resources/opendata/scripts/translations.js:17
+msgid ""
+"You can rearrange the resources by dragging them using the arrow icon. Drag "
+"the resource to the right and place it to the desired location on the list. "
+"When you are done, click the \"Save order\" -button."
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:83
+msgid "Save order"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:86
+#: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
+#: ckanext/ytp/resources/opendata/scripts/translations.js:9
+msgid "Cancel"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:96
+msgid "Saving..."
+msgstr ""
+
 #: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:69
 msgid "Please Confirm Action"
 msgstr ""
@@ -1573,13 +1614,8 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
-#: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
-#: ckanext/ytp/resources/opendata/scripts/translations.js:9
-msgid "Cancel"
-msgstr ""
-
 #: ckanext/ytp/resources/opendata/scripts/form.js:144
-#: ckanext/ytp/templates/snippets/search_form.html:23
+#: ckanext/ytp/templates/snippets/search_form.html:29
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:90
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:78
 msgid "Remove"
@@ -1630,17 +1666,6 @@ msgstr ""
 msgid "Add email"
 msgstr ""
 
-#: ckanext/ytp/resources/opendata/scripts/translations.js:16
-msgid "Reorder resources"
-msgstr ""
-
-#: ckanext/ytp/resources/opendata/scripts/translations.js:17
-msgid ""
-"You can rearrange the resources by dragging them using the arrow icon. Drag "
-"the resource to the right and place it to the desired location on the list. "
-"When you are done, click the \"Save order\" -button."
-msgstr ""
-
 #: ckanext/ytp/resources/vendor/bootstrap-table/dist/extensions/filter-control/utils.js:10
 msgid "Can't call method on "
 msgstr ""
@@ -1650,7 +1675,7 @@ msgid "Give feedback"
 msgstr ""
 
 #: ckanext/ytp/templates/page.html:13
-#: ckanext/ytp/templates/snippets/search_form.html:104
+#: ckanext/ytp/templates/snippets/search_form.html:110
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:72
 msgid "Hide search filters"
 msgstr ""
@@ -1701,6 +1726,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:126
 #: ckanext/ytp/templates/organization/read_base.html:37
+#: ckanext/ytp/templates/package/read_base.html:15
 #: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:10
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:12
@@ -1792,7 +1818,7 @@ msgstr ""
 #: ckanext/ytp/templates/organization/index.html:4
 #: ckanext/ytp/templates/organization/read.html:16
 #: ckanext/ytp/templates/package/search.html:57
-#: ckanext/ytp/templates/snippets/search_form.html:59
+#: ckanext/ytp/templates/snippets/search_form.html:65
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:34
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
@@ -1802,7 +1828,7 @@ msgstr ""
 #: ckanext/ytp/templates/organization/index.html:4
 #: ckanext/ytp/templates/organization/read.html:17
 #: ckanext/ytp/templates/package/search.html:58
-#: ckanext/ytp/templates/snippets/search_form.html:59
+#: ckanext/ytp/templates/snippets/search_form.html:65
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:34
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
@@ -1825,7 +1851,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/group/read.html:19
 #: ckanext/ytp/templates/organization/read.html:23
-#: ckanext/ytp/templates/snippets/search_form.html:3
+#: ckanext/ytp/templates/snippets/search_form.html:7
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:3
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:3
 msgid "Search datasets..."
@@ -1940,18 +1966,18 @@ msgid "Search organizations..."
 msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:27
-#: ckanext/ytp/templates/snippets/search_form.html:42
+#: ckanext/ytp/templates/snippets/search_form.html:48
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:17
 msgid "Submit"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:34
-#: ckanext/ytp/templates/snippets/search_form.html:82
+#: ckanext/ytp/templates/snippets/search_form.html:88
 msgid "Sorting"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:43
-#: ckanext/ytp/templates/snippets/search_form.html:91
+#: ckanext/ytp/templates/snippets/search_form.html:97
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:59
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
@@ -1986,7 +2012,10 @@ msgstr ""
 #: ckanext/ytp/templates/organization/member_new.html:67
 #: ckanext/ytp/templates/organization/members.html:56
 #: ckanext/ytp/templates/organization/read_base.html:24
+#: ckanext/ytp/templates/package/activity.html:3
+#: ckanext/ytp/templates/package/activity.html:8
 #: ckanext/ytp/templates/package/group_list.html:10
+#: ckanext/ytp/templates/package/read_base.html:27
 msgid "Activity Stream"
 msgstr ""
 
@@ -2077,10 +2106,12 @@ msgid "Close without saving"
 msgstr ""
 
 #: ckanext/ytp/templates/package/group_list.html:5
+#: ckanext/ytp/templates/package/read_base.html:22
 msgid "Apiset"
 msgstr ""
 
 #: ckanext/ytp/templates/package/group_list.html:7
+#: ckanext/ytp/templates/package/read_base.html:24
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:5
 msgid "Dataset"
 msgstr ""
@@ -2235,6 +2266,10 @@ msgstr ""
 #: ckanext/ytp/templates/package/resource_read.html:234
 #: ckanext/ytp/templates/package/resource_read.html:238
 #: ckanext/ytp/templates/package/resource_read.html:242
+#: ckanext/ytp/templates/snippets/activity_stream.html:10
+#: ckanext/ytp/templates/snippets/activity_stream.html:17
+#: ckanext/ytp/templates/snippets/activity_stream.html:25
+#: ckanext/ytp/templates/snippets/activity_stream.html:39
 msgid "unknown"
 msgstr ""
 
@@ -2448,20 +2483,7 @@ msgid ""
 "Creative Commons Attribution 4.0 International License</a>."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:57
-#, python-format
-msgid ""
-"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
-"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
-"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
-"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
-"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
-"href=\"%(creator_url)s\" >%(creator)s</a> %(resource_type)s is licensed under"
-" a <a rel=\"license\" href=\"https://creativecommons.org/licenses/by/4.0/\"> "
-"Creative Commons Attribution 4.0 International License</a>."
-msgstr ""
-
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:70
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:60
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
@@ -3129,25 +3151,29 @@ msgstr ""
 msgid "Last Harvested"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:12
+#: ckanext/ytp/templates/snippets/search_form.html:5
+msgid "Search apis..."
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/search_form.html:18
 msgid "Filters"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:65
+#: ckanext/ytp/templates/snippets/search_form.html:71
 msgid " Use advanced search "
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:98
+#: ckanext/ytp/templates/snippets/search_form.html:104
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:66
 msgid "Filter search"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:112
+#: ckanext/ytp/templates/snippets/search_form.html:118
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:102
 msgid "Please try another search or change search facets."
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:120
+#: ckanext/ytp/templates/snippets/search_form.html:126
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:110
 msgid "<strong>There was an error while searching.</strong> Please try again."
 msgstr ""
@@ -3244,6 +3270,22 @@ msgid "{number} organization found"
 msgid_plural "{number} organizations found"
 msgstr[0] ""
 msgstr[1] ""
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:8
+msgid "{actor} updated the api {dataset}"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:10
+msgid "{actor} updated the dataset {dataset}"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:18
+msgid "View this version"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:22
+msgid "Changes"
+msgstr ""
 
 #: ckanext/ytp/templates/source/read_base.html:19
 msgid "read more"

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-01 13:07+0000\n"
+"POT-Creation-Date: 2022-11-09 12:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -217,7 +217,7 @@ msgid "Unauthorized to edit user %s"
 msgstr ""
 
 #: ckanext/ytp/controller.py:621 ckanext/ytp/controller.py:689
-#: ckanext/ytp/logic.py:46
+#: ckanext/ytp/logic.py:47
 msgid "User not found"
 msgstr ""
 
@@ -248,28 +248,28 @@ msgstr ""
 msgid "-"
 msgstr ""
 
-#: ckanext/ytp/logic.py:49
+#: ckanext/ytp/logic.py:50
 msgid "Cannot change username"
 msgstr ""
 
-#: ckanext/ytp/logic.py:51
+#: ckanext/ytp/logic.py:52
 msgid "Cannot change email"
 msgstr ""
 
-#: ckanext/ytp/logic.py:62
+#: ckanext/ytp/logic.py:63
 msgid "Have to be logged in to edit user"
 msgstr ""
 
-#: ckanext/ytp/logic.py:70
+#: ckanext/ytp/logic.py:71
 #, python-format
 msgid "User %s not authorized to edit user %s"
 msgstr ""
 
-#: ckanext/ytp/logic.py:76
+#: ckanext/ytp/logic.py:77
 msgid "Have to be logged in to list users"
 msgstr ""
 
-#: ckanext/ytp/logic.py:82
+#: ckanext/ytp/logic.py:83
 msgid "Have to be logged in to list admins"
 msgstr ""
 
@@ -2251,27 +2251,27 @@ msgid "sha256"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:271
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:111
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:125
 msgid "Stats"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:272
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:112
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Last 30 days, updated daily"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:275
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:119
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:133
 msgid "All time downloads:"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:285
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 msgid "Year"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:285
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:11
 msgid "Downloads"
 msgstr ""
@@ -2366,32 +2366,40 @@ msgstr ""
 msgid "Edit categories"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:27
+msgid "License offered by the api"
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:29
 #: ckanext/ytp/templates/snippets/license.html:21
 msgid "License"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:61
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:67
 msgid "License Not Specified"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:70
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:76
 msgid "Openness score"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:91
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:98
+msgid "Recommend apiset"
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:104
 msgid "Recommend dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:117
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:131
 msgid "Downloads during last 12 months"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:118
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:132
 msgid "All time visits:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:10
 msgid "Visits"
 msgstr ""
@@ -2404,7 +2412,7 @@ msgstr ""
 msgid "Social"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:17
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:18
 #, python-format
 msgid ""
 "To the extent possible under law <a rel=\"dct:publisher\" "
@@ -2414,7 +2422,20 @@ msgid ""
 "property=\"dct:title\">%(content_title)s</span></a>."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:31
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:34
+#, python-format
+msgid ""
+"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
+"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
+"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
+"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
+"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
+"href=\"%(creator_url)s\" >%(creator)s</a> apiset is licensed under a <a "
+"rel=\"license\" href=\"https://creativecommons.org/licenses/by/4.0/\"> "
+"Creative Commons Attribution 4.0 International License</a>."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:45
 #, python-format
 msgid ""
 "<span xmlns:dct=\"https://purl.org/dc/terms/\" "
@@ -2427,7 +2448,20 @@ msgid ""
 "Creative Commons Attribution 4.0 International License</a>."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:43
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:57
+#, python-format
+msgid ""
+"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
+"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
+"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
+"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
+"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
+"href=\"%(creator_url)s\" >%(creator)s</a> %(resource_type)s is licensed under"
+" a <a rel=\"license\" href=\"https://creativecommons.org/licenses/by/4.0/\"> "
+"Creative Commons Attribution 4.0 International License</a>."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:70
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-11 10:19+0000\n"
+"POT-Creation-Date: 2022-11-16 13:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1561,12 +1561,12 @@ msgstr ""
 msgid "Not authorized to see this page"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:54
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:52
 #: ckanext/ytp/resources/opendata/scripts/translations.js:20
 msgid "Reorder apiset"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:55
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:53
 #: ckanext/ytp/resources/opendata/scripts/translations.js:21
 msgid ""
 "You can rearrange the apiset resources by dragging them using the arrow icon."
@@ -1574,12 +1574,12 @@ msgid ""
 "list. When you are done, click the \"Save order\" -button."
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:59
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:57
 #: ckanext/ytp/resources/opendata/scripts/translations.js:16
 msgid "Reorder resources"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:60
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:58
 #: ckanext/ytp/resources/opendata/scripts/translations.js:17
 msgid ""
 "You can rearrange the resources by dragging them using the arrow icon. Drag "
@@ -1587,17 +1587,17 @@ msgid ""
 "When you are done, click the \"Save order\" -button."
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:83
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:81
 msgid "Save order"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:86
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:84
 #: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
 #: ckanext/ytp/resources/opendata/scripts/translations.js:9
 msgid "Cancel"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:96
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:94
 msgid "Saving..."
 msgstr ""
 
@@ -3280,11 +3280,20 @@ msgid "{actor} updated the dataset {dataset}"
 msgstr ""
 
 #: ckanext/ytp/templates/snippets/activities/changed_package.html:18
+#: ckanext/ytp/templates/snippets/activities/new_package.html:16
 msgid "View this version"
 msgstr ""
 
 #: ckanext/ytp/templates/snippets/activities/changed_package.html:22
 msgid "Changes"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/new_package.html:6
+msgid "{actor} created the api {dataset}"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/new_package.html:8
+msgid "{actor} created the dataset {dataset}"
 msgstr ""
 
 #: ckanext/ytp/templates/source/read_base.html:19

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-09 12:02+0000\n"
+"POT-Creation-Date: 2022-11-11 10:19+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -852,6 +852,7 @@ msgstr "Search categories..."
 #: ckanext/ytp/templates/group/read_base.html:4
 #: ckanext/ytp/templates/package/group_list.html:9
 #: ckanext/ytp/templates/package/group_list.html:14
+#: ckanext/ytp/templates/package/read_base.html:26
 #: ckanext/ytp/translations.py:132
 msgid "Groups"
 msgstr "Categories"
@@ -1622,6 +1623,50 @@ msgstr ""
 msgid "Not authorized to see this page"
 msgstr ""
 
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:54
+#: ckanext/ytp/resources/opendata/scripts/translations.js:20
+msgid "Reorder apiset"
+msgstr "Reorder apis"
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:55
+#: ckanext/ytp/resources/opendata/scripts/translations.js:21
+msgid ""
+"You can rearrange the apiset resources by dragging them using the arrow "
+"icon. Drag the resource to the right and place it to the desired location on"
+" the list. When you are done, click the \"Save order\" -button."
+msgstr ""
+"Drag the resource box to the desired location on the list and let go. When "
+"you are done, select \"Save order\"."
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:59
+#: ckanext/ytp/resources/opendata/scripts/translations.js:16
+msgid "Reorder resources"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:60
+#: ckanext/ytp/resources/opendata/scripts/translations.js:17
+msgid ""
+"You can rearrange the resources by dragging them using the arrow icon. Drag "
+"the resource to the right and place it to the desired location on the list. "
+"When you are done, click the \"Save order\" -button."
+msgstr ""
+"Drag the resource box to the desired location on the list and let go. When "
+"you are done, select \"Save order\"."
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:83
+msgid "Save order"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:86
+#: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
+#: ckanext/ytp/resources/opendata/scripts/translations.js:9
+msgid "Cancel"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:96
+msgid "Saving..."
+msgstr ""
+
 #: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:69
 msgid "Please Confirm Action"
 msgstr ""
@@ -1635,13 +1680,8 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
-#: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
-#: ckanext/ytp/resources/opendata/scripts/translations.js:9
-msgid "Cancel"
-msgstr ""
-
 #: ckanext/ytp/resources/opendata/scripts/form.js:144
-#: ckanext/ytp/templates/snippets/search_form.html:23
+#: ckanext/ytp/templates/snippets/search_form.html:29
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:90
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:78
 msgid "Remove"
@@ -1692,19 +1732,6 @@ msgstr ""
 msgid "Add email"
 msgstr ""
 
-#: ckanext/ytp/resources/opendata/scripts/translations.js:16
-msgid "Reorder resources"
-msgstr ""
-
-#: ckanext/ytp/resources/opendata/scripts/translations.js:17
-msgid ""
-"You can rearrange the resources by dragging them using the arrow icon. Drag "
-"the resource to the right and place it to the desired location on the list. "
-"When you are done, click the \"Save order\" -button."
-msgstr ""
-"Drag the resource box to the desired location on the list and let go. When "
-"you are done, select \"Save order\"."
-
 #: ckanext/ytp/resources/vendor/bootstrap-table/dist/extensions/filter-control/utils.js:10
 msgid "Can't call method on "
 msgstr ""
@@ -1714,7 +1741,7 @@ msgid "Give feedback"
 msgstr ""
 
 #: ckanext/ytp/templates/page.html:13
-#: ckanext/ytp/templates/snippets/search_form.html:104
+#: ckanext/ytp/templates/snippets/search_form.html:110
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:72
 msgid "Hide search filters"
 msgstr ""
@@ -1765,6 +1792,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:126
 #: ckanext/ytp/templates/organization/read_base.html:37
+#: ckanext/ytp/templates/package/read_base.html:15
 #: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:10
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:12
@@ -1856,7 +1884,7 @@ msgstr ""
 #: ckanext/ytp/templates/organization/index.html:4
 #: ckanext/ytp/templates/organization/read.html:16
 #: ckanext/ytp/templates/package/search.html:57
-#: ckanext/ytp/templates/snippets/search_form.html:59
+#: ckanext/ytp/templates/snippets/search_form.html:65
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:34
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
@@ -1866,7 +1894,7 @@ msgstr ""
 #: ckanext/ytp/templates/organization/index.html:4
 #: ckanext/ytp/templates/organization/read.html:17
 #: ckanext/ytp/templates/package/search.html:58
-#: ckanext/ytp/templates/snippets/search_form.html:59
+#: ckanext/ytp/templates/snippets/search_form.html:65
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:34
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
@@ -1889,7 +1917,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/group/read.html:19
 #: ckanext/ytp/templates/organization/read.html:23
-#: ckanext/ytp/templates/snippets/search_form.html:3
+#: ckanext/ytp/templates/snippets/search_form.html:7
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:3
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:3
 msgid "Search datasets..."
@@ -2004,18 +2032,18 @@ msgid "Search organizations..."
 msgstr "Search publishers..."
 
 #: ckanext/ytp/templates/organization/index.html:27
-#: ckanext/ytp/templates/snippets/search_form.html:42
+#: ckanext/ytp/templates/snippets/search_form.html:48
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:17
 msgid "Submit"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:34
-#: ckanext/ytp/templates/snippets/search_form.html:82
+#: ckanext/ytp/templates/snippets/search_form.html:88
 msgid "Sorting"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:43
-#: ckanext/ytp/templates/snippets/search_form.html:91
+#: ckanext/ytp/templates/snippets/search_form.html:97
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:59
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
@@ -2050,7 +2078,10 @@ msgstr ""
 #: ckanext/ytp/templates/organization/member_new.html:67
 #: ckanext/ytp/templates/organization/members.html:56
 #: ckanext/ytp/templates/organization/read_base.html:24
+#: ckanext/ytp/templates/package/activity.html:3
+#: ckanext/ytp/templates/package/activity.html:8
 #: ckanext/ytp/templates/package/group_list.html:10
+#: ckanext/ytp/templates/package/read_base.html:27
 msgid "Activity Stream"
 msgstr ""
 
@@ -2146,10 +2177,12 @@ msgid "Close without saving"
 msgstr ""
 
 #: ckanext/ytp/templates/package/group_list.html:5
+#: ckanext/ytp/templates/package/read_base.html:22
 msgid "Apiset"
 msgstr "API"
 
 #: ckanext/ytp/templates/package/group_list.html:7
+#: ckanext/ytp/templates/package/read_base.html:24
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:5
 msgid "Dataset"
 msgstr ""
@@ -2304,6 +2337,10 @@ msgstr ""
 #: ckanext/ytp/templates/package/resource_read.html:234
 #: ckanext/ytp/templates/package/resource_read.html:238
 #: ckanext/ytp/templates/package/resource_read.html:242
+#: ckanext/ytp/templates/snippets/activity_stream.html:10
+#: ckanext/ytp/templates/snippets/activity_stream.html:17
+#: ckanext/ytp/templates/snippets/activity_stream.html:25
+#: ckanext/ytp/templates/snippets/activity_stream.html:39
 msgid "unknown"
 msgstr ""
 
@@ -2525,21 +2562,7 @@ msgid ""
 "Creative Commons Attribution 4.0 International License</a>."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:57
-#, python-format
-msgid ""
-"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
-"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
-"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
-"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
-"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
-"href=\"%(creator_url)s\" >%(creator)s</a> %(resource_type)s is licensed "
-"under a <a rel=\"license\" "
-"href=\"https://creativecommons.org/licenses/by/4.0/\"> Creative Commons "
-"Attribution 4.0 International License</a>."
-msgstr ""
-
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:70
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:60
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
@@ -3213,25 +3236,29 @@ msgstr "There is no description for this organisation"
 msgid "Last Harvested"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:12
+#: ckanext/ytp/templates/snippets/search_form.html:5
+msgid "Search apis..."
+msgstr "Search apis..."
+
+#: ckanext/ytp/templates/snippets/search_form.html:18
 msgid "Filters"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:65
+#: ckanext/ytp/templates/snippets/search_form.html:71
 msgid " Use advanced search "
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:98
+#: ckanext/ytp/templates/snippets/search_form.html:104
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:66
 msgid "Filter search"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:112
+#: ckanext/ytp/templates/snippets/search_form.html:118
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:102
 msgid "Please try another search or change search facets."
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:120
+#: ckanext/ytp/templates/snippets/search_form.html:126
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:110
 msgid "<strong>There was an error while searching.</strong> Please try again."
 msgstr ""
@@ -3330,6 +3357,22 @@ msgid "{number} organization found"
 msgid_plural "{number} organizations found"
 msgstr[0] "{number} organisation found"
 msgstr[1] "{number} publishers"
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:8
+msgid "{actor} updated the api {dataset}"
+msgstr "{actor} updated the api {dataset}"
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:10
+msgid "{actor} updated the dataset {dataset}"
+msgstr "{actor} updated the dataset {dataset}"
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:18
+msgid "View this version"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:22
+msgid "Changes"
+msgstr ""
 
 #: ckanext/ytp/templates/source/read_base.html:19
 msgid "read more"

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
@@ -10,17 +10,17 @@
 # Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2020
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
 # Daniel Vainio, 2021
-# Ville Teräväinen, 2022
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-01 13:07+0000\n"
+"POT-Creation-Date: 2022-11-09 12:02+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2022\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -228,7 +228,7 @@ msgid "Unauthorized to edit user %s"
 msgstr ""
 
 #: ckanext/ytp/controller.py:621 ckanext/ytp/controller.py:689
-#: ckanext/ytp/logic.py:46
+#: ckanext/ytp/logic.py:47
 msgid "User not found"
 msgstr ""
 
@@ -259,28 +259,28 @@ msgstr ""
 msgid "-"
 msgstr ""
 
-#: ckanext/ytp/logic.py:49
+#: ckanext/ytp/logic.py:50
 msgid "Cannot change username"
 msgstr ""
 
-#: ckanext/ytp/logic.py:51
+#: ckanext/ytp/logic.py:52
 msgid "Cannot change email"
 msgstr ""
 
-#: ckanext/ytp/logic.py:62
+#: ckanext/ytp/logic.py:63
 msgid "Have to be logged in to edit user"
 msgstr ""
 
-#: ckanext/ytp/logic.py:70
+#: ckanext/ytp/logic.py:71
 #, python-format
 msgid "User %s not authorized to edit user %s"
 msgstr ""
 
-#: ckanext/ytp/logic.py:76
+#: ckanext/ytp/logic.py:77
 msgid "Have to be logged in to list users"
 msgstr ""
 
-#: ckanext/ytp/logic.py:82
+#: ckanext/ytp/logic.py:83
 msgid "Have to be logged in to list admins"
 msgstr ""
 
@@ -2320,27 +2320,27 @@ msgid "sha256"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:271
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:111
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:125
 msgid "Stats"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:272
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:112
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Last 30 days, updated daily"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:275
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:119
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:133
 msgid "All time downloads:"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:285
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 msgid "Year"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:285
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:11
 msgid "Downloads"
 msgstr ""
@@ -2435,32 +2435,40 @@ msgstr "Show more"
 msgid "Edit categories"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:27
+msgid "License offered by the api"
+msgstr "License"
+
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:29
 #: ckanext/ytp/templates/snippets/license.html:21
 msgid "License"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:61
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:67
 msgid "License Not Specified"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:70
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:76
 msgid "Openness score"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:91
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:98
+msgid "Recommend apiset"
+msgstr "Like this API"
+
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:104
 msgid "Recommend dataset"
 msgstr "Like this dataset"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:117
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:131
 msgid "Downloads during last 12 months"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:118
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:132
 msgid "All time visits:"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:10
 msgid "Visits"
 msgstr ""
@@ -2473,7 +2481,7 @@ msgstr ""
 msgid "Social"
 msgstr "Share in social media"
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:17
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:18
 #, python-format
 msgid ""
 "To the extent possible under law <a rel=\"dct:publisher\" "
@@ -2483,7 +2491,28 @@ msgid ""
 "property=\"dct:title\">%(content_title)s</span></a>."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:31
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:34
+#, python-format
+msgid ""
+"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
+"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
+"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
+"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
+"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
+"href=\"%(creator_url)s\" >%(creator)s</a> apiset is licensed under a <a "
+"rel=\"license\" href=\"https://creativecommons.org/licenses/by/4.0/\"> "
+"Creative Commons Attribution 4.0 International License</a>."
+msgstr ""
+"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
+"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
+"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
+"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
+"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
+"href=\"%(creator_url)s\" >%(creator)s</a> is licensed under a <a "
+"rel=\"license\" href=\"https://creativecommons.org/licenses/by/4.0/\"> "
+"Creative Commons Attribution 4.0 International License</a>."
+
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:45
 #, python-format
 msgid ""
 "<span xmlns:dct=\"https://purl.org/dc/terms/\" "
@@ -2496,7 +2525,21 @@ msgid ""
 "Creative Commons Attribution 4.0 International License</a>."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:43
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:57
+#, python-format
+msgid ""
+"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
+"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
+"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
+"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
+"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
+"href=\"%(creator_url)s\" >%(creator)s</a> %(resource_type)s is licensed "
+"under a <a rel=\"license\" "
+"href=\"https://creativecommons.org/licenses/by/4.0/\"> Creative Commons "
+"Attribution 4.0 International License</a>."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:70
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/en_GB/LC_MESSAGES/ckanext-ytp_main.po
@@ -18,7 +18,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-11 10:19+0000\n"
+"POT-Creation-Date: 2022-11-16 13:30+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: English (United Kingdom) (https://www.transifex.com/avoindata/teams/7979/en_GB/)\n"
@@ -1623,27 +1623,28 @@ msgstr ""
 msgid "Not authorized to see this page"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:54
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:52
 #: ckanext/ytp/resources/opendata/scripts/translations.js:20
 msgid "Reorder apiset"
-msgstr "Reorder apis"
+msgstr "Reorder resources"
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:55
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:53
 #: ckanext/ytp/resources/opendata/scripts/translations.js:21
 msgid ""
 "You can rearrange the apiset resources by dragging them using the arrow "
 "icon. Drag the resource to the right and place it to the desired location on"
 " the list. When you are done, click the \"Save order\" -button."
 msgstr ""
-"Drag the resource box to the desired location on the list and let go. When "
-"you are done, select \"Save order\"."
+"You can rearrange the resources by dragging them using the arrow icon. Drag "
+"the resource to the right and place it to the desired location on the list. "
+"When you are done, click the \"Save order\" -button."
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:59
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:57
 #: ckanext/ytp/resources/opendata/scripts/translations.js:16
 msgid "Reorder resources"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:60
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:58
 #: ckanext/ytp/resources/opendata/scripts/translations.js:17
 msgid ""
 "You can rearrange the resources by dragging them using the arrow icon. Drag "
@@ -1653,17 +1654,17 @@ msgstr ""
 "Drag the resource box to the desired location on the list and let go. When "
 "you are done, select \"Save order\"."
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:83
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:81
 msgid "Save order"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:86
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:84
 #: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
 #: ckanext/ytp/resources/opendata/scripts/translations.js:9
 msgid "Cancel"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:96
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:94
 msgid "Saving..."
 msgstr ""
 
@@ -2474,7 +2475,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:27
 msgid "License offered by the api"
-msgstr "License"
+msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:29
 #: ckanext/ytp/templates/snippets/license.html:21
@@ -2491,7 +2492,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:98
 msgid "Recommend apiset"
-msgstr "Like this API"
+msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:104
 msgid "Recommend dataset"
@@ -2540,14 +2541,6 @@ msgid ""
 "rel=\"license\" href=\"https://creativecommons.org/licenses/by/4.0/\"> "
 "Creative Commons Attribution 4.0 International License</a>."
 msgstr ""
-"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
-"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
-"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
-"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
-"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
-"href=\"%(creator_url)s\" >%(creator)s</a> is licensed under a <a "
-"rel=\"license\" href=\"https://creativecommons.org/licenses/by/4.0/\"> "
-"Creative Commons Attribution 4.0 International License</a>."
 
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:45
 #, python-format
@@ -3238,7 +3231,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/snippets/search_form.html:5
 msgid "Search apis..."
-msgstr "Search apis..."
+msgstr ""
 
 #: ckanext/ytp/templates/snippets/search_form.html:18
 msgid "Filters"
@@ -3360,18 +3353,27 @@ msgstr[1] "{number} publishers"
 
 #: ckanext/ytp/templates/snippets/activities/changed_package.html:8
 msgid "{actor} updated the api {dataset}"
-msgstr "{actor} updated the api {dataset}"
+msgstr ""
 
 #: ckanext/ytp/templates/snippets/activities/changed_package.html:10
 msgid "{actor} updated the dataset {dataset}"
-msgstr "{actor} updated the dataset {dataset}"
+msgstr ""
 
 #: ckanext/ytp/templates/snippets/activities/changed_package.html:18
+#: ckanext/ytp/templates/snippets/activities/new_package.html:16
 msgid "View this version"
 msgstr ""
 
 #: ckanext/ytp/templates/snippets/activities/changed_package.html:22
 msgid "Changes"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/new_package.html:6
+msgid "{actor} created the api {dataset}"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/new_package.html:8
+msgid "{actor} created the dataset {dataset}"
 msgstr ""
 
 #: ckanext/ytp/templates/source/read_base.html:19

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -13,17 +13,17 @@
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2021
 # Daniel Vainio, 2021
 # Pasi Laakso <pasi.laakso@gofore.com>, 2022
-# Ville Teräväinen, 2022
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Ville Teräväinen, 2022
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-01 13:07+0000\n"
+"POT-Creation-Date: 2022-11-09 12:02+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Meeri Hakala <meeri.hakala@dvv.fi>, 2022\n"
+"Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -231,7 +231,7 @@ msgid "Unauthorized to edit user %s"
 msgstr "Käyttäjän muokkaus ei sallittu %s"
 
 #: ckanext/ytp/controller.py:621 ckanext/ytp/controller.py:689
-#: ckanext/ytp/logic.py:46
+#: ckanext/ytp/logic.py:47
 msgid "User not found"
 msgstr "Käyttäjää ei löytynyt"
 
@@ -264,28 +264,28 @@ msgstr "Nimetön data-aineisto"
 msgid "-"
 msgstr ""
 
-#: ckanext/ytp/logic.py:49
+#: ckanext/ytp/logic.py:50
 msgid "Cannot change username"
 msgstr "Käyttäjätunnusta ei voi muuttaa"
 
-#: ckanext/ytp/logic.py:51
+#: ckanext/ytp/logic.py:52
 msgid "Cannot change email"
 msgstr "Sähköpostiosoitetta ei voi muuttaa"
 
-#: ckanext/ytp/logic.py:62
+#: ckanext/ytp/logic.py:63
 msgid "Have to be logged in to edit user"
 msgstr "Pitää olla kirjautunut sisään muokatakseen käyttäjää"
 
-#: ckanext/ytp/logic.py:70
+#: ckanext/ytp/logic.py:71
 #, python-format
 msgid "User %s not authorized to edit user %s"
 msgstr "Käyttäjällä %s ei ole oikeuksia muokata käyttäjää %s"
 
-#: ckanext/ytp/logic.py:76
+#: ckanext/ytp/logic.py:77
 msgid "Have to be logged in to list users"
 msgstr "Pitää olla kirjautunut sisään nähdäkseen listan käyttäjistä"
 
-#: ckanext/ytp/logic.py:82
+#: ckanext/ytp/logic.py:83
 msgid "Have to be logged in to list admins"
 msgstr "PItää olla sisäänkirjautunut listataksesi ylläpitäjät"
 
@@ -2372,27 +2372,27 @@ msgid "sha256"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:271
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:111
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:125
 msgid "Stats"
 msgstr "Tilastot"
 
 #: ckanext/ytp/templates/package/resource_read.html:272
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:112
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Last 30 days, updated daily"
 msgstr "Viimeiset 30 päivää, päivitetään päivittäin"
 
 #: ckanext/ytp/templates/package/resource_read.html:275
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:119
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:133
 msgid "All time downloads:"
 msgstr "Latauksia kaikkiaan:"
 
 #: ckanext/ytp/templates/package/resource_read.html:285
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 msgid "Year"
 msgstr "Vuosi"
 
 #: ckanext/ytp/templates/package/resource_read.html:285
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:11
 msgid "Downloads"
 msgstr "Latauksia"
@@ -2494,32 +2494,40 @@ msgstr "Näytä lisää"
 msgid "Edit categories"
 msgstr "Muokkaa kategorioita"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:27
+msgid "License offered by the api"
+msgstr "Rajapinnan tarjoaman tiedon lisenssi"
+
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:29
 #: ckanext/ytp/templates/snippets/license.html:21
 msgid "License"
 msgstr "Lisenssi"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:61
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:67
 msgid "License Not Specified"
 msgstr "Lisenssiä ei ole määritelty"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:70
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:76
 msgid "Openness score"
 msgstr "Avoimuusaste"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:91
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:98
+msgid "Recommend apiset"
+msgstr "Tykkää rajapinnasta"
+
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:104
 msgid "Recommend dataset"
 msgstr "Tykkää tietoaineistosta"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:117
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:131
 msgid "Downloads during last 12 months"
 msgstr "Latauksia viimeisen 12kk aikana."
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:118
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:132
 msgid "All time visits:"
 msgstr "Sivunäyttöjä kaikkiaan:"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:10
 msgid "Visits"
 msgstr "Sivunäytöt"
@@ -2532,7 +2540,7 @@ msgstr "Käyttösovellukset"
 msgid "Social"
 msgstr "Jaa sosiaalisessa mediassa"
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:17
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:18
 #, python-format
 msgid ""
 "To the extent possible under law <a rel=\"dct:publisher\" "
@@ -2542,7 +2550,29 @@ msgid ""
 "property=\"dct:title\">%(content_title)s</span></a>."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:31
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:34
+#, python-format
+msgid ""
+"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
+"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
+"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
+"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
+"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
+"href=\"%(creator_url)s\" >%(creator)s</a> apiset is licensed under a <a "
+"rel=\"license\" href=\"https://creativecommons.org/licenses/by/4.0/\"> "
+"Creative Commons Attribution 4.0 International License</a>."
+msgstr ""
+"<a  href=\"%(creator_url)s\" >%(creator)s</a> on julkaissut rajapinnan <span"
+" xmlns:dct=\"https://purl.org/dc/terms/\" "
+"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
+"rel=\"dct:type\"><a xmlns:cc=\"https://creativecommons.org/ns#\" "
+"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
+"rel=\"cc:attributionURL\">%(content_title)s</a></span> lisenssillä <a "
+"rel=\"license\" "
+"href=\"https://creativecommons.org/licenses/by/4.0/\">Creative Commons "
+"Attribution 4.0 International License."
+
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:45
 #, python-format
 msgid ""
 "<span xmlns:dct=\"https://purl.org/dc/terms/\" "
@@ -2564,7 +2594,21 @@ msgstr ""
 "href=\"https://creativecommons.org/licenses/by/4.0/\">Creative Commons "
 "Attribution 4.0 International License</a>."
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:43
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:57
+#, python-format
+msgid ""
+"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
+"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
+"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
+"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
+"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
+"href=\"%(creator_url)s\" >%(creator)s</a> %(resource_type)s is licensed "
+"under a <a rel=\"license\" "
+"href=\"https://creativecommons.org/licenses/by/4.0/\"> Creative Commons "
+"Attribution 4.0 International License</a>."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:70
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-11 10:19+0000\n"
+"POT-Creation-Date: 2022-11-16 13:30+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
@@ -1668,27 +1668,27 @@ msgstr ""
 msgid "Not authorized to see this page"
 msgstr "Ei oikeuksia nähdä tätä sivua"
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:54
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:52
 #: ckanext/ytp/resources/opendata/scripts/translations.js:20
 msgid "Reorder apiset"
-msgstr "Järjestä rajapinnat"
+msgstr "Järjestä resurssit"
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:55
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:53
 #: ckanext/ytp/resources/opendata/scripts/translations.js:21
 msgid ""
 "You can rearrange the apiset resources by dragging them using the arrow "
 "icon. Drag the resource to the right and place it to the desired location on"
 " the list. When you are done, click the \"Save order\" -button."
 msgstr ""
-"Ota hiirellä kiinni rajapinnan laatikosta ja raahaa se haluamallesi "
-"paikalle. Valitse lopuksi \"Tallenna järjestys\"."
+"Ota hiirellä kiinni resurssin laatikosta ja raahaa se haluamallesi paikalle."
+" Valitse lopuksi \"Tallenna järjestys\"."
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:59
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:57
 #: ckanext/ytp/resources/opendata/scripts/translations.js:16
 msgid "Reorder resources"
 msgstr "Järjestä data-aineistot"
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:60
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:58
 #: ckanext/ytp/resources/opendata/scripts/translations.js:17
 msgid ""
 "You can rearrange the resources by dragging them using the arrow icon. Drag "
@@ -1698,17 +1698,17 @@ msgstr ""
 "Ota hiirellä kiinni data-aineiston laatikosta ja raahaa se haluamallesi "
 "paikalle. Valitse lopuksi \"Tallenna järjestys\"."
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:83
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:81
 msgid "Save order"
 msgstr ""
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:86
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:84
 #: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
 #: ckanext/ytp/resources/opendata/scripts/translations.js:9
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:96
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:94
 msgid "Saving..."
 msgstr ""
 
@@ -2416,12 +2416,12 @@ msgstr "Tilastot"
 #: ckanext/ytp/templates/package/resource_read.html:272
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Last 30 days, updated daily"
-msgstr "Viimeiset 30 päivää, päivitetään päivittäin"
+msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:275
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:133
 msgid "All time downloads:"
-msgstr "Latauksia kaikkiaan:"
+msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:285
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:141
@@ -2558,11 +2558,11 @@ msgstr "Tykkää tietoaineistosta"
 
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:131
 msgid "Downloads during last 12 months"
-msgstr "Latauksia viimeisen 12kk aikana."
+msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:132
 msgid "All time visits:"
-msgstr "Sivunäyttöjä kaikkiaan:"
+msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:10
@@ -2607,7 +2607,7 @@ msgstr ""
 "rel=\"cc:attributionURL\">%(content_title)s</a></span> lisenssillä <a "
 "rel=\"license\" "
 "href=\"https://creativecommons.org/licenses/by/4.0/\">Creative Commons "
-"Attribution 4.0 International License."
+"Attribution 4.0 International License</a>."
 
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:45
 #, python-format
@@ -3483,14 +3483,23 @@ msgstr "{actor} päivitti rajapintaa {dataset}"
 
 #: ckanext/ytp/templates/snippets/activities/changed_package.html:10
 msgid "{actor} updated the dataset {dataset}"
-msgstr "{actor} päivitti tietoaineistoa {dataset}"
+msgstr ""
 
 #: ckanext/ytp/templates/snippets/activities/changed_package.html:18
+#: ckanext/ytp/templates/snippets/activities/new_package.html:16
 msgid "View this version"
 msgstr ""
 
 #: ckanext/ytp/templates/snippets/activities/changed_package.html:22
 msgid "Changes"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/new_package.html:6
+msgid "{actor} created the api {dataset}"
+msgstr "{actor} loi rajapinnan {dataset}"
+
+#: ckanext/ytp/templates/snippets/activities/new_package.html:8
+msgid "{actor} created the dataset {dataset}"
 msgstr ""
 
 #: ckanext/ytp/templates/source/read_base.html:19

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -21,7 +21,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-11-09 12:02+0000\n"
+"POT-Creation-Date: 2022-11-11 10:19+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
@@ -862,6 +862,7 @@ msgstr "Etsi kategorioita..."
 #: ckanext/ytp/templates/group/read_base.html:4
 #: ckanext/ytp/templates/package/group_list.html:9
 #: ckanext/ytp/templates/package/group_list.html:14
+#: ckanext/ytp/templates/package/read_base.html:26
 #: ckanext/ytp/translations.py:132
 msgid "Groups"
 msgstr "Kategoriat"
@@ -1667,6 +1668,50 @@ msgstr ""
 msgid "Not authorized to see this page"
 msgstr "Ei oikeuksia nähdä tätä sivua"
 
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:54
+#: ckanext/ytp/resources/opendata/scripts/translations.js:20
+msgid "Reorder apiset"
+msgstr "Järjestä rajapinnat"
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:55
+#: ckanext/ytp/resources/opendata/scripts/translations.js:21
+msgid ""
+"You can rearrange the apiset resources by dragging them using the arrow "
+"icon. Drag the resource to the right and place it to the desired location on"
+" the list. When you are done, click the \"Save order\" -button."
+msgstr ""
+"Ota hiirellä kiinni rajapinnan laatikosta ja raahaa se haluamallesi "
+"paikalle. Valitse lopuksi \"Tallenna järjestys\"."
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:59
+#: ckanext/ytp/resources/opendata/scripts/translations.js:16
+msgid "Reorder resources"
+msgstr "Järjestä data-aineistot"
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:60
+#: ckanext/ytp/resources/opendata/scripts/translations.js:17
+msgid ""
+"You can rearrange the resources by dragging them using the arrow icon. Drag "
+"the resource to the right and place it to the desired location on the list. "
+"When you are done, click the \"Save order\" -button."
+msgstr ""
+"Ota hiirellä kiinni data-aineiston laatikosta ja raahaa se haluamallesi "
+"paikalle. Valitse lopuksi \"Tallenna järjestys\"."
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:83
+msgid "Save order"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:86
+#: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
+#: ckanext/ytp/resources/opendata/scripts/translations.js:9
+msgid "Cancel"
+msgstr "Peruuta"
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:96
+msgid "Saving..."
+msgstr ""
+
 #: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:69
 msgid "Please Confirm Action"
 msgstr "Vahvista toimenpide"
@@ -1680,13 +1725,8 @@ msgstr "Oletko varma, että haluat tehdä tämän?"
 msgid "Confirm"
 msgstr "Vahvista"
 
-#: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
-#: ckanext/ytp/resources/opendata/scripts/translations.js:9
-msgid "Cancel"
-msgstr "Peruuta"
-
 #: ckanext/ytp/resources/opendata/scripts/form.js:144
-#: ckanext/ytp/templates/snippets/search_form.html:23
+#: ckanext/ytp/templates/snippets/search_form.html:29
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:90
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:78
 msgid "Remove"
@@ -1737,19 +1777,6 @@ msgstr "Lisää linkki"
 msgid "Add email"
 msgstr "Lisää sähköposti"
 
-#: ckanext/ytp/resources/opendata/scripts/translations.js:16
-msgid "Reorder resources"
-msgstr "Järjestä data-aineistot"
-
-#: ckanext/ytp/resources/opendata/scripts/translations.js:17
-msgid ""
-"You can rearrange the resources by dragging them using the arrow icon. Drag "
-"the resource to the right and place it to the desired location on the list. "
-"When you are done, click the \"Save order\" -button."
-msgstr ""
-"Ota hiirellä kiinni data-aineiston laatikosta ja raahaa se haluamallesi "
-"paikalle. Valitse lopuksi \"Tallenna järjestys\"."
-
 #: ckanext/ytp/resources/vendor/bootstrap-table/dist/extensions/filter-control/utils.js:10
 msgid "Can't call method on "
 msgstr ""
@@ -1759,7 +1786,7 @@ msgid "Give feedback"
 msgstr "Anna palautetta"
 
 #: ckanext/ytp/templates/page.html:13
-#: ckanext/ytp/templates/snippets/search_form.html:104
+#: ckanext/ytp/templates/snippets/search_form.html:110
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:72
 msgid "Hide search filters"
 msgstr "Piilota suodattimet"
@@ -1810,6 +1837,7 @@ msgstr "Lisätiedot"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:126
 #: ckanext/ytp/templates/organization/read_base.html:37
+#: ckanext/ytp/templates/package/read_base.html:15
 #: ckanext/ytp/templates/package/resource_read.html:66
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:10
 #: ckanext/ytp/templates/package/snippets/resource_item2.html:12
@@ -1902,7 +1930,7 @@ msgstr "Osuvin ensin"
 #: ckanext/ytp/templates/organization/index.html:4
 #: ckanext/ytp/templates/organization/read.html:16
 #: ckanext/ytp/templates/package/search.html:57
-#: ckanext/ytp/templates/snippets/search_form.html:59
+#: ckanext/ytp/templates/snippets/search_form.html:65
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:34
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
@@ -1912,7 +1940,7 @@ msgstr "Nimen mukaan nousevasti"
 #: ckanext/ytp/templates/organization/index.html:4
 #: ckanext/ytp/templates/organization/read.html:17
 #: ckanext/ytp/templates/package/search.html:58
-#: ckanext/ytp/templates/snippets/search_form.html:59
+#: ckanext/ytp/templates/snippets/search_form.html:65
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:34
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
@@ -1935,7 +1963,7 @@ msgstr "Suosittu"
 
 #: ckanext/ytp/templates/group/read.html:19
 #: ckanext/ytp/templates/organization/read.html:23
-#: ckanext/ytp/templates/snippets/search_form.html:3
+#: ckanext/ytp/templates/snippets/search_form.html:7
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:3
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:3
 msgid "Search datasets..."
@@ -2050,18 +2078,18 @@ msgid "Search organizations..."
 msgstr "Etsi tuottajia..."
 
 #: ckanext/ytp/templates/organization/index.html:27
-#: ckanext/ytp/templates/snippets/search_form.html:42
+#: ckanext/ytp/templates/snippets/search_form.html:48
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:17
 msgid "Submit"
 msgstr "Lähetä"
 
 #: ckanext/ytp/templates/organization/index.html:34
-#: ckanext/ytp/templates/snippets/search_form.html:82
+#: ckanext/ytp/templates/snippets/search_form.html:88
 msgid "Sorting"
 msgstr "Lajittelu"
 
 #: ckanext/ytp/templates/organization/index.html:43
-#: ckanext/ytp/templates/snippets/search_form.html:91
+#: ckanext/ytp/templates/snippets/search_form.html:97
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:59
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
@@ -2096,7 +2124,10 @@ msgstr "Päivitä jäsen"
 #: ckanext/ytp/templates/organization/member_new.html:67
 #: ckanext/ytp/templates/organization/members.html:56
 #: ckanext/ytp/templates/organization/read_base.html:24
+#: ckanext/ytp/templates/package/activity.html:3
+#: ckanext/ytp/templates/package/activity.html:8
 #: ckanext/ytp/templates/package/group_list.html:10
+#: ckanext/ytp/templates/package/read_base.html:27
 msgid "Activity Stream"
 msgstr "Tapahtumatiedot"
 
@@ -2194,10 +2225,12 @@ msgid "Close without saving"
 msgstr "Sulje tallentamatta"
 
 #: ckanext/ytp/templates/package/group_list.html:5
+#: ckanext/ytp/templates/package/read_base.html:22
 msgid "Apiset"
 msgstr "Rajapinta"
 
 #: ckanext/ytp/templates/package/group_list.html:7
+#: ckanext/ytp/templates/package/read_base.html:24
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:5
 msgid "Dataset"
 msgstr "Tietoaineisto"
@@ -2356,6 +2389,10 @@ msgstr "Muoto"
 #: ckanext/ytp/templates/package/resource_read.html:234
 #: ckanext/ytp/templates/package/resource_read.html:238
 #: ckanext/ytp/templates/package/resource_read.html:242
+#: ckanext/ytp/templates/snippets/activity_stream.html:10
+#: ckanext/ytp/templates/snippets/activity_stream.html:17
+#: ckanext/ytp/templates/snippets/activity_stream.html:25
+#: ckanext/ytp/templates/snippets/activity_stream.html:39
 msgid "unknown"
 msgstr "tuntematon"
 
@@ -2594,21 +2631,7 @@ msgstr ""
 "href=\"https://creativecommons.org/licenses/by/4.0/\">Creative Commons "
 "Attribution 4.0 International License</a>."
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:57
-#, python-format
-msgid ""
-"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
-"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
-"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
-"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
-"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
-"href=\"%(creator_url)s\" >%(creator)s</a> %(resource_type)s is licensed "
-"under a <a rel=\"license\" "
-"href=\"https://creativecommons.org/licenses/by/4.0/\"> Creative Commons "
-"Attribution 4.0 International License</a>."
-msgstr ""
-
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:70
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:60
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
@@ -3328,27 +3351,31 @@ msgstr "Tällä organisaatiolla ei ole kuvausta"
 msgid "Last Harvested"
 msgstr "Harvestoitu viimeksi"
 
-#: ckanext/ytp/templates/snippets/search_form.html:12
+#: ckanext/ytp/templates/snippets/search_form.html:5
+msgid "Search apis..."
+msgstr "Etsi rajapintoja..."
+
+#: ckanext/ytp/templates/snippets/search_form.html:18
 msgid "Filters"
 msgstr "Rajaukset"
 
-#: ckanext/ytp/templates/snippets/search_form.html:65
+#: ckanext/ytp/templates/snippets/search_form.html:71
 msgid " Use advanced search "
 msgstr "Käytä laajennettua hakua"
 
-#: ckanext/ytp/templates/snippets/search_form.html:98
+#: ckanext/ytp/templates/snippets/search_form.html:104
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:66
 msgid "Filter search"
 msgstr "Rajaa hakua"
 
-#: ckanext/ytp/templates/snippets/search_form.html:112
+#: ckanext/ytp/templates/snippets/search_form.html:118
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:102
 msgid "Please try another search or change search facets."
 msgstr ""
 "Tarkista, että kirjoitit hakusanan oikein. Kokeile käyttää erilaisia "
 "hakusanoja tai muuttaa valitsemiasi hakuehtoja. "
 
-#: ckanext/ytp/templates/snippets/search_form.html:120
+#: ckanext/ytp/templates/snippets/search_form.html:126
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:110
 msgid "<strong>There was an error while searching.</strong> Please try again."
 msgstr "<strong>Haussa tapahtui virhe.</strong> Yritä uudelleen."
@@ -3449,6 +3476,22 @@ msgid "{number} organization found"
 msgid_plural "{number} organizations found"
 msgstr[0] "Löytyi {number} organisaatio"
 msgstr[1] "{number} tuottajaa"
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:8
+msgid "{actor} updated the api {dataset}"
+msgstr "{actor} päivitti rajapintaa {dataset}"
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:10
+msgid "{actor} updated the dataset {dataset}"
+msgstr "{actor} päivitti tietoaineistoa {dataset}"
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:18
+msgid "View this version"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:22
+msgid "Changes"
+msgstr ""
 
 #: ckanext/ytp/templates/source/read_base.html:19
 msgid "read more"

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
@@ -17,7 +17,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-10-12 10:15+0000\n"
+"POT-Creation-Date: 2022-11-16 13:30+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Ville Teräväinen, 2022\n"
 "Language-Team: Swedish (https://www.transifex.com/avoindata/teams/7979/sv/)\n"
@@ -98,7 +98,7 @@ msgstr "Redigera eller lägg till språkversioner"
 #: ckanext/ytp/templates/organization/user_list.html:53
 #: ckanext/ytp/templates/package/new_package_form.html:29
 #: ckanext/ytp/templates/package/snippets/package_form.html:25
-#: ckanext/ytp/templates/package/snippets/resource_form.html:59
+#: ckanext/ytp/templates/package/snippets/resource_form.html:63
 #: ckanext/ytp/templates/scheming/organization/group_form.html:47
 #: ckanext/ytp/templates/user/edit_user_form.html:47
 msgid "Delete"
@@ -229,7 +229,7 @@ msgid "Unauthorized to edit user %s"
 msgstr "Behörighet krävs för redigering av användarens %s"
 
 #: ckanext/ytp/controller.py:621 ckanext/ytp/controller.py:689
-#: ckanext/ytp/logic.py:43
+#: ckanext/ytp/logic.py:47
 msgid "User not found"
 msgstr "Kunde inte hitta användaren"
 
@@ -254,7 +254,7 @@ msgstr ""
 msgid "Date format incorrect"
 msgstr "Felaktigt datumformat"
 
-#: ckanext/ytp/helpers.py:103 ckanext/ytp/plugin.py:358
+#: ckanext/ytp/helpers.py:103 ckanext/ytp/plugin.py:361
 msgid "Unnamed resource"
 msgstr "Namnlös dataresurs"
 
@@ -262,28 +262,28 @@ msgstr "Namnlös dataresurs"
 msgid "-"
 msgstr ""
 
-#: ckanext/ytp/logic.py:46
+#: ckanext/ytp/logic.py:50
 msgid "Cannot change username"
 msgstr "Användarnamnet kan inte ändras"
 
-#: ckanext/ytp/logic.py:48
+#: ckanext/ytp/logic.py:52
 msgid "Cannot change email"
 msgstr "E-postadressen kan inte ändras"
 
-#: ckanext/ytp/logic.py:59
+#: ckanext/ytp/logic.py:63
 msgid "Have to be logged in to edit user"
 msgstr "Du måste vara inloggad för att redigera användaren"
 
-#: ckanext/ytp/logic.py:67
+#: ckanext/ytp/logic.py:71
 #, python-format
 msgid "User %s not authorized to edit user %s"
 msgstr "Användaren %s har inte rättigheter för att redigera användaren %s"
 
-#: ckanext/ytp/logic.py:73
+#: ckanext/ytp/logic.py:77
 msgid "Have to be logged in to list users"
 msgstr "Du måste vara inloggad för att se användarlistan"
 
-#: ckanext/ytp/logic.py:79
+#: ckanext/ytp/logic.py:83
 msgid "Have to be logged in to list admins"
 msgstr "Du måste vara inloggad för att lista admins"
 
@@ -357,13 +357,13 @@ msgstr "Publicera öppna data"
 msgid "Publish Data"
 msgstr "Publicera data"
 
-#: ckanext/ytp/plugin.py:290 ckanext/ytp/plugin.py:300
-#: ckanext/ytp/plugin.py:314
+#: ckanext/ytp/plugin.py:293 ckanext/ytp/plugin.py:303
+#: ckanext/ytp/plugin.py:317
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:14
 msgid "Tags"
 msgstr "Nyckelord"
 
-#: ckanext/ytp/plugin.py:291 ckanext/ytp/plugin.py:301
+#: ckanext/ytp/plugin.py:294 ckanext/ytp/plugin.py:304
 #: ckanext/ytp/templates/report/administrative_branch_summary_report.html:44
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:6
 #: ckanext/ytp/templates/snippets/organization.html:21
@@ -371,41 +371,41 @@ msgstr "Nyckelord"
 msgid "Organization"
 msgstr "Producent"
 
-#: ckanext/ytp/plugin.py:292 ckanext/ytp/plugin.py:302
-#: ckanext/ytp/plugin.py:316 ckanext/ytp/translations.py:35
+#: ckanext/ytp/plugin.py:295 ckanext/ytp/plugin.py:305
+#: ckanext/ytp/plugin.py:319 ckanext/ytp/translations.py:35
 msgid "Formats"
 msgstr "Filformat"
 
-#: ckanext/ytp/plugin.py:293 ckanext/ytp/plugin.py:303
+#: ckanext/ytp/plugin.py:296 ckanext/ytp/plugin.py:306
 msgid "Licenses"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:294 ckanext/ytp/plugin.py:304
+#: ckanext/ytp/plugin.py:297 ckanext/ytp/plugin.py:307
 msgid "Category"
 msgstr ""
 
-#: ckanext/ytp/plugin.py:295 ckanext/ytp/plugin.py:305
+#: ckanext/ytp/plugin.py:298 ckanext/ytp/plugin.py:308
 #: ckanext/ytp/translations.py:87
 msgid "Producer type"
 msgstr "Regional täckning/Producenttyp"
 
-#: ckanext/ytp/plugin.py:297
+#: ckanext/ytp/plugin.py:300
 msgid "International Benchmarks"
 msgstr "Internationella jämförelser"
 
-#: ckanext/ytp/plugin.py:298 ckanext/ytp/translations.py:68
+#: ckanext/ytp/plugin.py:301 ckanext/ytp/translations.py:68
 msgid "Geographical coverage"
 msgstr "Geografisk täckning"
 
-#: ckanext/ytp/plugin.py:299 ckanext/ytp/plugin.py:313
+#: ckanext/ytp/plugin.py:302 ckanext/ytp/plugin.py:316
 msgid "Collection Types"
 msgstr "Typer av datamängder"
 
-#: ckanext/ytp/plugin.py:315
+#: ckanext/ytp/plugin.py:318
 msgid "Content Types"
 msgstr "Innehållstyper"
 
-#: ckanext/ytp/plugin.py:358
+#: ckanext/ytp/plugin.py:361
 #: ckanext/ytp/templates/package/snippets/additional_info.html:2
 #: ckanext/ytp/templates/scheming/organization/about.html:20
 msgid "Additional Info"
@@ -478,7 +478,7 @@ msgstr "Intern"
 msgid "Created"
 msgstr "Skapad"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:18
+#: ckanext/ytp/templates/package/snippets/resource_form.html:22
 #: ckanext/ytp/translations.py:30
 msgid "URL"
 msgstr "URL"
@@ -828,7 +828,7 @@ msgstr "Applikationer"
 msgid "Add to group"
 msgstr "Lägg till i gruppen"
 
-#: ckanext/ytp/templates/package/group_list.html:15
+#: ckanext/ytp/templates/package/group_list.html:22
 #: ckanext/ytp/translations.py:126
 msgid "There are no groups associated with this dataset"
 msgstr "Inga grupper har kopplats till datamängden"
@@ -837,7 +837,7 @@ msgstr "Inga grupper har kopplats till datamängden"
 msgid "Remove dataset from this group"
 msgstr "Ta bort datamängden från denna grupp"
 
-#: ckanext/ytp/templates/package/group_list.html:36
+#: ckanext/ytp/templates/package/group_list.html:52
 #: ckanext/ytp/translations.py:128
 msgid "Associate this group with this dataset"
 msgstr "Koppla denna grupp till denna datamängd"
@@ -856,8 +856,9 @@ msgstr "Sök grupper ..."
 
 #: ckanext/ytp/templates/group/index.html:4
 #: ckanext/ytp/templates/group/read_base.html:4
-#: ckanext/ytp/templates/package/group_list.html:5
-#: ckanext/ytp/templates/package/group_list.html:10
+#: ckanext/ytp/templates/package/group_list.html:9
+#: ckanext/ytp/templates/package/group_list.html:14
+#: ckanext/ytp/templates/package/read_base.html:26
 #: ckanext/ytp/translations.py:132
 msgid "Groups"
 msgstr "Grupper"
@@ -1355,207 +1356,216 @@ msgstr "Startdatum"
 msgid "End date"
 msgstr "Slutdatum"
 
-#: ckanext/ytp/translations.py:248
-msgid "Producer name"
+#: ckanext/ytp/translations.py:246
+msgid "Geographical accuracy"
 msgstr ""
 
-#: ckanext/ytp/translations.py:249
-msgid "Producer description"
+#: ckanext/ytp/translations.py:247
+msgid ""
+"If your data includes geographic information, specify the accuracy in meters"
 msgstr ""
 
 #: ckanext/ytp/translations.py:250
-msgid "Common, compact and plain description about producer"
+msgid "Producer name"
 msgstr ""
 
 #: ckanext/ytp/translations.py:251
+msgid "Producer description"
+msgstr ""
+
+#: ckanext/ytp/translations.py:252
+msgid "Common, compact and plain description about producer"
+msgstr ""
+
+#: ckanext/ytp/translations.py:253
 msgid "Other information"
 msgstr ""
 
-#: ckanext/ytp/translations.py:254
+#: ckanext/ytp/translations.py:256
 msgid "cc-by"
 msgstr ""
 
-#: ckanext/ytp/translations.py:255
+#: ckanext/ytp/translations.py:257
 msgid "cc-by-4-fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:256
+#: ckanext/ytp/translations.py:258
 msgid "cc-by-4.0"
 msgstr ""
 
-#: ckanext/ytp/translations.py:257
+#: ckanext/ytp/translations.py:259
 msgid "cc-by-sa"
 msgstr ""
 
-#: ckanext/ytp/translations.py:258
+#: ckanext/ytp/translations.py:260
 msgid "cc-by-sa-1-fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:259
+#: ckanext/ytp/translations.py:261
 msgid "cc-nc"
 msgstr ""
 
-#: ckanext/ytp/translations.py:260
+#: ckanext/ytp/translations.py:262
 msgid "cc-zero"
 msgstr ""
 
-#: ckanext/ytp/translations.py:261
+#: ckanext/ytp/translations.py:263
 msgid "cc-zero-1.0"
 msgstr ""
 
-#: ckanext/ytp/translations.py:262
+#: ckanext/ytp/translations.py:264
 msgid "gfdl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:263
+#: ckanext/ytp/translations.py:265
 msgid "helsinkikanava-opendata-tos"
 msgstr ""
 
-#: ckanext/ytp/translations.py:264
+#: ckanext/ytp/translations.py:266
 msgid "hri-tietoaineistot-lisenssi-nimea"
 msgstr ""
 
-#: ckanext/ytp/translations.py:265
+#: ckanext/ytp/translations.py:267
 msgid "ilmoitettumuualla"
 msgstr ""
 
-#: ckanext/ytp/translations.py:266
+#: ckanext/ytp/translations.py:268
 msgid "kmo-aluejakorajat"
 msgstr ""
 
-#: ckanext/ytp/translations.py:267
+#: ckanext/ytp/translations.py:269
 msgid "notspecified"
 msgstr ""
 
-#: ckanext/ytp/translations.py:268
+#: ckanext/ytp/translations.py:270
 msgid "odc-by"
 msgstr ""
 
-#: ckanext/ytp/translations.py:269
+#: ckanext/ytp/translations.py:271
 msgid "odc-odbl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:270
+#: ckanext/ytp/translations.py:272
 msgid "odc-pddl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:271
+#: ckanext/ytp/translations.py:273
 msgid "other"
 msgstr ""
 
-#: ckanext/ytp/translations.py:272
+#: ckanext/ytp/translations.py:274
 msgid "other-at"
 msgstr ""
 
-#: ckanext/ytp/translations.py:273
+#: ckanext/ytp/translations.py:275
 msgid "other-closed"
 msgstr ""
 
-#: ckanext/ytp/translations.py:274
+#: ckanext/ytp/translations.py:276
 msgid "other-nc"
 msgstr ""
 
-#: ckanext/ytp/translations.py:275
+#: ckanext/ytp/translations.py:277
 msgid "other-open"
 msgstr ""
 
-#: ckanext/ytp/translations.py:276
+#: ckanext/ytp/translations.py:278
 msgid "other-pd"
 msgstr ""
 
-#: ckanext/ytp/translations.py:277
+#: ckanext/ytp/translations.py:279
 msgid "uk-ogl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:280
+#: ckanext/ytp/translations.py:282
 msgid "Platforms"
 msgstr ""
 
-#: ckanext/ytp/translations.py:283
+#: ckanext/ytp/translations.py:285
 msgid "Show more collection_type"
 msgstr "Vias flera Datamängder"
 
-#: ckanext/ytp/translations.py:284
+#: ckanext/ytp/translations.py:286
 msgid "Show more vocab_international_benchmarks"
 msgstr "Visa flera Internationella Jämförelser"
 
-#: ckanext/ytp/translations.py:285
+#: ckanext/ytp/translations.py:287
 msgid "Show more vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:286
+#: ckanext/ytp/translations.py:288
 msgid "Show more vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:287
+#: ckanext/ytp/translations.py:289
 msgid "Show more vocab_keywords_sv"
 msgstr "Visa flera Nyckelord"
 
-#: ckanext/ytp/translations.py:288
+#: ckanext/ytp/translations.py:290
 msgid "Show more organization"
 msgstr "Visa flera Producenter"
 
-#: ckanext/ytp/translations.py:289
+#: ckanext/ytp/translations.py:291
 msgid "Show more res_format"
 msgstr "Visa flera Format"
 
-#: ckanext/ytp/translations.py:290
+#: ckanext/ytp/translations.py:292
 msgid "Show more source"
 msgstr "Visa flera Källor"
 
-#: ckanext/ytp/translations.py:291
+#: ckanext/ytp/translations.py:293
 msgid "Show more license_id"
 msgstr "Visa flera Licenser"
 
-#: ckanext/ytp/translations.py:292
+#: ckanext/ytp/translations.py:294
 msgid "Show more groups"
 msgstr "Visa flera Grupper"
 
-#: ckanext/ytp/translations.py:293
+#: ckanext/ytp/translations.py:295
 msgid "Show more vocab_platform"
 msgstr "Visa flera Plattformar"
 
-#: ckanext/ytp/translations.py:296
+#: ckanext/ytp/translations.py:298
 msgid "Show less collection_type"
 msgstr "Vias färre Datamängder"
 
-#: ckanext/ytp/translations.py:297
+#: ckanext/ytp/translations.py:299
 msgid "Show less vocab_international_benchmarks"
 msgstr "Visa färre Internationella Jämförelser"
 
-#: ckanext/ytp/translations.py:298
+#: ckanext/ytp/translations.py:300
 msgid "Show less vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:299
+#: ckanext/ytp/translations.py:301
 msgid "Show less vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:300
+#: ckanext/ytp/translations.py:302
 msgid "Show less vocab_keywords_sv"
 msgstr "Visa färre Nyckelord"
 
-#: ckanext/ytp/translations.py:301
+#: ckanext/ytp/translations.py:303
 msgid "Show less organization"
 msgstr "Visa färre Producenter"
 
-#: ckanext/ytp/translations.py:302
+#: ckanext/ytp/translations.py:304
 msgid "Show less res_format"
 msgstr "Visa färre Format"
 
-#: ckanext/ytp/translations.py:303
+#: ckanext/ytp/translations.py:305
 msgid "Show less source"
 msgstr "Visa färre Källor"
 
-#: ckanext/ytp/translations.py:304
+#: ckanext/ytp/translations.py:306
 msgid "Show less license_id"
 msgstr "Visa färre Licenser"
 
-#: ckanext/ytp/translations.py:305
+#: ckanext/ytp/translations.py:307
 msgid "Show less groups"
 msgstr "Visa färre Grupper"
 
-#: ckanext/ytp/translations.py:306
+#: ckanext/ytp/translations.py:308
 msgid "Show less vocab_platform"
 msgstr "Visa färre Plattformar"
 
@@ -1630,6 +1640,48 @@ msgstr ""
 msgid "Not authorized to see this page"
 msgstr "Behörighet krävs för att visa sidan"
 
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:52
+#: ckanext/ytp/resources/opendata/scripts/translations.js:20
+msgid "Reorder apiset"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:53
+#: ckanext/ytp/resources/opendata/scripts/translations.js:21
+msgid ""
+"You can rearrange the apiset resources by dragging them using the arrow "
+"icon. Drag the resource to the right and place it to the desired location on"
+" the list. When you are done, click the \"Save order\" -button."
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:57
+#: ckanext/ytp/resources/opendata/scripts/translations.js:16
+msgid "Reorder resources"
+msgstr "Ordna dataresurserna"
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:58
+#: ckanext/ytp/resources/opendata/scripts/translations.js:17
+msgid ""
+"You can rearrange the resources by dragging them using the arrow icon. Drag "
+"the resource to the right and place it to the desired location on the list. "
+"When you are done, click the \"Save order\" -button."
+msgstr ""
+"Drag och släpp resurslådan med musen till önskad plats på listan. Avsluta "
+"genom att klicka på ”Spara ordningen”."
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:81
+msgid "Save order"
+msgstr ""
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:84
+#: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
+#: ckanext/ytp/resources/opendata/scripts/translations.js:9
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: ckanext/ytp/public/base/javascript/modules/resource-reorder.js:94
+msgid "Saving..."
+msgstr ""
+
 #: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:69
 msgid "Please Confirm Action"
 msgstr "Bekräfta åtgärd"
@@ -1643,13 +1695,8 @@ msgstr "Vill du verkligen utföra denna åtgärd?"
 msgid "Confirm"
 msgstr "Bekräfta"
 
-#: ckanext/ytp/resources/opendata/scripts/bulk-confirm-action.js:76
-#: ckanext/ytp/resources/opendata/scripts/translations.js:9
-msgid "Cancel"
-msgstr "Avbryt"
-
 #: ckanext/ytp/resources/opendata/scripts/form.js:144
-#: ckanext/ytp/templates/snippets/search_form.html:23
+#: ckanext/ytp/templates/snippets/search_form.html:29
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:90
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:78
 msgid "Remove"
@@ -1662,7 +1709,7 @@ msgstr "Ta bort"
 #: ckanext/ytp/templates/organization/user_list.html:50
 #: ckanext/ytp/templates/package/resource_edit.html:11
 #: ckanext/ytp/templates/package/snippets/related_item.html:62
-#: ckanext/ytp/templates/package/snippets/resource_item.html:67
+#: ckanext/ytp/templates/package/snippets/resource_item.html:73
 msgid "Edit"
 msgstr "Redigera"
 
@@ -1700,19 +1747,6 @@ msgstr "Lägg till länk"
 msgid "Add email"
 msgstr "Lägg till e-post"
 
-#: ckanext/ytp/resources/opendata/scripts/translations.js:16
-msgid "Reorder resources"
-msgstr "Ordna dataresurserna"
-
-#: ckanext/ytp/resources/opendata/scripts/translations.js:17
-msgid ""
-"You can rearrange the resources by dragging them using the arrow icon. Drag "
-"the resource to the right and place it to the desired location on the list. "
-"When you are done, click the \"Save order\" -button."
-msgstr ""
-"Drag och släpp resurslådan med musen till önskad plats på listan. Avsluta "
-"genom att klicka på ”Spara ordningen”."
-
 #: ckanext/ytp/resources/vendor/bootstrap-table/dist/extensions/filter-control/utils.js:10
 msgid "Can't call method on "
 msgstr ""
@@ -1722,7 +1756,7 @@ msgid "Give feedback"
 msgstr ""
 
 #: ckanext/ytp/templates/page.html:13
-#: ckanext/ytp/templates/snippets/search_form.html:104
+#: ckanext/ytp/templates/snippets/search_form.html:110
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:72
 msgid "Hide search filters"
 msgstr "Dölj filtren"
@@ -1742,6 +1776,7 @@ msgstr ""
 #: ckanext/ytp/templates/package/search.html:14
 #: ckanext/ytp/templates/package/search.html:20
 #: ckanext/ytp/templates/snippets/organization.html:52
+#: ckanext/ytp/templates/source/read_base.html:27
 #: ckanext/ytp/templates/user/dashboard_datasets.html:6
 #: ckanext/ytp/templates/user/read.html:5
 msgid "Datasets"
@@ -1752,6 +1787,7 @@ msgstr "Datamängder"
 #: ckanext/ytp/templates/package/base.html:17
 #: ckanext/ytp/templates/package/search.html:14
 #: ckanext/ytp/templates/package/search.html:20
+#: ckanext/ytp/templates/source/read_base.html:33
 msgid "Apisets"
 msgstr ""
 
@@ -1771,8 +1807,10 @@ msgstr ""
 
 #: ckanext/ytp/templates/apiset/resource_read.html:126
 #: ckanext/ytp/templates/organization/read_base.html:37
+#: ckanext/ytp/templates/package/read_base.html:15
 #: ckanext/ytp/templates/package/resource_read.html:66
-#: ckanext/ytp/templates/package/snippets/resource_item2.html:9
+#: ckanext/ytp/templates/package/snippets/resource_item2.html:10
+#: ckanext/ytp/templates/package/snippets/resource_item2.html:12
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:9
 msgid "Manage"
 msgstr "Redigera"
@@ -1790,15 +1828,15 @@ msgstr "API-slutpunkt"
 #: ckanext/ytp/templates/apiset/resource_read.html:136
 #: ckanext/ytp/templates/package/resource_read.html:76
 #: ckanext/ytp/templates/package/snippets/related_item.html:65
-#: ckanext/ytp/templates/package/snippets/resource_item2.html:13
+#: ckanext/ytp/templates/package/snippets/resource_item2.html:17
 #: ckanext/ytp/templates/package/snippets/resource_item3.html:11
 msgid "Open"
 msgstr "Öppna"
 
 #: ckanext/ytp/templates/apiset/resource_read.html:138
 #: ckanext/ytp/templates/package/resource_read.html:78
-#: ckanext/ytp/templates/package/snippets/resource_item.html:51
-#: ckanext/ytp/templates/package/snippets/resource_item2.html:15
+#: ckanext/ytp/templates/package/snippets/resource_item.html:57
+#: ckanext/ytp/templates/package/snippets/resource_item2.html:19
 msgid "Download"
 msgstr "Ladda ned"
 
@@ -1842,7 +1880,7 @@ msgid "Are you sure you want to delete this member?"
 msgstr "Vill du verkligen radera denna medlem?"
 
 #: ckanext/ytp/templates/group/member_new.html:46
-#: ckanext/ytp/templates/package/group_list.html:36
+#: ckanext/ytp/templates/package/group_list.html:54
 #: ckanext/ytp/templates/scheming/organization/group_form.html:57
 msgid "Save"
 msgstr "Spara"
@@ -1863,7 +1901,7 @@ msgstr "Relevans"
 #: ckanext/ytp/templates/organization/index.html:4
 #: ckanext/ytp/templates/organization/read.html:16
 #: ckanext/ytp/templates/package/search.html:57
-#: ckanext/ytp/templates/snippets/search_form.html:59
+#: ckanext/ytp/templates/snippets/search_form.html:65
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:34
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Ascending"
@@ -1873,7 +1911,7 @@ msgstr "Stigande efter namn"
 #: ckanext/ytp/templates/organization/index.html:4
 #: ckanext/ytp/templates/organization/read.html:17
 #: ckanext/ytp/templates/package/search.html:58
-#: ckanext/ytp/templates/snippets/search_form.html:59
+#: ckanext/ytp/templates/snippets/search_form.html:65
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:34
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:30
 msgid "Name Descending"
@@ -1882,7 +1920,7 @@ msgstr "Namn i fallande ordning"
 #: ckanext/ytp/templates/group/read.html:16
 #: ckanext/ytp/templates/organization/read.html:18
 #: ckanext/ytp/templates/package/search.html:59
-#: ckanext/ytp/templates/package/snippets/resource_form.html:45
+#: ckanext/ytp/templates/package/snippets/resource_form.html:49
 msgid "Last Modified"
 msgstr "Senast redigerat"
 
@@ -1896,7 +1934,7 @@ msgstr "Populär"
 
 #: ckanext/ytp/templates/group/read.html:19
 #: ckanext/ytp/templates/organization/read.html:23
-#: ckanext/ytp/templates/snippets/search_form.html:3
+#: ckanext/ytp/templates/snippets/search_form.html:7
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:3
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:3
 msgid "Search datasets..."
@@ -2011,18 +2049,18 @@ msgid "Search organizations..."
 msgstr "Sök producenter ..."
 
 #: ckanext/ytp/templates/organization/index.html:27
-#: ckanext/ytp/templates/snippets/search_form.html:42
+#: ckanext/ytp/templates/snippets/search_form.html:48
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:17
 msgid "Submit"
 msgstr "Skicka in"
 
 #: ckanext/ytp/templates/organization/index.html:34
-#: ckanext/ytp/templates/snippets/search_form.html:82
+#: ckanext/ytp/templates/snippets/search_form.html:88
 msgid "Sorting"
 msgstr ""
 
 #: ckanext/ytp/templates/organization/index.html:43
-#: ckanext/ytp/templates/snippets/search_form.html:91
+#: ckanext/ytp/templates/snippets/search_form.html:97
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:59
 #: ckanext/ytp/templates/snippets/search_form_without_input.html:44
 msgid "Go"
@@ -2057,7 +2095,10 @@ msgstr "Uppdatera medlem"
 #: ckanext/ytp/templates/organization/member_new.html:67
 #: ckanext/ytp/templates/organization/members.html:56
 #: ckanext/ytp/templates/organization/read_base.html:24
-#: ckanext/ytp/templates/package/group_list.html:6
+#: ckanext/ytp/templates/package/activity.html:3
+#: ckanext/ytp/templates/package/activity.html:8
+#: ckanext/ytp/templates/package/group_list.html:10
+#: ckanext/ytp/templates/package/read_base.html:27
 msgid "Activity Stream"
 msgstr "Aktivitetsflöde"
 
@@ -2148,22 +2189,42 @@ msgstr ""
 msgid "Close without saving"
 msgstr "Stäng utan att spara"
 
-#: ckanext/ytp/templates/package/group_list.html:4
+#: ckanext/ytp/templates/package/group_list.html:5
+#: ckanext/ytp/templates/package/read_base.html:22
+msgid "Apiset"
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:7
+#: ckanext/ytp/templates/package/read_base.html:24
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:5
 msgid "Dataset"
 msgstr "Datamängd"
 
-#: ckanext/ytp/templates/package/group_list.html:21
+#: ckanext/ytp/templates/package/group_list.html:20
+msgid "There are no groups associated with this apiset"
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:29
 msgid "Dataset categories"
 msgstr ""
 
-#: ckanext/ytp/templates/package/group_list.html:33
+#: ckanext/ytp/templates/package/group_list.html:42
+msgid ""
+"Categories to which the apiset is mainly related to. Choose one category or "
+"multiple accurate categories."
+msgstr ""
+
+#: ckanext/ytp/templates/package/group_list.html:44
 msgid ""
 "Categories to which the dataset is mainly related to. Choose one category or"
 " multiple accurate categories."
 msgstr ""
 "Välj minst en kategori som datamängden passar i. Du kan också välja flera "
 "kategorier."
+
+#: ckanext/ytp/templates/package/group_list.html:50
+msgid "Associate this group with this apiset"
+msgstr ""
 
 #: ckanext/ytp/templates/package/new.html:9
 msgid "Create new dataset"
@@ -2193,7 +2254,7 @@ msgstr "Vill du verkligen radera datamängden?"
 
 #: ckanext/ytp/templates/package/new_package_form.html:31
 #: ckanext/ytp/templates/package/snippets/package_form.html:27
-#: ckanext/ytp/templates/package/snippets/resource_form.html:62
+#: ckanext/ytp/templates/package/snippets/resource_form.html:66
 #: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:277
 msgid "Abort"
 msgstr "Avbryt"
@@ -2241,7 +2302,7 @@ msgid "%(dataset)s"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:142
-#: ckanext/ytp/templates/package/snippets/resource_item.html:40
+#: ckanext/ytp/templates/package/snippets/resource_item.html:46
 #: ckanext/ytp/templates/snippets/datapreview_embed_dialog.html:18
 msgid "Preview"
 msgstr "Förhandsgranskning"
@@ -2283,7 +2344,7 @@ msgid "Extra information"
 msgstr "Ytterligare information"
 
 #: ckanext/ytp/templates/package/resource_read.html:195
-#: ckanext/ytp/templates/package/snippets/resource_form.html:31
+#: ckanext/ytp/templates/package/snippets/resource_form.html:35
 msgid "Format"
 msgstr "Format"
 
@@ -2291,6 +2352,10 @@ msgstr "Format"
 #: ckanext/ytp/templates/package/resource_read.html:234
 #: ckanext/ytp/templates/package/resource_read.html:238
 #: ckanext/ytp/templates/package/resource_read.html:242
+#: ckanext/ytp/templates/snippets/activity_stream.html:10
+#: ckanext/ytp/templates/snippets/activity_stream.html:17
+#: ckanext/ytp/templates/snippets/activity_stream.html:25
+#: ckanext/ytp/templates/snippets/activity_stream.html:39
 msgid "unknown"
 msgstr "okänd"
 
@@ -2307,27 +2372,27 @@ msgid "sha256"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:271
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:111
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:125
 msgid "Stats"
 msgstr "Rapporter"
 
 #: ckanext/ytp/templates/package/resource_read.html:272
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:112
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Last 30 days, updated daily"
-msgstr "Senaste 30 dagarna, uppdateras dagligen"
+msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:275
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:119
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:133
 msgid "All time downloads:"
-msgstr "Nedladdningar totalt:"
+msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:285
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 msgid "Year"
 msgstr "År"
 
 #: ckanext/ytp/templates/package/resource_read.html:285
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:11
 msgid "Downloads"
 msgstr "Nedladdningar"
@@ -2427,32 +2492,40 @@ msgstr "Visa flera"
 msgid "Edit categories"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:26
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:27
+msgid "License offered by the api"
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:29
 #: ckanext/ytp/templates/snippets/license.html:21
 msgid "License"
 msgstr "Licens"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:61
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:67
 msgid "License Not Specified"
 msgstr "Ingen licens angiven"
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:70
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:76
 msgid "Openness score"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:91
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:98
+msgid "Recommend apiset"
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:104
 msgid "Recommend dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:117
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:131
 msgid "Downloads during last 12 months"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:118
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:132
 msgid "All time visits:"
-msgstr "Sidvisningar totalt:"
+msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/dataset_info.html:127
+#: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:10
 msgid "Visits"
 msgstr "Sidvisningar"
@@ -2465,7 +2538,7 @@ msgstr "Applikationer"
 msgid "Social"
 msgstr "Dela i sociala medier"
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:17
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:18
 #, python-format
 msgid ""
 "To the extent possible under law <a rel=\"dct:publisher\" "
@@ -2475,7 +2548,20 @@ msgid ""
 "property=\"dct:title\">%(content_title)s</span></a>."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:31
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:34
+#, python-format
+msgid ""
+"<span xmlns:dct=\"https://purl.org/dc/terms/\" "
+"href=\"https://purl.org/dc/dcmitype/Dataset\" property=\"dct:title\" "
+"rel=\"dct:type\"> <a xmlns:cc=\"https://creativecommons.org/ns#\" "
+"href=\"%(attribution_url)s\" property=\"cc:attributionName\" "
+"rel=\"cc:attributionURL\">%(content_title)s</a></span> by <a  "
+"href=\"%(creator_url)s\" >%(creator)s</a> apiset is licensed under a <a "
+"rel=\"license\" href=\"https://creativecommons.org/licenses/by/4.0/\"> "
+"Creative Commons Attribution 4.0 International License</a>."
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:45
 #, python-format
 msgid ""
 "<span xmlns:dct=\"https://purl.org/dc/terms/\" "
@@ -2488,7 +2574,7 @@ msgid ""
 "Creative Commons Attribution 4.0 International License</a>."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/license_rdf.html:43
+#: ckanext/ytp/templates/package/snippets/license_rdf.html:60
 msgid "https://creativecommons.org/licenses/by/4.0/"
 msgstr ""
 
@@ -2558,98 +2644,98 @@ msgid ""
 "logging in."
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:18
+#: ckanext/ytp/templates/package/snippets/resource_form.html:22
 msgid "Data"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:18
+#: ckanext/ytp/templates/package/snippets/resource_form.html:22
 msgid "http://example.com/external-data.csv"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:22
+#: ckanext/ytp/templates/package/snippets/resource_form.html:26
 msgid "Name"
 msgstr "Namn"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:22
+#: ckanext/ytp/templates/package/snippets/resource_form.html:26
 msgid "eg. January 2011 Gold Prices"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:26
+#: ckanext/ytp/templates/package/snippets/resource_form.html:30
 #: ckanext/ytp/templates/scheming/organization/about.html:16
 msgid "Description"
 msgstr "Beskrivning"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:26
+#: ckanext/ytp/templates/package/snippets/resource_form.html:30
 msgid "Some useful notes about the data"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:31
+#: ckanext/ytp/templates/package/snippets/resource_form.html:35
 msgid "eg. CSV, XML or JSON"
 msgstr "t.ex. CSV, XML eller JSON"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:34
+#: ckanext/ytp/templates/package/snippets/resource_form.html:38
 msgid "This will be guessed automatically. Leave blank if you wish"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:45
+#: ckanext/ytp/templates/package/snippets/resource_form.html:49
 msgid "eg. 2012-06-05"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:47
+#: ckanext/ytp/templates/package/snippets/resource_form.html:51
 msgid "File Size"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:47
+#: ckanext/ytp/templates/package/snippets/resource_form.html:51
 msgid "eg. 1024"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:49
-#: ckanext/ytp/templates/package/snippets/resource_form.html:51
+#: ckanext/ytp/templates/package/snippets/resource_form.html:53
+#: ckanext/ytp/templates/package/snippets/resource_form.html:55
 msgid "MIME Type"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:49
-#: ckanext/ytp/templates/package/snippets/resource_form.html:51
+#: ckanext/ytp/templates/package/snippets/resource_form.html:53
+#: ckanext/ytp/templates/package/snippets/resource_form.html:55
 msgid "eg. application/json"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:59
+#: ckanext/ytp/templates/package/snippets/resource_form.html:63
 msgid "Are you sure you want to delete this resource?"
 msgstr "Vill du verkligen radera denna datamängd?"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:66
+#: ckanext/ytp/templates/package/snippets/resource_form.html:70
 msgid "Previous"
 msgstr "Föregående"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:69
+#: ckanext/ytp/templates/package/snippets/resource_form.html:73
 msgid "Save & add another"
 msgstr "Spara och lägg till fler"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:75
+#: ckanext/ytp/templates/package/snippets/resource_form.html:79
 msgid "Save api"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:77
+#: ckanext/ytp/templates/package/snippets/resource_form.html:81
 msgid "Save dataset"
 msgstr "Spara datamängden"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:84
+#: ckanext/ytp/templates/package/snippets/resource_form.html:88
 msgid "Add"
 msgstr "Lägg till"
 
-#: ckanext/ytp/templates/package/snippets/resource_item.html:31
+#: ckanext/ytp/templates/package/snippets/resource_item.html:37
 msgid "Explore"
 msgstr "Utforska"
 
-#: ckanext/ytp/templates/package/snippets/resource_item.html:43
+#: ckanext/ytp/templates/package/snippets/resource_item.html:49
 msgid "More information"
 msgstr "Mer information"
 
-#: ckanext/ytp/templates/package/snippets/resource_item.html:54
+#: ckanext/ytp/templates/package/snippets/resource_item.html:60
 msgid "Go to resource"
 msgstr "Visa dataresursen"
 
-#: ckanext/ytp/templates/package/snippets/resource_item.html:60
+#: ckanext/ytp/templates/package/snippets/resource_item.html:66
 msgid "Download as CSV"
 msgstr "Ladda ned som CSV"
 
@@ -3174,25 +3260,29 @@ msgstr "Organisationen saknar beskrivning."
 msgid "Last Harvested"
 msgstr "Senast skördat"
 
-#: ckanext/ytp/templates/snippets/search_form.html:12
+#: ckanext/ytp/templates/snippets/search_form.html:5
+msgid "Search apis..."
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/search_form.html:18
 msgid "Filters"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:65
+#: ckanext/ytp/templates/snippets/search_form.html:71
 msgid " Use advanced search "
 msgstr "Avancerad sökning"
 
-#: ckanext/ytp/templates/snippets/search_form.html:98
+#: ckanext/ytp/templates/snippets/search_form.html:104
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:66
 msgid "Filter search"
 msgstr "Filtrera sökning"
 
-#: ckanext/ytp/templates/snippets/search_form.html:112
+#: ckanext/ytp/templates/snippets/search_form.html:118
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:102
 msgid "Please try another search or change search facets."
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/search_form.html:120
+#: ckanext/ytp/templates/snippets/search_form.html:126
 #: ckanext/ytp/templates/snippets/search_form_with_table_header.html:110
 msgid "<strong>There was an error while searching.</strong> Please try again."
 msgstr ""
@@ -3291,6 +3381,39 @@ msgid "{number} organization found"
 msgid_plural "{number} organizations found"
 msgstr[0] "{number} producent hittades"
 msgstr[1] "{number} producenter hittades"
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:8
+msgid "{actor} updated the api {dataset}"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:10
+msgid "{actor} updated the dataset {dataset}"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:18
+#: ckanext/ytp/templates/snippets/activities/new_package.html:16
+msgid "View this version"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/changed_package.html:22
+msgid "Changes"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/new_package.html:6
+msgid "{actor} created the api {dataset}"
+msgstr ""
+
+#: ckanext/ytp/templates/snippets/activities/new_package.html:8
+msgid "{actor} created the dataset {dataset}"
+msgstr ""
+
+#: ckanext/ytp/templates/source/read_base.html:19
+msgid "read more"
+msgstr ""
+
+#: ckanext/ytp/templates/source/read_base.html:22
+msgid "There is no description for this harvest source"
+msgstr ""
 
 #: ckanext/ytp/templates/spatial/snippets/dataset_map_sidebar.html:17
 msgid "Dataset extent"

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/public/base/javascript/modules/resource-reorder.js
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/public/base/javascript/modules/resource-reorder.js
@@ -1,0 +1,169 @@
+/* Module for reordering resources
+ */
+
+this.ckan.module('resource-reorder', function($) {
+    return {
+      options: {
+        id: false
+      },
+      template: {
+        title: '<h1></h1>',
+        help_text: '<p></p>',
+        button: [
+          '<a href="javascript:;" class="btn btn-default">',
+          '<i class="fa fa-bars"></i>',
+          '<span></span>',
+          '</a>'
+        ].join('\n'),
+        form_actions: [
+          '<div class="form-actions">',
+          '<a href="javascript:;" class="cancel btn btn-danger pull-left"></a>',
+          '<a href="javascript:;" class="save btn btn-primary"></a>',
+          '</div>'
+        ].join('\n'),
+        handle: [
+          '<a href="javascript:;" class="handle">',
+          '<i class="fa fa-arrows"></i>',
+          '</a>'
+        ].join('\n'),
+        saving: [
+          '<span class="saving text-muted m-right">',
+          '<i class="fa fa-spinner fa-spin"></i>',
+          '<span></span>',
+          '</span>'
+        ].join('\n')
+      },
+      is_reordering: false,
+      cache: false,
+  
+      initialize: function() {
+        jQuery.proxyAll(this, /_on/);
+  
+        var module = this;
+        // Determine texts based on the resource type
+        module.sandbox.client.call('POST', 'package_show', {
+            id: module.options.id,
+          }, function(response) {
+            // Get the set type from the response
+            let result = response['result'] ?? {};
+            let set_type = result['type'] ?? "dataset";
+
+            if (set_type == 'apiset'){
+                var labelText = module._('Reorder apiset');
+                var helpText = module._('You can rearrange the apiset resources by dragging them using the arrow icon. Drag the resource ' +
+                'to the right and place it to the desired location on the list. When you are done, click the "Save order" -button.');
+            }
+            else{
+                var labelText = module._('Reorder resources');
+                var helpText = module._('You can rearrange the resources by dragging them using the arrow icon. Drag the resource ' +
+                'to the right and place it to the desired location on the list. When you are done, click the "Save order" -button.');
+            }
+
+            module.html_title = $(module.template.title)
+            .text(labelText)
+            .insertBefore(module.el)
+            .hide();
+    
+            module.html_help_text = $(module.template.help_text)
+            .text(helpText)
+            .insertBefore(module.el)
+            .hide();
+    
+            var button = $(module.template.button)
+            .on('click', module._onHandleStartReorder)
+            .appendTo('.page_primary_action');
+            $('span', button).text(labelText);
+    
+            module.html_form_actions = $(module.template.form_actions)
+            .hide()
+            .insertAfter(module.el);
+            $('.save', module.html_form_actions)
+            .text(module._('Save order'))
+            .on('click', module._onHandleSave);
+            $('.cancel', module.html_form_actions)
+            .text(module._('Cancel'))
+            .on('click', module._onHandleCancel);
+    
+            module.html_handles = $(module.template.handle)
+            .hide()
+            .appendTo($('.resource-item', module.el));
+    
+            module.html_saving = $(module.template.saving)
+            .hide()
+            .insertBefore($('.save', module.html_form_actions));
+            $('span', module.html_saving).text(module._('Saving...'));
+    
+            module.cache = module.el.html();
+    
+            module.el
+            .sortable()
+            .sortable('disable');
+          });
+
+      },
+  
+      _onHandleStartReorder: function() {
+        if (!this.is_reordering) {
+          this.html_form_actions
+            .add(this.html_handles)
+            .add(this.html_title)
+            .add(this.html_help_text)
+            .show();
+          this.el
+            .addClass('reordering')
+            .sortable('enable');
+          $('.page_primary_action').hide();
+          this.is_reordering = true;
+        }
+      },
+  
+      _onHandleCancel: function() {
+        if (
+          this.is_reordering
+          && !$('.cancel', this.html_form_actions).hasClass('disabled')
+        ) {
+          this.reset();
+          this.is_reordering = false;
+          this.el.html(this.cache)
+            .sortable()
+            .sortable('disable');
+          this.html_handles = $('.handle', this.el);
+        }
+      },
+  
+      _onHandleSave: function() {
+        if (!$('.save', this.html_form_actions).hasClass('disabled')) {
+          var module = this;
+          module.html_saving.show();
+          $('.save, .cancel', module.html_form_actions).addClass('disabled');
+          var order = [];
+          $('.resource-item', module.el).each(function() {
+            order.push($(this).data('id'));
+          });
+          module.sandbox.client.call('POST', 'package_resource_reorder', {
+            id: module.options.id,
+            order: order
+          }, function() {
+            module.html_saving.hide();
+            $('.save, .cancel', module.html_form_actions).removeClass('disabled');
+            module.cache = module.el.html();
+            module.reset();
+            module.is_reordering = false;
+          });
+        }
+      },
+  
+      reset: function() {
+        this.html_form_actions
+          .add(this.html_handles)
+          .add(this.html_title)
+          .add(this.html_help_text)
+          .hide();
+        this.el
+          .removeClass('reordering')
+          .sortable('disable');
+        $('.page_primary_action').show();
+      }
+  
+    };
+  });

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resources/opendata/scripts/translations.js
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resources/opendata/scripts/translations.js
@@ -17,3 +17,6 @@ _('Reorder resources');
 _('You can rearrange the resources by dragging them using the arrow icon. Drag the resource ' +
   'to the right and place it to the desired location on the list. ' +
   'When you are done, click the "Save order" -button.');
+_('Reorder apiset');
+_('You can rearrange the apiset resources by dragging them using the arrow icon. Drag the resource ' +
+  'to the right and place it to the desired location on the list. When you are done, click the "Save order" -button.');

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/activity.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/activity.html
@@ -1,0 +1,12 @@
+{% extends "package/read_base.html" %}
+
+{% block subtitle %}{{ _('Activity Stream') }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block primary_content_inner %}
+  <h1 class="hide-heading">
+    {% block page_heading %}
+      {{ _('Activity Stream') }}
+    {% endblock %}
+  </h1>
+  {% snippet 'snippets/activity_stream.html', activity_stream=activity_stream, id=id, object_type='package', package_type=dataset_type %}
+{% endblock %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/read_base.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/read_base.html
@@ -1,0 +1,53 @@
+{% extends "package/base.html" %}
+
+{% block subtitle %}{{ h.dataset_display_name(pkg) }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
+
+{% block head_extras -%}
+  {{ super() }}
+  {% set description = h.markdown_extract(pkg.notes, extract_length=200)|forceescape %}
+  <meta property="og:title" content="{{ h.dataset_display_name(pkg) }} - {{ g.site_title }}">
+  <meta property="og:description" content="{{ description|forceescape|trim }}">
+{% endblock -%}
+
+{% block content_action %}
+  {% if not is_activity_archive %}
+    {% if h.check_access('package_update', {'id':pkg.id }) %}
+      {% link_for _('Manage'), named_route=pkg.type ~ '.edit', id=pkg.name, class_='btn btn-default', icon='wrench' %}
+    {% endif %}
+  {% endif %}
+{% endblock %}
+
+{% block content_primary_nav %}
+    {% if pkg.get('type') == 'apiset' %}
+        {{ h.build_nav_icon(dataset_type ~ '.read', _('Apiset'), id=pkg.id if is_activity_archive else pkg.name, icon='sitemap') }}
+    {% else %}
+        {{ h.build_nav_icon(dataset_type ~ '.read', _('Dataset'), id=pkg.id if is_activity_archive else pkg.name, icon='sitemap') }}
+    {% endif%}
+  {{ h.build_nav_icon(dataset_type ~ '.groups', _('Groups'), id=pkg.id if is_activity_archive else pkg.name, icon='users') }}
+  {{ h.build_nav_icon(dataset_type ~ '.activity', _('Activity Stream'), id=pkg.id if is_activity_archive else pkg.name, icon='clock-o') }}
+{% endblock %}
+
+{% block secondary_content %}
+
+  {% block secondary_help_content %}{% endblock %}
+
+  {% block package_info %}
+    {% snippet 'package/snippets/info.html', pkg=pkg %}
+  {% endblock %}
+
+  {% block package_organization %}
+    {% if pkg.organization %}
+      {% set org = h.get_organization(pkg.organization.id) %}
+      {% snippet "snippets/organization.html", organization=org, has_context_title=true %}
+    {% endif %}
+  {% endblock %}
+
+  {% block package_social %}
+    {% snippet "snippets/social.html" %}
+  {% endblock %}
+
+  {% block package_license %}
+    {% snippet "snippets/license.html", pkg_dict=pkg %}
+  {% endblock %}
+
+{% endblock %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/dataset_info.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/dataset_info.html
@@ -23,7 +23,11 @@
     {% endblock %}
 
     {% block license_info %}
-        {{ layout.moduleBoxHead(_('License')) }}
+        {% if pkg.get('type') == 'apiset' %}
+            {{ layout.moduleBoxHead(_('License offered by the api')) }}
+        {% else %}
+            {{ layout.moduleBoxHead(_('License')) }}
+        {% endif %}
             {% if  pkg.license_id == 'cc-zero-1.0' or pkg.license_id == 'cc-by-4.0' or pkg.license_id == 'cc-by-4-fi' %}
                 {% set creator_user=h.get_user(pkg.get('creator_user_id')) %}
                 {% if pkg.organization and pkg.organization.get('name') == "yksityishenkilo"  and creator_user.display_name %}
@@ -32,14 +36,16 @@
                     content_title=pkg.title,
                     creator=creator_user.display_name,
                     creator_url=creator_user.url,
-                    attribution_url='/data/' + h.lang() + '/dataset/'+pkg.get('name') %}
+                    attribution_url='/data/' + h.lang() + '/' + pkg.get('type') + '/' + pkg.get('name') ,
+                    resource_type = pkg.get('type') %}
                 {% elif pkg.organization %}
                     {% snippet 'package/snippets/license_rdf.html',
                     license_id=pkg.license_id,
                     content_title=pkg.title,
                     creator=h.extra_translation(pkg.organization, 'title'),
                     creator_url='/data/' +  h.lang() + '/organization/' + pkg.organization.get('name'),
-                    attribution_url='/data/' +  h.lang() + '/dataset/' + pkg.get('name') %}
+                    attribution_url='/data/' +  h.lang() + '/' + pkg.get('type') + '/' + pkg.get('name'),
+                    resource_type = pkg.get('type') %}
                 {% endif %}
             {% else %}
                 {% if 'license_url' in pkg %}
@@ -88,11 +94,19 @@
     #}
 
     {% block recommendations %}
-        {{ layout.moduleBoxHead(_('Recommend dataset')) }}
-            <div class="recommendations-dataset">
-                {% snippet 'recommendations/snippets/recommendations.html', package=pkg %}
-            </div>
-        {{ layout.moduleBoxFoot() }}
+        {% if pkg.get('type') == 'apiset' %}
+            {{ layout.moduleBoxHead(_('Recommend apiset')) }}
+                <div class="recommendations-dataset">
+                    {% snippet 'recommendations/snippets/recommendations.html', package=pkg %}
+                </div>
+            {{ layout.moduleBoxFoot() }}
+        {% else %}
+            {{ layout.moduleBoxHead(_('Recommend dataset')) }}
+                <div class="recommendations-dataset">
+                    {% snippet 'recommendations/snippets/recommendations.html', package=pkg %}
+                </div>
+            {{ layout.moduleBoxFoot() }}
+        {% endif %}
     {% endblock %}
 
     {% block follow %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/license_rdf.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/license_rdf.html
@@ -4,7 +4,8 @@
                   content_title=pkg.title,
                   creator=creator_user.display_name,
                   creator_url=creator_user.url,
-                  attribution_url=h.url_for('', qualified=True) %}
+                  attribution_url=h.url_for('', qualified=True),
+                  resource_type='dataset'%}
 #}
 
 {% if license_id=='cc-zero-1.0' %}
@@ -27,21 +28,37 @@ To the extent possible under law
 
 {% if license_id=='cc-by-4.0' or license_id=='cc-by-4-fi' %}
 
-<div class="small license-smallprint">
-{% trans %}
-<span xmlns:dct="https://purl.org/dc/terms/"
-  href="https://purl.org/dc/dcmitype/Dataset"
-  property="dct:title" rel="dct:type">
-  <a xmlns:cc="https://creativecommons.org/ns#" href="{{attribution_url}}" property="cc:attributionName"
-  rel="cc:attributionURL">{{content_title}}</a></span>
-  by <a  href="{{creator_url}}" >{{creator}}</a>
-  is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">
-    Creative Commons Attribution 4.0 International License</a>.
-{% endtrans %}
-</div>
-<div class="license-icon">
-<a rel="license" href="{{ _('https://creativecommons.org/licenses/by/4.0/') }}">
-    <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by/4.0/88x31.png" />
-</a>
-</div>
+  <div class="small license-smallprint">
+
+  {% if resource_type == 'apiset' %}
+    {% trans %}
+    <span xmlns:dct="https://purl.org/dc/terms/"
+      href="https://purl.org/dc/dcmitype/Dataset"
+      property="dct:title" rel="dct:type">
+      <a xmlns:cc="https://creativecommons.org/ns#" href="{{attribution_url}}" property="cc:attributionName"
+      rel="cc:attributionURL">{{content_title}}</a></span>
+      by <a  href="{{creator_url}}" >{{creator}}</a>
+      apiset is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">
+        Creative Commons Attribution 4.0 International License</a>.
+    {% endtrans %}
+  {% else %}
+    {% trans %}
+    <span xmlns:dct="https://purl.org/dc/terms/"
+      href="https://purl.org/dc/dcmitype/Dataset"
+      property="dct:title" rel="dct:type">
+      <a xmlns:cc="https://creativecommons.org/ns#" href="{{attribution_url}}" property="cc:attributionName"
+      rel="cc:attributionURL">{{content_title}}</a></span>
+      by <a  href="{{creator_url}}" >{{creator}}</a>
+      is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">
+        Creative Commons Attribution 4.0 International License</a>.
+    {% endtrans %}
+  {% endif %}
+
+  </div>
+
+  <div class="license-icon">
+  <a rel="license" href="{{ _('https://creativecommons.org/licenses/by/4.0/') }}">
+      <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by/4.0/88x31.png" />
+  </a>
+  </div>
 {% endif %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/package/snippets/additional_info.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/package/snippets/additional_info.html
@@ -60,7 +60,7 @@
     <th scope="row" class="dataset-label">{{ _("Last modified") }}</th>
     <td class="dataset-details">
       {{ h.render_datetime(pkg_dict.get('metadata_modified'), "%d.%m.%Y") }}<br />
-      <a href="/data/{{ h.lang() }}/dataset/activity/{{pkg_dict.get('name')}}">{{_('Show change log')}}</a>
+      <a href="/data/{{ h.lang() }}/{{pkg_dict.get('type')}}/activity/{{pkg_dict.get('name')}}">{{_('Show change log')}}</a>
     </td>
   </tr>
   <tr>

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/activities/changed_package.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/activities/changed_package.html
@@ -1,0 +1,27 @@
+{% set dataset_type = package_type or 'dataset' %}
+
+<li class="item {{ activity.activity_type|replace(' ', '-')|lower }}">
+  <i class="fa icon fa-sitemap"></i>
+
+  <p>
+    {% if package_type == 'apiset' %}
+      {{ _('{actor} updated the api {dataset}').format(actor=ah.actor(activity), dataset=ah.apiset(activity))|safe }}
+    {% else %}
+      {{ _('{actor} updated the dataset {dataset}').format(actor=ah.actor(activity), dataset=ah.dataset(activity))|safe }}
+    {% endif %}
+    <br />
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+      {% if can_show_activity_detail %}
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for(dataset_type ~ '.read', id=activity.object_id, activity_id=activity.id) }}">
+          {{ _('View this version') }}
+        </a>
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for(dataset_type ~ '.changes', id=activity.id) }}">
+          {{ _('Changes') }}
+        </a>
+      {% endif %}
+    </span>
+  </p>
+</li>

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/activities/new_package.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/activities/new_package.html
@@ -1,9 +1,10 @@
-{% set dataset_type = activity.data.package.type or 'dataset' %}
+{% set dataset_type = package_type or 'dataset' %}
+
 <li class="item {{ activity.activity_type|replace(' ', '-')|lower }}">
   <i class="fa icon fa-sitemap"></i>
   <p>
     {% if package_type == 'apiset' %}
-        {{ _('{actor} created the api {dataset}').format(actor=ah.actor(activity),dataset=ah.dataset(activity))|safe }}
+        {{ _('{actor} created the api {dataset}').format(actor=ah.actor(activity),dataset=ah.apiset(activity))|safe }}
     {% else %}
     {{ _('{actor} created the dataset {dataset}').format(actor=ah.actor(activity),dataset=ah.dataset(activity))|safe }}
     {% endif %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/activities/new_package.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/activities/new_package.html
@@ -1,0 +1,21 @@
+{% set dataset_type = activity.data.package.type or 'dataset' %}
+<li class="item {{ activity.activity_type|replace(' ', '-')|lower }}">
+  <i class="fa icon fa-sitemap"></i>
+  <p>
+    {% if package_type == 'apiset' %}
+        {{ _('{actor} created the api {dataset}').format(actor=ah.actor(activity),dataset=ah.dataset(activity))|safe }}
+    {% else %}
+    {{ _('{actor} created the dataset {dataset}').format(actor=ah.actor(activity),dataset=ah.dataset(activity))|safe }}
+    {% endif %}
+    <br />
+    <span class="date" title="{{ h.render_datetime(activity.timestamp, with_hours=True) }}">
+      {{ h.time_ago_from_timestamp(activity.timestamp) }}
+      {% if can_show_activity_detail %}
+        &nbsp;|&nbsp;
+        <a href="{{ h.url_for(dataset_type ~ '.read', id=activity.object_id, activity_id=activity.id) }}">
+          {{ _('View this version') }}
+        </a>
+      {% endif %}
+    </span>
+  </p>
+</li>

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/activity_stream.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/activity_stream.html
@@ -1,0 +1,74 @@
+{% macro actor(activity) %}
+  <span class="actor">
+    {{ h.linked_user(activity.user_id, 0, 30) }}
+  </span>
+{% endmacro %}
+
+{% macro dataset(activity) %}
+  {% set dataset_type = activity.data.package.type or 'dataset' %}
+  <span class="dataset">
+    {{ h.link_to(activity.data.package.title if activity.data.package else _('unknown'),
+      h.url_for(dataset_type ~ '.read', id=activity.object_id)) }}
+    {# object_id because the object_name may be out of date) #}
+  </span>
+{% endmacro %}
+
+{% macro organization(activity) %}
+  {{ h.link_to(activity.data.group.title if activity.data.group else _('unknown'),
+               h.url_for('organization.read', id=activity.object_id)) }}
+               {# object_id because the object_name may be out of date) #}
+{% endmacro %}
+
+{% macro apiset(activity) %}
+  {% set dataset_type = activity.data.package.type or 'apiset' %}
+  <span class="apiset">
+    {{ h.link_to(activity.data.package.title if activity.data.package else _('unknown'),
+      h.url_for(dataset_type ~ '.read', id=activity.object_id)) }}
+    {# object_id because the object_name may be out of date) #}
+  </span>
+{% endmacro %}
+
+{% macro user(activity) %}
+<span class="actor">
+  {{ h.linked_user(activity.object_id, 0, 20) }}
+</span>
+{% endmacro %}
+
+{% macro group(activity) %}
+<span class="group">
+  {{ h.link_to(activity.data.group.title if activity.data.group else _('unknown'),
+               h.url_for('group.read', id=activity.object_id)) }}
+               {# object_id because the object_name may be out of date) #}
+</span>
+{% endmacro %}
+
+{# Displays an activity stream
+
+activity_stream - the activity data. e.g. the output from package_activity_list
+id - the id or current name of the object (e.g. package name, user id)
+object_type - 'package', 'organization', 'group', 'user'
+
+#}
+{% block activity_stream %}
+  <ul class="activity">
+  {% set can_show_activity_detail = h.check_access('activity_list', {'id': id, 'include_data': True, 'object_type': object_type}) %}
+  {% for activity in activity_stream %}
+    {%- snippet "snippets/activities/{}.html".format(
+      activity.activity_type.replace(' ', '_')
+      ), "snippets/activities/fallback.html",
+      activity=activity, can_show_activity_detail=can_show_activity_detail,
+      ah={
+        'actor': actor,
+        'dataset': dataset,
+        'organization': organization,
+        'user': user,
+        'group': group,
+        'apiset': apiset,
+      }, 
+      id=id, 
+      package_type=package_type
+    -%}
+  {% endfor %}
+  </ul>
+
+{% endblock %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -1,6 +1,12 @@
 {% import 'macros/form.html' as form %}
 
-{% set placeholder = placeholder if placeholder else _('Search datasets...') %}
+<!-- TODO -->
+{% if type == 'apiset' %}
+    {% set placeholder = placeholder if placeholder else _('Search apis...') %}
+{% else %}
+    {% set placeholder = placeholder if placeholder else _('Search datasets...') %}
+{% endif%}
+
 {% set search_class = search_class if search_class else 'search-giant' %}
 {% set no_bottom_border = no_bottom_border if no_bottom_border else false %}
 
@@ -29,7 +35,7 @@
         {% endif %}
     {% endblock %}
 
-    {% block search_input %}
+    {% block search_input %}        
         <div class="search-input control-group {{ search_class }} m-0">
             <input type="text" class="search search-dataset form-control" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
             {% for param in query_params %}


### PR DESCRIPTION
AV-1844:
Updated the following texts to use apiset related terminology:
- Apiset like button title
- Apiset license title and text
- Apiset changelog and changelog page tab + feed
- Apiset search default text
- Apiset edit resources resource ordering button text + info text

AV-1845:
- Changelog links now uses the correct /apiset url
- License linkin to apiset now uses the correct /apiset url

