### PR TITLE
Forms should not have language attributes

### DIFF
--- a/drupal/modules/avoindata-header/src/Plugin/Form/SearchForm.php
+++ b/drupal/modules/avoindata-header/src/Plugin/Form/SearchForm.php
@@ -27,7 +27,6 @@ class SearchForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['language'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
     $form['searchfilter'] = [
       '#type' => 'textfield',
@@ -36,8 +35,6 @@ class SearchForm extends FormBase {
     ];
 
     $form['#theme'] = ['avoindata_search'];
-
-    $form['#language'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
     $form['search'] = [
       '#type' => 'textfield',

--- a/drupal/modules/avoindata-hero/src/Plugin/Form/HeroForm.php
+++ b/drupal/modules/avoindata-hero/src/Plugin/Form/HeroForm.php
@@ -27,8 +27,6 @@ class HeroForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['language'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
-
     $form['searchfilter'] = [
       '#type' => 'textfield',
       '#default_value' => '1',
@@ -36,8 +34,6 @@ class HeroForm extends FormBase {
     ];
 
     $form['#theme'] = ['avoindata_hero'];
-
-    $form['#language'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
 
     $form['search'] = [
       '#type' => 'textfield',


### PR DESCRIPTION
BuildForms should not have language attributes which generate errors in logs and sentry.