### PR TITLE
AV-1944: Add maintainer_note_translated to dataset schema

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/ckanext-ytp_main.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-06-01 12:41+0000\n"
+"POT-Creation-Date: 2023-07-14 20:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1196,25 +1196,37 @@ msgid ""
 "organization."
 msgstr ""
 
+#: ckanext/ytp/translations.py:226
+msgid "Maintainer note"
+msgstr ""
+
+#: ckanext/ytp/translations.py:227
+msgid "e.g. Dataset updated 15.5.2023"
+msgstr ""
+
 #: ckanext/ytp/translations.py:228
+msgid "Inform users about dataset updates"
+msgstr ""
+
+#: ckanext/ytp/translations.py:231
 msgid "Data resource title"
 msgstr ""
 
-#: ckanext/ytp/translations.py:229
+#: ckanext/ytp/translations.py:232
 msgid ""
 "Write a short and descriptive name for the data resource. If the data covers "
 "a specific time frame, mention that in the name."
 msgstr ""
 
-#: ckanext/ytp/translations.py:230
+#: ckanext/ytp/translations.py:233
 msgid "e.g. Most popular Finnish first names 2019"
 msgstr ""
 
-#: ckanext/ytp/translations.py:231
+#: ckanext/ytp/translations.py:234
 msgid "Resource *"
 msgstr ""
 
-#: ckanext/ytp/translations.py:232
+#: ckanext/ytp/translations.py:235
 msgid ""
 "Add the data resource by uploading a file or adding a link to the "
 "data.<br>Select or drag the files here.<br>The maximum file size is 5 Gb. "
@@ -1222,283 +1234,283 @@ msgid ""
 "pptx, odt, ods, txt.<br>Link: Add a link to the data."
 msgstr ""
 
-#: ckanext/ytp/translations.py:233
+#: ckanext/ytp/translations.py:236
 msgid "Data resource description"
 msgstr ""
 
-#: ckanext/ytp/translations.py:234
+#: ckanext/ytp/translations.py:237
 msgid "Write a description for the resource"
 msgstr ""
 
-#: ckanext/ytp/translations.py:235
+#: ckanext/ytp/translations.py:238
 msgid ""
 "Describe the data clearly and concisely. Use as confining terms as possible "
 "to make it easier to find and understand the data."
 msgstr ""
 
-#: ckanext/ytp/translations.py:236
+#: ckanext/ytp/translations.py:239
 msgid "Additional information"
 msgstr ""
 
-#: ckanext/ytp/translations.py:237
+#: ckanext/ytp/translations.py:240
 msgid "Data status"
 msgstr ""
 
-#: ckanext/ytp/translations.py:238
+#: ckanext/ytp/translations.py:241
 msgid ""
 "Define a state for the data. This is recommended especially if your dataset "
 "has data resources from multiple years."
 msgstr ""
 
-#: ckanext/ytp/translations.py:239
+#: ckanext/ytp/translations.py:242
 msgid "Coordinate system"
 msgstr ""
 
-#: ckanext/ytp/translations.py:240
+#: ckanext/ytp/translations.py:243
 msgid ""
 "If your data includes geographic information, specify the coordinate system "
 "it uses."
 msgstr ""
 
-#: ckanext/ytp/translations.py:241
+#: ckanext/ytp/translations.py:244
 msgid "e.g. WGS84 (World Geodetic System 1984)"
 msgstr ""
 
-#: ckanext/ytp/translations.py:242
+#: ckanext/ytp/translations.py:245
 msgid ""
 "Select the time frame by which the data is separated. For example, does the "
 "resource include data from every week or month."
 msgstr ""
 
-#: ckanext/ytp/translations.py:243
+#: ckanext/ytp/translations.py:246
 msgid "e.g. a month"
 msgstr ""
 
-#: ckanext/ytp/translations.py:244
+#: ckanext/ytp/translations.py:247
 msgid "Time Frame"
 msgstr ""
 
-#: ckanext/ytp/translations.py:245
+#: ckanext/ytp/translations.py:248
 msgid "Start date"
 msgstr ""
 
-#: ckanext/ytp/translations.py:246
+#: ckanext/ytp/translations.py:249
 msgid "End date"
 msgstr ""
 
-#: ckanext/ytp/translations.py:247
+#: ckanext/ytp/translations.py:250
 msgid "Geographical accuracy"
 msgstr ""
 
-#: ckanext/ytp/translations.py:248
+#: ckanext/ytp/translations.py:251
 msgid "If your data includes geographic information, specify the accuracy in meters"
 msgstr ""
 
-#: ckanext/ytp/translations.py:251
+#: ckanext/ytp/translations.py:254
 msgid "Producer name"
 msgstr ""
 
-#: ckanext/ytp/translations.py:252
+#: ckanext/ytp/translations.py:255
 msgid "Producer description"
 msgstr ""
 
-#: ckanext/ytp/translations.py:253
+#: ckanext/ytp/translations.py:256
 msgid "Common, compact and plain description about producer"
 msgstr ""
 
-#: ckanext/ytp/translations.py:254
+#: ckanext/ytp/translations.py:257
 msgid "Other information"
 msgstr ""
 
-#: ckanext/ytp/translations.py:255
+#: ckanext/ytp/translations.py:258
 msgid "Upload logo"
 msgstr ""
 
-#: ckanext/ytp/translations.py:258
+#: ckanext/ytp/translations.py:261
 msgid "cc-by"
 msgstr ""
 
-#: ckanext/ytp/translations.py:259
+#: ckanext/ytp/translations.py:262
 msgid "cc-by-4-fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:260
+#: ckanext/ytp/translations.py:263
 msgid "cc-by-4.0"
 msgstr ""
 
-#: ckanext/ytp/translations.py:261
+#: ckanext/ytp/translations.py:264
 msgid "cc-by-sa"
 msgstr ""
 
-#: ckanext/ytp/translations.py:262
+#: ckanext/ytp/translations.py:265
 msgid "cc-by-sa-1-fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:263
+#: ckanext/ytp/translations.py:266
 msgid "cc-nc"
 msgstr ""
 
-#: ckanext/ytp/translations.py:264
+#: ckanext/ytp/translations.py:267
 msgid "cc-zero"
 msgstr ""
 
