### PR TITLE
Test parallelization

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,15 +64,15 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: ${{ matrix.submodules }}
 
       - name: setup docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.AWS_BUILD_ROLE }}
           role-session-name: github-actions
@@ -103,7 +103,7 @@ jobs:
 
       - name: install nodejs v16
         if: ${{ matrix.build-frontend == true && matrix.build-container == true }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'npm'
@@ -120,7 +120,7 @@ jobs:
         working-directory: ./opendata-assets
 
       - name: build images
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         if: ${{ matrix.build-container == true }}
         with:
           context: ${{ matrix.context }}
@@ -134,7 +134,7 @@ jobs:
 
       - name: build images with dynatrace
         if: ${{ matrix.dynatrace == true  && matrix.build-container == true }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -160,7 +160,7 @@ jobs:
       sha: ${{ steps.envtemplate.outputs.commit_sha || github.sha }}
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: ${{ matrix.submodules }}
           token: ${{ secrets.BOT_TOKEN }}
@@ -221,17 +221,17 @@ jobs:
       contents: read
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ needs.commit-new-images.outputs.sha }}
 
       - name: install nodejs v16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
       - name: cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node_cdk_v16-${{ hashFiles('**/package-lock.json') }}
@@ -256,7 +256,7 @@ jobs:
           REPOSITORY: ${{ secrets.REPOSITORY }}
 
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.AWS_BETA_DEPLOY_ROLE }}
           role-session-name: github-actions

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -22,15 +22,15 @@ jobs:
       contents: read
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: install nodejs v16
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
       - name: cache node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node_cdk_v16-${{ hashFiles('**/package-lock.json') }}
@@ -55,7 +55,7 @@ jobs:
           REPOSITORY: ${{ secrets.REPOSITORY }}
 
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.AWS_ROLE }}
           role-session-name: github-actions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: build images
         if: ${{ matrix.build-container == true }}
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -174,7 +174,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: setup docker buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: install nodejs v16
         uses: actions/setup-node@v3
@@ -253,7 +253,7 @@ jobs:
           npx cypress version
 
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.AWS_DEV_ROLE }}
           role-session-name: github-actions
@@ -342,14 +342,14 @@ jobs:
           path: /tmp/opendata_*.log
 
       - name: upload cypress screenshot artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: screenshots
           path: cypress/screenshots
 
       - name: upload cypress video artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: videos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3]
+        containers: [1, 2, 3, 4, 5]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,8 +165,10 @@ jobs:
     env:
       CI: 1
       TERM: xterm
-    matrix:
-      containers: [1, 2, 3]
+    strategy:
+      fail-fast: false
+      matrix:
+        containers: [1, 2, 3]
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,8 @@ jobs:
     env:
       CI: 1
       TERM: xterm
+    matrix:
+      containers: [1, 2, 3]
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -317,7 +319,7 @@ jobs:
 
       - name: run cypress e2e tests
         run: |
