### PR TITLE
Enable stats collection and extra threads and processes to uwsgi

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -190,6 +190,9 @@ FROM ckan_build AS production-dynatrace-0
 #
 FROM production-dynatrace-${DYNATRACE_ENABLED} AS production
 
+# Install uwsgitop for stats analyzing
+RUN pip install uwsgitop
+
 # copy extensions
 COPY --from=modules_build ${EXT_DIR} ${EXT_DIR}
 

--- a/ckan/src/ckan/ckan-uwsgi.ini
+++ b/ckan/src/ckan/ckan-uwsgi.ini
@@ -15,6 +15,9 @@ max-requests        =  5000
 vacuum              =  true
 callable            =  application
 buffer-size         =  32768
+stats               = /tmp/stats.sock
+processes           = 2
+threads             = 2
 
 # Fix SQLAlchemy SSL errors
 # <https://stackoverflow.com/questions/22752521/uwsgi-flask-sqlalchemy-and-postgres-ssl-error-decryption-failed-or-bad-reco>


### PR DESCRIPTION
Monitoring uwsgi can be done by running `uwsgitop /tmp/stats.sock`