### PR TITLE
AV-2029: Fix dataset map search

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/spatial/snippets/spatial_query.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/spatial/snippets/spatial_query.html
@@ -29,6 +29,4 @@ e.g.
 {% asset 'ckanext-spatial/spatial_query_js' %}
 {% asset 'ckanext-spatial/spatial_query_css' %}
 {% asset 'ytp_resources/spatial_query_css' %}
-{% asset 'ckanext-spatial/dataset_map_js' %}
-{% asset 'ckanext-spatial/dataset_map_css' %}
 {% asset 'ytp_resources/spatial_search_js' %}


### PR DESCRIPTION
- Leaflet was being loaded twice from two different webassets: once with Draw and once without
- Made Leaflet its own webasset in ckanext-spatial to prevent repeated loading
- Removed unnecessary assets from spatial query template