-#: ckanext/ytp/translations.py:265
+#: ckanext/ytp/translations.py:268
 msgid "cc-zero-1.0"
 msgstr ""
 
-#: ckanext/ytp/translations.py:266
+#: ckanext/ytp/translations.py:269
 msgid "gfdl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:267
+#: ckanext/ytp/translations.py:270
 msgid "helsinkikanava-opendata-tos"
 msgstr ""
 
-#: ckanext/ytp/translations.py:268
+#: ckanext/ytp/translations.py:271
 msgid "hri-tietoaineistot-lisenssi-nimea"
 msgstr ""
 
-#: ckanext/ytp/translations.py:269
+#: ckanext/ytp/translations.py:272
 msgid "ilmoitettumuualla"
 msgstr ""
 
-#: ckanext/ytp/translations.py:270
+#: ckanext/ytp/translations.py:273
 msgid "kmo-aluejakorajat"
 msgstr ""
 
-#: ckanext/ytp/translations.py:271
+#: ckanext/ytp/translations.py:274
 msgid "notspecified"
 msgstr ""
 
-#: ckanext/ytp/translations.py:272
+#: ckanext/ytp/translations.py:275
 msgid "odc-by"
 msgstr ""
 
-#: ckanext/ytp/translations.py:273
+#: ckanext/ytp/translations.py:276
 msgid "odc-odbl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:274
+#: ckanext/ytp/translations.py:277
 msgid "odc-pddl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:275
+#: ckanext/ytp/translations.py:278
 msgid "other"
 msgstr ""
 
-#: ckanext/ytp/translations.py:276
+#: ckanext/ytp/translations.py:279
 msgid "other-at"
 msgstr ""
 
-#: ckanext/ytp/translations.py:277
+#: ckanext/ytp/translations.py:280
 msgid "other-closed"
 msgstr ""
 
-#: ckanext/ytp/translations.py:278
+#: ckanext/ytp/translations.py:281
 msgid "other-nc"
 msgstr ""
 
-#: ckanext/ytp/translations.py:279
+#: ckanext/ytp/translations.py:282
 msgid "other-open"
 msgstr ""
 
-#: ckanext/ytp/translations.py:280
+#: ckanext/ytp/translations.py:283
 msgid "other-pd"
 msgstr ""
 
-#: ckanext/ytp/translations.py:281
+#: ckanext/ytp/translations.py:284
 msgid "uk-ogl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:284
+#: ckanext/ytp/translations.py:287
 msgid "Platforms"
 msgstr ""
 
-#: ckanext/ytp/translations.py:287
+#: ckanext/ytp/translations.py:290
 msgid "Show more collection_type"
 msgstr ""
 
-#: ckanext/ytp/translations.py:288
+#: ckanext/ytp/translations.py:291
 msgid "Show more vocab_international_benchmarks"
 msgstr ""
 
-#: ckanext/ytp/translations.py:289
+#: ckanext/ytp/translations.py:292
 msgid "Show more vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:290
+#: ckanext/ytp/translations.py:293
 msgid "Show more vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:291
+#: ckanext/ytp/translations.py:294
 msgid "Show more vocab_keywords_sv"
 msgstr ""
 
-#: ckanext/ytp/translations.py:292
+#: ckanext/ytp/translations.py:295
 msgid "Show more organization"
 msgstr ""
 
-#: ckanext/ytp/translations.py:293
+#: ckanext/ytp/translations.py:296
 msgid "Show more res_format"
 msgstr ""
 
-#: ckanext/ytp/translations.py:294
+#: ckanext/ytp/translations.py:297
 msgid "Show more source"
 msgstr ""
 
-#: ckanext/ytp/translations.py:295
+#: ckanext/ytp/translations.py:298
 msgid "Show more license_id"
 msgstr ""
 
-#: ckanext/ytp/translations.py:296
+#: ckanext/ytp/translations.py:299
 msgid "Show more groups"
 msgstr ""
 
-#: ckanext/ytp/translations.py:297
+#: ckanext/ytp/translations.py:300
 msgid "Show more vocab_platform"
 msgstr ""
 
-#: ckanext/ytp/translations.py:300
+#: ckanext/ytp/translations.py:303
 msgid "Show less collection_type"
 msgstr ""
 
-#: ckanext/ytp/translations.py:301
+#: ckanext/ytp/translations.py:304
 msgid "Show less vocab_international_benchmarks"
 msgstr ""
 
-#: ckanext/ytp/translations.py:302
+#: ckanext/ytp/translations.py:305
 msgid "Show less vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:303
+#: ckanext/ytp/translations.py:306
 msgid "Show less vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:304
+#: ckanext/ytp/translations.py:307
 msgid "Show less vocab_keywords_sv"
 msgstr ""
 
-#: ckanext/ytp/translations.py:305
+#: ckanext/ytp/translations.py:308
 msgid "Show less organization"
 msgstr ""
 
-#: ckanext/ytp/translations.py:306
+#: ckanext/ytp/translations.py:309
 msgid "Show less res_format"
 msgstr ""
 
-#: ckanext/ytp/translations.py:307
+#: ckanext/ytp/translations.py:310
 msgid "Show less source"
 msgstr ""
 
-#: ckanext/ytp/translations.py:308
+#: ckanext/ytp/translations.py:311
 msgid "Show less license_id"
 msgstr ""
 
-#: ckanext/ytp/translations.py:309
+#: ckanext/ytp/translations.py:312
 msgid "Show less groups"
 msgstr ""
 
-#: ckanext/ytp/translations.py:310
+#: ckanext/ytp/translations.py:313
 msgid "Show less vocab_platform"
 msgstr ""
 
@@ -1702,10 +1714,6 @@ msgstr ""
 
 #: ckanext/ytp/resources/vendor/bootstrap-table/dist/extensions/filter-control/utils.js:10
 msgid "Can't call method on "
-msgstr ""
-
-#: ckanext/ytp/templates/disqus_comments.html:2
-msgid "Give feedback"
 msgstr ""
 
 #: ckanext/ytp/templates/page.html:13
@@ -2615,6 +2623,10 @@ msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/dataset_social.html:4
 msgid "Social"
+msgstr ""
+
+#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:36
+msgid "Dataset maintainer informs:"
 msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:18

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/fi/LC_MESSAGES/ckanext-ytp_main.po
@@ -14,18 +14,18 @@
 # Meeri Hakala <meeri.hakala@dvv.fi>, 2022
 # Zharktas <jari-pekka.voutilainen@gofore.com>, 2023
 # Teemu Erkkola <teemu.erkkola@iki.fi>, 2023
-# Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023
 # Roosa Lampinen, 2023
 # Suvi Nuttunen, 2023
+# Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023
 # 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-06-01 12:41+0000\n"
+"POT-Creation-Date: 2023-07-14 20:44+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
-"Last-Translator: Suvi Nuttunen, 2023\n"
+"Last-Translator: Eetu Mansikkamäki <eetu.mansikkamaki@gofore.com>, 2023\n"
 "Language-Team: Finnish (https://app.transifex.com/avoindata/teams/7979/fi/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -1286,11 +1286,23 @@ msgstr ""
 "Rajapinta on yksityinen. Se näkyy vain rajapinnan julkaisseen organisaation "
 "jäsenille. "
 
+#: ckanext/ytp/translations.py:226
+msgid "Maintainer note"
+msgstr "Ylläpitäjän ilmoitus"
+
+#: ckanext/ytp/translations.py:227
+msgid "e.g. Dataset updated 15.5.2023"
+msgstr "esim. Tietoaineisto päivitetty 15.5.2023"
+
 #: ckanext/ytp/translations.py:228
+msgid "Inform users about dataset updates"
+msgstr "Tiedota palvelun käyttäjille tietoaineiston päivittämisestä"
+
+#: ckanext/ytp/translations.py:231
 msgid "Data resource title"
 msgstr "Data-aineiston nimi"
 
-#: ckanext/ytp/translations.py:229
+#: ckanext/ytp/translations.py:232
 msgid ""
 "Write a short and descriptive name for the data resource. If the data covers"
 " a specific time frame, mention that in the name."
@@ -1298,15 +1310,15 @@ msgstr ""
 "Kirjoita lyhyt ja kuvaava nimi data-aineistolle. Jos data kattaa vain tietyn"
 " aikavälin, mainitse se nimessä."
 
-#: ckanext/ytp/translations.py:230
+#: ckanext/ytp/translations.py:233
 msgid "e.g. Most popular Finnish first names 2019"
 msgstr "esim. Suosituimmat suomalaiset etunimet 2019"
 
-#: ckanext/ytp/translations.py:231
+#: ckanext/ytp/translations.py:234
 msgid "Resource *"
 msgstr "Data-aineisto *"
 
-#: ckanext/ytp/translations.py:232
+#: ckanext/ytp/translations.py:235
 msgid ""
 "Add the data resource by uploading a file or adding a link to the "
 "data.<br>Select or drag the files here.<br>The maximum file size is 5 Gb. "
@@ -1318,15 +1330,15 @@ msgstr ""
 "ovat mm. pdf, jpg, jpeg, png, doc, docx, xls, xlsx, csv, ppt, pptx, odt, "
 "ods, txt."
 
-#: ckanext/ytp/translations.py:233
+#: ckanext/ytp/translations.py:236
 msgid "Data resource description"
 msgstr "Data-aineiston kuvaus"
 
-#: ckanext/ytp/translations.py:234
+#: ckanext/ytp/translations.py:237
 msgid "Write a description for the resource"
 msgstr "Kirjoita kuvaus data-aineistolle"
 
-#: ckanext/ytp/translations.py:235
+#: ckanext/ytp/translations.py:238
 msgid ""
 "Describe the data clearly and concisely. Use as confining terms as possible "
 "to make it easier to find and understand the data."
@@ -1334,15 +1346,15 @@ msgstr ""
 "Tiivis ja helppotajuinen kuvaus data-aineistosta. Käytä mahdollisimman "
 "rajaavia termejä helpottamaan datan ymmärtämistä."
 
-#: ckanext/ytp/translations.py:236
+#: ckanext/ytp/translations.py:239
 msgid "Additional information"
 msgstr "Lisätiedot"
 
-#: ckanext/ytp/translations.py:237
+#: ckanext/ytp/translations.py:240
 msgid "Data status"
 msgstr "Aineiston tila"
 
-#: ckanext/ytp/translations.py:238
+#: ckanext/ytp/translations.py:241
 msgid ""
 "Define a state for the data. This is recommended especially if your dataset "
 "has data resources from multiple years."
@@ -1350,11 +1362,11 @@ msgstr ""
 "Voit määritellä data-aineistolle tilan. Tämä on suositeltavaa erityisesti "
 "jos tietoaineistollasi on data-aineistoja useilta eri vuosilta."
 
-#: ckanext/ytp/translations.py:239
+#: ckanext/ytp/translations.py:242
 msgid "Coordinate system"
 msgstr "Sijaintikoordinaattien muoto"
 
-#: ckanext/ytp/translations.py:240
+#: ckanext/ytp/translations.py:243
 msgid ""
 "If your data includes geographic information, specify the coordinate system "
 "it uses."
@@ -1362,11 +1374,11 @@ msgstr ""
 "Kerro missä muodossa karttamuotoisen aineiston koordinaatit ovat. Esim. "
 "koordinaatisto, jossa sijaintidata tarjotaan."
 
-#: ckanext/ytp/translations.py:241
+#: ckanext/ytp/translations.py:244
 msgid "e.g. WGS84 (World Geodetic System 1984)"
 msgstr "esim. WGS84 (World Geodetic System 1984)"
 
-#: ckanext/ytp/translations.py:242
+#: ckanext/ytp/translations.py:245
 msgid ""
 "Select the time frame by which the data is separated. For example, does the "
 "resource include data from every week or month."
@@ -1374,240 +1386,240 @@ msgstr ""
 "Kerro, kuinka tarkasti data on eroteltu aineistossa. Esimerkiksi sisältääkö "
 "aineisto dataa joka viikolta tai kuukaudelta."
 
-#: ckanext/ytp/translations.py:243
+#: ckanext/ytp/translations.py:246
 msgid "e.g. a month"
 msgstr "esim. kuukausi"
 
-#: ckanext/ytp/translations.py:244
+#: ckanext/ytp/translations.py:247
 msgid "Time Frame"
 msgstr "Ajallinen kattavuus"
 
-#: ckanext/ytp/translations.py:245
+#: ckanext/ytp/translations.py:248
 msgid "Start date"
 msgstr "Alkuajankohta"
 
