### PR TITLE
AV-1857: Enable api analytics tracking

### DIFF
--- a/ckan/templates/production.ini.j2
+++ b/ckan/templates/production.ini.j2
@@ -219,6 +219,7 @@ ckanext.matomo.site_id = {{ environ('MATOMO_SITE_ID') }}
 ckanext.matomo.domain = https://{{ environ('MATOMO_DOMAIN') }}/
 ckanext.matomo.script_domain = {{ environ('MATOMO_SCRIPT_DOMAIN') }}
 ckanext.matomo.token_auth = {{ environ('MATOMO_TOKEN') }}
+ckanext.matomo.ignored_user_agents = docker-healthcheck
 {% endif %}
 
 ckanext.spatial.harvest.continue_on_validation_errors = true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -137,7 +137,7 @@ services:
     volumes:
       - ckan_data:/srv/app/data
     healthcheck:
-      test: ["CMD-SHELL", "curl --fail http://localhost:5000/api/3/action/status_show || exit 1"]
+      test: ["CMD-SHELL", "curl --fail http://localhost:5000/api/3/action/status_show --user-agent 'docker-healthcheck' || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Update matomo extensions and modifies configuration to ignore health check calls from analytics.