### PR TITLE
Fix CI docker compose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -370,7 +370,7 @@ jobs:
         shell: bash
         run: |
           docker logs opendata-ckan-1 > /tmp/opendata-ckan-1.log 2>&1
-          docker logs opendata-ckan_cron-1 > /tmp/opendata-ckan-cron-1.log 2>&1
+          docker logs opendata-ckan_cron-1 > /tmp/opendata-ckan_cron-1.log 2>&1
           docker logs opendata-drupal-1 > /tmp/opendata-drupal-1.log 2>&1
           docker logs opendata-solr-1 > /tmp/opendata-solr-1.log 2>&1
           docker logs opendata-datapusher-1 > /tmp/opendata-datapusher-1.log 2>&1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -319,7 +319,7 @@ jobs:
       - name: bring services up
         working-directory: docker
         run: |
-          docker-compose -f docker-compose.yml -f docker-compose.build.yml -p opendata up -d
+          docker compose -f docker-compose.yml -f docker-compose.build.yml -p opendata up -d
 
       - name: wait until services have started
         shell: bash
@@ -333,12 +333,12 @@ jobs:
           # print the list of containers
           docker ps -a
           # print logs to debug errors
-          docker logs opendata_ckan_1
-          docker logs opendata_drupal_1
-          docker logs opendata_solr_1
-          docker logs opendata_datapusher_1
-          docker logs opendata_nginx_1
-          docker logs opendata_fuseki_1
+          docker logs opendata-ckan-1
+          docker logs opendata-drupal-1
+          docker logs opendata-solr-1
+          docker logs opendata-datapusher-1
+          docker logs opendata-nginx-1
+          docker logs opendata-fuseki-1
 
       - name: Build cypress container
         run: docker build -t cypress/test cypress/
@@ -369,20 +369,20 @@ jobs:
         if: failure()
         shell: bash
         run: |
-          docker logs opendata_ckan_1 > /tmp/opendata_ckan_1.log 2>&1
-          docker logs opendata_ckan_cron_1 > /tmp/opendata_ckan_cron_1.log 2>&1
-          docker logs opendata_drupal_1 > /tmp/opendata_drupal_1.log 2>&1
-          docker logs opendata_solr_1 > /tmp/opendata_solr_1.log 2>&1
-          docker logs opendata_datapusher_1 > /tmp/opendata_datapusher_1.log 2>&1
-          docker logs opendata_nginx_1 > /tmp/opendata_nginx_1.log 2>&1
-          docker logs opendata_fuseki_1 > /tmp/opendata_fuseki_1.log 2>&1
+          docker logs opendata-ckan-1 > /tmp/opendata-ckan-1.log 2>&1
+          docker logs opendata-ckan_cron-1 > /tmp/opendata-ckan-cron-1.log 2>&1
+          docker logs opendata-drupal-1 > /tmp/opendata-drupal-1.log 2>&1
+          docker logs opendata-solr-1 > /tmp/opendata-solr-1.log 2>&1
+          docker logs opendata-datapusher-1 > /tmp/opendata-datapusher-1.log 2>&1
+          docker logs opendata-nginx-1 > /tmp/opendata-nginx-1.log 2>&1
+          docker logs opendata-fuseki-1 > /tmp/opendata-fuseki-1.log 2>&1
 
       - name: upload log artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: docker-logs
-          path: /tmp/opendata_*.log
+          path: /tmp/opendata-*.log
 
       - name: upload cypress screenshot artifacts
         uses: actions/upload-artifact@v4

--- a/docker/README.md
+++ b/docker/README.md
@@ -191,27 +191,27 @@ services:
 
 ### Build/rebuild & create/recreate
 ```bash
-docker-compose -p opendata up --build -d
+docker compose -p opendata up --build -d
 ```
 
 ### Bring services down
 ```bash
-docker-compose -p opendata down
+docker compose -p opendata down
 ```
 
 ### Destroy services
 ```bash
-docker-compose -p opendata down --volumes
+docker compose -p opendata down --volumes
 ```
 
 ### Example: Scale service X to N containers
 ```bash
-docker-compose -p opendata up --scale X=N -d
+docker compose -p opendata up --scale X=N -d
 ```
 
 ### Example: scaling drupal to 5 instances
 ```bash
-docker-compose -p opendata up --scale drupal=5 -d
+docker compose -p opendata up --scale drupal=5 -d
 ```
 
 ## Services that currently support scaling in local environment
@@ -259,10 +259,10 @@ npx cypress open
 ```
 #### Test environment
 
-When you want to separate tests from development environment, you can give docker-compose different project name:
+When you want to separate tests from development environment, you can give docker compose different project name:
 
 ```bash
-docker-compose -p opendata-test up
+docker compose -p opendata-test up
 ```
 
 To get rid of flask debug toolbar (cypress tests will fail when toolbar is visible), you can add environment-variable `TEST: 'true'` for ckan-service in `docker-compose.override.yml`

--- a/opendata-assets/README.md
+++ b/opendata-assets/README.md
@@ -1,4 +1,4 @@
-# ytp-assets-common
+# ytp-assets-common 
 
 Common assets (theme, fonts, JavaScript modules) for YTP Drupal and CKAN instances.
 


### PR DESCRIPTION
docker-compose v1 has been deprecated and removed, this replaces it with v2 which uses dashes instead of underscores in container names.