### PR TITLE
Double the resources of ckan service

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -658,8 +658,8 @@ const ckanStackProd = new CkanStack(app, 'CkanStack-prod', {
   analyticsEnabled: true,
   dynatraceEnabled: true,
   ckanTaskDef: {
-    taskCpu: 1024,
-    taskMem: 2048,
+    taskCpu: 2048,
+    taskMem: 4096,
     taskMinCapacity: 2,
     taskMaxCapacity: 4,
   },


### PR DESCRIPTION
Resources are running low when datastore apis actively used, adding CPU requires 4GB minimum as well.