### PR TITLE
AV-2234: Fix report grid alignment

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/report/index.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/report/index.html
@@ -9,7 +9,7 @@
 {% block primary_content_inner %}
   <div class="dataset">
     <div class="row equal">
-      {% for report in reports %}
+      {%- for report in reports -%}
         <div class="col-lg-3 col-md-4 col-sm-6 report-column">
           {% set report_url=h.url_for('report.view', report_name=report.name, **h.report__explicit_default_options(report.name)) %}
           <div class="report-summary">
@@ -25,7 +25,7 @@
             </div>
           </div>
         </div>
-      {% endfor %}
+      {%- endfor -%}
     </div>
   </div>
   <div>

--- a/opendata-assets/src/less/components/reports.less
+++ b/opendata-assets/src/less/components/reports.less
@@ -20,6 +20,11 @@
 .report-column {
   margin-bottom: 20px;
 
+  // fix grid layout
+  display: inline-block;
+  float: none;
+  vertical-align: top;
+
   .report-summary {
     padding: 10px 15px;
     border-color: @content-border;


### PR DESCRIPTION
- Remove whitespace from between columns
- Fix ["height problem"](https://stackoverflow.com/questions/22310912/bootstrap-row-with-columns-of-different-height) using `inline-block` items 

Before
![image](https://github.com/vrk-kpa/opendata/assets/726461/2b55514e-6d7c-43e8-a654-93997cd0d235)

After
![image](https://github.com/vrk-kpa/opendata/assets/726461/3c6fb404-71b6-4b8a-85e7-609d4929f56b)
