### PR TITLE
Fix error in deleting groups

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/converters.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/converters.py
@@ -172,7 +172,7 @@ def save_to_groups(key, data, errors, context):
                     data[group_key] = v
 
     else:
-        # if categories is missing, remove categories
+        # if categories is missing, remove groups
         data[key] = ""
         removed_keys = []
         for k in data.keys():

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/converters.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/converters.py
@@ -172,8 +172,15 @@ def save_to_groups(key, data, errors, context):
                     data[group_key] = v
 
     else:
-        # Convert categories and groups key values to empty string if categories key is missing
+        # if categories is missing, remove categories
         data[key] = ""
-        data[('groups',)] = ""
+        removed_keys = []
+        for k in data.keys():
+            if 'groups' in k:
+                removed_keys.append(k)
+
+        for k in removed_keys:
+            data[k] = ""
+
 
     return data[key]


### PR DESCRIPTION
If categories are missing and groups are still supplied, error was generated during validation. This change removes groups when categories are missing.