### PR TITLE
AV-1964: Update spatial

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -428,7 +428,7 @@ jobs:
       solr:
         image: ckan/ckan-solr-dev:2.9
       postgres:
-        image: postgis/postgis:10-3.1
+        image: postgres:12
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -455,10 +455,6 @@ jobs:
         psql --host=postgres --username=postgres --command="CREATE USER datastore_write WITH PASSWORD 'pass' NOSUPERUSER NOCREATEDB NOCREATEROLE;"
         psql --host=postgres --username=postgres --command="CREATE USER datastore_read WITH PASSWORD 'pass' NOSUPERUSER NOCREATEDB NOCREATEROLE;"
         createdb --encoding=utf-8 --host=postgres --username=postgres --owner=datastore_write datastore_test
-    - name: setup postgis
-      run: |
-        psql --host=postgres --username=postgres -d ckan_test --command="ALTER ROLE ckan_default WITH superuser;"
-        psql --host=postgres --username=postgres -d ckan_test --command="CREATE EXTENSION postgis;"
     - name: Install requirements
       run: |
         apk add proj proj-dev proj-util geos

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -423,7 +423,7 @@ jobs:
       - detect-changes
     if: ${{ needs.detect-changes.outputs.ckan == 'true' }}
     container:
-      image: openknowledge/ckan-dev:2.9
+      image: ckan/ckan-dev:2.9.9
     services:
       solr:
         image: ckan/ckan-solr-dev:2.9

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -475,9 +475,10 @@ jobs:
         cd ../ckanext-report
         pip install -r requirements.txt
         pip install -e .
-        cd ../ckanext-spatial
+        # Spatial is not currently used in tests
+        # cd ../ckanext-spatial
         # pip install -r requirements.txt
-        pip install -e .
+        # pip install -e .
         cd ../ckanext-organizationapproval
         pip install -r requirements.txt
         pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -476,7 +476,7 @@ jobs:
         pip install -r requirements.txt
         pip install -e .
         cd ../ckanext-spatial
-        pip install -r requirements.txt
+        # pip install -r requirements.txt
         pip install -e .
         cd ../ckanext-organizationapproval
         pip install -r requirements.txt

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -23,7 +23,7 @@ from ckan.model import Session
 from ckan.plugins import toolkit
 from ckan.plugins.toolkit import config, chained_action
 from ckanext.report.interfaces import IReport
-from ckanext.spatial.interfaces import ISpatialHarvester
+
 from ckanext.sitesearch.interfaces import ISiteSearch
 from ckanext.showcase.model import ShowcaseAdmin
 from sqlalchemy import and_, or_
@@ -565,6 +565,7 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
 
 
 class YTPSpatialHarvester(plugins.SingletonPlugin):
+    from ckanext.spatial.interfaces import ISpatialHarvester
     plugins.implements(ISpatialHarvester, inherit=True)
 
     # ISpatialHarvester

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -628,7 +628,7 @@ class YTPSpatialHarvester(plugins.SingletonPlugin):
                     package_dict['maintainer'] = contact.get('individual-name')
                     break
 
-        config_obj = json.loads(data_dict['harvest_object'].source.config)
+        config_obj = json.loads(data_dict['harvest_object'].source.config or "{}")
         license_from_source = config_obj.get("license", None)
         if license_from_source is not None:
             package_dict['license_id'] = license_from_source

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -565,8 +565,11 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
 
 
 class YTPSpatialHarvester(plugins.SingletonPlugin):
-    from ckanext.spatial.interfaces import ISpatialHarvester
-    plugins.implements(ISpatialHarvester, inherit=True)
+    try:
+        from ckanext.spatial.interfaces import ISpatialHarvester
+        plugins.implements(ISpatialHarvester, inherit=True)
+    except ImportError:
+        pass
 
     # ISpatialHarvester
 

