### PR TITLE
AV-2105: Add data updated field to UI and add timestamps as well

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/resource_read.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/resource_read.html
@@ -230,12 +230,17 @@
                             </th>
                           </tr>
                           <tr>
-                            <th>{{ _('Last updated') }}</th>
-                            <th>{{ h.render_datetime(res.last_modified) or h.render_datetime(res.revision_timestamp) or h.render_datetime(res.created) or _('unknown') }}</th>
+                            <th>{{ _('Data last updated') }}</th>
+                            <th>{{ h.render_datetime(res.last_modified, with_hours=True, with_seconds=True) or h.render_datetime(res.created, with_hours=True, with_seconds=True) or _('unknown') }}</th>
+                          </tr>
+
+                          <tr>
+                            <th>{{ _('Metadata last updated') }}</th>
+                            <th>{{ h.render_datetime(res.metadata_modified, with_hours=True, with_seconds=True) or h.render_datetime(res.created,with_hours=True, with_seconds=True) or _('unknown') }}</th>
                           </tr>
                           <tr>
                             <th>{{ _('Created') }}</th>
-                            <th>{{ h.render_datetime(res.created) or _('unknown') }}</th>
+                            <th>{{ h.render_datetime(res.created,with_hours=True,with_seconds=True) or _('unknown') }}</th>
                           </tr>
                           <tr>
                             <th>{{ _('sha256')|upper }}</th>

--- a/cypress/e2e/dataset_resource_spec.js
+++ b/cypress/e2e/dataset_resource_spec.js
@@ -154,7 +154,8 @@ describe('Dataset resource tests', function(){
             cy.get('.resource-module-table');
             cy.get('.resource-module-table').find('th').contains("Muoto");
             cy.get('.resource-module-table').find('th').contains("Katettu ajanjakso");
-            cy.get('.resource-module-table').find('th').contains("Viimeisin päivitys");
+            cy.get('.resource-module-table').find('th').contains("Data viimeksi päivitetty");
+            cy.get('.resource-module-table').find('th').contains("Metatieto viimeksi päivitetty");
             cy.get('.resource-module-table').find('th').contains("Luotu");
             cy.get('.resource-module-table').find('th').contains("SHA256");
         });
@@ -199,7 +200,8 @@ describe('Dataset resource tests', function(){
             cy.get('.resource-module-table');
             cy.get('.resource-module-table').find('th').contains("Format");
             cy.get('.resource-module-table').find('th').contains("Temporal Coverage");
-            cy.get('.resource-module-table').find('th').contains("Last updated");
+            cy.get('.resource-module-table').find('th').contains("Data last updated");
+            cy.get('.resource-module-table').find('th').contains("Metadata last updated");
             cy.get('.resource-module-table').find('th').contains("Created");
             cy.get('.resource-module-table').find('th').contains("SHA256");
         });
@@ -244,7 +246,8 @@ describe('Dataset resource tests', function(){
             cy.get('.resource-module-table');
             cy.get('.resource-module-table').find('th').contains("Format");
             cy.get('.resource-module-table').find('th').contains("Tidsmässig täckning");
-            cy.get('.resource-module-table').find('th').contains("Senaste uppdatering");
+            cy.get('.resource-module-table').find('th').contains("Data senast uppdaterad");
+            cy.get('.resource-module-table').find('th').contains("Metadata senast uppdaterad");
             cy.get('.resource-module-table').find('th').contains("Skapad");
             cy.get('.resource-module-table').find('th').contains("SHA256");
         });


### PR DESCRIPTION
Adds separate data updated and metadata updated field to the resource read UI based on ckan templates.

Add timestamps to the table so it doesn't just show a date in it.

![image](https://github.com/vrk-kpa/opendata/assets/830663/a5bb9cd5-e91f-4fec-a639-adeb3b27a122)
