### PR TITLE
AV-2084: Set language variable correctly

### DIFF
--- a/drupal/modules/avoindata-hero/avoindata_hero.module
+++ b/drupal/modules/avoindata-hero/avoindata_hero.module
@@ -29,6 +29,9 @@ function avoindata_hero_theme($existing, $type, $theme, $path) {
     'avoindata_hero' => [
       'render element' => 'form',
       'template' => 'avoindata_hero_form',
+      'variables' => [
+        'language' => []
+      ]
     ],
   ];
 }

--- a/drupal/modules/avoindata-hero/src/Plugin/Form/HeroForm.php
+++ b/drupal/modules/avoindata-hero/src/Plugin/Form/HeroForm.php
@@ -35,6 +35,7 @@ class HeroForm extends FormBase {
 
     $form['#theme'] = ['avoindata_hero'];
 
+    $form['#language'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
     $form['search'] = [
       '#type' => 'textfield',
       '#default_value' => '',

--- a/drupal/modules/avoindata-hero/templates/avoindata_hero_form.html.twig
+++ b/drupal/modules/avoindata-hero/templates/avoindata_hero_form.html.twig
@@ -55,7 +55,7 @@
                 <div class="text-center">
                     <h2>{{ count.count }}</h2>
                     <h4>
-                        <a href="/data/{{ form.language }}/{{ count.url }}">
+                        <a href="/data/{{ language }}/{{ count.url }}">
                             <strong>{{ count.text }}</strong>
                         </a>
                     </h4>
@@ -89,7 +89,7 @@
         </div>
         {{ form.searchfilter }}
         <div class="d-flex mt-3 justify-content-end">
-            <a href="/data/{{ form.language }}/advanced_search">
+            <a href="/data/{{ language }}/advanced_search">
                 {% trans %}
                     Use advanced search
                 {% endtrans %}


### PR DESCRIPTION
Language variables where removed in https://github.com/vrk-kpa/opendata/pull/1897, but they are actually required for urls to generate correctly, this should fix them without causing the original error.