### PR TITLE
Deploy domain stacks only to eu-west-1

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -739,11 +739,19 @@ const monitoringStackProd = new MonitoringStack(app, 'MonitoringStack-prod', {
 });
 
 const domainStackProd = new DomainStack(app, 'DomainStack-prod', {
+  env: {
+    account: prodProps.account,
+    region: prodProps.region,
+  },
   zoneName: prodProps.newDomainName,
   crossAccountId: betaProps.account
 })
 
 const subDomainStackBeta = new SubDomainStack(app, 'SubDomainStack-beta', {
+  env: {
+    account: betaProps.account,
+    region: betaProps.region
+  },
   prodAccountId: prodProps.account,
   subDomainName: betaProps.environment
 })


### PR DESCRIPTION
Domains are global, we do not want to deploy relevant stacks multiple times.