### PR TITLE
AV-2107: fix footer links by removing unnecessary default collapse

### DIFF
--- a/drupal/modules/avoindata-theme/templates/menu/vertical-menu-base-template.html.twig
+++ b/drupal/modules/avoindata-theme/templates/menu/vertical-menu-base-template.html.twig
@@ -15,7 +15,7 @@ Removed the navbar-nav class to make this a vertical menu
       <span class="icon-bar"></span>
     </button>
   </div>
-  <div class="opendata-menu-container collapse" id="{{ menu_id }}">
+  <div class="opendata-menu-container" id="{{ menu_id }}">
 
     {% import _self as menus %}
     {#


### PR DESCRIPTION
- During guide mobile view development an unnecessary default collapse had been added to vertical menus. Removing it restores the footer links.