### PR TITLE
AV-2240: Fix solr containers to mount volumes into correct paths

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -793,7 +793,7 @@ export class CkanStack extends Stack {
     });
 
     solrContainer.addMountPoints({
-      containerPath: '/opt/solr/server/solr/ckan/data',
+      containerPath: '/var/solr/data',
       readOnly: false,
       sourceVolume: 'solr_data',
     });

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -123,7 +123,7 @@ services:
     networks:
       - backend
     volumes:
-      - solr_data:/opt/solr/server/solr/ckan/data
+      - solr_data:/var/solr/data
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8983/solr/ckan/admin/ping?wt=json | grep -o 'OK'"]
       interval: 15s


### PR DESCRIPTION
Container writes its contents into `/var/solr/data` instead.