--- a/ckan/ckanext/ckanext-ytp_main/test.ini
+++ b/ckan/ckanext/ckanext-ytp_main/test.ini
@@ -1,6 +1,6 @@
 [app:main]
 use = config:/usr/lib/ckan/default/src/ckan/test-core.ini
-ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent report organizationapproval harvest hierarchy_display spatial_metadata spatial_query sixodp_showcase sixodp_showcasesubmit ytp_organizations ytp_user ytp_theme ytp_dataset sitesearch
+ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent report organizationapproval harvest hierarchy_display sixodp_showcase sixodp_showcasesubmit ytp_organizations ytp_user ytp_theme ytp_dataset sitesearch
 ckan.locale_default = fi
 ckanext.sixodp_showcasesubmit.creating_user_username = ckan_admin
 ckanext.sixodp_showcasesubmit.recaptcha_sitekey = ""

--- a/ckan/ckanext/ckanext-ytp_main/test.ini
+++ b/ckan/ckanext/ckanext-ytp_main/test.ini
@@ -1,6 +1,6 @@
 [app:main]
 use = config:/usr/lib/ckan/default/src/ckan/test-core.ini
-ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent report organizationapproval harvest hierarchy_display ytp_spatial spatial_metadata spatial_query sixodp_showcase sixodp_showcasesubmit ytp_organizations ytp_user ytp_theme ytp_dataset sitesearch
+ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent report organizationapproval harvest hierarchy_display spatial_metadata spatial_query sixodp_showcase sixodp_showcasesubmit ytp_organizations ytp_user ytp_theme ytp_dataset sitesearch
 ckan.locale_default = fi
 ckanext.sixodp_showcasesubmit.creating_user_username = ckan_admin
 ckanext.sixodp_showcasesubmit.recaptcha_sitekey = ""

--- a/ckan/scripts/init_ckan.sh
+++ b/ckan/scripts/init_ckan.sh
@@ -33,7 +33,6 @@ echo "init ckan extension databases ..."
 ckan -c ${APP_DIR}/production.ini opendata-model initdb
 ckan -c ${APP_DIR}/production.ini opendata-request init-db
 ckan -c ${APP_DIR}/production.ini harvester initdb
-ckan -c ${APP_DIR}/production.ini spatial initdb
 [[ "${CKAN_PLUGINS}" == *" archiver "* ]]     && ckan -c ${APP_DIR}/production.ini archiver init
 [[ "${CKAN_PLUGINS}" == *" qa "* ]]           && ckan -c ${APP_DIR}/production.ini qa init
 ckan -c ${APP_DIR}/production.ini report initdb

--- a/ckan/templates/production.ini.j2
+++ b/ckan/templates/production.ini.j2
@@ -220,7 +220,7 @@ ckanext.matomo.ignored_user_agents = docker-healthcheck
 {% endif %}
 
 ckanext.spatial.harvest.continue_on_validation_errors = true
-ckanext.spatial.search_backend = solr
+ckanext.spatial.search_backend = solr-bbox
 ckanext.spatial.common_map.type = custom
 ckanext.spatial.common_map.custom.url = https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
 ckanext.spatial.common_map.attribution = &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -172,8 +172,7 @@ services:
       start_period: 60s
 
   datapusher:
-    build:
-      context: ./datapusher-plus
+    image: ${REGISTRY}/${REPOSITORY}/datapusher:${DATAPUSHER_IMAGE_TAG}
     restart: always
     networks:
       - frontend

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgis/postgis:10-3.0
+FROM postgres:12
 
 # allow all connections
 RUN echo "host all  all    0.0.0.0/0  md5" >> /var/lib/postgresql/data/pg_hba.conf


### PR DESCRIPTION
Updates submodule to the already updated fork and with https://github.com/ckan/ckanext-spatial/pull/311 and https://github.com/ckan/ckanext-spatial/issues/301#issuecomment-1644978489

Postgis is no longer required so uses postgres container locally, postgis needs to be removed separately from rds instances. 

Also fixes docker compose to use built datapusher image from registry, instead of building it every time.