### PR TITLE
AV-2006: Migrate prh tools and enable them production

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -300,6 +300,7 @@ const ckanStackBeta = new CkanStack(app, 'CkanStack-beta', {
     threads: 2
   },
   ckanCronEnabled: true,
+  prhToolsInUse: false,
   archiverSendNotificationEmailsToMaintainers: false,
   archiverExemptDomainsFromBrokenLinkNotifications: [],
   cloudstorageEnabled: true,
@@ -646,6 +647,7 @@ const ckanStackProd = new CkanStack(app, 'CkanStack-prod', {
     threads: 2
   },
   ckanCronEnabled: true,
+  prhToolsInUse: true,
   archiverSendNotificationEmailsToMaintainers: true,
   archiverExemptDomainsFromBrokenLinkNotifications: ['fmi.fi'],
   cloudstorageEnabled: true,

--- a/cdk/lib/ckan-stack-props.ts
+++ b/cdk/lib/ckan-stack-props.ts
@@ -12,6 +12,7 @@ export interface CkanStackProps extends EcsStackProps {
   fusekiTaskDef: EcsStackPropsTaskDef,
   ckanUwsgiProps: CkanUwsgiProps,
   ckanCronEnabled: boolean;
+  prhToolsInUse: boolean;
   archiverSendNotificationEmailsToMaintainers: boolean;
   archiverExemptDomainsFromBrokenLinkNotifications: string[];
   cloudstorageEnabled: boolean;

--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -205,6 +205,10 @@ export class CkanStack extends Stack {
       'sitesearch',
     ];
 
+    if (props.prhToolsInUse) {
+      ckanPlugins.push('prh_tools')
+    }
+
     const ckanContainerEnv: { [key: string]: string; } = {
       // .env.ckan
       CKAN_IMAGE_TAG: props.envProps.CKAN_IMAGE_TAG,

--- a/cdk/test/ckan-stack.test.ts
+++ b/cdk/test/ckan-stack.test.ts
@@ -160,6 +160,7 @@ test('verify ckan stack resources', () => {
       threads: 2
     },
     ckanCronEnabled: true,
+    prhToolsInUse: false,
     archiverSendNotificationEmailsToMaintainers: false,
     archiverExemptDomainsFromBrokenLinkNotifications: [],
     cloudstorageEnabled: true,


### PR DESCRIPTION
Only enables data fetching in productions, not in use even in local environments by default.