### PR TITLE
Get Bootstrap styles for DCAT-AP namespace page from CDN

### DIFF
--- a/doc/dcat-ap/template.html.j2
+++ b/doc/dcat-ap/template.html.j2
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Suomi.fi Open Data DCAT-AP extension</title>
-    <link rel="stylesheet" href="/modules/opendata-assets/resources/vendor/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
   </head>
   <body class="container">
     <h1>Suomi.fi Open Data DCAT-AP extension</h1>

--- a/docker/nginx/www/ns/index.html
+++ b/docker/nginx/www/ns/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Suomi.fi Open Data DCAT-AP extension</title>
-    <link rel="stylesheet" href="/modules/opendata-assets/resources/vendor/bootstrap.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.4.1/dist/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
   </head>
   <body class="container">
     <h1>Suomi.fi Open Data DCAT-AP extension</h1>


### PR DESCRIPTION
- Get Bootstrap CSS from CDN instead of Drupal
  - Drupal static content depends on environment so it's not reliable