### PR TITLE
Update matomo extension

### DIFF
--- a/ckan/templates/production.ini.j2
+++ b/ckan/templates/production.ini.j2
@@ -218,6 +218,7 @@ ckanext.matomo.domain = https://{{ environ('MATOMO_DOMAIN') }}/
 ckanext.matomo.script_domain = {{ environ('MATOMO_SCRIPT_DOMAIN') }}
 ckanext.matomo.token_auth = {{ environ('MATOMO_TOKEN') }}
 ckanext.matomo.ignored_user_agents = docker-healthcheck
+ckanext.matomo.track_api = true
 {% endif %}
 
 ckanext.spatial.harvest.continue_on_validation_errors = true


### PR DESCRIPTION
Updates matomo extension to latest, changes include making extension usable with different matomo instances, api tracking is now optional and dataset graphs are included in the extension, opendata however still uses its own.