### PR TITLE
AV-2202: Fix server error in package_show api

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -182,7 +182,8 @@ RUN cd ${SRC_DIR}/ckan && \
     patch --strip=1 --input=patches/json_serializable_lazyjsonobject.patch && \
     patch --strip=1 --input=patches/implement_is_required_for_image_upload.patch && \
     patch --strip=1 --input=patches/add_drafts_to_search.patch && \
-    patch --strip=1 --input=patches/add_prefix_to_werkzeug.patch
+    patch --strip=1 --input=patches/add_prefix_to_werkzeug.patch && \
+    patch --strip=1 --input=patches/fix_use_default_schema_parameter.patch
 
 RUN \
   # Make scripts executable

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -448,7 +448,14 @@ class YTPDatasetForm(plugins.SingletonPlugin, toolkit.DefaultDatasetForm, YtpMai
                 'include_extras': True,
                 'groups': pkg_dict.get('categories')
             }
-            pkg_dict['groups'] = get_action('group_list')(context, translation_dict)
+
+            group_context = context.copy()
+
+            # Schema should be none for group_list -> group_show calls,
+            # otherwise it will produce an error as dataset schema is wrong for this
+            group_context.pop('schema', None)
+
+            pkg_dict['groups'] = get_action('group_list')(group_context, translation_dict)
 
     def before_index(self, pkg_dict):
         if 'tags' in pkg_dict:

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from ckan.tests.factories import Dataset
+from ckan.tests.factories import Dataset, Group
 from ckan.tests.helpers import call_action
 from ckan.plugins import toolkit
 
@@ -59,3 +59,19 @@ class TestYtpDatasetPlugin():
         result = call_action('package_patch', id=dataset['id'], external_urls=[''])
         assert result['external_urls'] == []
 
+
+    def test_categories_with_translations(self):
+        category = Group(title_translated={'fi': 'finnish title', 'sv': 'swedish title', 'en': 'english title'},
+                         description_translated={'fi': 'finnish description',
+                                                 'sv': 'swedish description',
+                                                 'en': 'english description'})
+
+        data_dict = create_minimal_dataset()
+        data_dict['categories'] = [category['name']]
+        dataset = Dataset(**data_dict)
+
+        result = call_action('package_show', id=dataset['id'])
+        assert result['groups'][0]['title_translated'] == {'fi': 'finnish title', 'sv': 'swedish title', 'en': 'english title'}
+        assert result['groups'][0]['description_translated'] == {'fi': 'finnish description',
+                                                                 'sv': 'swedish description',
+                                                                 'en': 'english description'}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
@@ -61,17 +61,15 @@ class TestYtpDatasetPlugin():
 
 
     def test_categories_with_translations(self):
-        category = Group(title_translated={'fi': 'finnish title', 'sv': 'swedish title', 'en': 'english title'},
-                         description_translated={'fi': 'finnish description',
-                                                 'sv': 'swedish description',
-                                                 'en': 'english description'})
+        translated_title = {'fi': 'finnish title', 'sv': 'swedish title', 'en': 'english title'}
+        translated_description = {'fi': 'finnish description', 'sv': 'swedish description', 'en': 'english description'}
+        category = Group(title_translated=translated_title,
+                         description_translated=translated_description)
 
         data_dict = create_minimal_dataset()
         data_dict['categories'] = [category['name']]
         dataset = Dataset(**data_dict)
 
         result = call_action('package_show', id=dataset['id'])
-        assert result['groups'][0]['title_translated'] == {'fi': 'finnish title', 'sv': 'swedish title', 'en': 'english title'}
-        assert result['groups'][0]['description_translated'] == {'fi': 'finnish description',
-                                                                 'sv': 'swedish description',
-                                                                 'en': 'english description'}
+        assert result['groups'][0]['title_translated'] == translated_title
+        assert result['groups'][0]['description_translated'] == translated_description

--- a/ckan/ckanext/ckanext-ytp_main/test.ini
+++ b/ckan/ckanext/ckanext-ytp_main/test.ini
@@ -2,13 +2,14 @@
 use = config:../../src/ckan/test-core.ini
 sqlalchemy.url = postgresql://ckan:ckan_pass@postgres/ckan_test
 solr_url = http://solr-test:8983/solr/ckan
-ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest hierarchy_display    ytp_dataset
+ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest hierarchy_display ytp_dataset
 ckan.locale_default = fi
 ckanext.sixodp_showcasesubmit.creating_user_username = ckan_admin
 ckanext.sixodp_showcasesubmit.recaptcha_sitekey = ""
 ckanext.sixodp_showcasesubmit.recaptcha_secret = ""
 ckanext.sixodp_showcasesubmit.recipient_emails = localhost
 scheming.dataset_schemas = ckanext.ytp.schemas:dataset.json
+scheming.group_schemas = ckanext.ytp.schemas:group.json
 scheming.presets = ckanext.ytp.schemas:presets.json ckanext.scheming:presets.json ckanext.fluent:presets.json
 
 [app:celery]

--- a/ckan/src/ckan/patches/fix_use_default_schema_parameter.patch
+++ b/ckan/src/ckan/patches/fix_use_default_schema_parameter.patch
@@ -1,0 +1,13 @@
+diff --git a/ckan/logic/action/get.py b/ckan/logic/action/get.py
+index f767c443e..5d016079c 100644
+--- a/ckan/logic/action/get.py
++++ b/ckan/logic/action/get.py
+@@ -985,7 +985,7 @@ def package_show(context, data_dict):
+ 
+     _check_access('package_show', context, data_dict)
+ 
+-    if data_dict.get('use_default_schema', False):
++    if asbool(data_dict.get('use_default_schema', False)):
+         context['schema'] = ckan.logic.schema.default_show_package_schema()
+     include_tracking = asbool(data_dict.get('include_tracking', False))
+ 


### PR DESCRIPTION
There is a bug in ckan that doesn't handle boolean with parameter `use_default_schema`, it just uses default schema if the parameter exists in the api call.

Fixes the server error by removing schema from context on `group_list` call, as the schema in context is dataset schema which is totally wrong for group calls.