-          npx cypress run --browser chrome:stable --record --key ${{ secrets.CYPRESS_RECORD_KEY }}
+          npx cypress run --browser chrome:stable --record --key ${{ secrets.CYPRESS_RECORD_KEY }} --parallel
 
       - name: export e2e test logs 
         if: failure()

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -5,9 +5,12 @@ describe('Apiset tests',
       openMode: 2,
     }
   }, function() {
+
+  const test_organization = 'apiset_test_organization';
+
   before(function () {
     cy.reset_db();
-    cy.create_organization_for_user('apiset_test_organization', 'test-user', true);
+    cy.create_organization_for_user(test_organization, 'test-user', true);
   });
 
   describe('Apiset filtering', function () {

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -33,16 +33,16 @@ describe('Apiset tests',
 
     const api1_form_data = {
       '#field-name_translated-fi': 'test api',
+      '#field-image-url': "http://example.com",
       '#field-description_translated-fi': 'test kuvaus',
       '#s2id_autogen1': {type: 'select2', values: ['JSON'], force: true},
-      '#field-image-url': "http://example.com"
     }
 
     const api2_form_data = {
       '#field-name_translated-fi': 'test api',
+      '#field-image-url': "http://example.com",
       '#field-description_translated-fi': 'test kuvaus',
       '#s2id_autogen1': {type: 'select2', values: ['CSV'], force: true},
-      '#field-image-url': "http://example.com"
     }
 
     beforeEach(function () {
@@ -232,6 +232,8 @@ describe('Apiset tests',
 
   describe('Apiset creation', function () {
     beforeEach(function () {
+      cy.reset_db();
+      cy.create_organization_for_user(test_organization, 'test-user', true);
       cy.login_post_request('test-user', 'test-user')
       cy.visit('/');
     });

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -1,440 +1,447 @@
-describe('Apiset tests', function(){
-
-  before(function(){
-    cy.reset_db();
-    cy.create_organization_for_user('apiset_test_organization', 'test-user', true);
-  });
-
-  describe('Apiset filtering', function(){
-    const apiset1_name = 'test_apiset_one';
-    const apiset2_name = 'test_apiset_two';
-    const apiset1_form_data = {
-      '#field-title_translated-fi': apiset1_name,
-      '#field-notes_translated-fi': 'test kuvaus',
-      '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
-      '#field-license_id':{type: 'select', value: 'cc-nc'},
-      '#field-api_provider': 'Api Provider',
-      '#field-api_provider_email': 'test.provider@example.com',
+describe('Apiset tests',
+  {
+    retries: {
+      runMode: 2,
+      openMode: 2,
     }
-
-    const apiset2_form_data = {
-      '#field-title_translated-fi': apiset2_name,
-      '#field-notes_translated-fi': 'test kuvaus',
-      '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
-      '#field-license_id':{type: 'select', value: 'cc-by-4.0'},
-      '#field-api_provider': 'Api Provider',
-      '#field-api_provider_email': 'test.provider@example.com',
-    }
-
-    const api1_form_data = {
-      '#field-name_translated-fi': 'test api',
-      '#field-description_translated-fi': 'test kuvaus',
-      '#s2id_autogen1': {type: 'select2', values: ['JSON'], force:true},
-    }
-
-    const api2_form_data = {
-      '#field-name_translated-fi': 'test api',
-      '#field-description_translated-fi': 'test kuvaus',
-      '#s2id_autogen1': {type: 'select2', values: ['CSV'], force:true},
-    }
-
-    beforeEach(function () {
-      cy.visit('/');
-      cy.login_post_request('test-user', 'test-user')
-      cy.visit("/data/fi/apiset/")
-    });
-
-    before(function(){
-      //create 2 apisets with different filter options
-      cy.login_post_request('test-user', 'test-user')
-      
-      //apiset one
-      cy.visit('/data/fi/apiset/new');
-      cy.get('.slug-preview button').contains('Muokkaa').click();
-      cy.get('#field-name').type(apiset1_name);
-      cy.fill_form_fields(apiset1_form_data);
-      cy.get('button[name=save]').click();
-      cy.fill_form_fields(api1_form_data);
-      cy.get('#field-image-upload').selectFile("cypress/sample_text_file.txt")
-      cy.get('button[name=save].suomifi-button-primary').click();
-      //wait for file to upload properly and the page to render before continuing
-      cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset1_name}/resource/new`)
-      cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset1_name}`)
-
-      //apiset two
-      cy.visit('/data/fi/apiset/new');
-      cy.get('.slug-preview button').contains('Muokkaa').click();
-      cy.get('#field-name').type(apiset2_name);
-      cy.fill_form_fields(apiset2_form_data);
-      cy.get('button[name=save]').click();
-      cy.fill_form_fields(api2_form_data);
-      cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
-      cy.get('button[name=save].suomifi-button-primary').click();
-      //wait for file to upload properly and the page to render before continuing
-      cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset2_name}/resource/new`)
-      cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset2_name}`)
-    })
-
-    it('Filter by keyword', function(){
-      //keywords and results exist
-      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-      cy.get('.container-search-result').should('contain.text', apiset1_name)
-      cy.get('.container-search-result').should('contain.text', apiset2_name)
-
-      //click keyword one filter
-      cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-      //filter list and results should now only contain the chosen keyword
-      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-      cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword two');
-      cy.get('.container-search-result').should('contain.text', apiset1_name)
-      cy.get('.container-search-result').should('not.contain.text', apiset2_name)
-
-      //release the filter
-      cy.get('.remove > .fal').click();
-
-      //both keywords and results exist
-      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-      cy.get('.container-search-result').should('contain.text', apiset1_name)
-      cy.get('.container-search-result').should('contain.text', apiset2_name)
-
-      //click keyword two filter
-      cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-      //filter list and results should now only contain the chosen keyword
-      cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword one');
-      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-      cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-      //release the filter
-      cy.get('.remove > .fal').click();
-
-      //both keywords and results exist
-      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-    })
-
-    it('Filter by organization', function(){
-      //both apisets belong to the same organization, so filter should not affect their visibility
-      cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-      cy.get(':nth-child(3) > nav > .list-unstyled > .nav-item > a > span').click();
-
-      //the results should still be the same
-      cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-      //release the filter
-      cy.get('.remove > .fal').click();
-
-      //the results should still be the same
-      cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-    });
-
-    it('Filter by file format', function(){
-      cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-      cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-      //filter to csv
-      cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-      //should not contain apiset1 (txt)
-      cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-      cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'csv');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('not.contain.text', apiset2_name);
-
-      //release the filter
-      cy.get('.remove > .fal').click();
-
-      cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-      cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-      //filter to txt
-      cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-      //should not contain apiset2 (csv)
-      cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'json');
-      cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-      cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-      //release the filter
-      cy.get('.remove > .fal').click();
-
-      cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-      cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-    });
-
-    it('Filter by licence', function(){
-      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-      //filter by Creative Commons Nimeä 4.0
-      cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-      cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Non-Commercial');
-      cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-      //release the filter
-      cy.get('.remove > .fal').click();
-
-      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-    
-      //filter by Creative Commons Non-Commercial
-      cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-      cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Nimeä 4.0');
-      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('not.contain.text', apiset2_name);
-
-      //release the filter
-      cy.get('.remove > .fal').click();
-
-      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-      cy.get('.container-search-result').should('contain.text', apiset1_name);
-      cy.get('.container-search-result').should('contain.text', apiset2_name);
-    })
-  })
-
-  describe('Apiset creation', function(){
-    beforeEach(function () {
-      cy.login_post_request('test-user', 'test-user')
-      cy.visit('/');
-    });
-
-    it('Create a new minimal api, edit it and delete it', function() {
-      const apis_name = 'test_api';
-      cy.create_new_apiset(apis_name);
-      cy.edit_apiset(apis_name);
-  
-      // Delete and make sure it was deleted. Edit doesn't affect the apiset name in url, so the unmodified
-      // name is passed as a parameter
-      cy.delete_apiset(apis_name);
-    });
-  
-    it("Create minimal apiset and add file as a api", function(){
-      const apiset = 'test_apiset_with_file';
-  
-      const apiset_form_data = {
-        "#field-title_translated-fi": apiset,
-        '#field-notes_translated-fi': 'Apiset test description',
-        // FIXME: This should just be 'test_keyword{enter}', see fill_form_fields in support/commands.js
-        '#s2id_autogen1': {type: 'select2', values: ['test_keyword']},
-        '#field-api_provider': 'Api Provider',
-        '#field-api_provider_email': 'test.provider@example.com'
-      };
-  
-      cy.visit('/data/fi/apiset/new');
-      cy.get('.slug-preview button').contains('Muokkaa').click();
-      cy.get('#field-name').type(apiset);
-      cy.fill_form_fields(apiset_form_data);
-      cy.get('button[name=save]').click();
-  
-  
-      const api = 'sample file';
-      const api_form_data = {
-        "#field-name_translated-fi": api
-      };
-      cy.fill_form_fields(api_form_data);
-  
-      cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
-  
-      cy.get('button[name=save].suomifi-button-primary').click();
-  
-      // wait for the location to change
-      cy.location('pathname', {timeout: 60000}).should('not.include', '/resource/new');
-  
-      cy.get('a').contains(api).click();
-  
-      cy.get('a').contains('Lataa')
-        .should('have.attr', 'href')
-        .then(function (href) {
-          cy.request(href).its('status')
-            .should('eq', 200)
+  },
+  function(){
+      before(function(){
+        cy.reset_db();
+        cy.create_organization_for_user('apiset_test_organization', 'test-user', true);
       });
-    });
-  
-    it('Create an apiset with all fields', function() {
-      const apiset_name = 'test_apiset_with_all_fields';
-      const apiset_form_data = {
-        '#field-title_translated-fi': apiset_name,
-        '#field-title_translated-en': apiset_name,
-        '#field-title_translated-sv': apiset_name,
-        '#field-notes_translated-fi': 'test kuvaus',
-        '#field-notes_translated-en': 'test description',
-        '#field-notes_translated-sv': 'test beskrivning',
-        // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
-        '#s2id_autogen1': {type: 'select2', values: ['test']},
-        '#s2id_autogen2': {type: 'select2', values: ['test']},
-        '#s2id_autogen3': {type: 'select2', values: ['test']},
-        '[name="private"]': {type: 'radio', value: 'true', force: true},
-        '#field-license_id': 'cc-by-4.0',
-        '#field-access_rights_translated-fi': 'Käyttöoikeudet',
-        '#field-access_rights_translated-en': 'Käyttöoikeudet',
-        '#field-access_rights_translated-sv': 'Käyttöoikeudet',
-        '#field-api_provider': 'Api Provider',
-        '#field-api_provider_email': 'test.provider@example.com',
-      };
-  
-      const api_form_data = {
-        '#field-name_translated-fi': 'test api',
-        '#field-name_translated-en': 'test api',
-        '#field-name_translated-sv': 'test api',
-        '#field-image-url': 'http://example.com',
-        '#field-description_translated-fi': 'test kuvaus',
-        '#field-description_translated-en': 'test description',
-        '#field-description_translated-sv': 'test beskrivning',
-        '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
-        // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
-        '#s2id_autogen1': {type: 'select2', values: ['CSV', 'JSON'], force:true},
-      };
-      cy.create_new_apiset(apiset_name, apiset_form_data, api_form_data);
-      cy.visit('/data/fi/apiset');
-      cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(1) > a').contains('csv');
-      cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(2) > a').contains('json');
 
-    });
-  
-    it('Creating an empty apiset fails', function() {
-      cy.visit('/data/fi/apiset/new');
-      cy.get('button[name=save]').click();
-      cy.get('.error-explanation');
-      cy.visit('/');
-    });
-  
-    it('Cannot create apiset if logged out', function() {
-      cy.logout_request();
-      cy.visit(('/data/fi/apiset/new'), {
-        failOnStatusCode: false
-      });
-      cy.contains('Ei oikeuksia luoda tietoaineistoa');
-    });
-  });
+      describe('Apiset filtering', function(){
+        const apiset1_name = 'test_apiset_one';
+        const apiset2_name = 'test_apiset_two';
+        const apiset1_form_data = {
+          '#field-title_translated-fi': apiset1_name,
+          '#field-notes_translated-fi': 'test kuvaus',
+          '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
+          '#field-license_id':{type: 'select', value: 'cc-nc'},
+          '#field-api_provider': 'Api Provider',
+          '#field-api_provider_email': 'test.provider@example.com',
+        }
 
-  describe('Associate datasets with an apiset', function(){
-    const dataset_name_1 = "first_dataset";
-    const dataset_name_2 = "second_dataset";
-    const apiset_name = 'test_api';
-  
-    beforeEach(function () {
-      cy.login_post_request('test-user', 'test-user')
-      cy.visit('/');
-    });
+        const apiset2_form_data = {
+          '#field-title_translated-fi': apiset2_name,
+          '#field-notes_translated-fi': 'test kuvaus',
+          '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
+          '#field-license_id':{type: 'select', value: 'cc-by-4.0'},
+          '#field-api_provider': 'Api Provider',
+          '#field-api_provider_email': 'test.provider@example.com',
+        }
 
-    before(function(){
-      cy.login_post_request('test-user', 'test-user')
-      cy.visit('/');
-      // Create 2 datasets that will be used to test the addition of datasets to an apiset
-      cy.create_new_dataset(dataset_name_1);
-      cy.create_new_dataset(dataset_name_2);
-      // Create an apiset that will be used for all the tests
-      cy.create_new_apiset(apiset_name);
-    })
+        const api1_form_data = {
+          '#field-name_translated-fi': 'test api',
+          '#field-description_translated-fi': 'test kuvaus',
+          '#s2id_autogen1': {type: 'select2', values: ['JSON'], force:true},
+        }
 
-    it('Add datasets to an apiset', function() {
-      //Currently there is no Ui navigation to apisets page, so use the direct url
-      cy.visit("/data/fi/apiset/");
-  
-      cy.get('.dataset-heading > a').contains(apiset_name).click();
-      // Wait for page to load
-      cy.url().should('include', `/apiset/${apiset_name}`); 
-      // No datasets should be associated
-      cy.get('.apiset-datasets-block').should('not.exist');
-  
-      cy.get('.admin-banner > a').click();
-      cy.url().should('include', `/apiset/edit/${apiset_name}`); 
-  
-      cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`)
-  
-      cy.get('.page-header > .nav > li').eq(2).click();
-      cy.url().should('include', `/apiset/manage_datasets/${apiset_name}`); 
-  
-      // apiset should not have any datasets associated with it yet
-      cy.get('.table > .table-bordered > .table-bulk-edit').should('not.exist'); 
-      cy.get('.empty').should('exist');
-  
-      // add a dataset to the apiset
-      // select correct dataset
-      cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_1)
-      .parent()
-      .within($tr => { 
-        cy.get('span').click()
+        const api2_form_data = {
+          '#field-name_translated-fi': 'test api',
+          '#field-description_translated-fi': 'test kuvaus',
+          '#s2id_autogen1': {type: 'select2', values: ['CSV'], force:true},
+        }
+
+        beforeEach(function () {
+          cy.visit('/');
+          cy.login_post_request('test-user', 'test-user')
+          cy.visit("/data/fi/apiset/")
+        });
+
+        before(function(){
+          //create 2 apisets with different filter options
+          cy.login_post_request('test-user', 'test-user')
+
+          //apiset one
+          cy.visit('/data/fi/apiset/new');
+          cy.get('.slug-preview button').contains('Muokkaa').click();
+          cy.get('#field-name').type(apiset1_name);
+          cy.fill_form_fields(apiset1_form_data);
+          cy.get('button[name=save]').click();
+          cy.fill_form_fields(api1_form_data);
+          cy.get('#field-image-upload').selectFile("cypress/sample_text_file.txt")
+          cy.get('button[name=save].suomifi-button-primary').click();
+          //wait for file to upload properly and the page to render before continuing
+          cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset1_name}/resource/new`)
+          cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset1_name}`)
+
+          //apiset two
+          cy.visit('/data/fi/apiset/new');
+          cy.get('.slug-preview button').contains('Muokkaa').click();
+          cy.get('#field-name').type(apiset2_name);
+          cy.fill_form_fields(apiset2_form_data);
+          cy.get('button[name=save]').click();
+          cy.fill_form_fields(api2_form_data);
+          cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
+          cy.get('button[name=save].suomifi-button-primary').click();
+          //wait for file to upload properly and the page to render before continuing
+          cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset2_name}/resource/new`)
+          cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset2_name}`)
+        })
+
+        it('Filter by keyword', function(){
+          //keywords and results exist
+          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+          cy.get('.container-search-result').should('contain.text', apiset1_name)
+          cy.get('.container-search-result').should('contain.text', apiset2_name)
+
+          //click keyword one filter
+          cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(1) > a > span').click();
+
+          //filter list and results should now only contain the chosen keyword
+          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+          cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword two');
+          cy.get('.container-search-result').should('contain.text', apiset1_name)
+          cy.get('.container-search-result').should('not.contain.text', apiset2_name)
+
+          //release the filter
+          cy.get('.remove > .fal').click();
+
+          //both keywords and results exist
+          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+          cy.get('.container-search-result').should('contain.text', apiset1_name)
+          cy.get('.container-search-result').should('contain.text', apiset2_name)
+
+          //click keyword two filter
+          cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(2) > a > span').click();
+
+          //filter list and results should now only contain the chosen keyword
+          cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword one');
+          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+          cy.get('.container-search-result').should('not.contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+          //release the filter
+          cy.get('.remove > .fal').click();
+
+          //both keywords and results exist
+          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+        })
+
+        it('Filter by organization', function(){
+          //both apisets belong to the same organization, so filter should not affect their visibility
+          cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+          cy.get(':nth-child(3) > nav > .list-unstyled > .nav-item > a > span').click();
+
+          //the results should still be the same
+          cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+          //release the filter
+          cy.get('.remove > .fal').click();
+
+          //the results should still be the same
+          cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        });
+
+        it('Filter by file format', function(){
+          cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+          cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+          //filter to csv
+          cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(2) > a > span').click();
+
+          //should not contain apiset1 (txt)
+          cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+          cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'csv');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('not.contain.text', apiset2_name);
+
+          //release the filter
+          cy.get('.remove > .fal').click();
+
+          cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+          cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+          //filter to txt
+          cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(1) > a > span').click();
+
+          //should not contain apiset2 (csv)
+          cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'json');
+          cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+          cy.get('.container-search-result').should('not.contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+          //release the filter
+          cy.get('.remove > .fal').click();
+
+          cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+          cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+        });
+
+        it('Filter by licence', function(){
+          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+          //filter by Creative Commons Nimeä 4.0
+          cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(1) > a > span').click();
+
+          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+          cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Non-Commercial');
+          cy.get('.container-search-result').should('not.contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+          //release the filter
+          cy.get('.remove > .fal').click();
+
+          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+          //filter by Creative Commons Non-Commercial
+          cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(2) > a > span').click();
+
+          cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Nimeä 4.0');
+          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('not.contain.text', apiset2_name);
+
+          //release the filter
+          cy.get('.remove > .fal').click();
+
+          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+          cy.get('.container-search-result').should('contain.text', apiset1_name);
+          cy.get('.container-search-result').should('contain.text', apiset2_name);
+        })
       })
-      cy.get('.action-button-group > button').click();
-  
-      // Wait for the dataset to get added
-      cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').should('exist');
-  
-  
-      // // Check if the dataset has been added to the apiset
-      cy.visit(`data/fi/apiset/${apiset_name}`)
-      cy.url().should('include', `/apiset/${apiset_name}`); 
-      cy.get('.showcase-package > a').contains(dataset_name_1);
-    });
-  
-    it("Remove dataset from apiset", function(){
-        //Currently there is no Ui navigation to apisets page, so use the direct url
-        cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
-  
-        // select dataset to add to the apiset
-        cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_2)
-        .parent()
-        .within($tr => { 
-          cy.get('span').click()
-        })
-        cy.get('.action-button-group > button').click();
-        
-        // Wait for dataset to be added
-        cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').contains(dataset_name_2)
-        // Check that the dataset is added on the apiset page
-        cy.visit(`data/fi/apiset/${apiset_name}`)
-        cy.get('.showcase-package > a').contains(dataset_name_2);
-  
-        // Remove dataset from apiset
-        cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
-        cy.get(`.apiset-datasets-block > :nth-child(1) > [method="POST"] > .table > tbody > tr > td`).contains(dataset_name_2)
-        .parent()
-        .within($tr => { 
-          cy.get('span').click()
-        })
-        cy.get('.btn-group > .btn').click();
-  
-        // Check that datasets doesn't contain the removed dataset
-        cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr ').contains(dataset_name_2).should('not.exist');
-        cy.visit(`data/fi/apiset/${apiset_name}`)
-        cy.get('.showcase-package > a').contains(dataset_name_2).should('not.exist');
-    })
 
+      describe('Apiset creation', function(){
+        beforeEach(function () {
+          cy.login_post_request('test-user', 'test-user')
+          cy.visit('/');
+        });
+
+        it('Create a new minimal api, edit it and delete it', function() {
+          const apis_name = 'test_api';
+          cy.create_new_apiset(apis_name);
+          cy.edit_apiset(apis_name);
+
+          // Delete and make sure it was deleted. Edit doesn't affect the apiset name in url, so the unmodified
+          // name is passed as a parameter
+          cy.delete_apiset(apis_name);
+        });
+
+        it("Create minimal apiset and add file as a api", function(){
+          const apiset = 'test_apiset_with_file';
+
+          const apiset_form_data = {
+            "#field-title_translated-fi": apiset,
+            '#field-notes_translated-fi': 'Apiset test description',
+            // FIXME: This should just be 'test_keyword{enter}', see fill_form_fields in support/commands.js
+            '#s2id_autogen1': {type: 'select2', values: ['test_keyword']},
+            '#field-api_provider': 'Api Provider',
+            '#field-api_provider_email': 'test.provider@example.com'
+          };
+
+          cy.visit('/data/fi/apiset/new');
+          cy.get('.slug-preview button').contains('Muokkaa').click();
+          cy.get('#field-name').type(apiset);
+          cy.fill_form_fields(apiset_form_data);
+          cy.get('button[name=save]').click();
+
+
+          const api = 'sample file';
+          const api_form_data = {
+            "#field-name_translated-fi": api
+          };
+          cy.fill_form_fields(api_form_data);
+
+          cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
+
+          cy.get('button[name=save].suomifi-button-primary').click();
+
+          // wait for the location to change
+          cy.location('pathname', {timeout: 60000}).should('not.include', '/resource/new');
+
+          cy.get('a').contains(api).click();
+
+          cy.get('a').contains('Lataa')
+            .should('have.attr', 'href')
+            .then(function (href) {
+              cy.request(href).its('status')
+                .should('eq', 200)
+            });
+        });
+
+        it('Create an apiset with all fields', function() {
+          const apiset_name = 'test_apiset_with_all_fields';
+          const apiset_form_data = {
+            '#field-title_translated-fi': apiset_name,
+            '#field-title_translated-en': apiset_name,
+            '#field-title_translated-sv': apiset_name,
+            '#field-notes_translated-fi': 'test kuvaus',
+            '#field-notes_translated-en': 'test description',
+            '#field-notes_translated-sv': 'test beskrivning',
+            // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
+            '#s2id_autogen1': {type: 'select2', values: ['test']},
+            '#s2id_autogen2': {type: 'select2', values: ['test']},
+            '#s2id_autogen3': {type: 'select2', values: ['test']},
+            '[name="private"]': {type: 'radio', value: 'true', force: true},
+            '#field-license_id': 'cc-by-4.0',
+            '#field-access_rights_translated-fi': 'Käyttöoikeudet',
+            '#field-access_rights_translated-en': 'Käyttöoikeudet',
+            '#field-access_rights_translated-sv': 'Käyttöoikeudet',
+            '#field-api_provider': 'Api Provider',
+            '#field-api_provider_email': 'test.provider@example.com',
+          };
+
+          const api_form_data = {
+            '#field-name_translated-fi': 'test api',
+            '#field-name_translated-en': 'test api',
+            '#field-name_translated-sv': 'test api',
+            '#field-image-url': 'http://example.com',
+            '#field-description_translated-fi': 'test kuvaus',
+            '#field-description_translated-en': 'test description',
+            '#field-description_translated-sv': 'test beskrivning',
+            '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
+            // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
+            '#s2id_autogen1': {type: 'select2', values: ['CSV', 'JSON'], force:true},
+          };
+          cy.create_new_apiset(apiset_name, apiset_form_data, api_form_data);
+          cy.visit('/data/fi/apiset');
+          cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(1) > a').contains('csv');
+          cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(2) > a').contains('json');
+
+        });
+
+        it('Creating an empty apiset fails', function() {
+          cy.visit('/data/fi/apiset/new');
+          cy.get('button[name=save]').click();
+          cy.get('.error-explanation');
+          cy.visit('/');
+        });
+
+        it('Cannot create apiset if logged out', function() {
+          cy.logout_request();
+          cy.visit(('/data/fi/apiset/new'), {
+            failOnStatusCode: false
+          });
+          cy.contains('Ei oikeuksia luoda tietoaineistoa');
+        });
+      });
+
+      describe('Associate datasets with an apiset', function(){
+        const dataset_name_1 = "first_dataset";
+        const dataset_name_2 = "second_dataset";
+        const apiset_name = 'test_api';
+
+        beforeEach(function () {
+          cy.login_post_request('test-user', 'test-user')
+          cy.visit('/');
+        });
+
+        before(function(){
+          cy.login_post_request('test-user', 'test-user')
+          cy.visit('/');
+          // Create 2 datasets that will be used to test the addition of datasets to an apiset
+          cy.create_new_dataset(dataset_name_1);
+          cy.create_new_dataset(dataset_name_2);
+          // Create an apiset that will be used for all the tests
+          cy.create_new_apiset(apiset_name);
+        })
+
+        it('Add datasets to an apiset', function() {
+          //Currently there is no Ui navigation to apisets page, so use the direct url
+          cy.visit("/data/fi/apiset/");
+
+          cy.get('.dataset-heading > a').contains(apiset_name).click();
+          // Wait for page to load
+          cy.url().should('include', `/apiset/${apiset_name}`);
+          // No datasets should be associated
+          cy.get('.apiset-datasets-block').should('not.exist');
+
+          cy.get('.admin-banner > a').click();
+          cy.url().should('include', `/apiset/edit/${apiset_name}`);
+
+          cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`)
+
+          cy.get('.page-header > .nav > li').eq(2).click();
+          cy.url().should('include', `/apiset/manage_datasets/${apiset_name}`);
+
+          // apiset should not have any datasets associated with it yet
+          cy.get('.table > .table-bordered > .table-bulk-edit').should('not.exist');
+          cy.get('.empty').should('exist');
+
+          // add a dataset to the apiset
+          // select correct dataset
+          cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_1)
+            .parent()
+            .within($tr => {
+              cy.get('span').click()
+            })
+          cy.get('.action-button-group > button').click();
+
+          // Wait for the dataset to get added
+          cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').should('exist');
+
+
+          // // Check if the dataset has been added to the apiset
+          cy.visit(`data/fi/apiset/${apiset_name}`)
+          cy.url().should('include', `/apiset/${apiset_name}`);
+          cy.get('.showcase-package > a').contains(dataset_name_1);
+        });
+
+        it("Remove dataset from apiset", function(){
+          //Currently there is no Ui navigation to apisets page, so use the direct url
+          cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
+
+          // select dataset to add to the apiset
+          cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_2)
+            .parent()
+            .within($tr => {
+              cy.get('span').click()
+            })
+          cy.get('.action-button-group > button').click();
+
+          // Wait for dataset to be added
+          cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').contains(dataset_name_2)
+          // Check that the dataset is added on the apiset page
+          cy.visit(`data/fi/apiset/${apiset_name}`)
+          cy.get('.showcase-package > a').contains(dataset_name_2);
+
+          // Remove dataset from apiset
+          cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
+          cy.get(`.apiset-datasets-block > :nth-child(1) > [method="POST"] > .table > tbody > tr > td`).contains(dataset_name_2)
+            .parent()
+            .within($tr => {
+              cy.get('span').click()
+            })
+          cy.get('.btn-group > .btn').click();
+
+          // Check that datasets doesn't contain the removed dataset
+          cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr ').contains(dataset_name_2).should('not.exist');
+          cy.visit(`data/fi/apiset/${apiset_name}`)
+          cy.get('.showcase-package > a').contains(dataset_name_2).should('not.exist');
+        })
+
+      });
+
+    }
   });
-
-});
 
 
 

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -35,12 +35,14 @@ describe('Apiset tests',
       '#field-name_translated-fi': 'test api',
       '#field-description_translated-fi': 'test kuvaus',
       '#s2id_autogen1': {type: 'select2', values: ['JSON'], force: true},
+      '#field-image-url': "http://example.com"
     }
 
     const api2_form_data = {
       '#field-name_translated-fi': 'test api',
       '#field-description_translated-fi': 'test kuvaus',
       '#s2id_autogen1': {type: 'select2', values: ['CSV'], force: true},
+      '#field-image-url': "http://example.com"
     }
 
     beforeEach(function () {
@@ -60,7 +62,7 @@ describe('Apiset tests',
       cy.fill_form_fields(apiset1_form_data);
       cy.get('button[name=save]').click();
       cy.fill_form_fields(api1_form_data);
-      cy.get('#field-image-upload').selectFile("cypress/sample_text_file.txt")
+      //cy.get('#field-image-upload').selectFile("cypress/sample_text_file.txt")
       cy.get('button[name=save].suomifi-button-primary').click();
       //wait for file to upload properly and the page to render before continuing
       cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset1_name}/resource/new`)
@@ -73,7 +75,7 @@ describe('Apiset tests',
       cy.fill_form_fields(apiset2_form_data);
       cy.get('button[name=save]').click();
       cy.fill_form_fields(api2_form_data);
-      cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
+      //cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
       cy.get('button[name=save].suomifi-button-primary').click();
       //wait for file to upload properly and the page to render before continuing
       cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset2_name}/resource/new`)

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -64,6 +64,8 @@ describe('Apiset tests',
       cy.get('#field-name').type(apiset1_name);
       cy.fill_form_fields(apiset1_form_data);
       cy.get('button[name=save]').click();
+
+      cy.contains('a', 'Linkki').click();
       cy.fill_form_fields(api1_form_data);
       //cy.get('#field-image-upload').selectFile("cypress/sample_text_file.txt")
       cy.get('button[name=save].suomifi-button-primary').click();
@@ -77,6 +79,8 @@ describe('Apiset tests',
       cy.get('#field-name').type(apiset2_name);
       cy.fill_form_fields(apiset2_form_data);
       cy.get('button[name=save]').click();
+
+      cy.contains('a', 'Linkki').click();
       cy.fill_form_fields(api2_form_data);
       //cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
       cy.get('button[name=save].suomifi-button-primary').click();

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -5,441 +5,441 @@ describe('Apiset tests',
       openMode: 2,
     }
   },
-  function(){
-      before(function(){
-        cy.reset_db();
-        cy.create_organization_for_user('apiset_test_organization', 'test-user', true);
+  function() {
+    before(function () {
+      cy.reset_db();
+      cy.create_organization_for_user('apiset_test_organization', 'test-user', true);
+    });
+
+    describe('Apiset filtering', function () {
+      const apiset1_name = 'test_apiset_one';
+      const apiset2_name = 'test_apiset_two';
+      const apiset1_form_data = {
+        '#field-title_translated-fi': apiset1_name,
+        '#field-notes_translated-fi': 'test kuvaus',
+        '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
+        '#field-license_id': {type: 'select', value: 'cc-nc'},
+        '#field-api_provider': 'Api Provider',
+        '#field-api_provider_email': 'test.provider@example.com',
+      }
+
+      const apiset2_form_data = {
+        '#field-title_translated-fi': apiset2_name,
+        '#field-notes_translated-fi': 'test kuvaus',
+        '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
+        '#field-license_id': {type: 'select', value: 'cc-by-4.0'},
+        '#field-api_provider': 'Api Provider',
+        '#field-api_provider_email': 'test.provider@example.com',
+      }
+
+      const api1_form_data = {
+        '#field-name_translated-fi': 'test api',
+        '#field-description_translated-fi': 'test kuvaus',
+        '#s2id_autogen1': {type: 'select2', values: ['JSON'], force: true},
+      }
+
+      const api2_form_data = {
+        '#field-name_translated-fi': 'test api',
+        '#field-description_translated-fi': 'test kuvaus',
+        '#s2id_autogen1': {type: 'select2', values: ['CSV'], force: true},
+      }
+
+      beforeEach(function () {
+        cy.visit('/');
+        cy.login_post_request('test-user', 'test-user')
+        cy.visit("/data/fi/apiset/")
       });
 
-      describe('Apiset filtering', function(){
-        const apiset1_name = 'test_apiset_one';
-        const apiset2_name = 'test_apiset_two';
-        const apiset1_form_data = {
-          '#field-title_translated-fi': apiset1_name,
-          '#field-notes_translated-fi': 'test kuvaus',
-          '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
-          '#field-license_id':{type: 'select', value: 'cc-nc'},
-          '#field-api_provider': 'Api Provider',
-          '#field-api_provider_email': 'test.provider@example.com',
-        }
+      before(function () {
+        //create 2 apisets with different filter options
+        cy.login_post_request('test-user', 'test-user')
 
-        const apiset2_form_data = {
-          '#field-title_translated-fi': apiset2_name,
-          '#field-notes_translated-fi': 'test kuvaus',
-          '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
-          '#field-license_id':{type: 'select', value: 'cc-by-4.0'},
-          '#field-api_provider': 'Api Provider',
-          '#field-api_provider_email': 'test.provider@example.com',
-        }
+        //apiset one
+        cy.visit('/data/fi/apiset/new');
+        cy.get('.slug-preview button').contains('Muokkaa').click();
+        cy.get('#field-name').type(apiset1_name);
+        cy.fill_form_fields(apiset1_form_data);
+        cy.get('button[name=save]').click();
+        cy.fill_form_fields(api1_form_data);
+        cy.get('#field-image-upload').selectFile("cypress/sample_text_file.txt")
+        cy.get('button[name=save].suomifi-button-primary').click();
+        //wait for file to upload properly and the page to render before continuing
+        cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset1_name}/resource/new`)
+        cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset1_name}`)
 
-        const api1_form_data = {
-          '#field-name_translated-fi': 'test api',
-          '#field-description_translated-fi': 'test kuvaus',
-          '#s2id_autogen1': {type: 'select2', values: ['JSON'], force:true},
-        }
-
-        const api2_form_data = {
-          '#field-name_translated-fi': 'test api',
-          '#field-description_translated-fi': 'test kuvaus',
-          '#s2id_autogen1': {type: 'select2', values: ['CSV'], force:true},
-        }
-
-        beforeEach(function () {
-          cy.visit('/');
-          cy.login_post_request('test-user', 'test-user')
-          cy.visit("/data/fi/apiset/")
-        });
-
-        before(function(){
-          //create 2 apisets with different filter options
-          cy.login_post_request('test-user', 'test-user')
-
-          //apiset one
-          cy.visit('/data/fi/apiset/new');
-          cy.get('.slug-preview button').contains('Muokkaa').click();
-          cy.get('#field-name').type(apiset1_name);
-          cy.fill_form_fields(apiset1_form_data);
-          cy.get('button[name=save]').click();
-          cy.fill_form_fields(api1_form_data);
-          cy.get('#field-image-upload').selectFile("cypress/sample_text_file.txt")
-          cy.get('button[name=save].suomifi-button-primary').click();
-          //wait for file to upload properly and the page to render before continuing
-          cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset1_name}/resource/new`)
-          cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset1_name}`)
-
-          //apiset two
-          cy.visit('/data/fi/apiset/new');
-          cy.get('.slug-preview button').contains('Muokkaa').click();
-          cy.get('#field-name').type(apiset2_name);
-          cy.fill_form_fields(apiset2_form_data);
-          cy.get('button[name=save]').click();
-          cy.fill_form_fields(api2_form_data);
-          cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
-          cy.get('button[name=save].suomifi-button-primary').click();
-          //wait for file to upload properly and the page to render before continuing
-          cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset2_name}/resource/new`)
-          cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset2_name}`)
-        })
-
-        it('Filter by keyword', function(){
-          //keywords and results exist
-          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-          cy.get('.container-search-result').should('contain.text', apiset1_name)
-          cy.get('.container-search-result').should('contain.text', apiset2_name)
-
-          //click keyword one filter
-          cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-          //filter list and results should now only contain the chosen keyword
-          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-          cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword two');
-          cy.get('.container-search-result').should('contain.text', apiset1_name)
-          cy.get('.container-search-result').should('not.contain.text', apiset2_name)
-
-          //release the filter
-          cy.get('.remove > .fal').click();
-
-          //both keywords and results exist
-          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-          cy.get('.container-search-result').should('contain.text', apiset1_name)
-          cy.get('.container-search-result').should('contain.text', apiset2_name)
-
-          //click keyword two filter
-          cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-          //filter list and results should now only contain the chosen keyword
-          cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword one');
-          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-          cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-          //release the filter
-          cy.get('.remove > .fal').click();
-
-          //both keywords and results exist
-          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-          cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-        })
-
-        it('Filter by organization', function(){
-          //both apisets belong to the same organization, so filter should not affect their visibility
-          cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-          cy.get(':nth-child(3) > nav > .list-unstyled > .nav-item > a > span').click();
-
-          //the results should still be the same
-          cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-          //release the filter
-          cy.get('.remove > .fal').click();
-
-          //the results should still be the same
-          cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        });
-
-        it('Filter by file format', function(){
-          cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-          cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-          //filter to csv
-          cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-          //should not contain apiset1 (txt)
-          cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-          cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'csv');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('not.contain.text', apiset2_name);
-
-          //release the filter
-          cy.get('.remove > .fal').click();
-
-          cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-          cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-          //filter to txt
-          cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-          //should not contain apiset2 (csv)
-          cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'json');
-          cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-          cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-          //release the filter
-          cy.get('.remove > .fal').click();
-
-          cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-          cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-        });
-
-        it('Filter by licence', function(){
-          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-          //filter by Creative Commons Nimeä 4.0
-          cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-          cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Non-Commercial');
-          cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-          //release the filter
-          cy.get('.remove > .fal').click();
-
-          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-          //filter by Creative Commons Non-Commercial
-          cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-          cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Nimeä 4.0');
-          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('not.contain.text', apiset2_name);
-
-          //release the filter
-          cy.get('.remove > .fal').click();
-
-          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-          cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-          cy.get('.container-search-result').should('contain.text', apiset1_name);
-          cy.get('.container-search-result').should('contain.text', apiset2_name);
-        })
+        //apiset two
+        cy.visit('/data/fi/apiset/new');
+        cy.get('.slug-preview button').contains('Muokkaa').click();
+        cy.get('#field-name').type(apiset2_name);
+        cy.fill_form_fields(apiset2_form_data);
+        cy.get('button[name=save]').click();
+        cy.fill_form_fields(api2_form_data);
+        cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
+        cy.get('button[name=save].suomifi-button-primary').click();
+        //wait for file to upload properly and the page to render before continuing
+        cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset2_name}/resource/new`)
+        cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset2_name}`)
       })
 
