### PR TITLE
AV-2242: fix cron script on last day of month on busybox

### DIFF
--- a/ckan/cron/scripts/prh-clear.sh
+++ b/ckan/cron/scripts/prh-clear.sh
@@ -6,5 +6,5 @@ set -e
 
 echo "job started: prh-clear"
 
-# run commands (only run during last day of the month)
-[[ "$(date --date=tomorrow +\%d)" == "01" ]] && ckan -c ${APP_DIR}/production.ini prh-tools clear ${CKAN_STORAGE_PATH}/prh
+# run commands (only run during last day of the month, if the next day is the first day of month)
+[[ "$(date -d "@$(( $(date +%s) + 1 * 24 * 60 * 60 ))" +%d)" == "01" ]] && ckan -c ${APP_DIR}/production.ini prh-tools clear ${CKAN_STORAGE_PATH}/prh


### PR DESCRIPTION
busybox date does not have string parsing, this calculates tomorrows date using arithmetic operations.