### PR TITLE
AV-1993: Add bypass cdn stack and allow the host in drupal

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -702,6 +702,20 @@ const loadBalancerStackProd = new LoadBalancerStack(app, 'LoadBalancerStack-prod
   cert: certificateStackProd.certificate
 });
 
+const bypassCdnStackProd = new BypassCdnStack(app, 'BypassCdnStack-prod', {
+  envProps: envProps,
+  env: {
+    account: prodProps.account,
+    region: prodProps.region,
+  },
+  environment: prodProps.environment,
+  fqdn: prodProps.fqdn,
+  secondaryFqdn: prodProps.secondaryFqdn,
+  domainName: prodProps.domainName,
+  secondaryDomainName: prodProps.secondaryDomainName,
+  loadbalancer: loadBalancerStackProd.loadBalancer
+})
+
 const cacheStackProd = new CacheStack(app, 'CacheStack-prod', {
   envProps: envProps,
   env: {

--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -418,7 +418,7 @@ const loadBalancerStackBeta = new LoadBalancerStack(app, 'LoadBalancerStack-beta
 });
 
 
-const bybassCdnStackBeta = new BypassCdnStack(app, 'BypassCdnStack-beta', {
+const bypassCdnStackBeta = new BypassCdnStack(app, 'BypassCdnStack-beta', {
   envProps: envProps,
   env: {
     account: betaProps.account,

--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -13,6 +13,7 @@ import { CkanStack } from '../lib/ckan-stack';
 import { WebStack } from '../lib/web-stack';
 import { BackupStack } from "../lib/backup-stack"
 import {CertificateStack} from "../lib/certificate-stack";
+import {BypassCdnStack} from "../lib/bypass-cdn-stack";
 
 // load .env file, shared with docker setup
 // mainly for ECR repo and image tag information
@@ -415,6 +416,21 @@ const loadBalancerStackBeta = new LoadBalancerStack(app, 'LoadBalancerStack-beta
   vpc: clusterStackBeta.vpc,
   cert: certificateStackBeta.certificate
 });
+
+
+const bybassCdnStackBeta = new BypassCdnStack(app, 'BypassCdnStack-beta', {
+  envProps: envProps,
+  env: {
+    account: betaProps.account,
+    region: betaProps.region,
+  },
+  environment: betaProps.environment,
+  fqdn: betaProps.fqdn,
+  secondaryFqdn: betaProps.secondaryFqdn,
+  domainName: betaProps.domainName,
+  secondaryDomainName: betaProps.secondaryDomainName,
+  loadbalancer: loadBalancerStackBeta.loadBalancer
+})
 
 const cacheStackBeta = new CacheStack(app, 'CacheStack-beta', {
   envProps: envProps,

--- a/cdk/lib/bypass-cdn-stack-props.ts
+++ b/cdk/lib/bypass-cdn-stack-props.ts
@@ -1,0 +1,7 @@
+import {aws_route53} from "aws-cdk-lib";
+import * as elb from "aws-cdk-lib/aws-elasticloadbalancingv2";
+import {CommonStackProps} from "./common-stack-props";
+
+export interface BypassCdnStackProps extends CommonStackProps {
+  loadbalancer: elb.IApplicationLoadBalancer
+}

--- a/cdk/lib/bypass-cdn-stack.ts
+++ b/cdk/lib/bypass-cdn-stack.ts
@@ -1,0 +1,29 @@
+import {
+  aws_route53 as route53,
+  aws_route53_targets,
+  aws_certificatemanager as acm
+} from 'aws-cdk-lib';
+import {Stack} from "aws-cdk-lib";
+import {Construct} from "constructs";
+import {BypassCdnStackProps} from "./bypass-cdn-stack-props";
+
+export class BypassCdnStack extends Stack {
+  constructor(scope: Construct, id: string, props: BypassCdnStackProps) {
+    super(scope, id, props);
+
+    const zone = route53.HostedZone.fromLookup(this, 'OpendataZone', {
+      domainName: props.fqdn
+    })
+
+    let domain_record = new route53.ARecord(this, 'ARecord', {
+      zone: zone,
+      recordName: 'api',
+      target: route53.RecordTarget.fromAlias(new aws_route53_targets.LoadBalancerTarget(props.loadbalancer))
+    })
+
+
+
+  }
+}
+
+

--- a/cdk/lib/drupal-stack.ts
+++ b/cdk/lib/drupal-stack.ts
@@ -154,7 +154,7 @@ export class DrupalStack extends Stack {
       SMTP_PORT: pSmtpPort.stringValue,
       DISQUS_DOMAIN: pDisqusDomain.stringValue,
       SENTRY_ENV: props.environment,
-      BYBASS_CDN_DOMAIN: `api.${props.fqdn}`
+      BYPASS_CDN_DOMAIN: `api.${props.fqdn}`
     };
 
     let drupalContainerSecrets: { [key: string]: ecs.Secret; } = {

--- a/cdk/lib/drupal-stack.ts
+++ b/cdk/lib/drupal-stack.ts
@@ -154,6 +154,7 @@ export class DrupalStack extends Stack {
       SMTP_PORT: pSmtpPort.stringValue,
       DISQUS_DOMAIN: pDisqusDomain.stringValue,
       SENTRY_ENV: props.environment,
+      BYBASS_CDN_DOMAIN: `api.${props.fqdn}`
     };
 
     let drupalContainerSecrets: { [key: string]: ecs.Secret; } = {

--- a/drupal/templates/settings.php.j2
+++ b/drupal/templates/settings.php.j2
@@ -752,8 +752,8 @@ $settings['trusted_host_patterns'] = [
   '^{{ environ('SECONDARY_DOMAIN_NAME')|replace(".", "\.") }}$',
   {% endif -%}
   '^{{ environ('NGINX_HOST')|replace(".", "\.") }}$',
-  {% if environ('BYBASS_CDN_DOMAIN') is defined and environ('BYBASS_CDN_DOMAIN')|length -%}
-  '^{{ environ('BYBASS_CDN_DOMAIN')|replace(".", "\.") }}$',
+  {% if environ('BYPASS_CDN_DOMAIN') is defined and environ('BYPASS_CDN_DOMAIN')|length -%}
+  '^{{ environ('BYPASS_CDN_DOMAIN')|replace(".", "\.") }}$',
   {% endif -%}
 ];
 

--- a/drupal/templates/settings.php.j2
+++ b/drupal/templates/settings.php.j2
@@ -752,7 +752,7 @@ $settings['trusted_host_patterns'] = [
   '^{{ environ('SECONDARY_DOMAIN_NAME')|replace(".", "\.") }}$',
   {% endif -%}
   '^{{ environ('NGINX_HOST')|replace(".", "\.") }}$',
-  {% if environ('BYPASS_CDN_DOMAIN') is defined and environ('BYPASS_CDN_DOMAIN')|length -%}
+  {% if environ('BYPASS_CDN_DOMAIN') is not none and environ('BYPASS_CDN_DOMAIN')|length -%}
   '^{{ environ('BYPASS_CDN_DOMAIN')|replace(".", "\.") }}$',
   {% endif -%}
 ];

--- a/drupal/templates/settings.php.j2
+++ b/drupal/templates/settings.php.j2
@@ -752,6 +752,9 @@ $settings['trusted_host_patterns'] = [
   '^{{ environ('SECONDARY_DOMAIN_NAME')|replace(".", "\.") }}$',
   {% endif -%}
   '^{{ environ('NGINX_HOST')|replace(".", "\.") }}$',
+  {% if environ('BYBASS_CDN_DOMAIN') is defined and environ('BYBASS_CDN_DOMAIN')|length -%}
+  '^{{ environ('BYBASS_CDN_DOMAIN')|replace(".", "\.") }}$',
+  {% endif -%}
 ];
 
 /**


### PR DESCRIPTION
Adds api subdomain to route53, forwards the traffic to loadbalancer and allows the domain to be used in drupal.