### PR TITLE
AV-1959: Use suffix check instead of regexp

### DIFF
--- a/cdk/lib/monitoring-stack.ts
+++ b/cdk/lib/monitoring-stack.ts
@@ -26,7 +26,7 @@ export class MonitoringStack extends Stack {
       eventPattern: {
         source: ['aws.ecs'],
         detail: {
-          message: assertions.Match.stringLikeRegexp('service [^ ]+ task [0-9a-f]+ failed container health checks.')
+          message: [{suffix: 'failed container health checks.'}]
         }
       },
       targets: [sendToDeveloperZulipTarget, taskHealthCheckFailLogGroupTarget],


### PR DESCRIPTION
- For some reason Regexp matches were not supported, so changed to suffix check which may produce some false positives but no false negatives