### PR TITLE
AV-2067: create test bucket and role

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,16 +232,11 @@ jobs:
           sed -i.bak -E 's/^(REPOSITORY[[:blank:]]*=[[:blank:]]*).*/\1\"'"${REPOSITORY}"'\"/' docker/.env
           sed -i.bak -E 's/^(MATOMO_ENABLED[[:blank:]]*=[[:blank:]]*).*/\1false/' docker/.env
           sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_ENABLED[[:blank:]]*=[[:blank:]]*).*/\1\"'"${CKAN_CLOUDSTORAGE_ENABLED}"'\"/' docker/.env.ckan.local
-          sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_DRIVER_OPTIONS[[:blank:]]*=[[:blank:]]*).*/\1\"'"{'key': '${AWS_ACCESS_KEY_ID}', 'secret': '${AWS_SECRET_ACCESS_KEY}', 'token': ''}"'\"/' docker/.env.ckan.local
           sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_CONTAINER_NAME[[:blank:]]*=[[:blank:]]*).*/\1\"'"${CKAN_CLOUDSTORAGE_CONTAINER_NAME}"'\"/' docker/.env.ckan.local
-          sed -i.bak -E 's/^(AWS_ACCESS_KEY_ID[[:blank:]]*=[[:blank:]]*).*/\1\"'"${AWS_ACCESS_KEY_ID}"'\"/' docker/.env.ckan.local
-          sed -i.bak -E 's/^(AWS_SECRET_ACCESS_KEY[[:blank:]]*=[[:blank:]]*).*/\1\"'"${AWS_SECRET_ACCESS_KEY}"'\"/' docker/.env.ckan.local
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           REPOSITORY: ${{ secrets.REPOSITORY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          CKAN_CLOUDSTORAGE_ENABLED: ${{ secrets.CKAN_CLOUDSTORAGE_ENABLED }}
+          CKAN_CLOUDSTORAGE_ENABLED: true
           CKAN_CLOUDSTORAGE_CONTAINER_NAME: ${{ secrets.CKAN_CLOUDSTORAGE_CONTAINER_NAME }}
 
 
@@ -289,6 +284,18 @@ jobs:
         if: ${{ needs.detect-changes.outputs.nginx == 'true' }}
         run: |
           docker load --input /tmp/nginx/nginx.tar
+
+      - name: Pull from registry
+        working-directory: docker
+        run: |
+          docker compose pull
+
+      - name: configure AWS credentials for running tests
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_TEST_ROLE }}
+          role-session-name: github-actions
+          aws-region: eu-west-1
 
       - name: bring services up
         working-directory: docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -210,7 +210,7 @@ jobs:
         run: |
           aws sts get-caller-identity
 
-      - name: configure environment
+      - name: configure Cypress
         shell: bash
         run: |
           # configure cypress
@@ -239,53 +239,37 @@ jobs:
             },
           })
           EOT
-          # configure docker
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: configure .env
+        shell: bash
+        run: |
           cp -f docker/.env.template docker/.env
