### PR TITLE
AV-2240: Test number 2 to fix solr volumes

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -793,7 +793,7 @@ export class CkanStack extends Stack {
     });
 
     solrContainer.addMountPoints({
-      containerPath: '/var/solr/data',
+      containerPath: '/var/solr/data/ckan/data',
       readOnly: false,
       sourceVolume: 'solr_data',
     });

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -123,7 +123,7 @@ services:
     networks:
       - backend
     volumes:
-      - solr_data:/var/solr/data
+      - solr_data:/var/solr/data/ckan/data
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8983/solr/ckan/admin/ping?wt=json | grep -o 'OK'"]
       interval: 15s


### PR DESCRIPTION
`/var/solr/data` includes files from container so mounting efs volume in there doesn't work.