### PR TITLE
AV-1772: Faster organization tree template

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/organization/snippets/organization_tree.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/organization/snippets/organization_tree.html
@@ -1,0 +1,34 @@
+{#
+Displays a tree of organzations
+
+NB This template can be slow because it is recursive and uses link_for. At
+DGU we speeded up display of the tree 10 times (necessary as we have 1000
+organizations) by replacing this template with a recursive code routine:
+https://github.com/datagovuk/ckanext-dgu/blob/5fb78b354517c2198245bdc9c98fb5d6c82c6bcc/ckanext/dgu/lib/helpers.py#L140
+
+orgs    - List of organizations
+
+Example:
+
+{% snippet 'organization/snippets/organization_tree.html', top_nodes=h.group_tree(type_='organization'), use_longnames=False %}
+
+#}
+
+{% set type = 'asset' if h.ckan_version().split('.')[1] | int >= 9 else 'resource' %}
+{% include 'hierarchy/snippets/hierarchy_' ~ type ~ '.html' %}
+
+<ul class="hierarchy-tree-top">
+  {% for node in top_nodes recursive %}
+      {% set display_text = node.title %}
+      {% if node.highlighted %}
+          <li class="highlighted" id="node_{{ node.name }}">
+      {% else %}
+          <li id="node_{{ node.name }}">
+      {% endif %}
+      {% link_for display_text, controller='organization', action='read', id=node.name %}
+      {% if node.children %}
+        <ul class="hierarchy-tree"> {{ loop(node.children) }} </ul>
+      {% endif %}
+    </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
- ckanext-hierarchy's default template fetches each organization separately to generate a title already present in our hierarcy tree objects. Remove the extra work to speed up page loads