-#: ckanext/ytp/translations.py:246
+#: ckanext/ytp/translations.py:249
 msgid "End date"
 msgstr "Loppuajankohta"
 
-#: ckanext/ytp/translations.py:247
+#: ckanext/ytp/translations.py:250
 msgid "Geographical accuracy"
 msgstr "Maantieteellinen erottelutarkkuus"
 
-#: ckanext/ytp/translations.py:248
+#: ckanext/ytp/translations.py:251
 msgid ""
 "If your data includes geographic information, specify the accuracy in meters"
 msgstr ""
 "Kerro metreissä, kuinka tarkasti paikkatietoaineiston data on eroteltu. "
 "Esimerkiksi: 30 "
 
-#: ckanext/ytp/translations.py:251
+#: ckanext/ytp/translations.py:254
 msgid "Producer name"
 msgstr "Tuottajan nimi"
 
-#: ckanext/ytp/translations.py:252
+#: ckanext/ytp/translations.py:255
 msgid "Producer description"
 msgstr "Tuottajan kuvaus"
 
-#: ckanext/ytp/translations.py:253
+#: ckanext/ytp/translations.py:256
 msgid "Common, compact and plain description about producer"
 msgstr ""
 "Kerro, mitä organisaatiosi tekee ja millaisia palveluja sekä millaista dataa"
 " se tarjoaa. "
 
-#: ckanext/ytp/translations.py:254
+#: ckanext/ytp/translations.py:257
 msgid "Other information"
 msgstr "Muut tiedot"
 
-#: ckanext/ytp/translations.py:255
+#: ckanext/ytp/translations.py:258
 msgid "Upload logo"
 msgstr "Lataa logo"
 
-#: ckanext/ytp/translations.py:258
+#: ckanext/ytp/translations.py:261
 msgid "cc-by"
 msgstr "Creative Commons Attribution"
 
-#: ckanext/ytp/translations.py:259
+#: ckanext/ytp/translations.py:262
 msgid "cc-by-4-fi"
 msgstr " Creative Commons Nimeä 4.0"
 
-#: ckanext/ytp/translations.py:260
+#: ckanext/ytp/translations.py:263
 msgid "cc-by-4.0"
 msgstr " Creative Commons Nimeä 4.0"
 
-#: ckanext/ytp/translations.py:261
+#: ckanext/ytp/translations.py:264
 msgid "cc-by-sa"
 msgstr "Creative Commons Attribution Share-Alike"
 
-#: ckanext/ytp/translations.py:262
+#: ckanext/ytp/translations.py:265
 msgid "cc-by-sa-1-fi"
 msgstr "Creative Commons Nime\\xe4-Tarttuva 1.0 Suomi CC BY-SA 1.0"
 
-#: ckanext/ytp/translations.py:263
+#: ckanext/ytp/translations.py:266
 msgid "cc-nc"
 msgstr "Creative Commons Non-Commercial Any"
 
-#: ckanext/ytp/translations.py:264
+#: ckanext/ytp/translations.py:267
 msgid "cc-zero"
 msgstr "Creative Commons CCZero"
 
-#: ckanext/ytp/translations.py:265
+#: ckanext/ytp/translations.py:268
 msgid "cc-zero-1.0"
 msgstr "Creative Commons CCZero 1.0"
 
-#: ckanext/ytp/translations.py:266
+#: ckanext/ytp/translations.py:269
 msgid "gfdl"
 msgstr "GNU Free Documentation License"
 
-#: ckanext/ytp/translations.py:267
+#: ckanext/ytp/translations.py:270
 msgid "helsinkikanava-opendata-tos"
 msgstr " Helsinkikanava Open Data käyttöehdot"
 
-#: ckanext/ytp/translations.py:268
+#: ckanext/ytp/translations.py:271
 msgid "hri-tietoaineistot-lisenssi-nimea"
 msgstr " HRI - tietoaineistojen lisenssi - nimeä"
 
-#: ckanext/ytp/translations.py:269
+#: ckanext/ytp/translations.py:272
 msgid "ilmoitettumuualla"
 msgstr " Lisenssi ilmoitettu tietoaineiston ylläpitäjän palvelussa"
 
-#: ckanext/ytp/translations.py:270
+#: ckanext/ytp/translations.py:273
 msgid "kmo-aluejakorajat"
 msgstr " KMO aluejakorajojen vektoriaineistojen käyttöehdot"
 
-#: ckanext/ytp/translations.py:271
+#: ckanext/ytp/translations.py:274
 msgid "notspecified"
 msgstr " Lisenssiä ei ole määritelty"
 
-#: ckanext/ytp/translations.py:272
+#: ckanext/ytp/translations.py:275
 msgid "odc-by"
 msgstr "Open Data Commons Attribution License"
 
-#: ckanext/ytp/translations.py:273
+#: ckanext/ytp/translations.py:276
 msgid "odc-odbl"
 msgstr "Open Data Commons Open Database License ODbL"
 
-#: ckanext/ytp/translations.py:274
+#: ckanext/ytp/translations.py:277
 msgid "odc-pddl"
 msgstr "Open Data Commons Public Domain Dedication and Licence PDDL"
 
-#: ckanext/ytp/translations.py:275
+#: ckanext/ytp/translations.py:278
 msgid "other"
 msgstr " Muu"
 
-#: ckanext/ytp/translations.py:276
+#: ckanext/ytp/translations.py:279
 msgid "other-at"
 msgstr "Muu (Attribution)"
 
-#: ckanext/ytp/translations.py:277
+#: ckanext/ytp/translations.py:280
 msgid "other-closed"
 msgstr "Muu (Not Open)"
 
-#: ckanext/ytp/translations.py:278
+#: ckanext/ytp/translations.py:281
 msgid "other-nc"
 msgstr " Muu (Non-Commercial)"
 
-#: ckanext/ytp/translations.py:279
+#: ckanext/ytp/translations.py:282
 msgid "other-open"
 msgstr " Muu (avoin)"
 
-#: ckanext/ytp/translations.py:280
+#: ckanext/ytp/translations.py:283
 msgid "other-pd"
 msgstr " Muu (Public Domain)"
 
-#: ckanext/ytp/translations.py:281
+#: ckanext/ytp/translations.py:284
 msgid "uk-ogl"
 msgstr "UK Open Government Licence OGL"
 
