### PR TITLE
AV-2030: Increase prod datastore ephemeral storage

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -853,6 +853,7 @@ const ckanStackProd = new CkanStack(app, 'CkanStack-prod', {
     taskMem: 8192,
     taskMinCapacity: 1,
     taskMaxCapacity: 4,
+    taskStorage: 100
   },
   solrTaskDef: {
     taskCpu: 1024,

--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -546,6 +546,7 @@ export class CkanStack extends Stack {
     const datapusherTaskDef = new ecs.FargateTaskDefinition(this, 'datapusherTaskDef', {
       cpu: props.datapusherTaskDef.taskCpu,
       memoryLimitMiB: props.datapusherTaskDef.taskMem,
+      ephemeralStorageGiB: props.datapusherTaskDef.taskStorage
     });
 
     props.datastoreJobsSecret.grantRead(datapusherTaskDef.taskRole)

--- a/cdk/lib/ecs-stack-props.ts
+++ b/cdk/lib/ecs-stack-props.ts
@@ -52,4 +52,8 @@ export interface EcsStackPropsTaskDef {
    * Maximum number of tasks at a time.
    */
   taskMaxCapacity: number;
+  /**
+   * The amount (in GiB) of ephemeral storage to be allocated to the task.
+   */
+  taskStorage?: number;
 }


### PR DESCRIPTION
Datapusher-plus doesn't currently delete temp files so as a temporary fix this increases the ephemeral storage for datastore task to 100GiB