### PR TITLE
Revert "Output contents of lock files for debugging"

### DIFF
--- a/ckan/scripts/entrypoint_ckan.sh
+++ b/ckan/scripts/entrypoint_ckan.sh
@@ -20,8 +20,6 @@ fi
 
 echo "locking file for init.."
 echo "lock file: ${DATA_DIR}/.init-lock"
-cat ${DATA_DIR}/.init-lock
-cat ${DATA_DIR}/.init-done
 
 # init ckan if not done or version updated, otherwise run re-init
 flock -x ${DATA_DIR}/.init-lock -c 'echo "waiting for .init-lock to be released ..."'


### PR DESCRIPTION
Reverts vrk-kpa/opendata#1936, cats will fail if files do not exist.