-      describe('Apiset creation', function(){
-        beforeEach(function () {
-          cy.login_post_request('test-user', 'test-user')
-          cy.visit('/');
-        });
+      it('Filter by keyword', function () {
+        //keywords and results exist
+        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+        cy.get('.container-search-result').should('contain.text', apiset1_name)
+        cy.get('.container-search-result').should('contain.text', apiset2_name)
 
-        it('Create a new minimal api, edit it and delete it', function() {
-          const apis_name = 'test_api';
-          cy.create_new_apiset(apis_name);
-          cy.edit_apiset(apis_name);
+        //click keyword one filter
+        cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(1) > a > span').click();
 
-          // Delete and make sure it was deleted. Edit doesn't affect the apiset name in url, so the unmodified
-          // name is passed as a parameter
-          cy.delete_apiset(apis_name);
-        });
+        //filter list and results should now only contain the chosen keyword
+        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+        cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword two');
+        cy.get('.container-search-result').should('contain.text', apiset1_name)
+        cy.get('.container-search-result').should('not.contain.text', apiset2_name)
 
-        it("Create minimal apiset and add file as a api", function(){
-          const apiset = 'test_apiset_with_file';
+        //release the filter
+        cy.get('.remove > .fal').click();
 
-          const apiset_form_data = {
-            "#field-title_translated-fi": apiset,
-            '#field-notes_translated-fi': 'Apiset test description',
-            // FIXME: This should just be 'test_keyword{enter}', see fill_form_fields in support/commands.js
-            '#s2id_autogen1': {type: 'select2', values: ['test_keyword']},
-            '#field-api_provider': 'Api Provider',
-            '#field-api_provider_email': 'test.provider@example.com'
-          };
+        //both keywords and results exist
+        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+        cy.get('.container-search-result').should('contain.text', apiset1_name)
+        cy.get('.container-search-result').should('contain.text', apiset2_name)
 
-          cy.visit('/data/fi/apiset/new');
-          cy.get('.slug-preview button').contains('Muokkaa').click();
-          cy.get('#field-name').type(apiset);
-          cy.fill_form_fields(apiset_form_data);
-          cy.get('button[name=save]').click();
+        //click keyword two filter
+        cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(2) > a > span').click();
+
+        //filter list and results should now only contain the chosen keyword
+        cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword one');
+        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+        cy.get('.container-search-result').should('not.contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        //release the filter
+        cy.get('.remove > .fal').click();
+
+        //both keywords and results exist
+        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+      })
+
+      it('Filter by organization', function () {
+        //both apisets belong to the same organization, so filter should not affect their visibility
+        cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        cy.get(':nth-child(3) > nav > .list-unstyled > .nav-item > a > span').click();
+
+        //the results should still be the same
+        cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        //release the filter
+        cy.get('.remove > .fal').click();
+
+        //the results should still be the same
+        cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+      });
+
+      it('Filter by file format', function () {
+        cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+        cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        //filter to csv
+        cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(2) > a > span').click();
+
+        //should not contain apiset1 (txt)
+        cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+        cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'csv');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('not.contain.text', apiset2_name);
+
+        //release the filter
+        cy.get('.remove > .fal').click();
+
+        cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+        cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        //filter to txt
+        cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(1) > a > span').click();
+
+        //should not contain apiset2 (csv)
+        cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'json');
+        cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+        cy.get('.container-search-result').should('not.contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        //release the filter
+        cy.get('.remove > .fal').click();
+
+        cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+        cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+      });
+
+      it('Filter by licence', function () {
+        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        //filter by Creative Commons Nimeä 4.0
+        cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(1) > a > span').click();
+
+        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+        cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Non-Commercial');
+        cy.get('.container-search-result').should('not.contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        //release the filter
+        cy.get('.remove > .fal').click();
+
+        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+        //filter by Creative Commons Non-Commercial
+        cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(2) > a > span').click();
+
+        cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Nimeä 4.0');
+        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('not.contain.text', apiset2_name);
+
+        //release the filter
+        cy.get('.remove > .fal').click();
+
+        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+        cy.get('.container-search-result').should('contain.text', apiset1_name);
+        cy.get('.container-search-result').should('contain.text', apiset2_name);
+      })
+    })
+
+    describe('Apiset creation', function () {
+      beforeEach(function () {
+        cy.login_post_request('test-user', 'test-user')
+        cy.visit('/');
+      });
+
+      it('Create a new minimal api, edit it and delete it', function () {
+        const apis_name = 'test_api';
+        cy.create_new_apiset(apis_name);
+        cy.edit_apiset(apis_name);
+
+        // Delete and make sure it was deleted. Edit doesn't affect the apiset name in url, so the unmodified
+        // name is passed as a parameter
+        cy.delete_apiset(apis_name);
+      });
+
+      it("Create minimal apiset and add file as a api", function () {
+        const apiset = 'test_apiset_with_file';
+
+        const apiset_form_data = {
+          "#field-title_translated-fi": apiset,
+          '#field-notes_translated-fi': 'Apiset test description',
+          // FIXME: This should just be 'test_keyword{enter}', see fill_form_fields in support/commands.js
+          '#s2id_autogen1': {type: 'select2', values: ['test_keyword']},
+          '#field-api_provider': 'Api Provider',
+          '#field-api_provider_email': 'test.provider@example.com'
+        };
+
+        cy.visit('/data/fi/apiset/new');
+        cy.get('.slug-preview button').contains('Muokkaa').click();
+        cy.get('#field-name').type(apiset);
+        cy.fill_form_fields(apiset_form_data);
+        cy.get('button[name=save]').click();
 
 
-          const api = 'sample file';
-          const api_form_data = {
-            "#field-name_translated-fi": api
-          };
-          cy.fill_form_fields(api_form_data);
+        const api = 'sample file';
+        const api_form_data = {
+          "#field-name_translated-fi": api
+        };
+        cy.fill_form_fields(api_form_data);
 
-          cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
+        cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
 
-          cy.get('button[name=save].suomifi-button-primary').click();
+        cy.get('button[name=save].suomifi-button-primary').click();
 
-          // wait for the location to change
-          cy.location('pathname', {timeout: 60000}).should('not.include', '/resource/new');
+        // wait for the location to change
+        cy.location('pathname', {timeout: 60000}).should('not.include', '/resource/new');
 
-          cy.get('a').contains(api).click();
+        cy.get('a').contains(api).click();
 
-          cy.get('a').contains('Lataa')
-            .should('have.attr', 'href')
-            .then(function (href) {
-              cy.request(href).its('status')
-                .should('eq', 200)
-            });
-        });
-
-        it('Create an apiset with all fields', function() {
-          const apiset_name = 'test_apiset_with_all_fields';
-          const apiset_form_data = {
-            '#field-title_translated-fi': apiset_name,
-            '#field-title_translated-en': apiset_name,
-            '#field-title_translated-sv': apiset_name,
-            '#field-notes_translated-fi': 'test kuvaus',
-            '#field-notes_translated-en': 'test description',
-            '#field-notes_translated-sv': 'test beskrivning',
-            // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
-            '#s2id_autogen1': {type: 'select2', values: ['test']},
-            '#s2id_autogen2': {type: 'select2', values: ['test']},
-            '#s2id_autogen3': {type: 'select2', values: ['test']},
-            '[name="private"]': {type: 'radio', value: 'true', force: true},
-            '#field-license_id': 'cc-by-4.0',
-            '#field-access_rights_translated-fi': 'Käyttöoikeudet',
-            '#field-access_rights_translated-en': 'Käyttöoikeudet',
-            '#field-access_rights_translated-sv': 'Käyttöoikeudet',
-            '#field-api_provider': 'Api Provider',
-            '#field-api_provider_email': 'test.provider@example.com',
-          };
-
-          const api_form_data = {
-            '#field-name_translated-fi': 'test api',
-            '#field-name_translated-en': 'test api',
-            '#field-name_translated-sv': 'test api',
-            '#field-image-url': 'http://example.com',
-            '#field-description_translated-fi': 'test kuvaus',
-            '#field-description_translated-en': 'test description',
-            '#field-description_translated-sv': 'test beskrivning',
-            '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
-            // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
-            '#s2id_autogen1': {type: 'select2', values: ['CSV', 'JSON'], force:true},
-          };
-          cy.create_new_apiset(apiset_name, apiset_form_data, api_form_data);
-          cy.visit('/data/fi/apiset');
-          cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(1) > a').contains('csv');
-          cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(2) > a').contains('json');
-
-        });
-
-        it('Creating an empty apiset fails', function() {
-          cy.visit('/data/fi/apiset/new');
-          cy.get('button[name=save]').click();
-          cy.get('.error-explanation');
-          cy.visit('/');
-        });
-
-        it('Cannot create apiset if logged out', function() {
-          cy.logout_request();
-          cy.visit(('/data/fi/apiset/new'), {
-            failOnStatusCode: false
+        cy.get('a').contains('Lataa')
+          .should('have.attr', 'href')
+          .then(function (href) {
+            cy.request(href).its('status')
+              .should('eq', 200)
           });
-          cy.contains('Ei oikeuksia luoda tietoaineistoa');
-        });
       });
 
-      describe('Associate datasets with an apiset', function(){
-        const dataset_name_1 = "first_dataset";
-        const dataset_name_2 = "second_dataset";
-        const apiset_name = 'test_api';
+      it('Create an apiset with all fields', function () {
+        const apiset_name = 'test_apiset_with_all_fields';
+        const apiset_form_data = {
+          '#field-title_translated-fi': apiset_name,
+          '#field-title_translated-en': apiset_name,
+          '#field-title_translated-sv': apiset_name,
+          '#field-notes_translated-fi': 'test kuvaus',
+          '#field-notes_translated-en': 'test description',
+          '#field-notes_translated-sv': 'test beskrivning',
+          // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
+          '#s2id_autogen1': {type: 'select2', values: ['test']},
+          '#s2id_autogen2': {type: 'select2', values: ['test']},
+          '#s2id_autogen3': {type: 'select2', values: ['test']},
+          '[name="private"]': {type: 'radio', value: 'true', force: true},
+          '#field-license_id': 'cc-by-4.0',
+          '#field-access_rights_translated-fi': 'Käyttöoikeudet',
+          '#field-access_rights_translated-en': 'Käyttöoikeudet',
+          '#field-access_rights_translated-sv': 'Käyttöoikeudet',
+          '#field-api_provider': 'Api Provider',
+          '#field-api_provider_email': 'test.provider@example.com',
+        };
 
-        beforeEach(function () {
-          cy.login_post_request('test-user', 'test-user')
-          cy.visit('/');
-        });
-
-        before(function(){
-          cy.login_post_request('test-user', 'test-user')
-          cy.visit('/');
-          // Create 2 datasets that will be used to test the addition of datasets to an apiset
-          cy.create_new_dataset(dataset_name_1);
-          cy.create_new_dataset(dataset_name_2);
-          // Create an apiset that will be used for all the tests
-          cy.create_new_apiset(apiset_name);
-        })
-
-        it('Add datasets to an apiset', function() {
-          //Currently there is no Ui navigation to apisets page, so use the direct url
-          cy.visit("/data/fi/apiset/");
-
-          cy.get('.dataset-heading > a').contains(apiset_name).click();
-          // Wait for page to load
-          cy.url().should('include', `/apiset/${apiset_name}`);
-          // No datasets should be associated
-          cy.get('.apiset-datasets-block').should('not.exist');
-
-          cy.get('.admin-banner > a').click();
-          cy.url().should('include', `/apiset/edit/${apiset_name}`);
-
-          cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`)
-
-          cy.get('.page-header > .nav > li').eq(2).click();
-          cy.url().should('include', `/apiset/manage_datasets/${apiset_name}`);
-
-          // apiset should not have any datasets associated with it yet
-          cy.get('.table > .table-bordered > .table-bulk-edit').should('not.exist');
-          cy.get('.empty').should('exist');
-
-          // add a dataset to the apiset
-          // select correct dataset
-          cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_1)
-            .parent()
-            .within($tr => {
-              cy.get('span').click()
-            })
-          cy.get('.action-button-group > button').click();
-
-          // Wait for the dataset to get added
-          cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').should('exist');
-
-
-          // // Check if the dataset has been added to the apiset
-          cy.visit(`data/fi/apiset/${apiset_name}`)
-          cy.url().should('include', `/apiset/${apiset_name}`);
-          cy.get('.showcase-package > a').contains(dataset_name_1);
-        });
-
-        it("Remove dataset from apiset", function(){
-          //Currently there is no Ui navigation to apisets page, so use the direct url
-          cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
-
-          // select dataset to add to the apiset
-          cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_2)
-            .parent()
-            .within($tr => {
-              cy.get('span').click()
-            })
-          cy.get('.action-button-group > button').click();
-
-          // Wait for dataset to be added
-          cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').contains(dataset_name_2)
-          // Check that the dataset is added on the apiset page
-          cy.visit(`data/fi/apiset/${apiset_name}`)
-          cy.get('.showcase-package > a').contains(dataset_name_2);
-
-          // Remove dataset from apiset
-          cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
-          cy.get(`.apiset-datasets-block > :nth-child(1) > [method="POST"] > .table > tbody > tr > td`).contains(dataset_name_2)
-            .parent()
-            .within($tr => {
-              cy.get('span').click()
-            })
-          cy.get('.btn-group > .btn').click();
-
-          // Check that datasets doesn't contain the removed dataset
-          cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr ').contains(dataset_name_2).should('not.exist');
-          cy.visit(`data/fi/apiset/${apiset_name}`)
-          cy.get('.showcase-package > a').contains(dataset_name_2).should('not.exist');
-        })
+        const api_form_data = {
+          '#field-name_translated-fi': 'test api',
+          '#field-name_translated-en': 'test api',
+          '#field-name_translated-sv': 'test api',
+          '#field-image-url': 'http://example.com',
+          '#field-description_translated-fi': 'test kuvaus',
+          '#field-description_translated-en': 'test description',
+          '#field-description_translated-sv': 'test beskrivning',
+          '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
+          // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
+          '#s2id_autogen1': {type: 'select2', values: ['CSV', 'JSON'], force: true},
+        };
+        cy.create_new_apiset(apiset_name, apiset_form_data, api_form_data);
+        cy.visit('/data/fi/apiset');
+        cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(1) > a').contains('csv');
+        cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(2) > a').contains('json');
 
       });
-  });
+
+      it('Creating an empty apiset fails', function () {
+        cy.visit('/data/fi/apiset/new');
+        cy.get('button[name=save]').click();
+        cy.get('.error-explanation');
+        cy.visit('/');
+      });
+
+      it('Cannot create apiset if logged out', function () {
+        cy.logout_request();
+        cy.visit(('/data/fi/apiset/new'), {
+          failOnStatusCode: false
+        });
+        cy.contains('Ei oikeuksia luoda tietoaineistoa');
+      });
+    });
+
+    describe('Associate datasets with an apiset', function () {
+      const dataset_name_1 = "first_dataset";
+      const dataset_name_2 = "second_dataset";
+      const apiset_name = 'test_api';
+
+      beforeEach(function () {
+        cy.login_post_request('test-user', 'test-user')
+        cy.visit('/');
+      });
+
+      before(function () {
+        cy.login_post_request('test-user', 'test-user')
+        cy.visit('/');
+        // Create 2 datasets that will be used to test the addition of datasets to an apiset
+        cy.create_new_dataset(dataset_name_1);
+        cy.create_new_dataset(dataset_name_2);
+        // Create an apiset that will be used for all the tests
+        cy.create_new_apiset(apiset_name);
+      })
+
+      it('Add datasets to an apiset', function () {
+        //Currently there is no Ui navigation to apisets page, so use the direct url
+        cy.visit("/data/fi/apiset/");
+
+        cy.get('.dataset-heading > a').contains(apiset_name).click();
+        // Wait for page to load
+        cy.url().should('include', `/apiset/${apiset_name}`);
+        // No datasets should be associated
+        cy.get('.apiset-datasets-block').should('not.exist');
+
+        cy.get('.admin-banner > a').click();
+        cy.url().should('include', `/apiset/edit/${apiset_name}`);
+
+        cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`)
+
+        cy.get('.page-header > .nav > li').eq(2).click();
+        cy.url().should('include', `/apiset/manage_datasets/${apiset_name}`);
+
+        // apiset should not have any datasets associated with it yet
+        cy.get('.table > .table-bordered > .table-bulk-edit').should('not.exist');
+        cy.get('.empty').should('exist');
+
+        // add a dataset to the apiset
+        // select correct dataset
+        cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_1)
+          .parent()
+          .within($tr => {
+            cy.get('span').click()
+          })
+        cy.get('.action-button-group > button').click();
+
+        // Wait for the dataset to get added
+        cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').should('exist');
+
+
+        // // Check if the dataset has been added to the apiset
+        cy.visit(`data/fi/apiset/${apiset_name}`)
+        cy.url().should('include', `/apiset/${apiset_name}`);
+        cy.get('.showcase-package > a').contains(dataset_name_1);
+      });
+
+      it("Remove dataset from apiset", function () {
+        //Currently there is no Ui navigation to apisets page, so use the direct url
+        cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
+
+        // select dataset to add to the apiset
+        cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_2)
+          .parent()
+          .within($tr => {
+            cy.get('span').click()
+          })
+        cy.get('.action-button-group > button').click();
+
+        // Wait for dataset to be added
+        cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').contains(dataset_name_2)
+        // Check that the dataset is added on the apiset page
+        cy.visit(`data/fi/apiset/${apiset_name}`)
+        cy.get('.showcase-package > a').contains(dataset_name_2);
+
+        // Remove dataset from apiset
+        cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
+        cy.get(`.apiset-datasets-block > :nth-child(1) > [method="POST"] > .table > tbody > tr > td`).contains(dataset_name_2)
+          .parent()
+          .within($tr => {
+            cy.get('span').click()
+          })
+        cy.get('.btn-group > .btn').click();
+
+        // Check that datasets doesn't contain the removed dataset
+        cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr ').contains(dataset_name_2).should('not.exist');
+        cy.visit(`data/fi/apiset/${apiset_name}`)
+        cy.get('.showcase-package > a').contains(dataset_name_2).should('not.exist');
+      })
+
+    });
+  })
 
 
 

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -1,445 +1,444 @@
 describe('Apiset tests',
   {
-    retries: {
+    retries:{
       runMode: 2,
       openMode: 2,
     }
-  },
-  function() {
-    before(function () {
-      cy.reset_db();
-      cy.create_organization_for_user('apiset_test_organization', 'test-user', true);
+  }, function() {
+  before(function () {
+    cy.reset_db();
+    cy.create_organization_for_user('apiset_test_organization', 'test-user', true);
+  });
+
+  describe('Apiset filtering', function () {
+    const apiset1_name = 'test_apiset_one';
+    const apiset2_name = 'test_apiset_two';
+    const apiset1_form_data = {
+      '#field-title_translated-fi': apiset1_name,
+      '#field-notes_translated-fi': 'test kuvaus',
+      '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
+      '#field-license_id': {type: 'select', value: 'cc-nc'},
+      '#field-api_provider': 'Api Provider',
+      '#field-api_provider_email': 'test.provider@example.com',
+    }
+
+    const apiset2_form_data = {
+      '#field-title_translated-fi': apiset2_name,
+      '#field-notes_translated-fi': 'test kuvaus',
+      '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
+      '#field-license_id': {type: 'select', value: 'cc-by-4.0'},
+      '#field-api_provider': 'Api Provider',
+      '#field-api_provider_email': 'test.provider@example.com',
+    }
+
+    const api1_form_data = {
+      '#field-name_translated-fi': 'test api',
+      '#field-description_translated-fi': 'test kuvaus',
+      '#s2id_autogen1': {type: 'select2', values: ['JSON'], force: true},
+    }
+
+    const api2_form_data = {
+      '#field-name_translated-fi': 'test api',
+      '#field-description_translated-fi': 'test kuvaus',
+      '#s2id_autogen1': {type: 'select2', values: ['CSV'], force: true},
+    }
+
+    beforeEach(function () {
+      cy.visit('/');
+      cy.login_post_request('test-user', 'test-user')
+      cy.visit("/data/fi/apiset/")
     });
 
-    describe('Apiset filtering', function () {
-      const apiset1_name = 'test_apiset_one';
-      const apiset2_name = 'test_apiset_two';
-      const apiset1_form_data = {
-        '#field-title_translated-fi': apiset1_name,
-        '#field-notes_translated-fi': 'test kuvaus',
-        '#s2id_autogen1': {type: 'select2', values: ['keyword one']},
-        '#field-license_id': {type: 'select', value: 'cc-nc'},
-        '#field-api_provider': 'Api Provider',
-        '#field-api_provider_email': 'test.provider@example.com',
-      }
+    before(function () {
+      //create 2 apisets with different filter options
+      cy.login_post_request('test-user', 'test-user')
 
-      const apiset2_form_data = {
-        '#field-title_translated-fi': apiset2_name,
-        '#field-notes_translated-fi': 'test kuvaus',
-        '#s2id_autogen1': {type: 'select2', values: ['keyword two']},
-        '#field-license_id': {type: 'select', value: 'cc-by-4.0'},
-        '#field-api_provider': 'Api Provider',
-        '#field-api_provider_email': 'test.provider@example.com',
-      }
+      //apiset one
+      cy.visit('/data/fi/apiset/new');
+      cy.get('.slug-preview button').contains('Muokkaa').click();
+      cy.get('#field-name').type(apiset1_name);
+      cy.fill_form_fields(apiset1_form_data);
+      cy.get('button[name=save]').click();
+      cy.fill_form_fields(api1_form_data);
+      cy.get('#field-image-upload').selectFile("cypress/sample_text_file.txt")
+      cy.get('button[name=save].suomifi-button-primary').click();
+      //wait for file to upload properly and the page to render before continuing
+      cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset1_name}/resource/new`)
+      cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset1_name}`)
 
-      const api1_form_data = {
-        '#field-name_translated-fi': 'test api',
-        '#field-description_translated-fi': 'test kuvaus',
-        '#s2id_autogen1': {type: 'select2', values: ['JSON'], force: true},
-      }
-
-      const api2_form_data = {
-        '#field-name_translated-fi': 'test api',
-        '#field-description_translated-fi': 'test kuvaus',
-        '#s2id_autogen1': {type: 'select2', values: ['CSV'], force: true},
-      }
-
-      beforeEach(function () {
-        cy.visit('/');
-        cy.login_post_request('test-user', 'test-user')
-        cy.visit("/data/fi/apiset/")
-      });
-
-      before(function () {
-        //create 2 apisets with different filter options
-        cy.login_post_request('test-user', 'test-user')
-
-        //apiset one
-        cy.visit('/data/fi/apiset/new');
-        cy.get('.slug-preview button').contains('Muokkaa').click();
-        cy.get('#field-name').type(apiset1_name);
-        cy.fill_form_fields(apiset1_form_data);
-        cy.get('button[name=save]').click();
-        cy.fill_form_fields(api1_form_data);
-        cy.get('#field-image-upload').selectFile("cypress/sample_text_file.txt")
-        cy.get('button[name=save].suomifi-button-primary').click();
-        //wait for file to upload properly and the page to render before continuing
-        cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset1_name}/resource/new`)
-        cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset1_name}`)
-
-        //apiset two
-        cy.visit('/data/fi/apiset/new');
-        cy.get('.slug-preview button').contains('Muokkaa').click();
-        cy.get('#field-name').type(apiset2_name);
-        cy.fill_form_fields(apiset2_form_data);
-        cy.get('button[name=save]').click();
-        cy.fill_form_fields(api2_form_data);
-        cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
-        cy.get('button[name=save].suomifi-button-primary').click();
-        //wait for file to upload properly and the page to render before continuing
-        cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset2_name}/resource/new`)
-        cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset2_name}`)
-      })
-
-      it('Filter by keyword', function () {
-        //keywords and results exist
-        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-        cy.get('.container-search-result').should('contain.text', apiset1_name)
-        cy.get('.container-search-result').should('contain.text', apiset2_name)
-
-        //click keyword one filter
-        cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-        //filter list and results should now only contain the chosen keyword
-        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-        cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword two');
-        cy.get('.container-search-result').should('contain.text', apiset1_name)
-        cy.get('.container-search-result').should('not.contain.text', apiset2_name)
-
-        //release the filter
-        cy.get('.remove > .fal').click();
-
-        //both keywords and results exist
-        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-        cy.get('.container-search-result').should('contain.text', apiset1_name)
-        cy.get('.container-search-result').should('contain.text', apiset2_name)
-
-        //click keyword two filter
-        cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-        //filter list and results should now only contain the chosen keyword
-        cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword one');
-        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-        cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        //release the filter
-        cy.get('.remove > .fal').click();
-
-        //both keywords and results exist
-        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
-        cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-      })
-
-      it('Filter by organization', function () {
-        //both apisets belong to the same organization, so filter should not affect their visibility
-        cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        cy.get(':nth-child(3) > nav > .list-unstyled > .nav-item > a > span').click();
-
-        //the results should still be the same
-        cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        //release the filter
-        cy.get('.remove > .fal').click();
-
-        //the results should still be the same
-        cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-      });
-
-      it('Filter by file format', function () {
-        cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-        cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        //filter to csv
-        cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-        //should not contain apiset1 (txt)
-        cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-        cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'csv');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('not.contain.text', apiset2_name);
-
-        //release the filter
-        cy.get('.remove > .fal').click();
-
-        cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-        cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        //filter to txt
-        cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-        //should not contain apiset2 (csv)
-        cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'json');
-        cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-        cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        //release the filter
-        cy.get('.remove > .fal').click();
-
-        cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
-        cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-      });
-
-      it('Filter by licence', function () {
-        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        //filter by Creative Commons Nimeä 4.0
-        cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(1) > a > span').click();
-
-        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-        cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Non-Commercial');
-        cy.get('.container-search-result').should('not.contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        //release the filter
-        cy.get('.remove > .fal').click();
-
-        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-
-        //filter by Creative Commons Non-Commercial
-        cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(2) > a > span').click();
-
-        cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Nimeä 4.0');
-        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('not.contain.text', apiset2_name);
-
-        //release the filter
-        cy.get('.remove > .fal').click();
-
-        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
-        cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
-        cy.get('.container-search-result').should('contain.text', apiset1_name);
-        cy.get('.container-search-result').should('contain.text', apiset2_name);
-      })
+      //apiset two
+      cy.visit('/data/fi/apiset/new');
+      cy.get('.slug-preview button').contains('Muokkaa').click();
+      cy.get('#field-name').type(apiset2_name);
+      cy.fill_form_fields(apiset2_form_data);
+      cy.get('button[name=save]').click();
+      cy.fill_form_fields(api2_form_data);
+      cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
+      cy.get('button[name=save].suomifi-button-primary').click();
+      //wait for file to upload properly and the page to render before continuing
+      cy.location('pathname', {timeout: 60000}).should('not.contain', `/apiset/${apiset2_name}/resource/new`)
+      cy.location('pathname', {timeout: 60000}).should('contain', `/apiset/${apiset2_name}`)
     })
 
-    describe('Apiset creation', function () {
-      beforeEach(function () {
-        cy.login_post_request('test-user', 'test-user')
-        cy.visit('/');
-      });
+    it('Filter by keyword', function () {
+      //keywords and results exist
+      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+      cy.get('.container-search-result').should('contain.text', apiset1_name)
+      cy.get('.container-search-result').should('contain.text', apiset2_name)
 
-      it('Create a new minimal api, edit it and delete it', function () {
-        const apis_name = 'test_api';
-        cy.create_new_apiset(apis_name);
-        cy.edit_apiset(apis_name);
+      //click keyword one filter
+      cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(1) > a > span').click();
 
-        // Delete and make sure it was deleted. Edit doesn't affect the apiset name in url, so the unmodified
-        // name is passed as a parameter
-        cy.delete_apiset(apis_name);
-      });
+      //filter list and results should now only contain the chosen keyword
+      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+      cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword two');
+      cy.get('.container-search-result').should('contain.text', apiset1_name)
+      cy.get('.container-search-result').should('not.contain.text', apiset2_name)
 
-      it("Create minimal apiset and add file as a api", function () {
-        const apiset = 'test_apiset_with_file';
+      //release the filter
+      cy.get('.remove > .fal').click();
 
-        const apiset_form_data = {
-          "#field-title_translated-fi": apiset,
-          '#field-notes_translated-fi': 'Apiset test description',
-          // FIXME: This should just be 'test_keyword{enter}', see fill_form_fields in support/commands.js
-          '#s2id_autogen1': {type: 'select2', values: ['test_keyword']},
-          '#field-api_provider': 'Api Provider',
-          '#field-api_provider_email': 'test.provider@example.com'
-        };
+      //both keywords and results exist
+      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+      cy.get('.container-search-result').should('contain.text', apiset1_name)
+      cy.get('.container-search-result').should('contain.text', apiset2_name)
 
-        cy.visit('/data/fi/apiset/new');
-        cy.get('.slug-preview button').contains('Muokkaa').click();
-        cy.get('#field-name').type(apiset);
-        cy.fill_form_fields(apiset_form_data);
-        cy.get('button[name=save]').click();
+      //click keyword two filter
+      cy.get(':nth-child(2) > nav > .list-unstyled > :nth-child(2) > a > span').click();
 
+      //filter list and results should now only contain the chosen keyword
+      cy.get('.secondary > :nth-child(2)').should('not.contain.text', 'keyword one');
+      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+      cy.get('.container-search-result').should('not.contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
 
-        const api = 'sample file';
-        const api_form_data = {
-          "#field-name_translated-fi": api
-        };
-        cy.fill_form_fields(api_form_data);
+      //release the filter
+      cy.get('.remove > .fal').click();
 
-        cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
+      //both keywords and results exist
+      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword one');
+      cy.get('.secondary > :nth-child(2)').should('contain.text', 'keyword two');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
+    })
 
-        cy.get('button[name=save].suomifi-button-primary').click();
+    it('Filter by organization', function () {
+      //both apisets belong to the same organization, so filter should not affect their visibility
+      cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
 
-        // wait for the location to change
-        cy.location('pathname', {timeout: 60000}).should('not.include', '/resource/new');
+      cy.get(':nth-child(3) > nav > .list-unstyled > .nav-item > a > span').click();
 
-        cy.get('a').contains(api).click();
+      //the results should still be the same
+      cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
 
-        cy.get('a').contains('Lataa')
-          .should('have.attr', 'href')
-          .then(function (href) {
-            cy.request(href).its('status')
-              .should('eq', 200)
-          });
-      });
+      //release the filter
+      cy.get('.remove > .fal').click();
 
-      it('Create an apiset with all fields', function () {
-        const apiset_name = 'test_apiset_with_all_fields';
-        const apiset_form_data = {
-          '#field-title_translated-fi': apiset_name,
-          '#field-title_translated-en': apiset_name,
-          '#field-title_translated-sv': apiset_name,
-          '#field-notes_translated-fi': 'test kuvaus',
-          '#field-notes_translated-en': 'test description',
-          '#field-notes_translated-sv': 'test beskrivning',
-          // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
-          '#s2id_autogen1': {type: 'select2', values: ['test']},
-          '#s2id_autogen2': {type: 'select2', values: ['test']},
-          '#s2id_autogen3': {type: 'select2', values: ['test']},
-          '[name="private"]': {type: 'radio', value: 'true', force: true},
-          '#field-license_id': 'cc-by-4.0',
-          '#field-access_rights_translated-fi': 'Käyttöoikeudet',
-          '#field-access_rights_translated-en': 'Käyttöoikeudet',
-          '#field-access_rights_translated-sv': 'Käyttöoikeudet',
-          '#field-api_provider': 'Api Provider',
-          '#field-api_provider_email': 'test.provider@example.com',
-        };
-
-        const api_form_data = {
-          '#field-name_translated-fi': 'test api',
-          '#field-name_translated-en': 'test api',
-          '#field-name_translated-sv': 'test api',
-          '#field-image-url': 'http://example.com',
-          '#field-description_translated-fi': 'test kuvaus',
-          '#field-description_translated-en': 'test description',
-          '#field-description_translated-sv': 'test beskrivning',
-          '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
-          // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
-          '#s2id_autogen1': {type: 'select2', values: ['CSV', 'JSON'], force: true},
-        };
-        cy.create_new_apiset(apiset_name, apiset_form_data, api_form_data);
-        cy.visit('/data/fi/apiset');
-        cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(1) > a').contains('csv');
-        cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(2) > a').contains('json');
-
-      });
-
-      it('Creating an empty apiset fails', function () {
-        cy.visit('/data/fi/apiset/new');
-        cy.get('button[name=save]').click();
-        cy.get('.error-explanation');
-        cy.visit('/');
-      });
-
-      it('Cannot create apiset if logged out', function () {
-        cy.logout_request();
-        cy.visit(('/data/fi/apiset/new'), {
-          failOnStatusCode: false
-        });
-        cy.contains('Ei oikeuksia luoda tietoaineistoa');
-      });
-    });
-
-    describe('Associate datasets with an apiset', function () {
-      const dataset_name_1 = "first_dataset";
-      const dataset_name_2 = "second_dataset";
-      const apiset_name = 'test_api';
-
-      beforeEach(function () {
-        cy.login_post_request('test-user', 'test-user')
-        cy.visit('/');
-      });
-
-      before(function () {
-        cy.login_post_request('test-user', 'test-user')
-        cy.visit('/');
-        // Create 2 datasets that will be used to test the addition of datasets to an apiset
-        cy.create_new_dataset(dataset_name_1);
-        cy.create_new_dataset(dataset_name_2);
-        // Create an apiset that will be used for all the tests
-        cy.create_new_apiset(apiset_name);
-      })
-
-      it('Add datasets to an apiset', function () {
-        //Currently there is no Ui navigation to apisets page, so use the direct url
-        cy.visit("/data/fi/apiset/");
-
-        cy.get('.dataset-heading > a').contains(apiset_name).click();
-        // Wait for page to load
-        cy.url().should('include', `/apiset/${apiset_name}`);
-        // No datasets should be associated
-        cy.get('.apiset-datasets-block').should('not.exist');
-
-        cy.get('.admin-banner > a').click();
-        cy.url().should('include', `/apiset/edit/${apiset_name}`);
-
-        cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`)
-
-        cy.get('.page-header > .nav > li').eq(2).click();
-        cy.url().should('include', `/apiset/manage_datasets/${apiset_name}`);
-
-        // apiset should not have any datasets associated with it yet
-        cy.get('.table > .table-bordered > .table-bulk-edit').should('not.exist');
-        cy.get('.empty').should('exist');
-
-        // add a dataset to the apiset
-        // select correct dataset
-        cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_1)
-          .parent()
-          .within($tr => {
-            cy.get('span').click()
-          })
-        cy.get('.action-button-group > button').click();
-
-        // Wait for the dataset to get added
-        cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').should('exist');
-
-
-        // // Check if the dataset has been added to the apiset
-        cy.visit(`data/fi/apiset/${apiset_name}`)
-        cy.url().should('include', `/apiset/${apiset_name}`);
-        cy.get('.showcase-package > a').contains(dataset_name_1);
-      });
-
-      it("Remove dataset from apiset", function () {
-        //Currently there is no Ui navigation to apisets page, so use the direct url
-        cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
-
-        // select dataset to add to the apiset
-        cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_2)
-          .parent()
-          .within($tr => {
-            cy.get('span').click()
-          })
-        cy.get('.action-button-group > button').click();
-
-        // Wait for dataset to be added
-        cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').contains(dataset_name_2)
-        // Check that the dataset is added on the apiset page
-        cy.visit(`data/fi/apiset/${apiset_name}`)
-        cy.get('.showcase-package > a').contains(dataset_name_2);
-
-        // Remove dataset from apiset
-        cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
-        cy.get(`.apiset-datasets-block > :nth-child(1) > [method="POST"] > .table > tbody > tr > td`).contains(dataset_name_2)
-          .parent()
-          .within($tr => {
-            cy.get('span').click()
-          })
-        cy.get('.btn-group > .btn').click();
-
-        // Check that datasets doesn't contain the removed dataset
-        cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr ').contains(dataset_name_2).should('not.exist');
-        cy.visit(`data/fi/apiset/${apiset_name}`)
-        cy.get('.showcase-package > a').contains(dataset_name_2).should('not.exist');
-      })
+      //the results should still be the same
+      cy.get('.secondary > :nth-child(3)').should('contain.text', 'apiset_test_organization');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
 
     });
+
+    it('Filter by file format', function () {
+      cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+      cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+      //filter to csv
+      cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(2) > a > span').click();
+
+      //should not contain apiset1 (txt)
+      cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+      cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'csv');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('not.contain.text', apiset2_name);
+
+      //release the filter
+      cy.get('.remove > .fal').click();
+
+      cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+      cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+      //filter to txt
+      cy.get(':nth-child(4) > nav > .list-unstyled > :nth-child(1) > a > span').click();
+
+      //should not contain apiset2 (csv)
+      cy.get('.secondary > :nth-child(4)').should('not.contain.text', 'json');
+      cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+      cy.get('.container-search-result').should('not.contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+      //release the filter
+      cy.get('.remove > .fal').click();
+
+      cy.get('.secondary > :nth-child(4)').should('contain.text', 'json');
+      cy.get('.secondary > :nth-child(4)').should('contain.text', 'csv');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
+    });
+
+    it('Filter by licence', function () {
+      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+      //filter by Creative Commons Nimeä 4.0
+      cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(1) > a > span').click();
+
+      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+      cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Non-Commercial');
+      cy.get('.container-search-result').should('not.contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+      //release the filter
+      cy.get('.remove > .fal').click();
+
+      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
+
+      //filter by Creative Commons Non-Commercial
+      cy.get(':nth-child(5) > nav > .list-unstyled > :nth-child(2) > a > span').click();
+
+      cy.get('.secondary > :nth-child(5)').should('not.contain.text', 'Creative Commons Nimeä 4.0');
+      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('not.contain.text', apiset2_name);
+
+      //release the filter
+      cy.get('.remove > .fal').click();
+
+      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Nimeä 4.0');
+      cy.get('.secondary > :nth-child(5)').should('contain.text', 'Creative Commons Non-Commercial');
+      cy.get('.container-search-result').should('contain.text', apiset1_name);
+      cy.get('.container-search-result').should('contain.text', apiset2_name);
+    })
   })
+
+  describe('Apiset creation', function () {
+    beforeEach(function () {
+      cy.login_post_request('test-user', 'test-user')
+      cy.visit('/');
+    });
+
+    it('Create a new minimal api, edit it and delete it', function () {
+      const apis_name = 'test_api';
+      cy.create_new_apiset(apis_name);
+      cy.edit_apiset(apis_name);
+
+      // Delete and make sure it was deleted. Edit doesn't affect the apiset name in url, so the unmodified
+      // name is passed as a parameter
+      cy.delete_apiset(apis_name);
+    });
+
+    it("Create minimal apiset and add file as a api", function () {
+      const apiset = 'test_apiset_with_file';
+
+      const apiset_form_data = {
+        "#field-title_translated-fi": apiset,
+        '#field-notes_translated-fi': 'Apiset test description',
+        // FIXME: This should just be 'test_keyword{enter}', see fill_form_fields in support/commands.js
+        '#s2id_autogen1': {type: 'select2', values: ['test_keyword']},
+        '#field-api_provider': 'Api Provider',
+        '#field-api_provider_email': 'test.provider@example.com'
+      };
+
+      cy.visit('/data/fi/apiset/new');
+      cy.get('.slug-preview button').contains('Muokkaa').click();
+      cy.get('#field-name').type(apiset);
+      cy.fill_form_fields(apiset_form_data);
+      cy.get('button[name=save]').click();
+
+
+      const api = 'sample file';
+      const api_form_data = {
+        "#field-name_translated-fi": api
+      };
+      cy.fill_form_fields(api_form_data);
+
+      cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv")
+
+      cy.get('button[name=save].suomifi-button-primary').click();
+
+      // wait for the location to change
+      cy.location('pathname', {timeout: 60000}).should('not.include', '/resource/new');
+
+      cy.get('a').contains(api).click();
+
+      cy.get('a').contains('Lataa')
+        .should('have.attr', 'href')
+        .then(function (href) {
+          cy.request(href).its('status')
+            .should('eq', 200)
+        });
+    });
+
+    it('Create an apiset with all fields', function () {
+      const apiset_name = 'test_apiset_with_all_fields';
+      const apiset_form_data = {
+        '#field-title_translated-fi': apiset_name,
+        '#field-title_translated-en': apiset_name,
+        '#field-title_translated-sv': apiset_name,
+        '#field-notes_translated-fi': 'test kuvaus',
+        '#field-notes_translated-en': 'test description',
+        '#field-notes_translated-sv': 'test beskrivning',
+        // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
+        '#s2id_autogen1': {type: 'select2', values: ['test']},
+        '#s2id_autogen2': {type: 'select2', values: ['test']},
+        '#s2id_autogen3': {type: 'select2', values: ['test']},
+        '[name="private"]': {type: 'radio', value: 'true', force: true},
+        '#field-license_id': 'cc-by-4.0',
+        '#field-access_rights_translated-fi': 'Käyttöoikeudet',
+        '#field-access_rights_translated-en': 'Käyttöoikeudet',
+        '#field-access_rights_translated-sv': 'Käyttöoikeudet',
+        '#field-api_provider': 'Api Provider',
+        '#field-api_provider_email': 'test.provider@example.com',
+      };
+
+      const api_form_data = {
+        '#field-name_translated-fi': 'test api',
+        '#field-name_translated-en': 'test api',
+        '#field-name_translated-sv': 'test api',
+        '#field-image-url': 'http://example.com',
+        '#field-description_translated-fi': 'test kuvaus',
+        '#field-description_translated-en': 'test description',
+        '#field-description_translated-sv': 'test beskrivning',
+        '[name="registration_required"]': {type: 'radio', value: 'true', force: true},
+        // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
+        '#s2id_autogen1': {type: 'select2', values: ['CSV', 'JSON'], force: true},
+      };
+      cy.create_new_apiset(apiset_name, apiset_form_data, api_form_data);
+      cy.visit('/data/fi/apiset');
+      cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(1) > a').contains('csv');
+      cy.get('.secondary > :nth-child(4) .nav-facet > .nav-item:nth-child(2) > a').contains('json');
+
+    });
+
+    it('Creating an empty apiset fails', function () {
+      cy.visit('/data/fi/apiset/new');
+      cy.get('button[name=save]').click();
+      cy.get('.error-explanation');
+      cy.visit('/');
+    });
+
+    it('Cannot create apiset if logged out', function () {
+      cy.logout_request();
+      cy.visit(('/data/fi/apiset/new'), {
+        failOnStatusCode: false
+      });
+      cy.contains('Ei oikeuksia luoda tietoaineistoa');
+    });
+  });
+
+  describe('Associate datasets with an apiset', function () {
+    const dataset_name_1 = "first_dataset";
+    const dataset_name_2 = "second_dataset";
+    const apiset_name = 'test_api';
+
+    beforeEach(function () {
+      cy.login_post_request('test-user', 'test-user')
+      cy.visit('/');
+    });
+
+    before(function () {
+      cy.login_post_request('test-user', 'test-user')
+      cy.visit('/');
+      // Create 2 datasets that will be used to test the addition of datasets to an apiset
+      cy.create_new_dataset(dataset_name_1);
+      cy.create_new_dataset(dataset_name_2);
+      // Create an apiset that will be used for all the tests
+      cy.create_new_apiset(apiset_name);
+    })
+
+    it('Add datasets to an apiset', function () {
+      //Currently there is no Ui navigation to apisets page, so use the direct url
+      cy.visit("/data/fi/apiset/");
+
+      cy.get('.dataset-heading > a').contains(apiset_name).click();
+      // Wait for page to load
+      cy.url().should('include', `/apiset/${apiset_name}`);
+      // No datasets should be associated
+      cy.get('.apiset-datasets-block').should('not.exist');
+
+      cy.get('.admin-banner > a').click();
+      cy.url().should('include', `/apiset/edit/${apiset_name}`);
+
+      cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`)
+
+      cy.get('.page-header > .nav > li').eq(2).click();
+      cy.url().should('include', `/apiset/manage_datasets/${apiset_name}`);
+
+      // apiset should not have any datasets associated with it yet
+      cy.get('.table > .table-bordered > .table-bulk-edit').should('not.exist');
+      cy.get('.empty').should('exist');
+
+      // add a dataset to the apiset
+      // select correct dataset
+      cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_1)
+        .parent()
+        .within($tr => {
+          cy.get('span').click()
+        })
+      cy.get('.action-button-group > button').click();
+
+      // Wait for the dataset to get added
+      cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').should('exist');
+
+
+      // // Check if the dataset has been added to the apiset
+      cy.visit(`data/fi/apiset/${apiset_name}`)
+      cy.url().should('include', `/apiset/${apiset_name}`);
+      cy.get('.showcase-package > a').contains(dataset_name_1);
+    });
+
+    it("Remove dataset from apiset", function () {
+      //Currently there is no Ui navigation to apisets page, so use the direct url
+      cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
+
+      // select dataset to add to the apiset
+      cy.get(':nth-child(3) > :nth-child(1) > [method="POST"] > .table > tbody > tr > td').contains(dataset_name_2)
+        .parent()
+        .within($tr => {
+          cy.get('span').click()
+        })
+      cy.get('.action-button-group > button').click();
+
+      // Wait for dataset to be added
+      cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr > .selectable-row').contains(dataset_name_2)
+      // Check that the dataset is added on the apiset page
+      cy.visit(`data/fi/apiset/${apiset_name}`)
+      cy.get('.showcase-package > a').contains(dataset_name_2);
+
+      // Remove dataset from apiset
+      cy.visit(`data/fi/apiset/manage_datasets/${apiset_name}`);
+      cy.get(`.apiset-datasets-block > :nth-child(1) > [method="POST"] > .table > tbody > tr > td`).contains(dataset_name_2)
+        .parent()
+        .within($tr => {
+          cy.get('span').click()
+        })
+      cy.get('.btn-group > .btn').click();
+
+      // Check that datasets doesn't contain the removed dataset
+      cy.get('.apiset-datasets-block > :nth-child(1) > form > .table > tbody > tr ').contains(dataset_name_2).should('not.exist');
+      cy.visit(`data/fi/apiset/${apiset_name}`)
+      cy.get('.showcase-package > a').contains(dataset_name_2).should('not.exist');
+    })
+
+  });
+})
 
 
 

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -439,8 +439,6 @@ describe('Apiset tests',
         })
 
       });
