### PR TITLE
AV-2199: Fix deleting external urls

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
@@ -3,6 +3,15 @@ import pytest
 
 from ckan.tests.factories import Dataset
 from ckan.tests.helpers import call_action
+from ckan.plugins import toolkit
+
+
+def create_minimal_dataset():
+    return {'name': 'test_dataset_1', 'title': 'test_title', 'title_translated': {'fi': "otsikko"},
+            'license_id': "licence_id", 'notes_translated': {'fi': "Test notes"},
+            'keywords': {'fi': ["tag1", "tag2"]},
+            'collection_type': 'Open Data', 'copyright_notice_translated': {'fi': 'test_notice'},
+            'maintainer': 'test_maintainer', 'maintainer_email': 'test@maintainer.org'}
 
 @pytest.mark.usefixtures('clean_db', 'clean_index')
 class TestYtpDatasetPlugin():
@@ -10,13 +19,7 @@ class TestYtpDatasetPlugin():
 
 
     def test_create_dataset(self):
-        data_dict = {'name': 'test_dataset_1', 'title': 'test_title', 'title_translated': {'fi': "otsikko"},
-                     'license_id': "licence_id", 'notes_translated': {'fi': "Test notes"},
-                     'keywords': {'fi': ["tag1", "tag2"]},
-                     'collection_type': 'Open Data', 'copyright_notice_translated': {'fi': 'test_notice'},
-                     'maintainer': 'test_maintainer', 'maintainer_email': 'test@maintainer.org'}
-
-
+        data_dict = create_minimal_dataset()
         Dataset(**data_dict)
 
         test_dataset = call_action('package_show', id='test_dataset_1')
@@ -25,3 +28,34 @@ class TestYtpDatasetPlugin():
 
         test_search_result = call_action('package_search', q='test')
         assert test_search_result['results'][0]['title_translated']['fi'] == 'otsikko'
+
+
+    def test_external_urls_input(self):
+
+        data_dict = create_minimal_dataset()
+        data_dict['external_urls'] = ["http://foo.com", "http://bar.com"]
+
+        dataset = Dataset(**data_dict)
+        assert dataset['external_urls'] == ["http://foo.com", "http://bar.com"]
+
+
+    def test_external_urls_invalid_input(self):
+        data_dict = create_minimal_dataset()
+        data_dict['external_urls'] = ["first", "second"]
+
+        with pytest.raises(toolkit.ValidationError):
+            Dataset(**data_dict)
+
+
+    def test_external_urls_removed(self):
+        data_dict = create_minimal_dataset()
+        data_dict['external_urls'] = ["http://foo.com", "http://bar.com"]
+
+        dataset = Dataset(**data_dict)
+
+
+        result = call_action('package_patch', id=dataset['id'], external_urls="")
+        assert result['external_urls'] == []
+        result = call_action('package_patch', id=dataset['id'], external_urls=[''])
+        assert result['external_urls'] == []
+

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/validators.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/validators.py
@@ -199,6 +199,9 @@ def repeating_text(key, data, errors, context):
 
         out = []
         for element in value:
+            if not element:
+                continue
+
             if isinstance(element, bytes):
                 try:
                     element = element.decode('utf-8')

--- a/ckan/ckanext/ckanext-ytp_main/test.ini
+++ b/ckan/ckanext/ckanext-ytp_main/test.ini
@@ -2,7 +2,7 @@
 use = config:../../src/ckan/test-core.ini
 sqlalchemy.url = postgresql://ckan:ckan_pass@postgres/ckan_test
 solr_url = http://solr-test:8983/solr/ckan
-ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent report organizationapproval harvest hierarchy_display sixodp_showcase sixodp_showcasesubmit ytp_organizations ytp_user ytp_theme ytp_dataset sitesearch
+ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest hierarchy_display    ytp_dataset
 ckan.locale_default = fi
 ckanext.sixodp_showcasesubmit.creating_user_username = ckan_admin
 ckanext.sixodp_showcasesubmit.recaptcha_sitekey = ""


### PR DESCRIPTION
The fix itself is a simple one where empty strings are ignored from repeating text input lists. This mostly adds tests related to external urls but the fix works also for other repeating text inputs.