### PR TITLE
AV-1942: Do not rewrite urls in datapusher in AWS

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -572,7 +572,7 @@ export class CkanStack extends Stack {
         DATAPUSHER_CHUNK_INSERT_ROWS: '250',
         DATAPUSHER_DOWNLOAD_TIMEOUT: '30',
         DATAPUSHER_SSL_VERIFY: 'False',
-        DATAPUSHER_REWRITE_RESOURCES: 'True',
+        DATAPUSHER_REWRITE_RESOURCES: 'False',
         // .env
         DATAPUSHER_REWRITE_URL: `http://ckan.${props.namespace.namespaceName}:5000/data`,
       },


### PR DESCRIPTION
In AWS the files are in S3, no need to rewrite the URLs as the file is not requested from the container. 