### PR TITLE
AV-1840: fixed category translations for create apiset form

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/ytp_multiple_checkbox_without_link_to_dataset_groups.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/ytp_multiple_checkbox_without_link_to_dataset_groups.html
@@ -18,8 +18,7 @@ fieldset.checkboxes label input {
     description=field.description) -%}
     {%- set choices = [] -%}
     {%- for c in h.scheming_field_choices(field) -%}
-        {%- do choices.append(
-        (c.value, h.scheming_language_text(c.label))) -%}
+        {%- do choices.append((c.value, h.get_translation(c.label))) -%}
     {%- endfor -%}
     <fieldset class="checkboxes">
         {%- for val, label in choices -%}


### PR DESCRIPTION
Fixed categories not getting translated in the create apiset form. This bug also appeared in the create showcase form and is fixed by this PR. 
![image](https://user-images.githubusercontent.com/24498487/201656272-a0968c70-0e64-40d1-aaeb-7b5a2b40e596.png)
