### PR TITLE
Upgrade sentry and add sentry cdn to allowed csp scripts

### DIFF
--- a/cdk/lib/web-stack.ts
+++ b/cdk/lib/web-stack.ts
@@ -49,6 +49,7 @@ export class WebStack extends Stack {
       'https://www.google.com',
       'cdn.matomo.cloud',
       'suomi.matomo.cloud',
+      "browser.sentry-cdn.com"
     ];
     const nginxCspStyleSrc: string[] = [
       'https://fonts.googleapis.com',

--- a/docker/.env.nginx.local
+++ b/docker/.env.nginx.local
@@ -4,6 +4,6 @@ NGINX_ROOT=/var/www/html
 NGINX_MAX_BODY_SIZE=5000M
 NGINX_EXPIRES=1h
 NGINX_CSP_DEFAULT_SRC="*.disquscdn.com https://disqus.com"
-NGINX_CSP_SCRIPT_SRC="platform.twitter.com syndication.twitter.com cdn.syndication.twimg.com *.disqus.com https://disqus.com *.disquscdn.com https://www.google.com/recaptcha/ https://www.gstatic.com/ https://www.google.com cdn.matomo.cloud suomi.matomo.cloud"
+NGINX_CSP_SCRIPT_SRC="platform.twitter.com syndication.twitter.com cdn.syndication.twimg.com *.disqus.com https://disqus.com *.disquscdn.com https://www.google.com/recaptcha/ https://www.gstatic.com/ https://www.google.com cdn.matomo.cloud suomi.matomo.cloud browser.sentry-cdn.com"
 NGINX_CSP_STYLE_SRC="https://fonts.googleapis.com https://platform.twitter.com https://ton.twimg.com *.disquscdn.com https://www.google.com https://ajax.googleapis.com https://www.gstatic.com"
 NGINX_CSP_FRAME_SRC="syndication.twitter.com https://platform.twitter.com https://disqus.com *.disqus.com https://www.google.com/recaptcha/"


### PR DESCRIPTION
Unpins sentry python sdk, so it will updated to latest automatically.
Loads js sdk from cdn as npm no longer has built sdks and add sentry cdn to allowed csp scripts.