-#: ckanext/ytp/translations.py:284
+#: ckanext/ytp/translations.py:287
 msgid "Platforms"
 msgstr "Käyttöympäristö (alusta)"
 
-#: ckanext/ytp/translations.py:287
+#: ckanext/ytp/translations.py:290
 msgid "Show more collection_type"
 msgstr "Näytä enemmän Tietoaineistoja"
 
-#: ckanext/ytp/translations.py:288
+#: ckanext/ytp/translations.py:291
 msgid "Show more vocab_international_benchmarks"
 msgstr "Näytä enemmän Kansainvälisiä Vertailuja"
 
-#: ckanext/ytp/translations.py:289
+#: ckanext/ytp/translations.py:292
 msgid "Show more vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:290
+#: ckanext/ytp/translations.py:293
 msgid "Show more vocab_keywords_fi"
 msgstr "Näytä enemmän Avainsanoja"
 
-#: ckanext/ytp/translations.py:291
+#: ckanext/ytp/translations.py:294
 msgid "Show more vocab_keywords_sv"
 msgstr ""
 
-#: ckanext/ytp/translations.py:292
+#: ckanext/ytp/translations.py:295
 msgid "Show more organization"
 msgstr "Näytä enemmän Tuottajia"
 
-#: ckanext/ytp/translations.py:293
+#: ckanext/ytp/translations.py:296
 msgid "Show more res_format"
 msgstr "Näytä enemmän Tiedostomuotoja"
 
-#: ckanext/ytp/translations.py:294
+#: ckanext/ytp/translations.py:297
 msgid "Show more source"
 msgstr "Näytä enemmän Lähteitä"
 
-#: ckanext/ytp/translations.py:295
+#: ckanext/ytp/translations.py:298
 msgid "Show more license_id"
 msgstr "Näytä enemmän Lisenssejä"
 
-#: ckanext/ytp/translations.py:296
+#: ckanext/ytp/translations.py:299
 msgid "Show more groups"
 msgstr "Näytä enemmän Kategorioita"
 
-#: ckanext/ytp/translations.py:297
+#: ckanext/ytp/translations.py:300
 msgid "Show more vocab_platform"
 msgstr "Näytä enemmän Käyttöympäristöjä"
 
-#: ckanext/ytp/translations.py:300
+#: ckanext/ytp/translations.py:303
 msgid "Show less collection_type"
 msgstr "Näytä vähemmän Tietoaineistoja"
 
-#: ckanext/ytp/translations.py:301
+#: ckanext/ytp/translations.py:304
 msgid "Show less vocab_international_benchmarks"
 msgstr "Näytä vähemmän Kansainvälisiä Vertailuja"
 
-#: ckanext/ytp/translations.py:302
+#: ckanext/ytp/translations.py:305
 msgid "Show less vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:303
+#: ckanext/ytp/translations.py:306
 msgid "Show less vocab_keywords_fi"
 msgstr "Näytä vähemmän Avainsanoja"
 
-#: ckanext/ytp/translations.py:304
+#: ckanext/ytp/translations.py:307
 msgid "Show less vocab_keywords_sv"
 msgstr ""
 
-#: ckanext/ytp/translations.py:305
+#: ckanext/ytp/translations.py:308
 msgid "Show less organization"
 msgstr "Näytä vähemmän Tuottajia"
 
-#: ckanext/ytp/translations.py:306
+#: ckanext/ytp/translations.py:309
 msgid "Show less res_format"
 msgstr "Näytä vähemmän Tiedostomuotoja"
 
-#: ckanext/ytp/translations.py:307
+#: ckanext/ytp/translations.py:310
 msgid "Show less source"
 msgstr "Näytä vähemmän Lähteitä"
 
-#: ckanext/ytp/translations.py:308
+#: ckanext/ytp/translations.py:311
 msgid "Show less license_id"
 msgstr "Näytä vähemmän Lisenssejä"
 
-#: ckanext/ytp/translations.py:309
+#: ckanext/ytp/translations.py:312
 msgid "Show less groups"
 msgstr "Näytä vähemmän Kategorioita"
 
-#: ckanext/ytp/translations.py:310
+#: ckanext/ytp/translations.py:313
 msgid "Show less vocab_platform"
 msgstr "Näytä vähemmän Käyttöympäristöjä"
 
@@ -1816,10 +1828,6 @@ msgstr "Lisää sähköposti"
 #: ckanext/ytp/resources/vendor/bootstrap-table/dist/extensions/filter-control/utils.js:10
 msgid "Can't call method on "
 msgstr ""
-
-#: ckanext/ytp/templates/disqus_comments.html:2
-msgid "Give feedback"
-msgstr "Anna palautetta"
 
 #: ckanext/ytp/templates/page.html:13
 #: ckanext/ytp/templates/snippets/search_form.html:110
@@ -2748,6 +2756,10 @@ msgstr "Käyttösovellukset"
 #: ckanext/ytp/templates/package/snippets/dataset_social.html:4
 msgid "Social"
 msgstr "Jaa sosiaalisessa mediassa"
+
+#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:36
+msgid "Dataset maintainer informs:"
+msgstr "Tietoaineiston ylläpitäjä tiedottaa:"
 
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:18
 #, python-format

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/i18n/sv/LC_MESSAGES/ckanext-ytp_main.po
@@ -19,7 +19,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ckanext-ytp_main 0.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-06-01 12:41+0000\n"
+"POT-Creation-Date: 2023-07-14 20:44+0000\n"
 "PO-Revision-Date: 2018-03-08 13:35+0000\n"
 "Last-Translator: Suvi Nuttunen, 2023\n"
 "Language-Team: Swedish (https://app.transifex.com/avoindata/teams/7979/sv/)\n"
@@ -979,7 +979,7 @@ msgstr "Fördelning av stäjrnor"
 
 #: ckanext/ytp/translations.py:163
 msgid "Score TBC"
-msgstr "Utan stjärna"
+msgstr "Utan värdering"
 
 #: ckanext/ytp/translations.py:164
 msgid "Score"
@@ -1264,11 +1264,23 @@ msgid ""
 "organization."
 msgstr ""
 
+#: ckanext/ytp/translations.py:226
+msgid "Maintainer note"
+msgstr ""
+
+#: ckanext/ytp/translations.py:227
+msgid "e.g. Dataset updated 15.5.2023"
+msgstr ""
+
 #: ckanext/ytp/translations.py:228
