### PR TITLE
AV-1985: Update translations

### DIFF
--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/fi/LC_MESSAGES/ckanext-sixodp_showcase.po
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/i18n/fi/LC_MESSAGES/ckanext-sixodp_showcase.po
@@ -8,9 +8,9 @@
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2018
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2019
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2020
-# Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2020
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
 # Ville Teräväinen, 2022
+# Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023
 # 
 #, fuzzy
 msgid ""
@@ -19,7 +19,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
 "POT-Creation-Date: 2022-10-06 09:27+0000\n"
 "PO-Revision-Date: 2018-03-14 11:02+0000\n"
-"Last-Translator: Ville Teräväinen, 2022\n"
+"Last-Translator: Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -530,15 +530,15 @@ msgstr "Hallitse tietoaineistoja"
 
 #: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:4
 msgid "apisets in this showcase"
-msgstr ""
+msgstr "Sovelluksessa käytetyt rajapinnat"
 
 #: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:8
 msgid "This showcase has no apisets associated to it"
-msgstr ""
+msgstr "Tähän sovellukseen ei ole liitetty rajapintoja"
 
 #: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:12
 msgid "Search and add apisets to a showcase"
-msgstr ""
+msgstr "Hae ja lisää rajapintoja sovellukselle"
 
 #: ckanext/sixodp_showcase/templates/showcase/manage_apisets.html:16
 msgid "No apisets could be found"
@@ -628,7 +628,7 @@ msgstr "Etsi käyttösovelluksia..."
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/edit_base.html:44
 msgid "Manage apisets"
-msgstr ""
+msgstr "Hallitse rajapintoja"
 
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new.html:5
 #: ckanext/sixodp_showcase/templates/sixodp_showcase/new.html:10

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -1,15 +1,15 @@
 # Translations template for ckanext-ytp_main.
-# Copyright (C) 2022 ORGANIZATION
+# Copyright (C) 2023 ORGANIZATION
 # This file is distributed under the same license as the ckanext-ytp_main
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-12-05 09:47+0000\n"
+"POT-Creation-Date: 2023-01-17 13:54+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -43,7 +43,7 @@ msgstr ""
 msgid "Only registered users can create organizations"
 msgstr ""
 
-#: ckanext/ytp/auth.py:105 ckanext/ytp/validators.py:468
+#: ckanext/ytp/auth.py:105 ckanext/ytp/validators.py:508
 #, python-format
 msgid "User %s is not administrator in the selected parent organization"
 msgstr ""
@@ -57,8 +57,8 @@ msgstr ""
 msgid "Cannot modify dataset because of organization policy"
 msgstr ""
 
-#: ckanext/ytp/auth.py:144 ckanext/ytp/views_organization.py:274
-#: ckanext/ytp/views_organization.py:322
+#: ckanext/ytp/auth.py:144 ckanext/ytp/views_organization.py:275
+#: ckanext/ytp/views_organization.py:323
 msgid "Only system administrators are allowed to view user list."
 msgstr ""
 
@@ -86,7 +86,7 @@ msgstr ""
 #: ckanext/ytp/templates/organization/user_list.html:53
 #: ckanext/ytp/templates/package/new_package_form.html:29
 #: ckanext/ytp/templates/package/snippets/package_form.html:25
-#: ckanext/ytp/templates/package/snippets/resource_form.html:63
+#: ckanext/ytp/templates/package/snippets/resource_form.html:68
 #: ckanext/ytp/templates/scheming/organization/group_form.html:47
 #: ckanext/ytp/templates/user/edit_user_form.html:47
 msgid "Delete"
@@ -312,6 +312,7 @@ msgid "Users"
 msgstr ""
 
 #: ckanext/ytp/menu.py:155 ckanext/ytp/templates/apiset/resource_read.html:31
+#: ckanext/ytp/templates/general_search/search_form.html:47
 #: ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/edit.html:4
 #: ckanext/ytp/templates/organization/index.html:14
@@ -804,7 +805,7 @@ msgstr ""
 msgid "Add to group"
 msgstr ""
 
