### PR TITLE
AV-2090: Fix navbar focus on dropdowns

### DIFF
--- a/opendata-assets/src/less/navbars.less
+++ b/opendata-assets/src/less/navbars.less
@@ -493,6 +493,10 @@ End of dropdown CSS
         }
       }
     }
+
+    .dropdown-toggle:focus {
+      outline:  5px auto -webkit-focus-ring-color;
+    }
   }
 
   // nav collapsed


### PR DESCRIPTION
Bootstrap 3 purposefully removes outline on dropdowns, this has been fixed on newer versions, but this replicates the css for our uses for now.