### PR TITLE
AV-2040: Set environment specific CKAN site titles

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -28,6 +28,10 @@ export class CkanStack extends Stack {
     super(scope, id, props);
 
     // get params
+    const pCkanSiteName = ssm.StringParameter.fromStringParameterAttributes(this, 'pCkanSiteName', {
+      parameterName: `/${props.environment}/opendata/common/site_name`,
+    });
+
     const pCkanHarvesterStatusRecipients = ssm.StringParameter.fromStringParameterAttributes(this, 'pCkanHarvesterStatusRecipients', {
       parameterName: `/${props.environment}/opendata/ckan/harvester_status_recipients`,
     });
@@ -204,6 +208,7 @@ export class CkanStack extends Stack {
     const ckanContainerEnv: { [key: string]: string; } = {
       // .env.ckan
       CKAN_IMAGE_TAG: props.envProps.CKAN_IMAGE_TAG,
+      CKAN_SITE_NAME: pCkanSiteName.stringValue,
       CKAN_SITE_URL: `https://${props.domainName}`,
       CKAN_DRUPAL_SITE_URL: `https://${props.domainName}`,
       CKAN_SITE_ID: 'default',

--- a/ckan/templates/production.ini.j2
+++ b/ckan/templates/production.ini.j2
@@ -75,7 +75,7 @@ scheming.group_schemas = ckanext.ytp.schemas:group.json
 scheming.organization_schemas = ckanext.ytp.schemas:organization.json
 advancedsearch.schema = ckanext.advancedsearch:search_fields.json
 
-ckan.site_title = Suomi.fi-avoindata
+ckan.site_title = {{ environ('CKAN_SITE_NAME') }}
 ckan.site_logo =
 ckan.site_description =
 

--- a/docker/.env.ckan.local
+++ b/docker/.env.ckan.local
@@ -1,6 +1,7 @@
 # runtime configuration for ckan
 
 # ckan.ini
+CKAN_SITE_NAME="Suomi.fi-avoindata (local)"
 CKAN_SITE_URL="http://localhost"
 CKAN_DRUPAL_SITE_URL="http://nginx"
 CKAN_BEAKER_SESSION_SECRET="9PBdkxokLGWW4M4jeTI25h+4t"


### PR DESCRIPTION
- Differentiate between sites in reports by setting `ckan.site_title` per environment