### PR TITLE
AV-2171: Fix additional info table styling

### DIFF
--- a/opendata-assets/src/less/ckan/upstream-overrides.less
+++ b/opendata-assets/src/less/ckan/upstream-overrides.less
@@ -22,6 +22,7 @@ body {
 
     .dataset-label {
       width: 30%;
+      vertical-align: middle;
     }
 
     .dataset-details {

--- a/opendata-assets/src/less/components/additional-info.less
+++ b/opendata-assets/src/less/components/additional-info.less
@@ -2,21 +2,10 @@
   ol {
     list-style: none;
     padding: 0;
+    margin-bottom: 0;
   }
 
   .tags {
-    .tag-list {
-      .tag {
-        background: none;
-        border-radius: 0;
-        margin: 0;
-        color: @color--black;
-
-        &:hover {
-          cursor: pointer;
-          background: transparent;
-        }
-      }
-    }
+    margin-top: 0;
   }
 }

--- a/opendata-assets/src/less/components/tags.less
+++ b/opendata-assets/src/less/components/tags.less
@@ -4,7 +4,7 @@
     display: block;
     display: flex;
     flex-wrap: wrap;
-    margin: -@margin__tag / 2;
+    margin: calc(-@margin__tag / 2);
 
     li {
       margin: 0;
@@ -12,7 +12,7 @@
     }
 
     .tag {
-      margin: @margin__tag / 2;
+      margin: calc(@margin__tag / 2);
       background: @opendata-brand-primary;
       border: none;
       box-shadow: none;


### PR DESCRIPTION
Aligns labels vertically:
![image](https://github.com/vrk-kpa/opendata/assets/830663/3b285556-73f2-44e2-95eb-e26035109f19)

Removes custom styling from table of tags, which might have been design error:

![image](https://github.com/vrk-kpa/opendata/assets/830663/6cd3fd83-3d1c-4ce3-aa56-25a06557ce26)

Fixes margins of tags which was invalid css and now they have actual margins:

![image](https://github.com/vrk-kpa/opendata/assets/830663/5744cadd-11bc-4575-bfa3-5f2f1b153f5a)
