### PR TITLE
AV-2061: Add links to suojattudata

### DIFF
--- a/drupal/modules/avoindata-explore/avoindata_explore.module
+++ b/drupal/modules/avoindata-explore/avoindata_explore.module
@@ -33,6 +33,10 @@ function avoindata_explore_theme($existing, $type, $theme, $path) {
       'variables' => ['language' => NULL,],
       'template' => 'avoindata_support_block',
     ],
+    'avoindata_external' => [
+      'variables' => ['language' => NULL,],
+      'template' => 'avoindata_external_block'
+    ]
   ];
 }
 

--- a/drupal/modules/avoindata-explore/src/Plugin/Block/ExternalBlock.php
+++ b/drupal/modules/avoindata-explore/src/Plugin/Block/ExternalBlock.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\avoindata_explore\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'Avoindata external' Block.
+ *
+ * @Block(
+ *   id = "avoindata_external",
+ *   admin_label = @Translation("Avoindata External"),
+ *   category = @Translation("Avoindata External"),
+ * )
+ */
+class ExternalBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      '#language' => \Drupal::languageManager()->getCurrentLanguage()->getId(),
+      '#theme' => 'avoindata_external',
+    ];
+  }
+
+}

--- a/drupal/modules/avoindata-explore/templates/avoindata_external_block.html.twig
+++ b/drupal/modules/avoindata-explore/templates/avoindata_external_block.html.twig
@@ -1,0 +1,51 @@
+{#
+/**
+ * @file
+ * Avoindata External Block
+ *
+ * @ingroup themeable
+ */
+#}
+
+<div class="avoindata-external pb-4">
+  <div class="avoindata-block-container justify-content-center">
+    <div class="row avoindata-block-header-row pt-3">
+      <h2>
+        {% trans %}
+          All finnish restricted data from one place
+        {% endtrans %}
+      </h2>
+    </div>
+
+    <div class="avoindata-block-items mt-3 mb-3">
+
+      <div class="avoindata-block-card mt-2">
+        <div class="avoindata-block-card-icon avoindata-external-service">
+          <img src="/themes/avoindata/images/logo-suomifi.svg"/>
+        </div>
+
+        <div class="avoindata-block-card-content">
+          <div class="avoindata-block-card-title">
+            <h3>
+              {% trans %}
+                Suomi.fi-suojattudata
+              {% endtrans %}
+            </h3>
+          </div>
+
+          <div class="avoindata-block-card-text">
+            <i class="far fa-chevron-right"></i>
+            <a href="https://suojattudata.fi">
+              {% trans %}
+               Navigate to site
+              {% endtrans %}
+            </a>
+          </div>
+        </div>
+
+      </div>
+
+    </div>
+
+  </div>
+</div>

--- a/drupal/modules/avoindata-header/templates/avoindata_header.html.twig
+++ b/drupal/modules/avoindata-header/templates/avoindata_header.html.twig
@@ -27,6 +27,12 @@
       {{ drupal_region('navigation') }}
     </div>
 
+
+    <a class="link-button borderless external" href="https://suojattudata.fi" target="_blank">
+      Suomi.fi-suojattudata
+    </a>
+
+
     {# Navigation (collapsible) #}
     <div id="navbar-collapse" class="navbar-collapse collapse">
       {{ drupal_region('navigation_collapsible') }}

--- a/drupal/modules/avoindata-theme/config/install/block.block.avoindata_external.yml
+++ b/drupal/modules/avoindata-theme/config/install/block.block.avoindata_external.yml
@@ -1,0 +1,24 @@
+langcode: fi
+status: true
+dependencies:
+  module:
+    - system
+  theme:
+    - avoindata
+id: avoindata_external
+theme: avoindata
+region: content
+weight: 5
+provider: null
+plugin: avoindata_external
+settings:
+  id: avoindata_external
+  label: 'Avoindata External'
+  provider: avoindata_external
+  label_display: '0'
+visibility:
+  request_path:
+    id: request_path
+    pages: '<front>'
+    negate: false
+    context_mapping: {  }

--- a/opendata-assets/src/images/logo-suomifi.svg
+++ b/opendata-assets/src/images/logo-suomifi.svg
@@ -1,0 +1,11 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group">
+<path id="Tausta" d="M31 0H1C0.447715 0 0 0.447715 0 1V31C0 31.5523 0.447715 32 1 32H31C31.5523 32 32 31.5523 32 31V1C32 0.447715 31.5523 0 31 0Z" fill="#00347A"/>
+<g id="Merkki">
+<path id="Vector" d="M8 12V9.14C8 8.51 8.51 8 9.14 8H12V12" fill="white"/>
+<path id="Vector_2" d="M8 16H12V23.47C12 23.76 11.74 24 11.43 24H8.57C8.26 24 8 23.76 8 23.47" fill="white"/>
+<path id="Vector_3" d="M16 8H23.43C23.74 8 24 8.26 24 8.57V12H16" fill="white"/>
+<path id="Vector_4" d="M23.43 20H16V16H24V19.43C24 19.75 23.74 20 23.43 20Z" fill="white"/>
+</g>
+</g>
+</svg>

--- a/opendata-assets/src/less/drupal/overrides.less
+++ b/opendata-assets/src/less/drupal/overrides.less
@@ -417,13 +417,23 @@ p:last-child,
   }
 }
 