+msgid "Inform users about dataset updates"
+msgstr ""
+
+#: ckanext/ytp/translations.py:231
 msgid "Data resource title"
 msgstr "Dataresursens namn"
 
-#: ckanext/ytp/translations.py:229
+#: ckanext/ytp/translations.py:232
 msgid ""
 "Write a short and descriptive name for the data resource. If the data covers"
 " a specific time frame, mention that in the name."
@@ -1276,15 +1288,15 @@ msgstr ""
 "Ange en kort och beskrivande namn för dataresursen. Om datan endast täcker "
 "en viss tidsintervall, uppge detta i namnet."
 
-#: ckanext/ytp/translations.py:230
+#: ckanext/ytp/translations.py:233
 msgid "e.g. Most popular Finnish first names 2019"
 msgstr "t.ex. de mest populära förnamnen i Finland 2019 "
 
-#: ckanext/ytp/translations.py:231
+#: ckanext/ytp/translations.py:234
 msgid "Resource *"
 msgstr "Dataresurs *"
 
-#: ckanext/ytp/translations.py:232
+#: ckanext/ytp/translations.py:235
 msgid ""
 "Add the data resource by uploading a file or adding a link to the "
 "data.<br>Select or drag the files here.<br>The maximum file size is 5 Gb. "
@@ -1296,15 +1308,15 @@ msgstr ""
 "Tillåtna filformat: pdf, jpg, jpeg, png, doc, docx, xls, xlsx, csv, ppt, "
 "pptx, odt, ods, txt.<br>Länk: Lägg till en länk till datan."
 
-#: ckanext/ytp/translations.py:233
+#: ckanext/ytp/translations.py:236
 msgid "Data resource description"
 msgstr "Beskrivning av dataresursen"
 
-#: ckanext/ytp/translations.py:234
+#: ckanext/ytp/translations.py:237
 msgid "Write a description for the resource"
 msgstr "Ange en beskrivning för resursen"
 
-#: ckanext/ytp/translations.py:235
+#: ckanext/ytp/translations.py:238
 msgid ""
 "Describe the data clearly and concisely. Use as confining terms as possible "
 "to make it easier to find and understand the data."
@@ -1312,15 +1324,15 @@ msgstr ""
 "En kortfattad och lättbegriplig beskrivning av applikationen. Använd så "
 "avgränsande termer som möjligt för att göra det enklare att förstå datan."
 
-#: ckanext/ytp/translations.py:236
+#: ckanext/ytp/translations.py:239
 msgid "Additional information"
 msgstr "Mer information"
 
-#: ckanext/ytp/translations.py:237
+#: ckanext/ytp/translations.py:240
 msgid "Data status"
 msgstr "Datastatus"
 
-#: ckanext/ytp/translations.py:238
+#: ckanext/ytp/translations.py:241
 msgid ""
 "Define a state for the data. This is recommended especially if your dataset "
 "has data resources from multiple years."
@@ -1328,11 +1340,11 @@ msgstr ""
 "Du kan fastställa ett status för datan. Det rekommenderas framför allt om "
 "din datamängd innehåller dataresurser från flera olika år."
 
-#: ckanext/ytp/translations.py:239
+#: ckanext/ytp/translations.py:242
 msgid "Coordinate system"
 msgstr "Koordinatsystem"
 
-#: ckanext/ytp/translations.py:240
+#: ckanext/ytp/translations.py:243
 msgid ""
 "If your data includes geographic information, specify the coordinate system "
 "it uses."
@@ -1340,11 +1352,11 @@ msgstr ""
 "Ange kartmaterialets koordinatsystem. T.ex. koordinatsystemet för "
 "positionsdata."
 
-#: ckanext/ytp/translations.py:241
+#: ckanext/ytp/translations.py:244
 msgid "e.g. WGS84 (World Geodetic System 1984)"
 msgstr "t.ex. WGS84 (World Geodetic System 1984)"
 
-#: ckanext/ytp/translations.py:242
+#: ckanext/ytp/translations.py:245
 msgid ""
 "Select the time frame by which the data is separated. For example, does the "
 "resource include data from every week or month."
@@ -1352,236 +1364,236 @@ msgstr ""
 "Ange hur noggrant datan är separerade i materialet, till exempel om "
 "materialet innehåller data från varje vecka eller månad."
 
-#: ckanext/ytp/translations.py:243
+#: ckanext/ytp/translations.py:246
 msgid "e.g. a month"
 msgstr "t.ex. en månad"
 
-#: ckanext/ytp/translations.py:244
+#: ckanext/ytp/translations.py:247
 msgid "Time Frame"
 msgstr "Tidsram"
 
-#: ckanext/ytp/translations.py:245
+#: ckanext/ytp/translations.py:248
 msgid "Start date"
 msgstr "Startdatum"
 
-#: ckanext/ytp/translations.py:246
+#: ckanext/ytp/translations.py:249
 msgid "End date"
 msgstr "Slutdatum"
 
-#: ckanext/ytp/translations.py:247
+#: ckanext/ytp/translations.py:250
 msgid "Geographical accuracy"
 msgstr ""
 
-#: ckanext/ytp/translations.py:248
+#: ckanext/ytp/translations.py:251
 msgid ""
 "If your data includes geographic information, specify the accuracy in meters"
 msgstr ""
 
-#: ckanext/ytp/translations.py:251
+#: ckanext/ytp/translations.py:254
 msgid "Producer name"
 msgstr "Namnet på producent"
 
-#: ckanext/ytp/translations.py:252
+#: ckanext/ytp/translations.py:255
 msgid "Producer description"
 msgstr "Beskrivning av producent"
 
-#: ckanext/ytp/translations.py:253
+#: ckanext/ytp/translations.py:256
 msgid "Common, compact and plain description about producer"
 msgstr "Allmän, kompakt och enkel beskrivning av producent"
 
-#: ckanext/ytp/translations.py:254
+#: ckanext/ytp/translations.py:257
 msgid "Other information"
 msgstr "Övrig information"
 
-#: ckanext/ytp/translations.py:255
+#: ckanext/ytp/translations.py:258
 msgid "Upload logo"
 msgstr "Ladda upp logo"
 
