### PR TITLE
AV-2238: Bypass cloudfront

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -22,6 +22,7 @@ import {SubDomainStack} from "../lib/sub-domain-stack";
 import {ShieldStack} from "../lib/shield-stack";
 import {CloudfrontParameterStack} from "../lib/cloudfront-parameter-stack";
 import {undefined} from "zod";
+import {ParameterStack} from "../lib/parameter-stack";
 
 // load .env file, shared with docker setup
 // mainly for ECR repo and image tag information
@@ -174,27 +175,34 @@ const cloudfrontParameterStackBeta = new CloudfrontParameterStack(app, 'Cloudfro
   environment: betaProps.environment,
 })
 
+const parameterStackBeta = new ParameterStack(app, 'ParameterStack-beta', {
+  env: {
+    account: betaProps.account,
+    region: betaProps.region
+  },
+  environment: betaProps.environment,
+})
 
 const shieldStackBeta = new ShieldStack(app, 'ShieldStack-beta', {
   env: {
     account: betaProps.account,
-    region: 'us-east-1',
+    region: betaProps.region,
   },
   environment: betaProps.environment,
   bannedIpsRequestSamplingEnabled: false,
   highPriorityRequestSamplingEnabled: false,
   rateLimitRequestSamplingEnabled: false,
   requestSampleAllTrafficEnabled: false,
-  cloudfrontDistributionArn: cloudfrontParameterStackBeta.cloudFrontDistributionArn,
-  bannedIpListParameterName: cloudfrontParameterStackBeta.bannedIpListParameterName,
-  whitelistedIpListParameterName: cloudfrontParameterStackBeta.whitelistedIpListParameterName,
-  highPriorityCountryCodeListParameterName: cloudfrontParameterStackBeta.highPriorityCountryCodeListParameterName,
-  highPriorityRateLimit: cloudfrontParameterStackBeta.highPriorityRateLimit,
-  rateLimit: cloudfrontParameterStackBeta.rateLimit,
-  managedRulesParameterName: cloudfrontParameterStackBeta.managedRulesParameterName,
-  snsTopicArn: cloudfrontParameterStackBeta.snsTopicArn,
-  wafAutomationArn: cloudfrontParameterStackBeta.wafAutomationArn,
-  evaluationPeriod: cloudfrontParameterStackBeta.evaluationPeriod
+  bannedIpListParameterName: parameterStackBeta.bannedIpListParameterName,
+  whitelistedIpListParameterName: parameterStackBeta.whitelistedIpListParameterName,
+  highPriorityCountryCodeListParameterName: parameterStackBeta.highPriorityCountryCodeListParameterName,
+  highPriorityRateLimit: parameterStackBeta.highPriorityRateLimit,
+  rateLimit: parameterStackBeta.rateLimit,
+  managedRulesParameterName: parameterStackBeta.managedRulesParameterName,
+  snsTopicArn: parameterStackBeta.snsTopicArn,
+  wafAutomationArn: parameterStackBeta.wafAutomationArn,
+  evaluationPeriod: parameterStackBeta.evaluationPeriod,
+  loadBalancer: loadBalancerStackBeta.loadBalancer
 })
 
 const cacheStackBeta = new CacheStack(app, 'CacheStack-beta', {
@@ -494,26 +502,34 @@ const cloudfrontParameterStackProd = new CloudfrontParameterStack(app, 'Cloudfro
   environment: prodProps.environment,
 })
 
+const parameterStackProd = new ParameterStack(app, 'ParameterStack-prod', {
+  env: {
+    account: prodProps.account,
+    region: prodProps.region
+  },
+  environment: prodProps.environment,
+})
+
 const shieldStackProd = new ShieldStack(app, 'ShieldStack-prod', {
   env: {
     account: prodProps.account,
-    region: 'us-east-1'
+    region: prodProps.region
   },
   environment: prodProps.environment,
   bannedIpsRequestSamplingEnabled: false,
   highPriorityRequestSamplingEnabled: false,
   rateLimitRequestSamplingEnabled: false,
   requestSampleAllTrafficEnabled: false,
-  cloudfrontDistributionArn: cloudfrontParameterStackProd.cloudFrontDistributionArn,
-  bannedIpListParameterName: cloudfrontParameterStackProd.bannedIpListParameterName,
-  whitelistedIpListParameterName: cloudfrontParameterStackProd.whitelistedIpListParameterName,
-  highPriorityCountryCodeListParameterName: cloudfrontParameterStackProd.highPriorityCountryCodeListParameterName,
-  highPriorityRateLimit: cloudfrontParameterStackProd.highPriorityRateLimit,
-  rateLimit: cloudfrontParameterStackProd.rateLimit,
-  managedRulesParameterName: cloudfrontParameterStackProd.managedRulesParameterName,
-  snsTopicArn: cloudfrontParameterStackProd.snsTopicArn,
-  wafAutomationArn: cloudfrontParameterStackProd.wafAutomationArn,
-  evaluationPeriod: cloudfrontParameterStackProd.evaluationPeriod
+  bannedIpListParameterName: parameterStackProd.bannedIpListParameterName,
+  whitelistedIpListParameterName: parameterStackProd.whitelistedIpListParameterName,
+  highPriorityCountryCodeListParameterName: parameterStackProd.highPriorityCountryCodeListParameterName,
+  highPriorityRateLimit: parameterStackProd.highPriorityRateLimit,
+  rateLimit: parameterStackProd.rateLimit,
+  managedRulesParameterName: parameterStackProd.managedRulesParameterName,
+  snsTopicArn: parameterStackProd.snsTopicArn,
+  wafAutomationArn: parameterStackProd.wafAutomationArn,
+  evaluationPeriod: parameterStackProd.evaluationPeriod,
+  loadBalancer: loadBalancerStackProd.loadBalancer
 })
 
 const cacheStackProd = new CacheStack(app, 'CacheStack-prod', {

--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -22,7 +22,7 @@ import {SubDomainStack} from "../lib/sub-domain-stack";
 import {ShieldStack} from "../lib/shield-stack";
 import {CloudfrontParameterStack} from "../lib/cloudfront-parameter-stack";
 import {undefined} from "zod";
-import {ParameterStack} from "../lib/parameter-stack";
+import {ShieldParameterStack} from "../lib/shield-parameter-stack";
 
 // load .env file, shared with docker setup
 // mainly for ECR repo and image tag information
@@ -175,7 +175,7 @@ const cloudfrontParameterStackBeta = new CloudfrontParameterStack(app, 'Cloudfro
   environment: betaProps.environment,
 })
 
-const parameterStackBeta = new ParameterStack(app, 'ParameterStack-beta', {
+const shieldParameterStackBeta = new ShieldParameterStack(app, 'ShieldParameterStack-beta', {
   env: {
     account: betaProps.account,
     region: betaProps.region
@@ -193,15 +193,15 @@ const shieldStackBeta = new ShieldStack(app, 'ShieldStack-beta', {
   highPriorityRequestSamplingEnabled: false,
   rateLimitRequestSamplingEnabled: false,
   requestSampleAllTrafficEnabled: false,
-  bannedIpListParameterName: parameterStackBeta.bannedIpListParameterName,
-  whitelistedIpListParameterName: parameterStackBeta.whitelistedIpListParameterName,
-  highPriorityCountryCodeListParameterName: parameterStackBeta.highPriorityCountryCodeListParameterName,
-  highPriorityRateLimit: parameterStackBeta.highPriorityRateLimit,
-  rateLimit: parameterStackBeta.rateLimit,
-  managedRulesParameterName: parameterStackBeta.managedRulesParameterName,
-  snsTopicArn: parameterStackBeta.snsTopicArn,
-  wafAutomationArn: parameterStackBeta.wafAutomationArn,
-  evaluationPeriod: parameterStackBeta.evaluationPeriod,
+  bannedIpListParameterName: shieldParameterStackBeta.bannedIpListParameterName,
+  whitelistedIpListParameterName: shieldParameterStackBeta.whitelistedIpListParameterName,
+  highPriorityCountryCodeListParameterName: shieldParameterStackBeta.highPriorityCountryCodeListParameterName,
+  highPriorityRateLimit: shieldParameterStackBeta.highPriorityRateLimit,
+  rateLimit: shieldParameterStackBeta.rateLimit,
+  managedRulesParameterName: shieldParameterStackBeta.managedRulesParameterName,
+  snsTopicArn: shieldParameterStackBeta.snsTopicArn,
+  wafAutomationArn: shieldParameterStackBeta.wafAutomationArn,
+  evaluationPeriod: shieldParameterStackBeta.evaluationPeriod,
   loadBalancer: loadBalancerStackBeta.loadBalancer
 })
 
@@ -502,7 +502,7 @@ const cloudfrontParameterStackProd = new CloudfrontParameterStack(app, 'Cloudfro
   environment: prodProps.environment,
 })
 
-const parameterStackProd = new ParameterStack(app, 'ParameterStack-prod', {
+const shieldParameterStackProd = new ShieldParameterStack(app, 'ShieldParameterStack-prod', {
   env: {
     account: prodProps.account,
     region: prodProps.region
@@ -520,15 +520,15 @@ const shieldStackProd = new ShieldStack(app, 'ShieldStack-prod', {
   highPriorityRequestSamplingEnabled: false,
   rateLimitRequestSamplingEnabled: false,
   requestSampleAllTrafficEnabled: false,
-  bannedIpListParameterName: parameterStackProd.bannedIpListParameterName,
-  whitelistedIpListParameterName: parameterStackProd.whitelistedIpListParameterName,
-  highPriorityCountryCodeListParameterName: parameterStackProd.highPriorityCountryCodeListParameterName,
-  highPriorityRateLimit: parameterStackProd.highPriorityRateLimit,
-  rateLimit: parameterStackProd.rateLimit,
-  managedRulesParameterName: parameterStackProd.managedRulesParameterName,
-  snsTopicArn: parameterStackProd.snsTopicArn,
-  wafAutomationArn: parameterStackProd.wafAutomationArn,
-  evaluationPeriod: parameterStackProd.evaluationPeriod,
+  bannedIpListParameterName: shieldParameterStackProd.bannedIpListParameterName,
+  whitelistedIpListParameterName: shieldParameterStackProd.whitelistedIpListParameterName,
+  highPriorityCountryCodeListParameterName: shieldParameterStackProd.highPriorityCountryCodeListParameterName,
+  highPriorityRateLimit: shieldParameterStackProd.highPriorityRateLimit,
+  rateLimit: shieldParameterStackProd.rateLimit,
+  managedRulesParameterName: shieldParameterStackProd.managedRulesParameterName,
+  snsTopicArn: shieldParameterStackProd.snsTopicArn,
+  wafAutomationArn: shieldParameterStackProd.wafAutomationArn,
+  evaluationPeriod: shieldParameterStackProd.evaluationPeriod,
   loadBalancer: loadBalancerStackProd.loadBalancer
 })
 

--- a/cdk/lib/bypass-cdn-stack.ts
+++ b/cdk/lib/bypass-cdn-stack.ts
@@ -15,14 +15,27 @@ export class BypassCdnStack extends Stack {
       domainName: props.fqdn
     })
 
+    const alternateZone = route53.HostedZone.fromLookup(this, 'AlternateOpendataZone', {
+      domainName: props.secondaryFqdn
+    })
+
     let domain_record = new route53.ARecord(this, 'ARecord', {
       zone: zone,
       recordName: 'vip',
       target: route53.RecordTarget.fromAlias(new aws_route53_targets.LoadBalancerTarget(props.loadbalancer))
     })
 
+    let root_record = new route53.ARecord(this, "rootRecord", {
+      zone: zone,
+      recordName: 'www',
+      target: route53.RecordTarget.fromAlias(new aws_route53_targets.LoadBalancerTarget(props.loadbalancer))
+    })
 
-
+    let alternate_root_record = new route53.ARecord(this, "alternateRootRecord", {
+      zone: alternateZone,
+      recordName: 'www',
+      target: route53.RecordTarget.fromAlias(new aws_route53_targets.LoadBalancerTarget(props.loadbalancer))
+    })
   }
 }
 

--- a/cdk/lib/load-balancer-stack.ts
+++ b/cdk/lib/load-balancer-stack.ts
@@ -1,13 +1,12 @@
-import {aws_ec2, aws_s3, Duration, Fn, Stack} from 'aws-cdk-lib';
+import {aws_ec2, aws_route53, aws_s3, Duration, Fn, Stack} from 'aws-cdk-lib';
 import * as elb from 'aws-cdk-lib/aws-elasticloadbalancingv2';
-import {IpAddressType} from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import {ApplicationProtocol, IpAddressType} from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import {Construct} from 'constructs';
 
 import {ElbStackProps} from './elb-stack-props';
-import {Peer, Port, Subnet} from "aws-cdk-lib/aws-ec2";
+import {Subnet} from "aws-cdk-lib/aws-ec2";
 import {BucketEncryption} from "aws-cdk-lib/aws-s3";
-import {StringParameter} from "aws-cdk-lib/aws-ssm";
-import {CfnWebACLAssociation} from "aws-cdk-lib/aws-wafv2";
+
 
 
 export class LoadBalancerStack extends Stack {
@@ -16,31 +15,11 @@ export class LoadBalancerStack extends Stack {
   constructor(scope: Construct, id: string, props: ElbStackProps) {
     super(scope, id, props);
 
-    // get params
-
-    const allowedIp1 = StringParameter.fromStringParameterName(this, 'allowedIp1',
-      `/${props.environment}/opendata/cdk/lb_allowed_ip_1`)
-
-    const allowedIp2 = StringParameter.fromStringParameterName(this, 'allowedIp2',
-      `/${props.environment}/opendata/cdk/lb_allowed_ip_2`)
-
-    const allowedIp3 = StringParameter.fromStringParameterName(this, 'allowedIp3',
-      `/${props.environment}/opendata/cdk/lb_allowed_ip_3`)
-
-    const allowedIp4 = StringParameter.fromStringParameterName(this, 'allowedIp4',
-      `/${props.environment}/opendata/cdk/lb_allowed_ip_4`)
-
     const secGroup = new aws_ec2.SecurityGroup(this, 'loadBalancerSecurityGroup', {
       vpc: props.vpc,
     })
 
-    // pl-4fa04526 is com.amazonaws.global.cloudfront.origin-facing
-    secGroup.addIngressRule(Peer.prefixList('pl-4fa04526'), Port.tcp(443))
-
-    secGroup.addIngressRule(Peer.ipv4(allowedIp1.stringValue), Port.tcp(443))
-    secGroup.addIngressRule(Peer.ipv4(allowedIp2.stringValue), Port.tcp(443))
-    secGroup.addIngressRule(Peer.ipv4(allowedIp3.stringValue), Port.tcp(443))
-    secGroup.addIngressRule(Peer.ipv4(allowedIp4.stringValue), Port.tcp(443))
+    secGroup.addIngressRule(aws_ec2.Peer.anyIpv4(), aws_ec2.Port.tcp(443), "HTTPS from anywhere")
 
     const publicSubnetA = Fn.importValue('vpc-SubnetPublicA')
     const publicSubnetB = Fn.importValue('vpc-SubnetPublicB')
@@ -53,6 +32,11 @@ export class LoadBalancerStack extends Stack {
         subnets: [Subnet.fromSubnetId(this, 'subnetA', publicSubnetA), Subnet.fromSubnetId(this, 'subnetB', publicSubnetB)]
       },
       securityGroup: secGroup
+    })
+
+    this.loadBalancer.addRedirect({
+      sourceProtocol: ApplicationProtocol.HTTP,
+      targetProtocol: ApplicationProtocol.HTTPS
     })
 
     const logBucket = new aws_s3.Bucket(this, 'logBucket', {
@@ -69,6 +53,6 @@ export class LoadBalancerStack extends Stack {
     })
 
     this.loadBalancer.logAccessLogs(logBucket, this.stackName)
-    
+
   }
 }

--- a/cdk/lib/parameter-stack.ts
+++ b/cdk/lib/parameter-stack.ts
@@ -1,0 +1,78 @@
+import {aws_ssm, CfnParameter, Stack} from "aws-cdk-lib";
+import {Construct} from "constructs";
+
+import {EnvStackProps} from "./env-stack-props";
+
+export class ParameterStack extends Stack {
+  readonly bannedIpListParameterName: string;
+  readonly whitelistedIpListParameterName: string;
+  readonly highPriorityCountryCodeListParameterName: string;
+  readonly highPriorityRateLimit: aws_ssm.IStringParameter;
+  readonly rateLimit: aws_ssm.IStringParameter;
+  readonly managedRulesParameterName: string;
+  readonly wafAutomationArn: aws_ssm.IStringParameter;
+  readonly snsTopicArn: aws_ssm.IStringParameter;
+  readonly evaluationPeriod: aws_ssm.IStringParameter;
+
+  constructor(scope: Construct, id: string, props: EnvStackProps ) {
+    super(scope, id, props);
+
+    this.bannedIpListParameterName = `/${props.environment}/waf/banned_ips`
+    new aws_ssm.StringListParameter(this, 'bannedIplist', {
+      stringListValue: ["127.0.0.1"],
+      description: 'List of banned IP addresses',
+      parameterName: this.bannedIpListParameterName
+    })
+
+    this.whitelistedIpListParameterName = `/${props.environment}/waf/whitelisted_ips`
+    new aws_ssm.StringListParameter(this, 'whitelistedIplist', {
+      stringListValue: ["127.0.0.1"],
+      description: 'List of whitelisted IP addresses',
+      parameterName: this.whitelistedIpListParameterName
+    })
+
+    this.highPriorityCountryCodeListParameterName = `/${props.environment}/waf/high_priority_country_codes`
+    new aws_ssm.StringListParameter(this, 'highPriorityCountryCodeList', {
+      stringListValue: ["Some bogus country code"],
+      description: 'Country codes deemed high priority',
+      parameterName: this.highPriorityCountryCodeListParameterName
+    })
+
+    this.highPriorityRateLimit = new aws_ssm.StringParameter(this, 'highPriorityRateLimit', {
+      stringValue: '0',
+      description: 'Rate limit for high priority country codes',
+      parameterName: `/${props.environment}/waf/high_priority_rate_limit`
+    })
+
+    this.rateLimit = new aws_ssm.StringParameter(this, 'rateLimit', {
+      stringValue: '0',
+      description: 'Rate limit for others',
+      parameterName: `/${props.environment}/waf/rate_limit`
+    })
+
+    this.managedRulesParameterName = `/${props.environment}/waf/managed_rules`
+    new aws_ssm.StringParameter(this, 'managedRules', {
+      stringValue: 'some placeholder',
+      description: 'JSON value for managed rules',
+      parameterName: this.managedRulesParameterName
+    })
+
+    this.wafAutomationArn = new aws_ssm.StringParameter(this, 'wafAutomationArn', {
+      stringValue: 'some placeholder',
+      description: 'Arn of waf automation lambda',
+      parameterName: `/${props.environment}/waf/waf_automation_arn`,
+    })
+
+    this.snsTopicArn = new aws_ssm.StringParameter(this, 'snsTopicArn', {
+      stringValue: 'some placeholder',
+      description: 'Arn of sns topic',
+      parameterName: `/${props.environment}/waf/sns_topic_arn`,
+    })
+
+    this.evaluationPeriod = new aws_ssm.StringParameter(this, 'evaluationPeriod', {
+      stringValue: '0',
+      description: 'Evaluation period for rate limits',
+      parameterName: `/${props.environment}/waf/evaluation_period`
+    })
+  }
+}

--- a/cdk/lib/shield-parameter-stack.ts
+++ b/cdk/lib/shield-parameter-stack.ts
@@ -3,7 +3,7 @@ import {Construct} from "constructs";
 
 import {EnvStackProps} from "./env-stack-props";
 
-export class ParameterStack extends Stack {
+export class ShieldParameterStack extends Stack {
   readonly bannedIpListParameterName: string;
   readonly whitelistedIpListParameterName: string;
   readonly highPriorityCountryCodeListParameterName: string;

--- a/cdk/lib/shield-stack-props.ts
+++ b/cdk/lib/shield-stack-props.ts
@@ -1,12 +1,11 @@
 import {EnvStackProps} from "./env-stack-props";
-import {aws_ssm} from "aws-cdk-lib";
+import {aws_ec2, aws_elasticloadbalancingv2, aws_ssm} from "aws-cdk-lib";
 
 export interface ShieldStackProps extends EnvStackProps{
   bannedIpsRequestSamplingEnabled: boolean,
   requestSampleAllTrafficEnabled: boolean,
   highPriorityRequestSamplingEnabled: boolean,
   rateLimitRequestSamplingEnabled: boolean,
-  cloudfrontDistributionArn: aws_ssm.IStringParameter,
   bannedIpListParameterName: string,
   whitelistedIpListParameterName: string,
   highPriorityCountryCodeListParameterName: string,
@@ -15,5 +14,6 @@ export interface ShieldStackProps extends EnvStackProps{
   managedRulesParameterName: string,
   wafAutomationArn: aws_ssm.IStringParameter,
   snsTopicArn: aws_ssm.IStringParameter,
-  evaluationPeriod: aws_ssm.IStringParameter
+  evaluationPeriod: aws_ssm.IStringParameter,
+  loadBalancer: aws_elasticloadbalancingv2.ApplicationLoadBalancer
 }

--- a/cdk/lib/shield-stack.ts
+++ b/cdk/lib/shield-stack.ts
@@ -17,8 +17,8 @@ export class ShieldStack extends Stack {
     super(scope, id, props);
 
     const cfnProtection = new aws_shield.CfnProtection(this, 'ShieldProtection', {
-      name: 'Cloudfront distribution',
-      resourceArn: props.cloudfrontDistributionArn.stringValue
+      name: 'Application Load Balancers',
+      resourceArn: props.loadBalancer.loadBalancerArn
     })
     
 
@@ -29,7 +29,7 @@ export class ShieldStack extends Stack {
 
     const cfnBannedIPSet = new aws_wafv2.CfnIPSet(this, 'BannedIPSet', {
       name: 'banned-ips',
-      scope: 'CLOUDFRONT',
+      scope: 'REGIONAL',
       ipAddressVersion: "IPV4",
       addresses: banned_ips.valueAsList
     })
@@ -41,7 +41,7 @@ export class ShieldStack extends Stack {
 
     const cfnWhiteListedIpSet = new aws_wafv2.CfnIPSet(this, 'WhitelistedIPSet', {
       name: 'whitelisted-ips',
-      scope: 'CLOUDFRONT',
+      scope: 'REGIONAL',
       ipAddressVersion: "IPV4",
       addresses: whitelisted_ips.valueAsList
     })
@@ -281,7 +281,7 @@ export class ShieldStack extends Stack {
 
 
     const cfnWebAcl = new aws_wafv2.CfnWebACL(this, 'WAFWebACL', {
-      scope: "CLOUDFRONT",
+      scope: "REGIONAL",
       defaultAction: {
         allow: {}
       },
@@ -291,6 +291,11 @@ export class ShieldStack extends Stack {
         sampledRequestsEnabled: props.requestSampleAllTrafficEnabled
       },
       rules: rules
+    })
+
+    new aws_wafv2.CfnWebACLAssociation(this, 'WafAssociation', {
+      resourceArn: props.loadBalancer.loadBalancerArn,
+      webAclArn: cfnWebAcl.attrArn
     })
 
     const WafAutomationLambdaFunction = aws_lambda.Function.fromFunctionArn(this, "WafAutomation", props.wafAutomationArn.stringValue)

--- a/cloudformation/cloudfront.yml
+++ b/cloudformation/cloudfront.yml
@@ -157,26 +157,7 @@ Resources:
         - Key: Name
           Value: !Sub avoindata-${EnvironmentName}
 
-  DomainName:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      Name: !Sub ${DNSHostName}.${DNSDomainName}.
-      Type: A
-      HostedZoneId: !Ref HostedZoneId
-      AliasTarget:
-        DNSName: !GetAtt Cloudfront.DomainName
-        HostedZoneId: 'Z2FDTNDATAQYW2'
-
-  DomainNameAlternate:
-    Type: AWS::Route53::RecordSet
-    Condition: CreateAlternateDomainRecord
-    Properties:
-      Name: !Sub ${DNSHostName}.${AlternateDNSDomainName}.
-      Type: A
-      HostedZoneId: !Ref HostedZoneIdAlternate
-      AliasTarget:
-        DNSName: !GetAtt Cloudfront.DomainName
-        HostedZoneId: 'Z2FDTNDATAQYW2'
+  
 
   LogBucket:
     Type: AWS::S3::Bucket

--- a/cloudformation/cloudfront.yml
+++ b/cloudformation/cloudfront.yml
@@ -85,9 +85,6 @@ Parameters:
   AlternateDNSDomainName:
     Description: "Alternate Domain name"
     Type: 'AWS::SSM::Parameter::Value<String>'
-  WAFWebACLId:
-    Description: "[Optional] Arn of WAF Web ACL"
-    Type: String
 Conditions:
   CreateAlternateDomainRecord: !Not [!Equals [!Ref HostedZoneIdAlternate, ""]]
   CloudfrontLogging: !Equals [!Ref LogEnabled, "true"]
@@ -152,7 +149,6 @@ Resources:
           MinimumProtocolVersion: 'TLSv1.1_2016'
           SslSupportMethod: 'sni-only'
         DefaultRootObject: 'fi'
-        WebACLId: !Ref WAFWebACLId
       Tags:
         - Key: Name
           Value: !Sub avoindata-${EnvironmentName}


### PR DESCRIPTION
Adds records for www subdomain in primary and alternate domains targeted to loadbalancer, requires deletion of old ones from cloudfront cloudformation template.

Removes firewall rules blocking access to loadbalancer from other than cloudfront.

Adds redirection from http to https in loadbalancer as it was done in cloudfront.

Creates parameter stack for waf parameters to eu-west-1 region.

Recreates shield stack to be in eu-west-1 region and binds it to loadbalancer.

