### PR TITLE
Add ckanext-matomo to open prs workflow

### DIFF
--- a/.github/workflows/open_prs.yml
+++ b/.github/workflows/open_prs.yml
@@ -14,7 +14,7 @@ jobs:
         id: fetch_open_prs
         uses: vrk-kpa/fetch-open-prs@main
         with:
-          repository: "vrk-kpa/opendata"
+          repository: '["vrk-kpa/opendata", "vrk-kpa/ckanext-matomo"]'
           format: "markdown"
           ignored_users: '["dependabot[bot]"]'
 


### PR DESCRIPTION
Implemented a feature for https://github.com/vrk-kpa/fetch-open-prs, where repository input can be a list, so that every repository does not need a workflow to notify in zulip about the open prs and no need to configure the secret to every repository.