-#: ckanext/ytp/translations.py:258
+#: ckanext/ytp/translations.py:261
 msgid "cc-by"
 msgstr ""
 
-#: ckanext/ytp/translations.py:259
+#: ckanext/ytp/translations.py:262
 msgid "cc-by-4-fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:260
+#: ckanext/ytp/translations.py:263
 msgid "cc-by-4.0"
 msgstr ""
 
-#: ckanext/ytp/translations.py:261
+#: ckanext/ytp/translations.py:264
 msgid "cc-by-sa"
 msgstr ""
 
-#: ckanext/ytp/translations.py:262
+#: ckanext/ytp/translations.py:265
 msgid "cc-by-sa-1-fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:263
+#: ckanext/ytp/translations.py:266
 msgid "cc-nc"
 msgstr ""
 
-#: ckanext/ytp/translations.py:264
+#: ckanext/ytp/translations.py:267
 msgid "cc-zero"
 msgstr ""
 
-#: ckanext/ytp/translations.py:265
+#: ckanext/ytp/translations.py:268
 msgid "cc-zero-1.0"
 msgstr ""
 
-#: ckanext/ytp/translations.py:266
+#: ckanext/ytp/translations.py:269
 msgid "gfdl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:267
+#: ckanext/ytp/translations.py:270
 msgid "helsinkikanava-opendata-tos"
 msgstr ""
 
-#: ckanext/ytp/translations.py:268
+#: ckanext/ytp/translations.py:271
 msgid "hri-tietoaineistot-lisenssi-nimea"
 msgstr ""
 
-#: ckanext/ytp/translations.py:269
+#: ckanext/ytp/translations.py:272
 msgid "ilmoitettumuualla"
 msgstr ""
 
-#: ckanext/ytp/translations.py:270
+#: ckanext/ytp/translations.py:273
 msgid "kmo-aluejakorajat"
 msgstr ""
 
-#: ckanext/ytp/translations.py:271
+#: ckanext/ytp/translations.py:274
 msgid "notspecified"
 msgstr "Ej specificerad"
 
-#: ckanext/ytp/translations.py:272
+#: ckanext/ytp/translations.py:275
 msgid "odc-by"
 msgstr ""
 
-#: ckanext/ytp/translations.py:273
+#: ckanext/ytp/translations.py:276
 msgid "odc-odbl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:274
+#: ckanext/ytp/translations.py:277
 msgid "odc-pddl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:275
+#: ckanext/ytp/translations.py:278
 msgid "other"
 msgstr ""
 
-#: ckanext/ytp/translations.py:276
+#: ckanext/ytp/translations.py:279
 msgid "other-at"
 msgstr ""
 
-#: ckanext/ytp/translations.py:277
+#: ckanext/ytp/translations.py:280
 msgid "other-closed"
 msgstr ""
 
-#: ckanext/ytp/translations.py:278
+#: ckanext/ytp/translations.py:281
 msgid "other-nc"
 msgstr ""
 
-#: ckanext/ytp/translations.py:279
+#: ckanext/ytp/translations.py:282
 msgid "other-open"
 msgstr ""
 
-#: ckanext/ytp/translations.py:280
+#: ckanext/ytp/translations.py:283
 msgid "other-pd"
 msgstr ""
 
-#: ckanext/ytp/translations.py:281
+#: ckanext/ytp/translations.py:284
 msgid "uk-ogl"
 msgstr ""
 
-#: ckanext/ytp/translations.py:284
+#: ckanext/ytp/translations.py:287
 msgid "Platforms"
 msgstr ""
 
-#: ckanext/ytp/translations.py:287
+#: ckanext/ytp/translations.py:290
 msgid "Show more collection_type"
 msgstr "Vias flera Datamängder"
 
-#: ckanext/ytp/translations.py:288
+#: ckanext/ytp/translations.py:291
 msgid "Show more vocab_international_benchmarks"
 msgstr "Visa mer Internationella Jämförelser"
 
-#: ckanext/ytp/translations.py:289
+#: ckanext/ytp/translations.py:292
 msgid "Show more vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:290
+#: ckanext/ytp/translations.py:293
 msgid "Show more vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:291
+#: ckanext/ytp/translations.py:294
 msgid "Show more vocab_keywords_sv"
 msgstr "Visa mer Nyckelord"
 
-#: ckanext/ytp/translations.py:292
+#: ckanext/ytp/translations.py:295
 msgid "Show more organization"
 msgstr "Visa mer Producenter"
 
-#: ckanext/ytp/translations.py:293
+#: ckanext/ytp/translations.py:296
 msgid "Show more res_format"
 msgstr "Visa mer Format"
 
-#: ckanext/ytp/translations.py:294
+#: ckanext/ytp/translations.py:297
 msgid "Show more source"
 msgstr "Visa mer Källor"
 
-#: ckanext/ytp/translations.py:295
+#: ckanext/ytp/translations.py:298
 msgid "Show more license_id"
 msgstr "Visa mer Licenser"
 
-#: ckanext/ytp/translations.py:296
+#: ckanext/ytp/translations.py:299
 msgid "Show more groups"
 msgstr "Visa mer Grupper"
 
-#: ckanext/ytp/translations.py:297
+#: ckanext/ytp/translations.py:300
 msgid "Show more vocab_platform"
 msgstr "Visa mer Plattformar"
 
-#: ckanext/ytp/translations.py:300
+#: ckanext/ytp/translations.py:303
 msgid "Show less collection_type"
 msgstr "Vias färre Datamängder"
 
-#: ckanext/ytp/translations.py:301
+#: ckanext/ytp/translations.py:304
 msgid "Show less vocab_international_benchmarks"
 msgstr "Visa färre Internationella Jämförelser"
 
-#: ckanext/ytp/translations.py:302
+#: ckanext/ytp/translations.py:305
 msgid "Show less vocab_keywords_en"
 msgstr ""
 
-#: ckanext/ytp/translations.py:303
+#: ckanext/ytp/translations.py:306
 msgid "Show less vocab_keywords_fi"
 msgstr ""
 
-#: ckanext/ytp/translations.py:304
+#: ckanext/ytp/translations.py:307
 msgid "Show less vocab_keywords_sv"
 msgstr "Visa färre Nyckelord"
 
