### PR TITLE
Do not try send zulip message if there are no open pull requests

### DIFF
--- a/.github/workflows/open_prs.yml
+++ b/.github/workflows/open_prs.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Send to zulip
         uses: zulip/github-actions-zulip/send-message@v1
+        if:  ${{ steps.fetch_open_prs.outputs.PRs }}
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}
           email: 'avoindata-bot@turina.dvv.fi'


### PR DESCRIPTION
If there are no open pull requests, the workflow was failing on empty message sending.