### PR TITLE
Cache cypress container to speed up tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -147,7 +147,7 @@ jobs:
         env:
           REGISTRY: ${{ secrets.REGISTRY }}
           REPOSITORY: ${{ secrets.REPOSITORY }}
-          DOCKER_BUILD_NO_SUMMARY: true
+          DOCKER_BUILD_RECORD_UPLOAD: false
 
       - name: upload images
         if: ${{ matrix.build-container == true }}
@@ -341,7 +341,17 @@ jobs:
           docker logs opendata-fuseki-1
 
       - name: Build cypress container
-        run: docker build -t cypress/test cypress/
+        uses: docker/build-push-action@v6
+        with:
+          context: ./cypress
+          file: ./cypress/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: cypress/test:latest
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+
 
       - name: run cypress e2e tests
         run: >


### PR DESCRIPTION
building cypress container every time takes half a minute, this might speed it up a little.

docker build action now has configuration option for not upload build summaries which is better than ignoring them completely.