### PR TITLE
Change bypass domain from api to vip

### DIFF
--- a/cdk/lib/bypass-cdn-stack.ts
+++ b/cdk/lib/bypass-cdn-stack.ts
@@ -17,7 +17,7 @@ export class BypassCdnStack extends Stack {
 
     let domain_record = new route53.ARecord(this, 'ARecord', {
       zone: zone,
-      recordName: 'api',
+      recordName: 'vip',
       target: route53.RecordTarget.fromAlias(new aws_route53_targets.LoadBalancerTarget(props.loadbalancer))
     })
 

--- a/cdk/lib/certificate-stack.ts
+++ b/cdk/lib/certificate-stack.ts
@@ -18,7 +18,7 @@ export class CertificateStack extends Stack {
 
     const alternativeNamePrefixes: string[] = [
       "www",
-      "api"
+      "vip"
     ]
 
     const alternativeNames: string[] = alternativeNamePrefixes.map((name) => {

--- a/cdk/lib/drupal-stack.ts
+++ b/cdk/lib/drupal-stack.ts
@@ -154,7 +154,7 @@ export class DrupalStack extends Stack {
       SMTP_PORT: pSmtpPort.stringValue,
       DISQUS_DOMAIN: pDisqusDomain.stringValue,
       SENTRY_ENV: props.environment,
-      BYPASS_CDN_DOMAIN: `api.${props.fqdn}`
+      BYPASS_CDN_DOMAIN: `vip.${props.fqdn}`
     };
 
     let drupalContainerSecrets: { [key: string]: ecs.Secret; } = {


### PR DESCRIPTION
Changes domain for bypassing cloudfront from route53, certificates and trusted hosts in drupal.