-#: ckanext/ytp/templates/package/group_list.html:22 ckanext/ytp/translations.py:126
+#: ckanext/ytp/templates/package/group_list.html:24 ckanext/ytp/translations.py:126
 msgid "There are no groups associated with this dataset"
 msgstr ""
 
@@ -812,7 +813,7 @@ msgstr ""
 msgid "Remove dataset from this group"
 msgstr ""
 
-#: ckanext/ytp/templates/package/group_list.html:52 ckanext/ytp/translations.py:128
+#: ckanext/ytp/templates/package/group_list.html:54 ckanext/ytp/translations.py:128
 msgid "Associate this group with this dataset"
 msgstr ""
 
@@ -830,9 +831,11 @@ msgstr ""
 
 #: ckanext/ytp/templates/group/index.html:4
 #: ckanext/ytp/templates/group/read_base.html:4
-#: ckanext/ytp/templates/package/group_list.html:9
-#: ckanext/ytp/templates/package/group_list.html:14
-#: ckanext/ytp/templates/package/read_base.html:26 ckanext/ytp/translations.py:132
+#: ckanext/ytp/templates/package/group_list.html:6
+#: ckanext/ytp/templates/package/group_list.html:10
+#: ckanext/ytp/templates/package/group_list.html:16
+#: ckanext/ytp/templates/package/read_base.html:23
+#: ckanext/ytp/templates/package/read_base.html:27 ckanext/ytp/translations.py:132
 msgid "Groups"
 msgstr ""
 
@@ -1509,7 +1512,7 @@ msgstr ""
 msgid "invalid type for repeating text: %r"
 msgstr ""
 
-#: ckanext/ytp/validators.py:263 ckanext/ytp/validators.py:590
+#: ckanext/ytp/validators.py:263 ckanext/ytp/validators.py:651
 msgid "expecting a list"
 msgstr ""
 
@@ -1538,7 +1541,11 @@ msgstr ""
 msgid "End date is before start date"
 msgstr ""
 
-#: ckanext/ytp/validators.py:519
+#: ckanext/ytp/validators.py:533
+msgid "Can not save organization parent as it would create loop in hierarchy"
+msgstr ""
+
+#: ckanext/ytp/validators.py:580
 #, python-format
 msgid "Only sysadmin can change feature: %s"
 msgstr ""
@@ -1548,17 +1555,17 @@ msgid "Unauthorized to create a group"
 msgstr ""
 
 #: ckanext/ytp/views_organization.py:74 ckanext/ytp/views_organization.py:103
-#: ckanext/ytp/views_organization.py:169 ckanext/ytp/views_organization.py:216
-#: ckanext/ytp/views_organization.py:401
+#: ckanext/ytp/views_organization.py:170 ckanext/ytp/views_organization.py:217
+#: ckanext/ytp/views_organization.py:402
 msgid "Group not found"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:219
+#: ckanext/ytp/views_organization.py:220
 #, python-format
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:343
+#: ckanext/ytp/views_organization.py:344
 msgid "Not authorized to see this page"
 msgstr ""
 
@@ -1879,6 +1886,7 @@ msgstr ""
 #: ckanext/ytp/templates/general_search/search_form.html:35
 #: ckanext/ytp/templates/general_search/search_form.html:39
 #: ckanext/ytp/templates/general_search/search_form.html:43
+#: ckanext/ytp/templates/general_search/search_form.html:47
 msgid "results found"
 msgstr ""
 
@@ -1887,33 +1895,33 @@ msgstr ""
 msgid "Showcases"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/package_item.html:21
+#: ckanext/ytp/templates/general_search/snippets/package_item.html:25
 msgid "showcase"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:13
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:19
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:14
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:20
 msgid "Previous page"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:28
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:37
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:59
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:71
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:85
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:29
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:38
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:60
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:72
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:86
 msgid "Page number:"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:52
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:53
 msgid "Current page number:"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:84
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:85
 msgid "Last page"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:93
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:99
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:94
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:100
 msgid "Next page"
 msgstr ""
 
@@ -1944,7 +1952,7 @@ msgid "Are you sure you want to delete this member?"
 msgstr ""
 
 #: ckanext/ytp/templates/group/member_new.html:46
