### PR TITLE
AV-2055: Add pg_trgm extension to database as drupal 10 requires it

### DIFF
--- a/docker/postgres/docker-entrypoint-initdb.d/00_init_db.sh
+++ b/docker/postgres/docker-entrypoint-initdb.d/00_init_db.sh
@@ -16,6 +16,11 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
     GRANT ALL PRIVILEGES ON DATABASE $DB_DRUPAL TO $POSTGRES_USER;
 EOSQL
 
+# Create pg_trgm extension for drupal, can be removed once postgres is at least 13 and drupal is in version 10
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -d "$DB_DRUPAL" <<-EOSQL
+    CREATE EXTENSION pg_trgm;
+EOSQL
+
 # init datapusher job database
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
     CREATE ROLE $DB_DATAPUSHER_JOBS_USER LOGIN PASSWORD '$DB_DATAPUSHER_JOBS_PASS';


### PR DESCRIPTION
Will add manually to current rds instances, probably will not be needed for new rds instances since future drupal will automatically create this with postgres 13 when creating a new database.