### PR TITLE
AV-2066: use only assets package-lock.json hash as cache key

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -101,7 +101,7 @@ jobs:
         id: cache-node_modules
         with:
           path: ./opendata-assets/node_modules
-          key: ${{ runner.os }}-build-node_v16-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-node_v16-${{ hashFiles('opendata-assets/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-node_v16-
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,7 +120,7 @@ jobs:
         id: cache-node_modules
         with:
           path: ./opendata-assets/node_modules
-          key: ${{ runner.os }}-build-node_v16-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-build-node_v16-${{ hashFiles('opendata-assets/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-build-node_v16-
 


### PR DESCRIPTION
Hashes seem to change between builds.