-#: ckanext/ytp/templates/package/group_list.html:54
+#: ckanext/ytp/templates/package/group_list.html:56
 #: ckanext/ytp/templates/scheming/organization/group_form.html:57
 msgid "Save"
 msgstr ""
@@ -2113,8 +2121,10 @@ msgstr ""
 #: ckanext/ytp/templates/organization/read_base.html:24
 #: ckanext/ytp/templates/package/activity.html:3
 #: ckanext/ytp/templates/package/activity.html:8
-#: ckanext/ytp/templates/package/group_list.html:10
-#: ckanext/ytp/templates/package/read_base.html:27
+#: ckanext/ytp/templates/package/group_list.html:7
+#: ckanext/ytp/templates/package/group_list.html:11
+#: ckanext/ytp/templates/package/read_base.html:24
+#: ckanext/ytp/templates/package/read_base.html:28
 msgid "Activity Stream"
 msgstr ""
 
@@ -2209,33 +2219,33 @@ msgstr ""
 msgid "Apiset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/group_list.html:7
-#: ckanext/ytp/templates/package/read_base.html:24
+#: ckanext/ytp/templates/package/group_list.html:9
+#: ckanext/ytp/templates/package/read_base.html:26
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:5
 msgid "Dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/group_list.html:20
+#: ckanext/ytp/templates/package/group_list.html:22
 msgid "There are no groups associated with this apiset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/group_list.html:29
+#: ckanext/ytp/templates/package/group_list.html:31
 msgid "Dataset categories"
 msgstr ""
 
-#: ckanext/ytp/templates/package/group_list.html:42
+#: ckanext/ytp/templates/package/group_list.html:44
 msgid ""
 "Categories to which the apiset is mainly related to. Choose one category or "
 "multiple accurate categories."
 msgstr ""
 
-#: ckanext/ytp/templates/package/group_list.html:44
+#: ckanext/ytp/templates/package/group_list.html:46
 msgid ""
 "Categories to which the dataset is mainly related to. Choose one category or "
 "multiple accurate categories."
 msgstr ""
 
-#: ckanext/ytp/templates/package/group_list.html:50
+#: ckanext/ytp/templates/package/group_list.html:52
 msgid "Associate this group with this apiset"
 msgstr ""
 
@@ -2268,7 +2278,7 @@ msgstr ""
 
 #: ckanext/ytp/templates/package/new_package_form.html:31
 #: ckanext/ytp/templates/package/snippets/package_form.html:27
-#: ckanext/ytp/templates/package/snippets/resource_form.html:66
+#: ckanext/ytp/templates/package/snippets/resource_form.html:71
 #: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:277
 msgid "Abort"
 msgstr ""
@@ -2299,7 +2309,7 @@ msgid "High value dataset"
 msgstr ""
 
 #: ckanext/ytp/templates/package/read.html:60
-msgid "Used datasets"
+msgid "Datasets provided by the API"
 msgstr ""
 
 #: ckanext/ytp/templates/package/resource_edit_base.html:3
@@ -2532,7 +2542,7 @@ msgid "Show more categories"
 msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/categories.html:28
-#: ckanext/ytp/templates/snippets/facet_list.html:93
+#: ckanext/ytp/templates/snippets/facet_list.html:95
 msgid "Show more"
 msgstr ""
 
@@ -2732,27 +2742,27 @@ msgstr ""
 msgid "eg. application/json"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:63
+#: ckanext/ytp/templates/package/snippets/resource_form.html:68
 msgid "Are you sure you want to delete this resource?"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:70
+#: ckanext/ytp/templates/package/snippets/resource_form.html:75
 msgid "Previous"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:73
+#: ckanext/ytp/templates/package/snippets/resource_form.html:78
 msgid "Save & add another"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:79
+#: ckanext/ytp/templates/package/snippets/resource_form.html:87
 msgid "Save api"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:81
+#: ckanext/ytp/templates/package/snippets/resource_form.html:89
 msgid "Save dataset"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:88
+#: ckanext/ytp/templates/package/snippets/resource_form.html:96
 msgid "Add"
 msgstr ""
 
@@ -3255,11 +3265,11 @@ msgstr ""
 msgid "Height:"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/facet_list.html:96
