### PR TITLE
Fix syntax error in shield stack

### DIFF
--- a/cdk/lib/shield-stack.ts
+++ b/cdk/lib/shield-stack.ts
@@ -194,7 +194,7 @@ export class ShieldStack extends Stack {
 
         let ruleActionOverrides = []
 
-        for (let excludedRule in rule.excludedRules) {
+        for (let excludedRule of rule.excludedRules) {
           let excludedRuleObj = {
             actionToUse: {
               count: {}


### PR DESCRIPTION
`for .. in` for lists produces indexes, `for .. of` produces actual elements.