### PR TITLE
Refactor env props in cdk not to reference unneeded properties

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -20,7 +20,6 @@ import {DomainStack} from "../lib/domain-stack";
 import {CiTestStack} from "../lib/ci-test-stack";
 import {SubDomainStack} from "../lib/sub-domain-stack";
 import {ShieldStack} from "../lib/shield-stack";
-import {CloudfrontParameterStack} from "../lib/cloudfront-parameter-stack";
 
 // load .env file, shared with docker setup
 // mainly for ECR repo and image tag information

--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -20,6 +20,7 @@ import {DomainStack} from "../lib/domain-stack";
 import {CiTestStack} from "../lib/ci-test-stack";
 import {SubDomainStack} from "../lib/sub-domain-stack";
 import {ShieldStack} from "../lib/shield-stack";
+import {CloudfrontParameterStack} from "../lib/cloudfront-parameter-stack";
 
 // load .env file, shared with docker setup
 // mainly for ECR repo and image tag information
@@ -59,46 +60,31 @@ const betaProps = {
 };
 
 const clusterStackBeta = new ClusterStack(app, 'ClusterStack-beta', {
-  envProps: envProps,
   env: {
     account: betaProps.account,
     region: betaProps.region,
   },
   environment: betaProps.environment,
-  fqdn: betaProps.fqdn,
-  secondaryFqdn: betaProps.secondaryFqdn,
-  domainName: betaProps.domainName,
-  secondaryDomainName: betaProps.secondaryDomainName,
   vpcId: 'vpc-0162f60213eb96ab2'
 });
 
 const backupStackBeta = new BackupStack(app, 'BackupStack-beta', {
-  envProps: envProps,
   env: {
     account: betaProps.account,
     region: betaProps.region,
   },
-  domainName: betaProps.domainName,
   environment: betaProps.environment,
-  fqdn: betaProps.fqdn,
-  secondaryDomainName: betaProps.secondaryDomainName,
-  secondaryFqdn: betaProps.secondaryFqdn,
   backups: true,
   importVault: true
 })
 
 
 const fileSystemStackBeta = new FileSystemStack(app, 'FileSystemStack-beta', {
-  envProps: envProps,
   env: {
     account: betaProps.account,
     region: betaProps.region,
   },
   environment: betaProps.environment,
-  fqdn: betaProps.fqdn,
-  secondaryFqdn: betaProps.secondaryFqdn,
-  domainName: betaProps.domainName,
-  secondaryDomainName: betaProps.secondaryDomainName,
   vpc: clusterStackBeta.vpc,
   backups: true,
   backupPlan: backupStackBeta.backupPlan,
@@ -106,16 +92,11 @@ const fileSystemStackBeta = new FileSystemStack(app, 'FileSystemStack-beta', {
 });
 
 const databaseStackBeta = new DatabaseStack(app, 'DatabaseStack-beta', {
-  envProps: envProps,
   env: {
     account: betaProps.account,
     region: betaProps.region,
   },
   environment: betaProps.environment,
-  fqdn: betaProps.fqdn,
-  secondaryFqdn: betaProps.secondaryFqdn,
-  domainName: betaProps.domainName,
-  secondaryDomainName: betaProps.secondaryDomainName,
   vpc: clusterStackBeta.vpc,
   backups: true,
   backupPlan: backupStackBeta.backupPlan,
@@ -123,16 +104,11 @@ const databaseStackBeta = new DatabaseStack(app, 'DatabaseStack-beta', {
 });
 
 const lambdaStackBeta = new LambdaStack(app, 'LambdaStack-beta', {
-  envProps: envProps,
   env: {
     account: betaProps.account,
     region: betaProps.region,
   },
   environment: betaProps.environment,
-  fqdn: betaProps.fqdn,
-  secondaryFqdn: betaProps.secondaryFqdn,
-  domainName: betaProps.domainName,
-  secondaryDomainName: betaProps.secondaryDomainName,
   datastoreInstance: databaseStackBeta.datastoreInstance,
   datastoreCredentials: databaseStackBeta.datastoreCredentials,
   vpc: clusterStackBeta.vpc
@@ -166,16 +142,11 @@ const certificateStackForCloudfrontBeta = new CertificateStack(app, 'Certificate
 
 
 const loadBalancerStackBeta = new LoadBalancerStack(app, 'LoadBalancerStack-beta', {
-  envProps: envProps,
   env: {
     account: betaProps.account,
     region: betaProps.region,
   },
   environment: betaProps.environment,
-  fqdn: betaProps.fqdn,
-  secondaryFqdn: betaProps.secondaryFqdn,
-  domainName: betaProps.domainName,
-  secondaryDomainName: betaProps.secondaryDomainName,
   vpc: clusterStackBeta.vpc
 });
 
@@ -195,34 +166,23 @@ const bypassCdnStackBeta = new BypassCdnStack(app, 'BypassCdnStack-beta', {
 })
 
 const shieldStackBeta = new ShieldStack(app, 'ShieldStack-beta', {
-  envProps: envProps,
   env: {
     account: betaProps.account,
     region: 'us-east-1',
   },
   environment: betaProps.environment,
-  fqdn: betaProps.fqdn,
-  secondaryFqdn: betaProps.secondaryFqdn,
-  domainName: betaProps.domainName,
-  secondaryDomainName: betaProps.secondaryDomainName,
   bannedIpsRequestSamplingEnabled: false,
   highPriorityRequestSamplingEnabled: false,
   rateLimitRequestSamplingEnabled: false,
   requestSampleAllTrafficEnabled: false,
 })
 
-
 const cacheStackBeta = new CacheStack(app, 'CacheStack-beta', {
-  envProps: envProps,
   env: {
     account: betaProps.account,
     region: betaProps.region,
   },
   environment: betaProps.environment,
-  fqdn: betaProps.fqdn,
-  secondaryFqdn: betaProps.secondaryFqdn,
-  domainName: betaProps.domainName,
-  secondaryDomainName: betaProps.secondaryDomainName,
   vpc: clusterStackBeta.vpc,
   cacheNodeType: 'cache.t3.small',
   cacheEngineVersion: '7.1',
@@ -379,16 +339,11 @@ const webStackBeta = new WebStack(app, 'WebStack-beta', {
 
 const monitoringStackBeta = new MonitoringStack(app, 'MonitoringStack-beta', {
   sendToZulipLambda: lambdaStackBeta.sendToZulipLambda,
-  envProps: envProps,
   env: {
     account: betaProps.account,
     region: betaProps.region,
   },
   environment: betaProps.environment,
-  fqdn: betaProps.fqdn,
-  secondaryFqdn: betaProps.secondaryFqdn,
-  domainName: betaProps.domainName,
-  secondaryDomainName: betaProps.secondaryDomainName,
 });
 
 //
@@ -407,45 +362,30 @@ const prodProps = {
 };
 
 const clusterStackProd = new ClusterStack(app, 'ClusterStack-prod', {
-  envProps: envProps,
   env: {
     account: prodProps.account,
     region: prodProps.region,
   },
   environment: prodProps.environment,
-  fqdn: prodProps.fqdn,
-  secondaryFqdn: prodProps.secondaryFqdn,
-  domainName: prodProps.domainName,
-  secondaryDomainName: prodProps.secondaryDomainName,
   vpcId: 'vpc-07f19c5db1390f949'
 });
 
 const backupStackProd = new BackupStack(app, 'BackupStack-prod', {
-  envProps: envProps,
   env: {
     account: prodProps.account,
     region: prodProps.region,
   },
-  domainName: prodProps.domainName,
   environment: prodProps.environment,
-  fqdn: prodProps.fqdn,
-  secondaryDomainName: prodProps.secondaryDomainName,
-  secondaryFqdn: prodProps.secondaryFqdn,
   backups: true,
   importVault: false
 })
 
 const fileSystemStackProd = new FileSystemStack(app, 'FileSystemStack-prod', {
-  envProps: envProps,
   env: {
     account: prodProps.account,
     region: prodProps.region,
   },
   environment: prodProps.environment,
-  fqdn: prodProps.fqdn,
-  secondaryFqdn: prodProps.secondaryFqdn,
-  domainName: prodProps.domainName,
-  secondaryDomainName: prodProps.secondaryDomainName,
   vpc: clusterStackProd.vpc,
   backups: true,
   backupPlan: backupStackProd.backupPlan,
@@ -453,16 +393,11 @@ const fileSystemStackProd = new FileSystemStack(app, 'FileSystemStack-prod', {
 });
 
 const databaseStackProd = new DatabaseStack(app, 'DatabaseStack-prod', {
-  envProps: envProps,
   env: {
     account: prodProps.account,
     region: prodProps.region,
   },
   environment: prodProps.environment,
-  fqdn: prodProps.fqdn,
-  secondaryFqdn: prodProps.secondaryFqdn,
-  domainName: prodProps.domainName,
-  secondaryDomainName: prodProps.secondaryDomainName,
   vpc: clusterStackProd.vpc,
   backups: true,
   backupPlan: backupStackProd.backupPlan,
@@ -470,16 +405,11 @@ const databaseStackProd = new DatabaseStack(app, 'DatabaseStack-prod', {
 });
 
 const lambdaStackProd = new LambdaStack(app, 'LambdaStack-prod', {
-  envProps: envProps,
   env: {
     account: prodProps.account,
     region: prodProps.region,
   },
   environment: prodProps.environment,
-  fqdn: prodProps.fqdn,
-  secondaryFqdn: prodProps.secondaryFqdn,
-  domainName: prodProps.domainName,
-  secondaryDomainName: prodProps.secondaryDomainName,
   datastoreInstance: databaseStackProd.datastoreInstance,
   datastoreCredentials: databaseStackProd.datastoreCredentials,
   vpc: clusterStackProd.vpc
@@ -514,16 +444,11 @@ const certificateStackForCloudfrontProd = new CertificateStack(app, 'Certificate
 })
 
 const loadBalancerStackProd = new LoadBalancerStack(app, 'LoadBalancerStack-prod', {
-  envProps: envProps,
   env: {
     account: prodProps.account,
     region: prodProps.region,
   },
   environment: prodProps.environment,
-  fqdn: prodProps.fqdn,
-  secondaryFqdn: prodProps.secondaryFqdn,
-  domainName: prodProps.domainName,
-  secondaryDomainName: prodProps.secondaryDomainName,
   vpc: clusterStackProd.vpc
 });
 
@@ -542,16 +467,11 @@ const bypassCdnStackProd = new BypassCdnStack(app, 'BypassCdnStack-prod', {
 })
 
 const shieldStackProd = new ShieldStack(app, 'ShieldStack-prod', {
-  envProps: envProps,
   env: {
     account: prodProps.account,
     region: 'us-east-1'
   },
   environment: prodProps.environment,
-  fqdn: prodProps.fqdn,
-  secondaryFqdn: prodProps.secondaryFqdn,
-  domainName: prodProps.domainName,
-  secondaryDomainName: prodProps.secondaryDomainName,
   bannedIpsRequestSamplingEnabled: false,
   highPriorityRequestSamplingEnabled: false,
   rateLimitRequestSamplingEnabled: false,
@@ -559,16 +479,11 @@ const shieldStackProd = new ShieldStack(app, 'ShieldStack-prod', {
 })
 
 const cacheStackProd = new CacheStack(app, 'CacheStack-prod', {
-  envProps: envProps,
   env: {
     account: prodProps.account,
     region: prodProps.region,
   },
   environment: prodProps.environment,
-  fqdn: prodProps.fqdn,
-  secondaryFqdn: prodProps.secondaryFqdn,
-  domainName: prodProps.domainName,
-  secondaryDomainName: prodProps.secondaryDomainName,
   vpc: clusterStackProd.vpc,
   cacheNodeType: 'cache.t3.small',
   cacheEngineVersion: '7.1',
@@ -725,16 +640,11 @@ const webStackProd = new WebStack(app, 'WebStack-prod', {
 
 const monitoringStackProd = new MonitoringStack(app, 'MonitoringStack-prod', {
   sendToZulipLambda: lambdaStackProd.sendToZulipLambda,
-  envProps: envProps,
   env: {
     account: prodProps.account,
     region: prodProps.region,
   },
   environment: prodProps.environment,
-  fqdn: prodProps.fqdn,
-  secondaryFqdn: prodProps.secondaryFqdn,
-  domainName: prodProps.domainName,
-  secondaryDomainName: prodProps.secondaryDomainName,
 });
 
 const domainStackProd = new DomainStack(app, 'DomainStack-prod', {

--- a/cdk/lib/backup-stack-props.ts
+++ b/cdk/lib/backup-stack-props.ts
@@ -1,6 +1,6 @@
-import {CommonStackProps} from "./common-stack-props";
+import {EnvStackProps} from "./env-stack-props";
 
-export interface BackupStackProps extends CommonStackProps {
+export interface BackupStackProps extends EnvStackProps {
     importVault: boolean;
     backups: boolean;
 

--- a/cdk/lib/cluster-stack-props.ts
+++ b/cdk/lib/cluster-stack-props.ts
@@ -1,5 +1,6 @@
-import {CommonStackProps} from "./common-stack-props";
 
-export interface ClusterStackProps extends CommonStackProps {
+import {EnvStackProps} from "./env-stack-props";
+
+export interface ClusterStackProps extends EnvStackProps {
   vpcId: string
 }

--- a/cdk/lib/common-stack-props.ts
+++ b/cdk/lib/common-stack-props.ts
@@ -1,9 +1,8 @@
-import { Duration, Stack, StackProps } from 'aws-cdk-lib';
-import { EnvProps } from './env-props';
+import {EnvStackProps} from "./env-stack-props";
+import {EnvProps} from "./env-props";
 
-export interface CommonStackProps extends StackProps {
+export interface CommonStackProps extends EnvStackProps {
   envProps: EnvProps;
-  environment: string;
   fqdn: string;
   secondaryFqdn: string;
   domainName: string;

--- a/cdk/lib/create-databases-and-users-props.ts
+++ b/cdk/lib/create-databases-and-users-props.ts
@@ -1,7 +1,7 @@
 import {aws_ec2, aws_rds, StackProps} from "aws-cdk-lib";
-import {CommonStackProps} from "./common-stack-props";
+import {EnvStackProps} from "./env-stack-props";
 
-export interface CreateDatabasesAndUsersProps extends CommonStackProps{
+export interface CreateDatabasesAndUsersProps extends EnvStackProps{
   datastoreInstance: aws_rds.IDatabaseInstance,
   datastoreCredentials: aws_rds.Credentials,
   vpc: aws_ec2.IVpc;

--- a/cdk/lib/ec-stack-props.ts
+++ b/cdk/lib/ec-stack-props.ts
@@ -1,8 +1,8 @@
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
-import { CommonStackProps } from './common-stack-props';
+import {EnvStackProps} from "./env-stack-props";
 
-export interface EcStackProps extends CommonStackProps {
+export interface EcStackProps extends EnvStackProps {
   vpc: ec2.IVpc;
   cacheNodeType: string;
   cacheEngineVersion: string;

--- a/cdk/lib/efs-stack-props.ts
+++ b/cdk/lib/efs-stack-props.ts
@@ -1,9 +1,9 @@
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
-import { CommonStackProps } from './common-stack-props';
 import {aws_backup} from "aws-cdk-lib";
+import {EnvStackProps} from "./env-stack-props";
 
-export interface EfsStackProps extends CommonStackProps {
+export interface EfsStackProps extends EnvStackProps {
   backupPlan: aws_backup.BackupPlan;
   vpc: ec2.IVpc;
   backups: boolean;

--- a/cdk/lib/elb-stack-props.ts
+++ b/cdk/lib/elb-stack-props.ts
@@ -1,7 +1,8 @@
 import {aws_ec2 as ec2, aws_certificatemanager as acm} from 'aws-cdk-lib';
 
-import { CommonStackProps } from './common-stack-props';
 
-export interface ElbStackProps extends CommonStackProps {
+import {EnvStackProps} from "./env-stack-props";
+
+export interface ElbStackProps extends EnvStackProps {
   vpc: ec2.IVpc;
 }

--- a/cdk/lib/env-stack-props.ts
+++ b/cdk/lib/env-stack-props.ts
@@ -1,0 +1,6 @@
+import {StackProps} from "aws-cdk-lib";
+import {EnvProps} from "./env-props";
+
+export interface EnvStackProps extends StackProps {
+  environment: string;
+}

--- a/cdk/lib/lambda-stack-props.ts
+++ b/cdk/lib/lambda-stack-props.ts
@@ -1,7 +1,8 @@
 import {aws_ec2, aws_rds, StackProps} from "aws-cdk-lib";
-import {CommonStackProps} from "./common-stack-props";
 
-export interface LambdaStackProps extends CommonStackProps {
+import {EnvStackProps} from "./env-stack-props";
+
+export interface LambdaStackProps extends EnvStackProps {
   datastoreInstance: aws_rds.IDatabaseInstance;
   datastoreCredentials: aws_rds.Credentials;
   vpc: aws_ec2.IVpc;

--- a/cdk/lib/lambda-stack.ts
+++ b/cdk/lib/lambda-stack.ts
@@ -17,13 +17,9 @@ export class LambdaStack extends Stack {
       datastoreInstance: props.datastoreInstance,
       datastoreCredentials: props.datastoreCredentials,
       vpc: props.vpc,
-      envProps: props.envProps,
       env: props.env,
       environment: props.environment,
-      fqdn: props.fqdn,
-      secondaryFqdn: props.secondaryFqdn,
-      domainName: props.domainName,
-      secondaryDomainName: props.secondaryDomainName,
+
     })
 
     this.datastoreJobsCredentials = Credentials.fromSecret(createDatabases.datastoreJobsSecret);
@@ -35,13 +31,8 @@ export class LambdaStack extends Stack {
       zulipApiUrl: 'turina.dvv.fi',
       zulipStream: 'Avoindata.fi',
       zulipTopic: 'Container restarts',
-      envProps: props.envProps,
       env: props.env,
       environment: props.environment,
-      fqdn: props.fqdn,
-      secondaryFqdn: props.secondaryFqdn,
-      domainName: props.domainName,
-      secondaryDomainName: props.secondaryDomainName,
     });
     this.sendToZulipLambda = sendToZulip.lambda;
   }

--- a/cdk/lib/monitoring-stack-props.ts
+++ b/cdk/lib/monitoring-stack-props.ts
@@ -1,7 +1,7 @@
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
-import { CommonStackProps } from './common-stack-props';
+import {EnvStackProps} from "./env-stack-props";
 
-export interface MonitoringStackProps extends CommonStackProps {
+export interface MonitoringStackProps extends EnvStackProps {
   sendToZulipLambda: NodejsFunction
 }
 

--- a/cdk/lib/rds-stack-props.ts
+++ b/cdk/lib/rds-stack-props.ts
@@ -1,9 +1,9 @@
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
-import { CommonStackProps } from './common-stack-props';
 import {aws_backup} from "aws-cdk-lib";
+import {EnvStackProps} from "./env-stack-props";
 
-export interface RdsStackProps extends CommonStackProps {
+export interface RdsStackProps extends EnvStackProps {
   backupPlan: aws_backup.BackupPlan;
   backups: boolean;
   vpc: ec2.IVpc;

--- a/cdk/lib/send-to-zulip-props.ts
+++ b/cdk/lib/send-to-zulip-props.ts
@@ -1,6 +1,6 @@
-import {CommonStackProps} from "./common-stack-props";
+import {EnvStackProps} from "./env-stack-props";
 
-export interface SendToZulipProps extends CommonStackProps {
+export interface SendToZulipProps extends EnvStackProps {
   zulipApiUser: string,
   zulipApiUrl: string,
   zulipStream: string,

--- a/cdk/lib/shield-stack-props.ts
+++ b/cdk/lib/shield-stack-props.ts
@@ -1,6 +1,6 @@
-import {CommonStackProps} from "./common-stack-props";
+import {EnvStackProps} from "./env-stack-props";
 
-export interface ShieldStackProps extends CommonStackProps{
+export interface ShieldStackProps extends EnvStackProps{
   bannedIpsRequestSamplingEnabled: boolean,
   requestSampleAllTrafficEnabled: boolean,
   highPriorityRequestSamplingEnabled: boolean,

--- a/cdk/test/cache-stack.test.ts
+++ b/cdk/test/cache-stack.test.ts
@@ -8,24 +8,14 @@ import { mockEnv, mockEnvProps } from './mock-constructs';
 test('verify cache stack resources', () => {
   const app = new cdk.App();
   const clusterStack = new ClusterStack(app, 'ClusterStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpcId: 'someid'
   });
   // WHEN
   const stack = new CacheStack(app, 'CacheStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc,
     cacheNodeType: 'cache.t2.micro',
     cacheEngineVersion: '6.x',

--- a/cdk/test/ckan-stack.test.ts
+++ b/cdk/test/ckan-stack.test.ts
@@ -15,36 +15,21 @@ import {LambdaStack} from "../lib/lambda-stack";
 test('verify ckan stack resources', () => {
   const app = new cdk.App();
   const clusterStack = new ClusterStack(app, 'ClusterStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpcId: 'someid'
   });
 
   const backupStack = new BackupStack(app, 'BackupStack-Test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     backups: true,
     importVault: false
   });
 
   const fileSystemStack = new FileSystemStack(app, 'FileSystemStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc,
     backups: true,
     backupPlan: backupStack.backupPlan,
@@ -52,13 +37,8 @@ test('verify ckan stack resources', () => {
   });
 
   const databaseStack = new DatabaseStack(app, 'DatabaseStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc,
     backups: true,
     backupPlan: backupStack.backupPlan,
@@ -66,26 +46,16 @@ test('verify ckan stack resources', () => {
   });
 
   const lambdaStack = new LambdaStack(app, 'LambdaStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     datastoreInstance: databaseStack.datastoreInstance,
     datastoreCredentials: databaseStack.datastoreCredentials,
     vpc: clusterStack.vpc
   })
 
   const cacheStack = new CacheStack(app, 'CacheStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc,
     cacheNodeType: 'cache.t2.micro',
     cacheEngineVersion: '6.x',

--- a/cdk/test/cluster-stack.test.ts
+++ b/cdk/test/cluster-stack.test.ts
@@ -8,13 +8,8 @@ test('verify cluster stack resources', () => {
   const app = new cdk.App();
   // WHEN
   const stack = new ClusterStack(app, 'ClusterStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpcId: 'someid'
   });
   // THEN

--- a/cdk/test/database-stack.test.ts
+++ b/cdk/test/database-stack.test.ts
@@ -9,37 +9,22 @@ import {BackupStack} from "../lib/backup-stack";
 test('verify database stack resources', () => {
   const app = new cdk.App();
   const clusterStack = new ClusterStack(app, 'ClusterStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpcId: 'someid'
   });
 
   const backupStack = new BackupStack(app, 'BackupStack-Test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     backups: true,
     importVault: false
   });
 
   // WHEN
   const stack = new DatabaseStack(app, 'DatabaseStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc,
     backups: true,
     backupPlan: backupStack.backupPlan,

--- a/cdk/test/drupal-stack.test.ts
+++ b/cdk/test/drupal-stack.test.ts
@@ -12,36 +12,21 @@ import {BackupStack} from "../lib/backup-stack";
 test('verify drupal stack resources', () => {
   const app = new cdk.App();
   const clusterStack = new ClusterStack(app, 'ClusterStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpcId: 'someid'
   });
 
   const backupStack = new BackupStack(app, 'BackupStack-Test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     backups: true,
     importVault: false
   });
 
   const fileSystemStack = new FileSystemStack(app, 'FileSystemStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc,
     backups: true,
     backupPlan: backupStack.backupPlan,
@@ -49,26 +34,16 @@ test('verify drupal stack resources', () => {
   });
 
   const databaseStack = new DatabaseStack(app, 'DatabaseStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc,
     backups: true,
     backupPlan: backupStack.backupPlan,
     multiAz: true
   });
   const cacheStack = new CacheStack(app, 'CacheStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc,
     cacheNodeType: 'cache.t2.micro',
     cacheEngineVersion: '6.x',

--- a/cdk/test/filesystem-stack.test.ts
+++ b/cdk/test/filesystem-stack.test.ts
@@ -9,36 +9,21 @@ import {BackupStack} from "../lib/backup-stack";
 test('verify filesystem stack resources', () => {
   const app = new cdk.App();
   const clusterStack = new ClusterStack(app, 'ClusterStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpcId: 'someid'
   });
   const backupStack = new BackupStack(app, 'BackupStack-Test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     backups: true,
     importVault: false
   });
 
   // WHEN
   const stack = new FileSystemStack(app, 'FileSystemStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc,
     backups: true,
     backupPlan: backupStack.backupPlan,

--- a/cdk/test/load-balancer-stack.test.ts
+++ b/cdk/test/load-balancer-stack.test.ts
@@ -9,25 +9,15 @@ import {CertificateStack} from "../lib/certificate-stack";
 test('verify load balancer stack resources', () => {
   const app = new cdk.App();
   const clusterStack = new ClusterStack(app, 'ClusterStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpcId: 'someid'
   });
   
   // WHEN
   const stack = new LoadBalancerStack(app, 'LoadBalancerStack-test', {
-    envProps: mockEnvProps,
     env: mockEnv,
     environment: 'mock-env',
-    fqdn: 'localhost',
-    secondaryFqdn: 'localhost',
-    domainName: 'mock.localhost',
-    secondaryDomainName: 'mock.localhost',
     vpc: clusterStack.vpc
   });
   // THEN


### PR DESCRIPTION
`CommonStackProps` had properties which weren't needed in most stacks, this moves `environment` property to separate `EnvStackProps` and simplifies amount of properties in the stacks.

```mermaid
---
title: Old Props
---
classDiagram
  class StackProps{
        object env
  }
  class CommonStackProps{
       EnvProps envProps
       string environment
       string fqdn
       string secondaryFqdn
       string domainName
       string secondaryDomainName
  }

class EnvProps {
      string REGISTRY
      string REPOSITORY
     ....
}

StackProps<|--CommonStackProps
EnvProps*--CommonStackProps

````

```mermaid
---
title: New Props
---
classDiagram
  class StackProps{
        object env
  }
  class CommonStackProps{
       EnvProps envProps
       string fqdn
       string secondaryFqdn
       string domainName
       string secondaryDomainName
  }

class EnvProps {
      string REGISTRY
      string REPOSITORY
     ....
}

class EnvStackProps{
     string environment
}

StackProps<|--EnvStackProps
EnvStackProps<|--CommonStackProps
EnvProps*--CommonStackProps

````