+#: ckanext/ytp/templates/snippets/facet_list.html:98
 msgid "Show less"
 msgstr ""
 
-#: ckanext/ytp/templates/snippets/facet_list.html:100
+#: ckanext/ytp/templates/snippets/facet_list.html:102
 msgid "There are no {facet_type} that match this search"
 msgstr ""
 

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -1,29 +1,29 @@
 # Translations template for ckanext-ytp_main.
-# Copyright (C) 2022 ORGANIZATION
+# Copyright (C) 2023 ORGANIZATION
 # This file is distributed under the same license as the ckanext-ytp_main
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
 # 
 # Translators:
 # Pentti Laitinen, 2018
 # Aaron Hakala <aaron.hakala@gofore.com>, 2019
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2020
-# Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2020
 # Jonna Jantunen <jonna.jantunen@vrk.fi>, 2020
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2021
 # Daniel Vainio, 2021
-# Meeri Hakala <meeri.hakala@dvv.fi>, 2022
-# Ville Teräväinen, 2022
 # Pasi Laakso <pasi.laakso@gofore.com>, 2022
+# Ville Teräväinen, 2022
+# Meeri Hakala <meeri.hakala@dvv.fi>, 2022
+# Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-12-05 09:47+0000\n"
+"POT-Creation-Date: 2023-01-17 13:54+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Pasi Laakso <pasi.laakso@gofore.com>, 2022\n"
+"Last-Translator: Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023\n"
 "Language-Team: Finnish (https://www.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -57,7 +57,7 @@ msgstr "Käyttäjällä %s ei ole oikeuksia luoda julkisia organisaatioita"
 msgid "Only registered users can create organizations"
 msgstr "Vain rekisteröityneet käyttäjät saavat luoda organisaatioita"
 
-#: ckanext/ytp/auth.py:105 ckanext/ytp/validators.py:468
+#: ckanext/ytp/auth.py:105 ckanext/ytp/validators.py:508
 #, python-format
 msgid "User %s is not administrator in the selected parent organization"
 msgstr "Käyttäjä %s ei ole ylläpitäjä valitussa yläorganisaatiossa"
@@ -71,8 +71,8 @@ msgstr "Käyttäjällä %s ei ole oikeuksia luoda organisaatioita"
 msgid "Cannot modify dataset because of organization policy"
 msgstr "Tietoaineiston muokkaaminen on vastoin organisaation käytäntöjä"
 
-#: ckanext/ytp/auth.py:144 ckanext/ytp/views_organization.py:274
-#: ckanext/ytp/views_organization.py:322
+#: ckanext/ytp/auth.py:144 ckanext/ytp/views_organization.py:275
+#: ckanext/ytp/views_organization.py:323
 msgid "Only system administrators are allowed to view user list."
 msgstr "Vain järjestelmän ylläpitäjä saa katsella käyttäjälistaa."
 
@@ -100,7 +100,7 @@ msgstr "Muokkaa tai lisää kieliversioita"
 #: ckanext/ytp/templates/organization/user_list.html:53
 #: ckanext/ytp/templates/package/new_package_form.html:29
 #: ckanext/ytp/templates/package/snippets/package_form.html:25
-#: ckanext/ytp/templates/package/snippets/resource_form.html:63
+#: ckanext/ytp/templates/package/snippets/resource_form.html:68
 #: ckanext/ytp/templates/scheming/organization/group_form.html:47
 #: ckanext/ytp/templates/user/edit_user_form.html:47
 msgid "Delete"
@@ -329,6 +329,7 @@ msgid "Users"
 msgstr "Käyttäjät"
 
 #: ckanext/ytp/menu.py:155 ckanext/ytp/templates/apiset/resource_read.html:31
+#: ckanext/ytp/templates/general_search/search_form.html:47
 #: ckanext/ytp/templates/organization/admin_list.html:31
 #: ckanext/ytp/templates/organization/edit.html:4
 #: ckanext/ytp/templates/organization/index.html:14
@@ -833,7 +834,7 @@ msgstr "Sovellukset"
 msgid "Add to group"
 msgstr "Lisää kategoriaan"
 
