### PR TITLE
AV-1880: Fix list of selectable parent organizations

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/helpers.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/helpers.py
@@ -596,6 +596,9 @@ def get_groups_where_user_is_admin(current_id=None, only_approved=False):
     context = {'model': model, 'session': model.Session, 'user': c.user}
     organizations = get_action('organization_list_for_user')(context, {'permission': 'admin'})
 
+    if only_approved:
+        organizations = [o for o in organizations if o.get('approval_status') == 'approved']
+
     # If list is fetched for existing company, return only allowed parents
     if current_id is not None:
         current_organization = model.Group.get(current_id)
@@ -603,10 +606,7 @@ def get_groups_where_user_is_admin(current_id=None, only_approved=False):
                               current_organization.groups_allowed_to_be_its_parent(type='organization')]
         return filter(lambda organization: organization.get('id') in allowed_parent_ids, organizations)
 
-    if only_approved:
-        return [o for o in organizations if o.get('approval_status') == 'approved']
-    else:
-        return organizations
+    return organizations
 
 
 def get_value_from_extras_by_key(object_with_extras, key):

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/org_hierarchy.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/scheming/form_snippets/org_hierarchy.html
@@ -3,16 +3,17 @@
   <div class="controls">
     {% set selected_parent = (data.get('groups') or [{'name': ''}])[0]['name'] %}
     {% set parent_groups = h.get_groups_where_user_is_admin(data.get('id'), only_approved=True) | list%}
-    <select id="field-parent" name="groups__0__name" data-module="autocomplete" {% if not parent_groups %}disabled{% endif %}>
+    {% set not_parent_admin = selected_parent and parent_groups|selectattr("name", "eq", selected_parent)|list|length == 0 %}
+    <select id="field-parent" name="groups__0__name" data-module="autocomplete" {% if not_parent_admin %}disabled{% endif %}>
       {{ selected_parent }}
-      {% if selected_parent and not parent_groups %}
+      {% if not_parent_admin %}
         <option value="{{ selected_parent }}" selected="selected">{{ _('Parent organization admin privileges are required to change parent organization') }}</option>
       {% else %}
         <option value="" {% if not selected_parent %} selected="selected" {% endif %}>{{ _('None - top level') }}</option>
+        {% for group in parent_groups %}
+          <option value="{{ group.name }}" {% if group.name == selected_parent %}selected="selected"{% endif %}>{{ h.get_translated(group, 'title') or group.name }}</option>
+        {% endfor %}
       {% endif %}
-      {% for group in parent_groups %}
-        <option value="{{ group.name }}" {% if group.name == selected_parent %}selected="selected"{% endif %}>{{ h.get_translated(group, 'title') or group.name }}</option>
-      {% endfor %}
     </select>
   </div>
 </div>


### PR DESCRIPTION
- Handle `only_approved` in `get_groups_where_user_is_admin` also when `current_id` is defined
- Handle case where user is not an admin of the current parent organization, but is an admin of some other organization in addition to the one being edited.