### PR TITLE
AV-2079: Fix resourcestatus causing an error

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -365,6 +365,7 @@ export class CkanStack extends Stack {
       ckanContainerEnv['CKAN_CLOUDSTORAGE_CONTAINER_NAME'] = pCkanCloudstorageContainerName.stringValue;
       ckanContainerEnv['CKAN_CLOUDSTORAGE_USE_SECURE_URLS'] = pCkanCloudstorageUseSecureUrls.stringValue;
       ckanContainerEnv['CKAN_CLOUDSTORAGE_AWS_USE_BOTO3_SESSIONS'] = '1';
+      ckanContainerEnv['CKAN_CLOUDSTORAGE_DRIVER_OPTIONS'] = '';
 
       const ckanTaskExecPolicyAllowCloudstorage = new iam.PolicyStatement({
         actions: ['*'],


### PR DESCRIPTION
resourcestatus expects an empty value for it use sessions fetching tags from aws. When driver_options is not defined, environ will input string "None" into it.