### PR TITLE
AV-1879 disable parent org edit if not parent admin

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -592,7 +592,7 @@ def get_apiset_package_list(package_id):
     return get_action('apiset_package_list')(context, {'apiset_id': package_id})
 
 
-def get_groups_where_user_is_admin(current_id=None):
+def get_groups_where_user_is_admin(current_id=None, only_approved=False):
     context = {'model': model, 'session': model.Session, 'user': c.user}
     organizations = get_action('organization_list_for_user')(context, {'permission': 'admin'})
 
@@ -603,7 +603,10 @@ def get_groups_where_user_is_admin(current_id=None):
                               current_organization.groups_allowed_to_be_its_parent(type='organization')]
         return filter(lambda organization: organization.get('id') in allowed_parent_ids, organizations)
 
-    return organizations
+    if only_approved:
+        return [o for o in organizations if o.get('approval_status') == 'approved']
+    else:
+        return organizations
 
 
 def get_value_from_extras_by_key(object_with_extras, key):

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/organization.json
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/organization.json
@@ -40,7 +40,7 @@
       "form_snippet": "org_hierarchy.html",
       "label": "Parent organization",
       "group_title": "Other information",
-      "validators": "is_allowed_parent is_admin_in_parent_if_changed"
+      "validators": "keep_old_value_if_missing is_allowed_parent is_admin_in_parent_if_changed"
     },
     {
       "field_name": "producer_type",

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/org_hierarchy.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/org_hierarchy.html
@@ -1,10 +1,15 @@
 <div class="control-group">
   <label class="control-label" for="field-parent">{{ h.scheming_language_text(field.label) }}</label>
   <div class="controls">
-    <select id="field-parent" name="groups__0__name" data-module="autocomplete">
-      {% set selected_parent = (data.get('groups') or [{'name': ''}])[0]['name'] %} {{ selected_parent }}
-      <option value="" {% if not selected_parent %} selected="selected" {% endif %}>{{ _('None - top level') }}</option>
-      {% set parent_groups = h.get_groups_where_user_is_admin(data.get('id'), only_approved=True) %}
+    {% set selected_parent = (data.get('groups') or [{'name': ''}])[0]['name'] %}
+    {% set parent_groups = h.get_groups_where_user_is_admin(data.get('id'), only_approved=True) | list%}
+    <select id="field-parent" name="groups__0__name" data-module="autocomplete" {% if not parent_groups %}disabled{% endif %}>
+      {{ selected_parent }}
+      {% if selected_parent and not parent_groups %}
+        <option value="{{ selected_parent }}" selected="selected">{{ _('Parent organization admin privileges are required to change parent organization') }}</option>
+      {% else %}
+        <option value="" {% if not selected_parent %} selected="selected" {% endif %}>{{ _('None - top level') }}</option>
+      {% endif %}
       {% for group in parent_groups %}
         <option value="{{ group.name }}" {% if group.name == selected_parent %}selected="selected"{% endif %}>{{ h.get_translated(group, 'title') or group.name }}</option>
       {% endfor %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/org_hierarchy.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/org_hierarchy.html
@@ -4,7 +4,7 @@
     <select id="field-parent" name="groups__0__name" data-module="autocomplete">
       {% set selected_parent = (data.get('groups') or [{'name': ''}])[0]['name'] %} {{ selected_parent }}
       <option value="" {% if not selected_parent %} selected="selected" {% endif %}>{{ _('None - top level') }}</option>
-      {% set parent_groups = h.get_groups_where_user_is_admin(data.get('id')) %}
+      {% set parent_groups = h.get_groups_where_user_is_admin(data.get('id'), only_approved=True) %}
       {% for group in parent_groups %}
         <option value="{{ group.name }}" {% if group.name == selected_parent %}selected="selected"{% endif %}>{{ h.get_translated(group, 'title') or group.name }}</option>
       {% endfor %}


### PR DESCRIPTION
- Add `keep_old_value_if_missing` to parent organization field to support control disabling
- Disable parent organization select if user is not an admin in currently selected parent organization 