### PR TITLE
AV-1961: Make external links in drupal content open in a new tab

### DIFF
--- a/drupal/modules/avoindata-ckeditor-plugins/js/plugin.js
+++ b/drupal/modules/avoindata-ckeditor-plugins/js/plugin.js
@@ -164,6 +164,7 @@
           el.addClass("external");
           el.append(svg);
           el.setAttribute('aria-label', textAriaLabelExternalSite);
+          el.setAttribute('target', '_blank');
         }
 
       });


### PR DESCRIPTION
- Set `target=_blank` attribute in external links