-          sed -i.bak -E 's/^(REGISTRY[[:blank:]]*=[[:blank:]]*).*/\1\"'"${REGISTRY}"'\"/' docker/.env
-          sed -i.bak -E 's/^(REPOSITORY[[:blank:]]*=[[:blank:]]*).*/\1\"'"${REPOSITORY}"'\"/' docker/.env
-          sed -i.bak -E 's/^(MATOMO_ENABLED[[:blank:]]*=[[:blank:]]*).*/\1false/' docker/.env
-          sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_ENABLED[[:blank:]]*=[[:blank:]]*).*/\1\"'"${CKAN_CLOUDSTORAGE_ENABLED}"'\"/' docker/.env.ckan.local
-          cat docker/.env
+          pip install "python-dotenv[cli]"
+          dotenv -f docker/.env set REGISTRY ${REGISTRY}
+          dotenv -f docker/.env set REPOSITORY ${REPOSITORY}
+          dotenv -f docker/.env set MATOMO_ENABLED false
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           REPOSITORY: ${{ secrets.REPOSITORY }}
+
+      - name: configure .env.ckan.local
+        shell: bash
+        run: |
+          dotenv -f docker/.env.ckan.local set CKAN_CLOUDSTORAGE_ENABLED ${CKAN_CLOUDSTORAGE_ENABLED}
+          dotenv -f docker/.env.ckan.local set CKAN_CLOUDSTORAGE_DRIVER_OPTIONS "{'key': '${AWS_ACCESS_KEY_ID}', 'secret': '${AWS_SECRET_ACCESS_KEY}', 'token': '${AWS_SESSION_TOKEN}' }"
+          dotenv -f docker/.env.ckan.local set CKAN_CLOUDSTORAGE_CONTAINER_NAME ${CKAN_CLOUDSTORAGE_CONTAINER_NAME}
+          dotenv -f docker/.env.ckan.local set AWS_ACCESS_KEY_ID ${AWS_ACCESS_KEY_ID}
+          dotenv -f docker/.env.ckan.local set AWS_SECRET_ACCESS_KEY ${AWS_SECRET_ACCESS_KEY}
+        env:
           CKAN_CLOUDSTORAGE_ENABLED: true
           CKAN_CLOUDSTORAGE_CONTAINER_NAME: ${{ secrets.CKAN_CLOUDSTORAGE_CONTAINER_NAME }}
           AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
           AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
-
-      - name: configure cloudstorage driver options
-        shell: bash
-        run: |
-          sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_DRIVER_OPTIONS[[:blank:]]*=[[:blank:]]*).*/\1\"'"{'key': '${AWS_ACCESS_KEY_ID}', 'secret': '${AWS_SECRET_ACCESS_KEY}', 'token': '${AWS_SESSION_TOKEN}'}"'\"/' docker/.env.ckan.local
-          cat docker/.env.ckan.local
-        env:
-          CKAN_CLOUDSTORAGE_CONTAINER_NAME: ${{ secrets.CKAN_CLOUDSTORAGE_CONTAINER_NAME }}
-          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
           AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
-
-      - name: configure cloudstorage container name
-        shell: bash
-        run: |
-          sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_CONTAINER_NAME[[:blank:]]*=[[:blank:]]*).*/\1\"'"${CKAN_CLOUDSTORAGE_CONTAINER_NAME}"'\"/' docker/.env.ckan.local
-          cat docker/.env.ckan.local
-        env:
-          CKAN_CLOUDSTORAGE_CONTAINER_NAME: ${{ secrets.CKAN_CLOUDSTORAGE_CONTAINER_NAME }}
-          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
-          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
-
-
-      - name: configure access keys
-        shell: bash
-        run: |
-          sed -i.bak -E 's/^(AWS_ACCESS_KEY_ID[[:blank:]]*=[[:blank:]]*).*/\1\"'"${AWS_ACCESS_KEY_ID}"'\"/' docker/.env.ckan.local
-          sed -i.bak -E 's/^(AWS_SECRET_ACCESS_KEY[[:blank:]]*=[[:blank:]]*).*/\1\"'"${AWS_SECRET_ACCESS_KEY}"'\"/' docker/.env.ckan.local
-          cat docker/.env.ckan.local
-        env:
-          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
-          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
 
       - name: configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,6 +197,19 @@ jobs:
 
       - run: npm ci
 
+      - name: configure AWS credentials for running tests
+        uses: aws-actions/configure-aws-credentials@v4
+        id: aws-credentials
+        with:
+          role-to-assume: ${{ secrets.AWS_TEST_ROLE }}
+          role-session-name: github-actions
+          aws-region: eu-west-1
+          output-credentials: true
+
+      - name: get caller identity
+        run: |
+          aws sts get-caller-identity
+
       - name: configure environment
         shell: bash
         run: |
