### PR TITLE
AV-2175: Avoid running background tasks every minute

### DIFF
--- a/ckan/cron/crontab
+++ b/ckan/cron/crontab
@@ -11,8 +11,8 @@
 #
 # NOTE: Please make sure this file is using LF line-endings, windows CRLF breaks it!
 #
-*   1   *       *   *   cd /srv/app && ./cron/scripts/matomo-fetch.sh
-*   3   */3     *   *   cd /srv/app && ./cron/scripts/archiver-update.sh
+0   1   *       *   *   cd /srv/app && ./cron/scripts/matomo-fetch.sh
+0   3   */3     *   *   cd /srv/app && ./cron/scripts/archiver-update.sh
 */5 *   *       *   *   cd /srv/app && ./cron/scripts/harvester-run.sh
 0   22  *       *   *   cd /srv/app && ./cron/scripts/ckan-refresh.sh
 0   2   *       *   *   cd /srv/app && ./cron/scripts/qa-update.sh


### PR DESCRIPTION
- `*` means every value, meaning these two tasks ran every minute on the given hour, change to `0` to run once