-#: ckanext/ytp/templates/package/group_list.html:22
+#: ckanext/ytp/templates/package/group_list.html:24
 #: ckanext/ytp/translations.py:126
 msgid "There are no groups associated with this dataset"
 msgstr "Tietoaineistoon ei ole liitetty kategorioita"
@@ -842,7 +843,7 @@ msgstr "Tietoaineistoon ei ole liitetty kategorioita"
 msgid "Remove dataset from this group"
 msgstr "Poista tietoaineisto tästä kategoriasta"
 
-#: ckanext/ytp/templates/package/group_list.html:52
+#: ckanext/ytp/templates/package/group_list.html:54
 #: ckanext/ytp/translations.py:128
 msgid "Associate this group with this dataset"
 msgstr "Liitä kategoria tähän tietoaineistoon"
@@ -861,9 +862,11 @@ msgstr "Etsi kategorioita..."
 
 #: ckanext/ytp/templates/group/index.html:4
 #: ckanext/ytp/templates/group/read_base.html:4
-#: ckanext/ytp/templates/package/group_list.html:9
-#: ckanext/ytp/templates/package/group_list.html:14
-#: ckanext/ytp/templates/package/read_base.html:26
+#: ckanext/ytp/templates/package/group_list.html:6
+#: ckanext/ytp/templates/package/group_list.html:10
+#: ckanext/ytp/templates/package/group_list.html:16
+#: ckanext/ytp/templates/package/read_base.html:23
+#: ckanext/ytp/templates/package/read_base.html:27
 #: ckanext/ytp/translations.py:132
 msgid "Groups"
 msgstr "Kategoriat"
@@ -1616,7 +1619,7 @@ msgstr ""
 msgid "invalid type for repeating text: %r"
 msgstr ""
 
-#: ckanext/ytp/validators.py:263 ckanext/ytp/validators.py:590
+#: ckanext/ytp/validators.py:263 ckanext/ytp/validators.py:651
 msgid "expecting a list"
 msgstr ""
 
@@ -1645,7 +1648,11 @@ msgstr "Alkupäivä on ennen loppupäivää"
 msgid "End date is before start date"
 msgstr "Loppupäivä on ennen alkupäivää"
 
-#: ckanext/ytp/validators.py:519
+#: ckanext/ytp/validators.py:533
+msgid "Can not save organization parent as it would create loop in hierarchy"
+msgstr ""
+
+#: ckanext/ytp/validators.py:580
 #, python-format
 msgid "Only sysadmin can change feature: %s"
 msgstr "Vain järjestelmän ylläpitäjät voivat muuttaa ominaisuutta: %s"
@@ -1655,17 +1662,17 @@ msgid "Unauthorized to create a group"
 msgstr ""
 
 #: ckanext/ytp/views_organization.py:74 ckanext/ytp/views_organization.py:103
-#: ckanext/ytp/views_organization.py:169 ckanext/ytp/views_organization.py:216
-#: ckanext/ytp/views_organization.py:401
+#: ckanext/ytp/views_organization.py:170 ckanext/ytp/views_organization.py:217
+#: ckanext/ytp/views_organization.py:402
 msgid "Group not found"
 msgstr "Kategoriaa ei löydy"
 
-#: ckanext/ytp/views_organization.py:219
+#: ckanext/ytp/views_organization.py:220
 #, python-format
 msgid "User %r not authorized to edit members of %s"
 msgstr ""
 
-#: ckanext/ytp/views_organization.py:343
+#: ckanext/ytp/views_organization.py:344
 msgid "Not authorized to see this page"
 msgstr "Ei oikeuksia nähdä tätä sivua"
 
@@ -1950,15 +1957,15 @@ msgstr ""
 
 #: ckanext/ytp/templates/general_search/index.html:34
 msgid "Search term"
-msgstr "Hakusana"
+msgstr ""
 
 #: ckanext/ytp/templates/general_search/index.html:38
 msgid "No search term provided"
-msgstr "Hakusanaa ei annettu"
+msgstr ""
 
 #: ckanext/ytp/templates/general_search/index.html:42
 msgid "Search results"