-#: ckanext/ytp/translations.py:305
+#: ckanext/ytp/translations.py:308
 msgid "Show less organization"
 msgstr "Visa färre Producenter"
 
-#: ckanext/ytp/translations.py:306
+#: ckanext/ytp/translations.py:309
 msgid "Show less res_format"
 msgstr "Visa färre Format"
 
-#: ckanext/ytp/translations.py:307
+#: ckanext/ytp/translations.py:310
 msgid "Show less source"
 msgstr "Visa färre Källor"
 
-#: ckanext/ytp/translations.py:308
+#: ckanext/ytp/translations.py:311
 msgid "Show less license_id"
 msgstr "Visa färre Licenser"
 
-#: ckanext/ytp/translations.py:309
+#: ckanext/ytp/translations.py:312
 msgid "Show less groups"
 msgstr "Visa färre Grupper"
 
-#: ckanext/ytp/translations.py:310
+#: ckanext/ytp/translations.py:313
 msgid "Show less vocab_platform"
 msgstr "Visa färre Plattformar"
 
@@ -1788,10 +1800,6 @@ msgstr "Lägg till e-post"
 #: ckanext/ytp/resources/vendor/bootstrap-table/dist/extensions/filter-control/utils.js:10
 msgid "Can't call method on "
 msgstr ""
-
-#: ckanext/ytp/templates/disqus_comments.html:2
-msgid "Give feedback"
-msgstr "Ge feedback"
 
 #: ckanext/ytp/templates/page.html:13
 #: ckanext/ytp/templates/snippets/search_form.html:110
@@ -2711,6 +2719,10 @@ msgstr "Applikationer"
 #: ckanext/ytp/templates/package/snippets/dataset_social.html:4
 msgid "Social"
 msgstr "Dela i sociala medier"
+
+#: ckanext/ytp/templates/package/snippets/dataset_state_banner.html:36
+msgid "Dataset maintainer informs:"
+msgstr ""
 
 #: ckanext/ytp/templates/package/snippets/license_rdf.html:18
 #, python-format

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
@@ -293,6 +293,17 @@
       "description": "The dataset publication date.",
       "validators": "keep_old_value_if_missing ignore_missing",
       "output_validators": "ignore_if_invalid_isodatetime override_field(metadata_created)"
+    },
+    {
+      "field_name": "maintainer_note_translated",
+      "label": "Maintainer note",
+      "preset": "fluent_core_translated_extended",
+      "form_languages": ["fi", "en", "sv"],
+      "form_placeholder": "e.g. Dataset updated 15.5.2023",
+      "form_attrs": {
+        "class": "form-control"
+      },
+      "description": "Inform users about dataset updates"
     }
   ],
   "resource_fields": [

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/schemas/dataset.json
@@ -297,7 +297,10 @@
     {
       "field_name": "maintainer_note_translated",
       "label": "Maintainer note",
-      "preset": "fluent_core_translated_extended",
+      "form_snippet": "fluent_text_ex.html",
+      "display_snippet": "null",
+      "validators": "fluent_text",
+      "output_validators": "fluent_core_translated_output",
       "form_languages": ["fi", "en", "sv"],
       "form_placeholder": "e.g. Dataset updated 15.5.2023",
       "form_attrs": {

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/dataset_state_banner.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/snippets/dataset_state_banner.html
@@ -1,3 +1,4 @@
+{% set maintainer_note = h.get_translated(pkg, 'maintainer_note') %}
 {% if pkg.get('state', '').startswith('deleted') %}
   <div class="well admin-banner private-or-draft-dataset deleted-dataset">
     <div>
@@ -28,6 +29,16 @@
       {% link_for _('Edit ' + dataset_type), named_route=dataset_type + '.edit', id=pkg.name %}"
     {% endif %}
   </div>
+{% elif maintainer_note %}
+<div class="well admin-banner maintainer-note">
+  <div>
+    <img src="/themes/avoindata/images/avoindata-note-icon.svg">
+    <span>{{ _('Dataset maintainer informs:') }}&nbsp;{{ maintainer_note }}</span>
+  </div>
+  {% if h.check_access('package_update', {'id':pkg.id }) %}
+    {% link_for _('Edit ' + dataset_type), named_route=dataset_type + '.edit', id=pkg.name %}
+  {% endif %}
+</div>
 {% else %}
   {% if h.check_access('package_update', {'id':pkg.id }) %}
     <div class="admin-banner">

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/translations.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/translations.py
@@ -223,6 +223,9 @@ def _translations():
     _('Deleted. The apiset is only visible to logged in users of the producer organization.')
     _('In draft state. The apiset is only visible to logged in users of the producer organization.')
     _('Private mode. The apiset is only visible to logged in users of the producer organization.')
+    _('Maintainer note')
+    _('e.g. Dataset updated 15.5.2023')
+    _('Inform users about dataset updates')
 
     # Resource
     _("Data resource title")

--- a/opendata-assets/src/less/components/dataset.less
+++ b/opendata-assets/src/less/components/dataset.less
@@ -67,7 +67,6 @@
 
 .admin-banner {
   display: flex;
-  justify-content: flex-end;
   margin-bottom: 20px;
 
   a {

--- a/opendata-assets/src/less/components/dataset.less
+++ b/opendata-assets/src/less/components/dataset.less
@@ -120,6 +120,36 @@
   background: @suomi-alertBase;
 }
 
+.maintainer-note {
+  background: @opendata-brand-gray;
+
+  div {
+    display: flex;
+    align-items: center;
+  }
+
+  img {
+    height: 20px;
+    width: 20px;
+    margin-right: 10px;
+  }
+
+  span {
+    color: @color--black;
+    font-family: @font-family-sans-serif;
+    font-size: @font-size-slightly-smaller-base;
+    font-weight: @font-weight-normal;
+    line-height: 24px;
+    display: inline-block;
+    vertical-align: middle;
+  }
+
+  a {
+    color: @color--black;
+    border: 1px solid @color--black;
+  }
+}
+
 #content .container-apiset {
   .filter-list .pill {
     font-size: 16px;


### PR DESCRIPTION
Add a multilingual textfield to dataset schema. 
If field has a value in selected language show a banner with the given note at the top of the dataset page
<img width="874" alt="image" src="https://github.com/vrk-kpa/opendata/assets/3969176/e4766bb9-70ef-4950-a27f-07deda5786bf">
