### PR TITLE
Add sentry browser domain to csp headers

### DIFF
--- a/cdk/lib/web-stack.ts
+++ b/cdk/lib/web-stack.ts
@@ -38,7 +38,8 @@ export class WebStack extends Stack {
       'https://www.google.com',
       'cdn.matomo.cloud',
       'suomi.matomo.cloud',
-      'js-de.sentry-cdn.com'
+      'https://js-de.sentry-cdn.com',
+      'https://browser.sentry-cdn.com'
     ];
     const nginxCspStyleSrc: string[] = [
       'https://fonts.googleapis.com',

--- a/cdk/lib/web-stack.ts
+++ b/cdk/lib/web-stack.ts
@@ -51,7 +51,7 @@ export class WebStack extends Stack {
       'https://avoindata-' + props.environment + '-datasets.s3.eu-west-1.amazonaws.com/'
     ];
 
-    const nginxCspConnecSrc: string[] = [
+    const nginxCspConnectSrc: string[] = [
       "suomi.matomo.cloud",
       "*.sentry.io"
     ]
@@ -71,7 +71,7 @@ export class WebStack extends Stack {
         NGINX_CSP_SCRIPT_SRC: nginxCspScriptSrc.join(' '),
         NGINX_CSP_STYLE_SRC: nginxCspStyleSrc.join(' '),
         NGINX_CSP_FRAME_SRC: nginxCspFrameSrc.join(' '),
-        NGINX_CSP_CONNECT_SRC: nginxCspConnecSrc.join(' '),
+        NGINX_CSP_CONNECT_SRC: nginxCspConnectSrc.join(' '),
         // .env
         NGINX_PORT: '80',
         DOMAIN_NAME: props.domainName,


### PR DESCRIPTION
CSP is creating a error as the other domain is missing from headers, also adds protocols to those and fixes one typo in variable.