-msgstr "Hakutulosta"
+msgstr ""
 
 #: ckanext/ytp/templates/general_search/search_form.html:6
 #: ckanext/ytp/templates/snippets/search_form.html:104
@@ -1968,7 +1975,7 @@ msgstr "Rajaa hakua"
 
 #: ckanext/ytp/templates/general_search/search_form.html:13
 msgid "Order"
-msgstr "Järjestys"
+msgstr ""
 
 #: ckanext/ytp/templates/general_search/search_form.html:22
 #: ckanext/ytp/templates/organization/index.html:43
@@ -1980,7 +1987,7 @@ msgstr "Siirry"
 
 #: ckanext/ytp/templates/general_search/search_form.html:27
 msgid "What you are searching"
-msgstr "Mitä etsit"
+msgstr ""
 
 #: ckanext/ytp/templates/general_search/search_form.html:31
 msgid "All"
@@ -1990,41 +1997,42 @@ msgstr ""
 #: ckanext/ytp/templates/general_search/search_form.html:35
 #: ckanext/ytp/templates/general_search/search_form.html:39
 #: ckanext/ytp/templates/general_search/search_form.html:43
+#: ckanext/ytp/templates/general_search/search_form.html:47
 msgid "results found"
-msgstr "kpl"
+msgstr ""
 
 #: ckanext/ytp/templates/general_search/search_form.html:43
 #: ckanext/ytp/templates/sixodp_showcasesubmit/base_form_page.html:6
 msgid "Showcases"
 msgstr "Sovellukset"
 
-#: ckanext/ytp/templates/general_search/snippets/package_item.html:21
+#: ckanext/ytp/templates/general_search/snippets/package_item.html:25
 msgid "showcase"
-msgstr "Käyttösovellus"
+msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:13
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:19
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:14
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:20
 msgid "Previous page"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:28
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:37
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:59
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:71
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:85
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:29
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:38
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:60
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:72
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:86
 msgid "Page number:"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:52
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:53
 msgid "Current page number:"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:84
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:85
 msgid "Last page"
 msgstr ""
 
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:93
-#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:99
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:94
+#: ckanext/ytp/templates/general_search/snippets/post_pagination.html:100
 msgid "Next page"
 msgstr ""
 
@@ -2056,7 +2064,7 @@ msgid "Are you sure you want to delete this member?"
 msgstr "Haluatko varmasti poistaa tämän jäsenen?"
 
 #: ckanext/ytp/templates/group/member_new.html:46
-#: ckanext/ytp/templates/package/group_list.html:54
+#: ckanext/ytp/templates/package/group_list.html:56
 #: ckanext/ytp/templates/scheming/organization/group_form.html:57
 msgid "Save"
 msgstr "Tallenna"
@@ -2225,8 +2233,10 @@ msgstr "Päivitä jäsen"
 #: ckanext/ytp/templates/organization/read_base.html:24
 #: ckanext/ytp/templates/package/activity.html:3
 #: ckanext/ytp/templates/package/activity.html:8
-#: ckanext/ytp/templates/package/group_list.html:10
-#: ckanext/ytp/templates/package/read_base.html:27
+#: ckanext/ytp/templates/package/group_list.html:7
+#: ckanext/ytp/templates/package/group_list.html:11
+#: ckanext/ytp/templates/package/read_base.html:24
+#: ckanext/ytp/templates/package/read_base.html:28
 msgid "Activity Stream"
 msgstr "Tapahtumatiedot"
 
@@ -2328,21 +2338,21 @@ msgstr "Sulje tallentamatta"
 msgid "Apiset"
 msgstr "Rajapinta"
 
-#: ckanext/ytp/templates/package/group_list.html:7
-#: ckanext/ytp/templates/package/read_base.html:24
+#: ckanext/ytp/templates/package/group_list.html:9
+#: ckanext/ytp/templates/package/read_base.html:26
 #: ckanext/ytp/templates/report/deprecated_dataset_report.html:5
 msgid "Dataset"
 msgstr "Tietoaineisto"
 
-#: ckanext/ytp/templates/package/group_list.html:20
+#: ckanext/ytp/templates/package/group_list.html:22
 msgid "There are no groups associated with this apiset"
 msgstr "Rajapinta ei kuulu mihinkään kategoriaan"
 