-.block-avoindata-support {
+.block-avoindata-support,
+.block-avoindata-external {
   margin-top: 30px;
 }
 
 .avoindata-explore,
 .avoindata-support {
   background-color: @suomi-highlightLight3;
+}
+
+.avoindata-external {
+  background-color: @suomi-highlightLight2;
+}
+
+.avoindata-explore,
+.avoindata-support,
+.avoindata-external {
 
   h2 {
     font-family: @font-family-sans-serif-semibold;
@@ -480,6 +490,22 @@ p:last-child,
   }
 }
 
+.avoindata-external {
+  .avoindata-block-card {
+    width: 470px;
+  }
+
+  .avoindata-block-card-icon {
+    max-width: 125px;
+  }
+
+  .avoindata-block-card-content {
+    width: max-content;
+    padding-right: 20px;
+  }
+}
+
+
 .avoindata-block-card-icon {
   height: 100%;
   width: 35%;
@@ -526,6 +552,10 @@ p:last-child,
 
 .avoindata-explore-showcase {
   background-color: @suomi-depthLight3;
+}
+
+.avoindata-external-service{
+  background-color: @suomi-depthSecondaryDark1;
 }
 
 .avoindata-datasetlist {

--- a/opendata-assets/src/less/drupal/overrides.less
+++ b/opendata-assets/src/less/drupal/overrides.less
@@ -427,14 +427,10 @@ p:last-child,
   background-color: @suomi-highlightLight3;
 }
 
-.avoindata-external {
-  background-color: @suomi-highlightLight2;
-}
 
 .avoindata-explore,
 .avoindata-support,
 .avoindata-external {
-
   h2 {
     font-family: @font-family-sans-serif-semibold;
     font-size: @font-size__module-h1;
@@ -491,6 +487,8 @@ p:last-child,
 }
 
 .avoindata-external {
+  background-color: @suomi-highlightLight2;
+
   .avoindata-block-card {
     width: 470px;
   }

--- a/opendata-assets/src/less/navbars.less
+++ b/opendata-assets/src/less/navbars.less
@@ -376,6 +376,45 @@ End of dropdown CSS
     font-size: 18px;
   }
 
+  .link-button {
+    color: @link-default-color;
+    border: 1px solid @link-default-color;
+    background: transparent;
+    padding: 0 20px;
+    margin: 10px;
+    border-radius: 2px;
+    box-shadow: none;
+    display: flex;
+    line-height: 40px;
+    font-weight: @font-weight-heavier;
+    letter-spacing: 0.4px;
+    font-size: @font-size-smaller-base;
+    text-decoration: none;
+    align-items: center;
+    gap: 8px;
+    float: right;
+
+    &.borderless {
+      border: 1px solid transparent;
+    }
+
+    &.external {
+      &::before {
+        font-family: "Font Awesome 5 Pro", "Font Awesome 5 Free", sans-serif;
+        font-size: 16px;
+        align-self: center;
+        content: "\f35d"
+      }
+    }
+
+    &:hover {
+      color: @link-default-color;
+      border: 1px solid #A5ADB1;
+      background: linear-gradient(to top, transparent 0%, rgba(255,255,255,0.085) 100%);
+      text-decoration: none;
+    }
+  }
+
   .navbar-collapse {
     border: 0;
   }

--- a/opendata-assets/src/less/navbars.less
+++ b/opendata-assets/src/less/navbars.less
@@ -410,7 +410,7 @@ End of dropdown CSS
     &:hover {
       color: @link-default-color;
       border: 1px solid #A5ADB1;
-      background: linear-gradient(to top, transparent 0%, rgba(255,255,255,0.085) 100%);
+      background: linear-gradient(to top, transparent 0%, rgb(255 255 255 / 8.5%) 100%);
       text-decoration: none;
     }
   }

--- a/opendata-assets/src/less/navbars.less
+++ b/opendata-assets/src/less/navbars.less
@@ -409,7 +409,7 @@ End of dropdown CSS
 
     &:hover {
       color: @link-default-color;
-      border: 1px solid #A5ADB1;
+      border: 1px solid @suomi-depthBase;
       background: linear-gradient(to top, transparent 0%, rgb(255 255 255 / 8.5%) 100%);
       text-decoration: none;
     }


### PR DESCRIPTION
Adds the following UI components:

Header has a new link:
![image](https://github.com/vrk-kpa/opendata/assets/830663/fa13e874-4e05-4490-8257-e99512c910f5)


Front page has a new block:
![image](https://github.com/vrk-kpa/opendata/assets/830663/46fc532e-2ccc-4de4-85d6-9758de785c37)


translations are still missing, well figure it out with technical writers.