### PR TITLE
Fix hero search by supplying the language through the form and not the rendering block

### DIFF
--- a/drupal/modules/avoindata-hero/avoindata_hero.module
+++ b/drupal/modules/avoindata-hero/avoindata_hero.module
@@ -29,9 +29,6 @@ function avoindata_hero_theme($existing, $type, $theme, $path) {
     'avoindata_hero' => [
       'render element' => 'form',
       'template' => 'avoindata_hero_form',
-      'variables' => [
-        'language' => []
-      ]
     ],
   ];
 }

--- a/drupal/modules/avoindata-hero/templates/avoindata_hero_form.html.twig
+++ b/drupal/modules/avoindata-hero/templates/avoindata_hero_form.html.twig
@@ -55,7 +55,7 @@
                 <div class="text-center">
                     <h2>{{ count.count }}</h2>
                     <h4>
-                        <a href="/data/{{ language }}/{{ count.url }}">
+                        <a href="/data/{{ form['#language'] }}/{{ count.url }}">
                             <strong>{{ count.text }}</strong>
                         </a>
                     </h4>
@@ -89,7 +89,7 @@
         </div>
         {{ form.searchfilter }}
         <div class="d-flex mt-3 justify-content-end">
-            <a href="/data/{{ language }}/advanced_search">
+            <a href="/data/{{ form['#language'] }}/advanced_search">
                 {% trans %}
                     Use advanced search
                 {% endtrans %}


### PR DESCRIPTION
The form lost its definitions if variables were given, the language is available in the form itself as an attribute.