-#: ckanext/ytp/templates/package/group_list.html:29
+#: ckanext/ytp/templates/package/group_list.html:31
 msgid "Dataset categories"
 msgstr "Datakategoriat"
 
-#: ckanext/ytp/templates/package/group_list.html:42
+#: ckanext/ytp/templates/package/group_list.html:44
 msgid ""
 "Categories to which the apiset is mainly related to. Choose one category or "
 "multiple accurate categories."
@@ -2350,7 +2360,7 @@ msgstr ""
 "Valitse vähintään yksi kategoria, joka liittyy rajapinnan aiheeseen. Voit "
 "myös valita useampia."
 
-#: ckanext/ytp/templates/package/group_list.html:44
+#: ckanext/ytp/templates/package/group_list.html:46
 msgid ""
 "Categories to which the dataset is mainly related to. Choose one category or"
 " multiple accurate categories."
@@ -2358,7 +2368,7 @@ msgstr ""
 "Valitse vähintään yksi tietoaineistolle sopiva kategoria. Voit myös valita "
 "useampia kategorioita."
 
-#: ckanext/ytp/templates/package/group_list.html:50
+#: ckanext/ytp/templates/package/group_list.html:52
 msgid "Associate this group with this apiset"
 msgstr "Lisää rajapinta tähän kategoriaan"
 
@@ -2391,14 +2401,14 @@ msgstr "Haluatko varmasti poistaa tietoaineiston?"
 
 #: ckanext/ytp/templates/package/new_package_form.html:31
 #: ckanext/ytp/templates/package/snippets/package_form.html:27
-#: ckanext/ytp/templates/package/snippets/resource_form.html:66
+#: ckanext/ytp/templates/package/snippets/resource_form.html:71
 #: ckanext/ytp/templates/sixodp_showcasesubmit/snippets/new_package_form.html:277
 msgid "Abort"
 msgstr "Keskeytä"
 
 #: ckanext/ytp/templates/package/new_resource.html:5
 msgid "Add data to the dataset"
-msgstr ""
+msgstr "Lisää dataa tietoaineistoon"
 
 #: ckanext/ytp/templates/package/new_resource.html:5
 msgid "Add data to the apiset"
@@ -2422,8 +2432,8 @@ msgid "High value dataset"
 msgstr "Korkean lisäarvon tietoaineisto"
 
 #: ckanext/ytp/templates/package/read.html:60
-msgid "Used datasets"
-msgstr "Käytetyt tietoaineistot"
+msgid "Datasets provided by the API"
+msgstr "Rajapinnan tarjoamat tietoaineistot"
 
 #: ckanext/ytp/templates/package/resource_edit_base.html:3
 msgid "Edit resource"
@@ -2524,33 +2534,33 @@ msgstr "Tilastot"
 #: ckanext/ytp/templates/package/resource_read.html:272
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:126
 msgid "Weekly visits for last 12 months"
-msgstr "Viikoittain viimeisten 12kk ajalta"
+msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:280
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:135
 msgid "Download counts"
-msgstr "Latausmäärät"
+msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:281
 #: ckanext/ytp/templates/package/resource_read.html:285
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:136
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:140
 msgid "During last 30 days"
-msgstr "Viimeisten 30 päivän aikana"
+msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:282
 #: ckanext/ytp/templates/package/resource_read.html:286
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:137
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:141
 msgid "During last 12 months"
-msgstr "Viimeisten 12kk aikana"
+msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:283
 #: ckanext/ytp/templates/package/resource_read.html:287
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:138
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:142
 msgid "All time:"
-msgstr "Kaikkiaan:"
+msgstr ""
 
 #: ckanext/ytp/templates/package/resource_read.html:284
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:139
@@ -2573,7 +2583,7 @@ msgstr "Latauksia"
 #: ckanext/ytp/templates/package/resource_read.html:300
 #: ckanext/ytp/templates/package/snippets/dataset_info.html:153
 msgid "Week"
-msgstr "Viikko"
+msgstr ""
 
 #: ckanext/ytp/templates/package/search.html:25
 msgid "Add Apiset"