-
-    }
   });
 
 

--- a/cypress/e2e/dataset_spec.js
+++ b/cypress/e2e/dataset_spec.js
@@ -339,13 +339,13 @@ describe('Dataset tests',
 
     const misc_dataset_resource_form_data = {
       '#field-name_translated-fi': dataset_name_translated,
-      '#field-description_translated-fi': dataset_description_translated,
       '#field-image-url': dataset_resource_url,
       '#field-size': dataset_resource_size,
       '#field-format': {
         value: dataset_resource_format,
         force: true
       },
+      '#field-description_translated-fi': dataset_description_translated,
       '#field-position_info': dataset_position_info,
       '#field-maturity':{type: 'select', value: dataset_maturity},
       // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js

--- a/cypress/e2e/dataset_spec.js
+++ b/cypress/e2e/dataset_spec.js
@@ -1,5 +1,11 @@
 
-describe('Dataset tests', function(){
+describe('Dataset tests',
+  {
+    retries:{
+      runMode: 2,
+      openMode: 2,
+    }
+  }, function(){
   const test_organization = 'dataset_test_organization';
 
   before(function(){

--- a/cypress/e2e/dataset_spec.js
+++ b/cypress/e2e/dataset_spec.js
@@ -307,6 +307,9 @@ describe('Dataset tests',
 
     const dataset_name_translated = 'test data';
     const dataset_description_translated = 'test kuvaus';
+    const dataset_resource_url = "https://example.com"
+    const dataset_resource_size = 12345
+    const dataset_resource_format = 'CSV'
     const dataset_position_info = "56.7 43.5";
     const dataset_temporal_granularity = "test";
     const dataset_maturity = "current";
@@ -335,6 +338,12 @@ describe('Dataset tests',
     const misc_dataset_resource_form_data = {
       '#field-name_translated-fi': dataset_name_translated,
       '#field-description_translated-fi': dataset_description_translated,
+      '#field-image-url': dataset_resource_url,
+      '#field-size': dataset_resource_size,
+      '#field-format': {
+        value: dataset_resource_format,
+        force: true
+      },
       '#field-position_info': dataset_position_info,
       '#field-maturity':{type: 'select', value: dataset_maturity},
       // FIXME: These should just be 'value{enter}' for each, see fill_form_fields in support/commands.js
@@ -362,7 +371,7 @@ describe('Dataset tests',
       //check that we are on the second form page
       cy.get('.last').should('have.class', 'active');
 
-      cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv");
+      //cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv");
       cy.fill_form_fields(misc_dataset_resource_form_data);
       cy.get('button[name=save].suomifi-button-primary').click();
 
@@ -424,9 +433,8 @@ describe('Dataset tests',
       //The api button placement might chance, so exclude it for now
 
       //dataset properties
-      // the file format may evaluate to 'CSV' or 'text/csv' so this checks for the existence of csv in a case insensitive way
-      cy.get('tbody > :nth-child(1) > :nth-child(2)').contains(/csv/i);
-      cy.get('tbody > :nth-child(2) > :nth-child(2)').should('contain.text', '4123652'); //filesize of the uploaded file
+      cy.get('tbody > :nth-child(1) > :nth-child(2)').should('contain.text', dataset_resource_format);
+      cy.get('tbody > :nth-child(2) > :nth-child(2)').should('contain.text', dataset_resource_size);
       cy.get('tbody > :nth-child(3) > :nth-child(2)').should('contain.text', 'Voimassa');
       cy.get('tbody > :nth-child(4) > :nth-child(2)').should('contain.text', dataset_position_info);
       cy.get(':nth-child(5) > :nth-child(2)').should('contain.text', check_from);//easier to check for both separately

--- a/cypress/e2e/dataset_spec.js
+++ b/cypress/e2e/dataset_spec.js
@@ -395,7 +395,7 @@ describe('Dataset tests',
       cy.get('.admin-banner > a');
       cy.get('.resource-item').should('contain.text', 'test data');
       cy.get('a.resource-action').should('contain.text', 'Muokkaa');
-      cy.get('.resource-url-analytics').should('contain.text', 'Lataa');
+      cy.get('.resource-url-analytics').should('contain.text', 'Avaa');
     
       //dataset collection information
       cy.get(':nth-child(1) > th').should('contain.text', 'Kokoelma');
@@ -432,7 +432,7 @@ describe('Dataset tests',
       cy.get('.module-small-title').should('contain.text', misc_dataset_name);
       cy.get('.page-heading').should('contain.text', dataset_name_translated);
       cy.get('ul > :nth-child(1) > .btn').should('contain.text', 'Muokkaa');
-      cy.get('ul > :nth-child(2) > .btn').should('contain.text', 'Lataa');
+      cy.get('ul > :nth-child(2) > .btn').should('contain.text', 'Avaa');
       //The api button placement might chance, so exclude it for now
 
       //dataset properties

--- a/cypress/e2e/dataset_spec.js
+++ b/cypress/e2e/dataset_spec.js
@@ -127,6 +127,8 @@ describe('Dataset tests',
 
   describe('Dataset creation and deletion tests', function() {
     beforeEach(function () {
+      cy.reset_db();
+      cy.create_organization_for_user(test_organization, 'test-user', true);
       cy.login_post_request('test-user', 'test-user')
       cy.visit('/data/fi/dataset');
     })

--- a/cypress/e2e/dataset_spec.js
+++ b/cypress/e2e/dataset_spec.js
@@ -373,6 +373,7 @@ describe('Dataset tests',
       //check that we are on the second form page
       cy.get('.last').should('have.class', 'active');
 
+      cy.contains('a', 'Linkki').click();
       //cy.get('#field-image-upload').selectFile("cypress/FL_insurance_sample.csv");
       cy.fill_form_fields(misc_dataset_resource_form_data);
       cy.get('button[name=save].suomifi-button-primary').click();

--- a/docker/datapusher-plus/Dockerfile
+++ b/docker/datapusher-plus/Dockerfile
@@ -1,4 +1,4 @@
-#############################
+############################# 
 ### Build DataPusher Plus ###
 #############################
 FROM public.ecr.aws/docker/library/python:3.10.9-alpine3.17

--- a/docker/docker-compose.build.yml
+++ b/docker/docker-compose.build.yml
@@ -10,3 +10,5 @@ services:
     image: ${REGISTRY}/${REPOSITORY}/nginx:latest
   solr:
     image: ${REGISTRY}/${REPOSITORY}/solr:latest
+  datapusher:
+    image: ${REGISTRY}/${REPOSITORY}/datapusher:latest

--- a/opendata-assets/README.md
+++ b/opendata-assets/README.md
@@ -49,4 +49,4 @@ Check out `resources` folder for results.
 
 ## Font Awesome
 
-* .npmrc is required for npm install to work, available in confluence
+* .npmrc is required for npm install to work, available in confluence 


### PR DESCRIPTION
Sets up 5 different machines to run tests in parallel.
Removes adding files in tests that do not need to test adding files, as there are separate tests for that.
Adds retrying to dataset an apiset tests as adding files is somewhat flaky.