### PR TITLE
Fix site search issues

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -82,4 +82,4 @@
 	url = https://github.com/vrk-kpa/ckanext-sentry.git
 [submodule "ckan/ckanext/ckanext-sitesearch"]
 	path = ckan/ckanext/ckanext-sitesearch
-	url = https://github.com/okfn/ckanext-sitesearch.git
+	url = https://github.com/vrk-kpa/ckanext-sitesearch.git

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -77,7 +77,8 @@ RUN cd ${SRC_DIR}/ckan && \
     patch --strip=1 --input=patches/implement_is_required_for_image_upload.patch && \
     patch --strip=1 --input=patches/add_drafts_to_search.patch && \
     patch --strip=1 --input=patches/ignore_write_errors.patch && \
-    patch --strip=1 --input=patches/add_prefix_to_werkzeug.patch
+    patch --strip=1 --input=patches/add_prefix_to_werkzeug.patch && \
+    patch --strip=1 --input=patches/add_entity_type_to_package_get_index.patch
 
 # install crontab
 RUN chmod +x ${CRON_DIR}/scripts/*.sh && \

--- a/ckan/src/ckan/patches/add_entity_type_to_package_get_index.patch
+++ b/ckan/src/ckan/patches/add_entity_type_to_package_get_index.patch
@@ -1,0 +1,13 @@
+diff --git a/ckan/lib/search/query.py b/ckan/lib/search/query.py
+index c2646f868..d928722b3 100644
+--- a/ckan/lib/search/query.py
++++ b/ckan/lib/search/query.py
+@@ -268,7 +268,7 @@ class PackageSearchQuery(SearchQuery):
+             'rows': 1,
+             'q': 'name:"%s" OR id:"%s"' % (reference,reference),
+             'wt': 'json',
+-            'fq': 'site_id:"%s"' % config.get('ckan.site_id')}
++            'fq': 'site_id:"%s" ' % config.get('ckan.site_id') + '+entity_type:package'}
+ 
+         try:
+             if query['q'].startswith('{!'):


### PR DESCRIPTION
Harvesting failed in an error due to a bug in sitesearch. Harvest page of single harvest fails when organization and harvest have the same name, due to how ckan works, filed a PR to ckan to fix it, patch is with this PR as well.