### PR TITLE
AV-1981: Double datapusher task memory

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -425,7 +425,7 @@ const ckanStackBeta = new CkanStack(app, 'CkanStack-beta', {
   },
   datapusherTaskDef: {
     taskCpu: 512,
-    taskMem: 1024,
+    taskMem: 2048,
     taskMinCapacity: 1,
     taskMaxCapacity: 3,
   },
@@ -671,7 +671,7 @@ const ckanStackProd = new CkanStack(app, 'CkanStack-prod', {
   },
   datapusherTaskDef: {
     taskCpu: 512,
-    taskMem: 1024,
+    taskMem: 2048,
     taskMinCapacity: 1,
     taskMaxCapacity: 4,
   },


### PR DESCRIPTION
Apparently analyzing larger csv files require more then 1GB memory.