### PR TITLE
AV-1880: Hide unapproved organizations in parent organization selection

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -592,7 +592,7 @@ def get_apiset_package_list(package_id):
     return get_action('apiset_package_list')(context, {'apiset_id': package_id})
 
 
-def get_groups_where_user_is_admin(current_id=None):
+def get_groups_where_user_is_admin(current_id=None, only_approved=False):
     context = {'model': model, 'session': model.Session, 'user': c.user}
     organizations = get_action('organization_list_for_user')(context, {'permission': 'admin'})
 
@@ -603,7 +603,10 @@ def get_groups_where_user_is_admin(current_id=None):
                               current_organization.groups_allowed_to_be_its_parent(type='organization')]
         return filter(lambda organization: organization.get('id') in allowed_parent_ids, organizations)
 
-    return organizations
+    if only_approved:
+        return [o for o in organizations if o.get('approval_status') == 'approved']
+    else:
+        return organizations
 
 
 def get_value_from_extras_by_key(object_with_extras, key):

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/org_hierarchy.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/org_hierarchy.html
@@ -4,7 +4,7 @@
     <select id="field-parent" name="groups__0__name" data-module="autocomplete">
       {% set selected_parent = (data.get('groups') or [{'name': ''}])[0]['name'] %} {{ selected_parent }}
       <option value="" {% if not selected_parent %} selected="selected" {% endif %}>{{ _('None - top level') }}</option>
-      {% set parent_groups = h.get_groups_where_user_is_admin(data.get('id')) %}
+      {% set parent_groups = h.get_groups_where_user_is_admin(data.get('id'), only_approved=True) %}
       {% for group in parent_groups %}
         <option value="{{ group.name }}" {% if group.name == selected_parent %}selected="selected"{% endif %}>{{ h.get_translated(group, 'title') or group.name }}</option>
       {% endfor %}


### PR DESCRIPTION
- Added option to `get_groups_where_user_is_admin` to only return approved organizations
- Used the option in parent organization selection control