### PR TITLE
Add sentry dsn to drupal stack

### DIFF
--- a/cdk/lib/drupal-stack.ts
+++ b/cdk/lib/drupal-stack.ts
@@ -164,6 +164,7 @@ export class DrupalStack extends Stack {
       DB_DRUPAL_PASS: ecs.Secret.fromSecretsManager(sCommonSecrets, 'db_drupal_pass'),
       SYSADMIN_PASS: ecs.Secret.fromSecretsManager(sCommonSecrets, 'sysadmin_pass'),
       SMTP_PASS: ecs.Secret.fromSecretsManager(sCommonSecrets, 'smtp_pass'),
+      SENTRY_DSN: ecs.Secret.fromSecretsManager(sCommonSecrets, 'sentry_dsn'),
     };
 
     for (let i = 0; i < pUsers.length; i++) {


### PR DESCRIPTION
Sentry dsn was missing from drupal stack.