@@ -232,13 +245,47 @@ jobs:
           sed -i.bak -E 's/^(REPOSITORY[[:blank:]]*=[[:blank:]]*).*/\1\"'"${REPOSITORY}"'\"/' docker/.env
           sed -i.bak -E 's/^(MATOMO_ENABLED[[:blank:]]*=[[:blank:]]*).*/\1false/' docker/.env
           sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_ENABLED[[:blank:]]*=[[:blank:]]*).*/\1\"'"${CKAN_CLOUDSTORAGE_ENABLED}"'\"/' docker/.env.ckan.local
-          sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_CONTAINER_NAME[[:blank:]]*=[[:blank:]]*).*/\1\"'"${CKAN_CLOUDSTORAGE_CONTAINER_NAME}"'\"/' docker/.env.ckan.local
+          cat docker/.env
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           REPOSITORY: ${{ secrets.REPOSITORY }}
           CKAN_CLOUDSTORAGE_ENABLED: true
           CKAN_CLOUDSTORAGE_CONTAINER_NAME: ${{ secrets.CKAN_CLOUDSTORAGE_CONTAINER_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
 
+      - name: configure cloudstorage driver options
+        shell: bash
+        run: |
+          sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_DRIVER_OPTIONS[[:blank:]]*=[[:blank:]]*).*/\1\"'"{'key': '${AWS_ACCESS_KEY_ID}', 'secret': '${AWS_SECRET_ACCESS_KEY}', 'token': '${AWS_SESSION_TOKEN}'}"'\"/' docker/.env.ckan.local
+          cat docker/.env.ckan.local
+        env:
+          CKAN_CLOUDSTORAGE_CONTAINER_NAME: ${{ secrets.CKAN_CLOUDSTORAGE_CONTAINER_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+
+      - name: configure cloudstorage container name
+        shell: bash
+        run: |
+          sed -i.bak -E 's/^(CKAN_CLOUDSTORAGE_CONTAINER_NAME[[:blank:]]*=[[:blank:]]*).*/\1\"'"${CKAN_CLOUDSTORAGE_CONTAINER_NAME}"'\"/' docker/.env.ckan.local
+          cat docker/.env.ckan.local
+        env:
+          CKAN_CLOUDSTORAGE_CONTAINER_NAME: ${{ secrets.CKAN_CLOUDSTORAGE_CONTAINER_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
+          AWS_SESSION_TOKEN: ${{ steps.aws-credentials.outputs.aws-session-token }}
+
+
+      - name: configure access keys
+        shell: bash
+        run: |
+          sed -i.bak -E 's/^(AWS_ACCESS_KEY_ID[[:blank:]]*=[[:blank:]]*).*/\1\"'"${AWS_ACCESS_KEY_ID}"'\"/' docker/.env.ckan.local
+          sed -i.bak -E 's/^(AWS_SECRET_ACCESS_KEY[[:blank:]]*=[[:blank:]]*).*/\1\"'"${AWS_SECRET_ACCESS_KEY}"'\"/' docker/.env.ckan.local
+          cat docker/.env.ckan.local
+        env:
+          AWS_ACCESS_KEY_ID: ${{ steps.aws-credentials.outputs.aws-access-key-id }}
+          AWS_SECRET_ACCESS_KEY: ${{ steps.aws-credentials.outputs.aws-secret-access-key }}
 
       - name: configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
@@ -284,18 +331,6 @@ jobs:
         if: ${{ needs.detect-changes.outputs.nginx == 'true' }}
         run: |
           docker load --input /tmp/nginx/nginx.tar
-
-      - name: Pull from registry
-        working-directory: docker
-        run: |
-          docker compose pull
-
-      - name: configure AWS credentials for running tests
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_TEST_ROLE }}
-          role-session-name: github-actions
-          aws-region: eu-west-1
 
       - name: bring services up
         working-directory: docker

--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -972,7 +972,7 @@ const monitoringStackProd = new MonitoringStack(app, 'MonitoringStack-prod', {
 });
 
 
-const ciTestStack = new CiTestStack(app, 'CiTestStack', {
+const ciTestStackBeta = new CiTestStack(app, 'CiTestStack-beta', {
   env: {
     account: betaProps.account,
     region: betaProps.region

--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -16,6 +16,7 @@ import {CertificateStack} from "../lib/certificate-stack";
 import {BypassCdnStack} from "../lib/bypass-cdn-stack";
 import {MonitoringStack} from "../lib/monitoring-stack";
 import {LambdaStack} from "../lib/lambda-stack";
+import {CiTestStack} from "../lib/ci-test-stack";
 
 // load .env file, shared with docker setup
 // mainly for ECR repo and image tag information
@@ -969,3 +970,15 @@ const monitoringStackProd = new MonitoringStack(app, 'MonitoringStack-prod', {
   domainName: prodProps.domainName,
   secondaryDomainName: prodProps.secondaryDomainName,
 });
+
+
+const ciTestStack = new CiTestStack(app, 'CiTestStack', {
+  env: {
+    account: betaProps.account,
+    region: betaProps.region
+  },
+  githubOrg: "vrk-kpa",
+  githubRepo: "opendata",
+  testBucketName: "avoindata-ci-test-bucket"
+
+})

--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -980,5 +980,4 @@ const ciTestStackBeta = new CiTestStack(app, 'CiTestStack-beta', {
   githubOrg: "vrk-kpa",
   githubRepo: "opendata",
   testBucketName: "avoindata-ci-test-bucket"
-
 })

--- a/cdk/lib/ci-test-stack-props.ts
+++ b/cdk/lib/ci-test-stack-props.ts
@@ -1,0 +1,7 @@
+import {StackProps} from "aws-cdk-lib";
+
+export interface CiTestStackProps extends StackProps {
+  testBucketName: string,
+  githubOrg: string,
+  githubRepo: string
+}

--- a/cdk/lib/ci-test-stack.ts
+++ b/cdk/lib/ci-test-stack.ts
@@ -11,7 +11,7 @@ export class CiTestStack extends Stack {
       blockPublicAccess: aws_s3.BlockPublicAccess.BLOCK_ALL,
       lifecycleRules: [
         {
-          expiration: Duration.hours(1)
+          expiration: Duration.days(1)
         }
       ]
     })

--- a/cdk/lib/ci-test-stack.ts
+++ b/cdk/lib/ci-test-stack.ts
@@ -33,6 +33,7 @@ export class CiTestStack extends Stack {
     })
 
     testBucket.grantWrite(testRole)
+    testBucket.grantRead(testRole)
   }
 
 }

--- a/cdk/lib/ci-test-stack.ts
+++ b/cdk/lib/ci-test-stack.ts
@@ -16,15 +16,16 @@ export class CiTestStack extends Stack {
       ]
     })
 
-
-
-    const oicdProvider = new aws_iam.OpenIdConnectProvider(this,  'oicdProvider', {
-      url: 'https://token.actions.githubusercontent.com',
-      clientIds: ['sts.amazonaws.com']
-    })
+    const oidcProviderArn = Stack.of(this).formatArn({
+        region: "",
+        partition: "aws",
+        resource: "oidc-provider",
+        service: "iam",
+        resourceName: "token.actions.githubusercontent.com"
+      })
 
     const testRole = new aws_iam.Role(this, 'TestRole', {
-      assumedBy: new aws_iam.FederatedPrincipal(oicdProvider.openIdConnectProviderArn, {
+      assumedBy: new aws_iam.WebIdentityPrincipal(oidcProviderArn, {
           StringLike: {
             "token.actions.githubusercontent.com:sub": `repo:${props.githubOrg}/${props.githubRepo}:*`
           }

--- a/cdk/lib/ci-test-stack.ts
+++ b/cdk/lib/ci-test-stack.ts
@@ -1,0 +1,37 @@
+import {aws_iam, aws_s3, Duration, Stack} from "aws-cdk-lib";
+import {Construct} from "constructs";
+import {CiTestStackProps} from "./ci-test-stack-props";
+
+export class CiTestStack extends Stack {
+  constructor(scope: Construct, id: string, props: CiTestStackProps) {
+    super(scope, id, props);
+
+    const testBucket = new aws_s3.Bucket(this,'TestBucket', {
+      bucketName: props.testBucketName,
+      blockPublicAccess: aws_s3.BlockPublicAccess.BLOCK_ALL,
+      lifecycleRules: [
+        {
+          expiration: Duration.hours(1)
+        }
+      ]
+    })
+
+
+
+    const oicdProvider = new aws_iam.OpenIdConnectProvider(this,  'oicdProvider', {
+      url: 'https://token.actions.githubusercontent.com',
+      clientIds: ['sts.amazonaws.com']
+    })
+
+    const testRole = new aws_iam.Role(this, 'TestRole', {
+      assumedBy: new aws_iam.FederatedPrincipal(oicdProvider.openIdConnectProviderArn, {
+          StringLike: {
+            "token.actions.githubusercontent.com:sub": `repo:${props.githubOrg}/${props.githubRepo}:*`
+          }
+      })
+    })
+
+    testBucket.grantWrite(testRole)
+  }
+
+}

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,4 +1,4 @@
-# build args
+# build args 
 ARG SECRET_NPMRC
 
 #

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
@@ -78,7 +78,14 @@ class CloudResourceStatus(ResourceStatus):
         filename = os.path.basename(urlparse(resource.get('url')).path)
         object_key = 'resources/%s/%s' % (resource_id, filename)
 
-        s3 = boto3.client('s3')
+        driver_options = config.get('ckanext.cloudstorage.driver_options')
+        if driver_options:
+            s3 = boto3.client('s3',
+                aws_access_key_id=driver_options.get('key'),
+                aws_secret_access_key=driver_options.get('secret'),
+                aws_session_token=driver_options.get('token'))
+        else:
+            s3 = boto3.client('s3')
         tags_response = s3.get_object_tagging(Bucket=aws_bucket_name, Key=object_key)
         self.tags = {item['Key']: item['Value'] for item in tags_response['TagSet']}
 

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
@@ -1,3 +1,5 @@
+import json
+
 import ckan.plugins as p
 from ckan.plugins.toolkit import config
 from ckan.lib.plugins import DefaultTranslation
@@ -80,6 +82,7 @@ class CloudResourceStatus(ResourceStatus):
 
         driver_options = config.get('ckanext.cloudstorage.driver_options')
         if driver_options:
+            driver_options = json.loads(driver_options)
             s3 = boto3.client('s3',
                 aws_access_key_id=driver_options.get('key'),
                 aws_secret_access_key=driver_options.get('secret'),

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
@@ -1,6 +1,5 @@
-import json
-
 import ckan.plugins as p
+import yaml
 from ckan.plugins.toolkit import config
 from ckan.lib.plugins import DefaultTranslation
 import ckan.logic as logic
@@ -82,9 +81,7 @@ class CloudResourceStatus(ResourceStatus):
 
         driver_options = config.get('ckanext.cloudstorage.driver_options')
         if driver_options:
-            # driver options might not be valid json, even though its a dict
-            driver_options = driver_options.replace("'", '"')
-            driver_options = json.loads(driver_options)
+            driver_options = yaml.safe_load(driver_options)
             s3 = boto3.client('s3',
                 aws_access_key_id=driver_options.get('key'),
                 aws_secret_access_key=driver_options.get('secret'),

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
@@ -82,6 +82,8 @@ class CloudResourceStatus(ResourceStatus):
 
         driver_options = config.get('ckanext.cloudstorage.driver_options')
         if driver_options:
+            # driver options might not be valid json, even though its a dict
+            driver_options = driver_options.replace("'", '"')
             driver_options = json.loads(driver_options)
             s3 = boto3.client('s3',
                 aws_access_key_id=driver_options.get('key'),


### PR DESCRIPTION
Creates a new stack which has test bucket and a role which has access to the bucket.
Github Actions now use the role to generate temporary credentials which are injected to docker environment variables.
Replaces sed with python-dotenv for easier maintainability in Github actions script.

Supplies cloudstorage driver options to resourcestatus plugin for it to fetch tags.