### PR TITLE
AV-2002: Fix ckan_cron healthcheck in CDK

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -525,7 +525,7 @@ export class CkanStack extends Stack {
           streamPrefix: 'ckan_cron-service',
         }),
         healthCheck: {
-          command: ['CMD-SHELL', 'ps -aux | grep -o "[c]ron -f" && ps -aux | grep -o "[s]upervisord --configuration"'],
+          command: ['CMD-SHELL', 'ps aux | grep -o "[c]rond -f" && ps aux | grep -o "[s]upervisord --configuration"'],
           interval: Duration.seconds(15),
           timeout: Duration.seconds(5),
           retries: 5,

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -218,7 +218,7 @@ RUN apk add --no-cache \
         unzip \
         rsync \
         proj-dev \
-        proj-util && \
+        proj-util \
         nfs-utils && \
     pip install \
       jinja2-cli \

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -219,6 +219,7 @@ RUN apk add --no-cache \
         rsync \
         proj-dev \
         proj-util && \
+        nfs-utils && \
     pip install \
       jinja2-cli \
       supervisor \


### PR DESCRIPTION
- use `crond` instead of `cron`
- the correct format is `ps aux` not `ps -aux`
- Added `nfs-utils` to installed packages