### PR TITLE
AV-2179: Allow frange query parser to fix spatial search

### DIFF
--- a/ckan/templates/production.ini.j2
+++ b/ckan/templates/production.ini.j2
@@ -226,6 +226,9 @@ ckanext.matomo.ignored_user_agents = docker-healthcheck
 ckanext.matomo.track_api = true
 {% endif %}
 
+
+ckan.search.solr_allowed_query_parsers = frange
+
 ckanext.spatial.harvest.continue_on_validation_errors = true
 ckanext.spatial.search_backend = solr-bbox
 ckanext.spatial.common_map.type = custom


### PR DESCRIPTION
CKAN 2.9.11 limited allowed query parsers by default and the spatial search failed. This adds the query parser used by ckanext-spatial to allowed list.