### PR TITLE
Add restart services workflows and necessary modifications

### DIFF
--- a/.github/workflows/restart_beta_containers.yml
+++ b/.github/workflows/restart_beta_containers.yml
@@ -1,0 +1,25 @@
+name: Restart beta containers
+
+on:
+  workflow_dispatch:
+
+jobs:
+  restart-dev:
+    name: restart beta containers
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    strategy:
+      matrix:
+        container: ["ckan", "ckanCron", "drupal"]
+    steps:
+      - name: configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.AWS_BETA_DEPLOY_ROLE }}
+          role-session-name: github-actions
+          aws-region: eu-north-1
+
+      - name: Restart containers
+        run: |
+          aws ecs update-service --cluster ${{ secrets.beta_cluster }} --service ${{ matrix.container }} --force-new-deployment

--- a/.github/workflows/restart_prod_containers.yml
+++ b/.github/workflows/restart_prod_containers.yml
@@ -1,0 +1,26 @@
+name: Restart Prod containers
+
+on:
+  workflow_dispatch:
+
+jobs:
+  restart-prod:
+    name: restart prod containers
+    runs-on: ubuntu-latest
+    environment: prod
+    permissions:
+      id-token: write
+    strategy:
+      matrix:
+        container: ["ckan", "ckanCron", "drupal"]
+    steps:
+      - name: configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE }}
+          role-session-name: github-actions
+          aws-region: eu-north-1
+
+      - name: Restart containers
+        run: |
+          aws ecs update-service --cluster ${{ secrets.prod_cluster }} --service ${{ matrix.container }} --force-new-deployment

--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -455,6 +455,7 @@ export class CkanStack extends Stack {
     this.ckanService = new ecs.FargateService(this, 'ckanService', {
       platformVersion: ecs.FargatePlatformVersion.VERSION1_4,
       cluster: props.cluster,
+      serviceName: "ckan",
       taskDefinition: ckanTaskDef,
       minHealthyPercent: 50,
       maxHealthyPercent: 200,
@@ -600,6 +601,7 @@ export class CkanStack extends Stack {
       this.ckanCronService = new ecs.FargateService(this, 'ckanCronService', {
         platformVersion: ecs.FargatePlatformVersion.VERSION1_4,
         cluster: props.cluster,
+        serviceName: "ckanCron",
         taskDefinition: ckanCronTaskDef,
         desiredCount: 1,
         minHealthyPercent: 0,

--- a/cdk/lib/drupal-stack.ts
+++ b/cdk/lib/drupal-stack.ts
@@ -255,6 +255,7 @@ export class DrupalStack extends Stack {
     this.drupalService = new ecs.FargateService(this, 'drupalService', {
       platformVersion: ecs.FargatePlatformVersion.VERSION1_4,
       cluster: props.cluster,
+      serviceName: "drupal",
       taskDefinition: drupalTaskDef,
       minHealthyPercent: 50,
       maxHealthyPercent: 200,

--- a/cloudformation/github-actions-stack.yml
+++ b/cloudformation/github-actions-stack.yml
@@ -20,11 +20,17 @@ Parameters:
   ECRRepositoryArn:
     Description: Arn for the ECR repositories.
     Type: String
+  CreateBuildRole:
+    Description: Is the build role required for this aws account
+    Type: String
+    Default: false
+    AllowedValues: [true, false]
 
 Conditions:
   CreateOIDCProvider: !Equals 
     - !Ref OIDCProviderArn
     - ""
+  ShouldCreateBuildRole: !Equals ['true', !Ref CreateBuildRole]
 
 Resources:
   Role:
@@ -50,6 +56,14 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: "ecr:GetAuthorizationToken"
+                Resource: "*"
+
+        - PolicyName: ecs-update-service
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: "ecs:UpdateService"
                 Resource: "*"
 
         - PolicyName: ecr-access
@@ -100,6 +114,7 @@ Resources:
 
   BuildRole:
     Type: AWS::IAM::Role
+    Condition: ShouldCreateBuildRole
     Properties:
       Description: Role for GitHub actions build workflow.
       AssumeRolePolicyDocument:
@@ -144,4 +159,5 @@ Outputs:
   Role:
     Value: !GetAtt Role.Arn
   BuildRole:
+    Condition: ShouldCreateBuildRole
     Value: !GetAtt BuildRole.Arn


### PR DESCRIPTION
Add workflows for restarting services in different environments. Updates role policies to allow this and makes build role optional in template, it doesn't exist in dev account. Adds names to services for easier referral in workflow.