### PR TITLE
AV-2012: use separate certificate for cloudfront

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -115,9 +115,8 @@ const certificateStackInfratest = new CertificateStack(app, 'CertificateStack-in
   envProps: envProps,
   env: {
     account: infratestProps.account,
-    region: 'us-east-1',
+    region: infratestProps.region,
   },
-  crossRegionReferences: true,
   environment: infratestProps.environment,
   fqdn: infratestProps.fqdn,
   secondaryFqdn: infratestProps.secondaryFqdn,
@@ -131,7 +130,6 @@ const loadBalancerStackInfratest = new LoadBalancerStack(app, 'LoadBalancerStack
     account: infratestProps.account,
     region: infratestProps.region,
   },
-  crossRegionReferences: true,
   environment: infratestProps.environment,
   fqdn: infratestProps.fqdn,
   secondaryFqdn: infratestProps.secondaryFqdn,
@@ -367,9 +365,8 @@ const certificateStackBeta = new CertificateStack(app, 'CertificateStack-beta', 
   envProps: envProps,
   env: {
     account: betaProps.account,
-    region: 'us-east-1',
+    region: betaProps.region,
   },
-  crossRegionReferences: true,
   environment: betaProps.environment,
   fqdn: betaProps.fqdn,
   secondaryFqdn: betaProps.secondaryFqdn,
@@ -377,13 +374,26 @@ const certificateStackBeta = new CertificateStack(app, 'CertificateStack-beta', 
   secondaryDomainName: betaProps.secondaryDomainName
 })
 
+const certificateStackForCloudfrontBeta = new CertificateStack(app, 'CertificateStackForCloudfront-beta', {
+  envProps: envProps,
+  env: {
+    account: betaProps.account,
+    region: 'us-east-1',
+  },
+  environment: betaProps.environment,
+  fqdn: betaProps.fqdn,
+  secondaryFqdn: betaProps.secondaryFqdn,
+  domainName: betaProps.domainName,
+  secondaryDomainName: betaProps.secondaryDomainName
+})
+
+
 const loadBalancerStackBeta = new LoadBalancerStack(app, 'LoadBalancerStack-beta', {
   envProps: envProps,
   env: {
     account: betaProps.account,
     region: betaProps.region,
   },
-  crossRegionReferences: true,
   environment: betaProps.environment,
   fqdn: betaProps.fqdn,
   secondaryFqdn: betaProps.secondaryFqdn,
@@ -626,9 +636,8 @@ const certificateStackProd = new CertificateStack(app, 'CertificateStack-prod', 
   envProps: envProps,
   env: {
     account: prodProps.account,
-    region: 'us-east-1',
+    region: prodProps.region
   },
-  crossRegionReferences: true,
   environment: prodProps.environment,
   fqdn: prodProps.fqdn,
   secondaryFqdn: prodProps.secondaryFqdn,
@@ -642,7 +651,6 @@ const loadBalancerStackProd = new LoadBalancerStack(app, 'LoadBalancerStack-prod
     account: prodProps.account,
     region: prodProps.region,
   },
-  crossRegionReferences: true,
   environment: prodProps.environment,
   fqdn: prodProps.fqdn,
   secondaryFqdn: prodProps.secondaryFqdn,

--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -124,6 +124,19 @@ const certificateStackInfratest = new CertificateStack(app, 'CertificateStack-in
   secondaryDomainName: infratestProps.secondaryDomainName
 })
 
+const certificateStackForCLoudfrontInfratest = new CertificateStack(app, 'CertificateStackForCloudfront-infra', {
+  envProps: envProps,
+  env: {
+    account: infratestProps.account,
+    region: 'us-east-1',
+  },
+  environment: infratestProps.environment,
+  fqdn: infratestProps.fqdn,
+  secondaryFqdn: infratestProps.secondaryFqdn,
+  domainName: infratestProps.domainName,
+  secondaryDomainName: infratestProps.secondaryDomainName
+})
+
 const loadBalancerStackInfratest = new LoadBalancerStack(app, 'LoadBalancerStackInfratest-infratest', {
   envProps: envProps,
   env: {
@@ -637,6 +650,19 @@ const certificateStackProd = new CertificateStack(app, 'CertificateStack-prod', 
   env: {
     account: prodProps.account,
     region: prodProps.region
+  },
+  environment: prodProps.environment,
+  fqdn: prodProps.fqdn,
+  secondaryFqdn: prodProps.secondaryFqdn,
+  domainName: prodProps.domainName,
+  secondaryDomainName: prodProps.secondaryDomainName
+})
+
+const certificateStackForCloudfrontProd = new CertificateStack(app, 'CertificateStackForCloudfront-prod', {
+  envProps: envProps,
+  env: {
+    account: prodProps.account,
+    region: 'us-east-1'
   },
   environment: prodProps.environment,
   fqdn: prodProps.fqdn,


### PR DESCRIPTION
Loadbalancer requires certificate in the same region and cloudfront requires it to be us-east-1, so this creates both, cloudfront is in cloudformation stack so it does not automatically update with cdk.