@@ -2662,7 +2672,7 @@ msgid "Show more categories"
 msgstr "Näytä lisää kategorioita"
 
 #: ckanext/ytp/templates/package/snippets/categories.html:28
-#: ckanext/ytp/templates/snippets/facet_list.html:93
+#: ckanext/ytp/templates/snippets/facet_list.html:95
 msgid "Show more"
 msgstr "Näytä lisää"
 
@@ -2885,27 +2895,27 @@ msgstr ""
 msgid "eg. application/json"
 msgstr ""
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:63
+#: ckanext/ytp/templates/package/snippets/resource_form.html:68
 msgid "Are you sure you want to delete this resource?"
 msgstr "Haluatko varmasti poistaa tämän data-aineiston?"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:70
+#: ckanext/ytp/templates/package/snippets/resource_form.html:75
 msgid "Previous"
 msgstr "Edellinen"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:73
+#: ckanext/ytp/templates/package/snippets/resource_form.html:78
 msgid "Save & add another"
 msgstr "Tallenna ja lisää toinen"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:79
+#: ckanext/ytp/templates/package/snippets/resource_form.html:87
 msgid "Save api"
 msgstr "Lisää rajapinta"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:81
+#: ckanext/ytp/templates/package/snippets/resource_form.html:89
 msgid "Save dataset"
 msgstr "Tallenna tietoaineisto"
 
-#: ckanext/ytp/templates/package/snippets/resource_form.html:88
+#: ckanext/ytp/templates/package/snippets/resource_form.html:96
 msgid "Add"
 msgstr "Lisää"
 
@@ -3195,6 +3205,9 @@ msgid ""
 "target=\"popover\" data-content=\"%(markdown_tooltip)s\" data-"
 "html=\"true\">Markdown formatting</a> here"
 msgstr ""
+"Voit käyttää <a href=\"#markdown\" title=\"Markdown quick reference\" data-"
+"target=\"popover\" data-content=\"%(markdown_tooltip)s\" data-"
+"html=\"true\">Markdown-muotoiluja</a>"
 
 #: ckanext/ytp/templates/scheming/organization/about.html:38
 msgid "Logo of organization {org}"
@@ -3455,11 +3468,11 @@ msgstr "Leveys:"
 msgid "Height:"
 msgstr "Korkeus:"
 
-#: ckanext/ytp/templates/snippets/facet_list.html:96
+#: ckanext/ytp/templates/snippets/facet_list.html:98
 msgid "Show less"
 msgstr "Näytä vähemmän"
 
-#: ckanext/ytp/templates/snippets/facet_list.html:100
+#: ckanext/ytp/templates/snippets/facet_list.html:102
 msgid "There are no {facet_type} that match this search"
 msgstr "Hakutulokset eivät sisällä \"{facet_type}\"-kenttiä"
 

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/read.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/read.html
@@ -57,7 +57,7 @@
         {% if dataset_type=='apiset' %}
         {% set pkgs = h.get_apiset_package_list(pkg.id) %}
         {% if pkgs %}
-            <h3 class="showcase-packages-title">{{ _('Used datasets') }}</h3>
+            <h3 class="showcase-packages-title">{{ _('Datasets provided by the API') }}</h3>
             {% snippet "sixodp_showcase/snippets/showcase_package_list.html", packages=pkgs, list_class='showcase-packages' %}
         {% endif %}
       {% endif %}


### PR DESCRIPTION
* Updated apiset link datasets header from 'Used datasets' to 'Datasets provided by the API'
* Updated translation key 'Datasets in this apiset' into 'Datasets provided by the API' for consistency as it was already translated into that
* Added some missing translations to sixodp_showcase manage_apisets
![image](https://user-images.githubusercontent.com/3969176/212934203-02f7f18f-2dfc-4783-879e-0d57386a80b5.png)
![image](https://user-images.githubusercontent.com/3969176/212934214-4773d518-fdbd-406b-86b5-09637cad042f.png)
![image](https://user-images.githubusercontent.com/3969176/212934235-8366d6c9-e5f4-495c-bc6a-1fd8e625dd32.png)
