### PR TITLE
AV-2320: Add all users to newly created groups as editors

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
@@ -220,4 +220,21 @@ class TestYtpDatasetPlugin():
         assert len(dataset['groups']) == 0
 
 
+    def test_user_can_add_datasets_to_newly_created_groups(self, app):
+        user = User()
+        organization = Organization(user=user)
+        dataset_fields = minimal_dataset_with_one_resource_fields(user)
+        dataset = Dataset(owner_org=organization['id'], **dataset_fields)
 
+        group = Group(title_translated={
+            "fi": "some title in finnish",
+            "sv": "some title in swedish",
+            "en": "some title in english"
+        })
+
+        updated_dataset = call_action('package_update',
+                                      context={'user': user['name'], 'ignore_auth': False},
+                                      name=dataset['id'],
+                                      groups=[{'name': group['name']}],
+                                      **dataset_fields)
+        assert len(updated_dataset['groups']) == 1

--- a/ckan/ckanext/ckanext-ytp_main/test.ini
+++ b/ckan/ckanext/ckanext-ytp_main/test.ini
@@ -2,7 +2,7 @@
 use = config:../../src/ckan/test-core.ini
 sqlalchemy.url = postgresql://ckan:ckan_pass@postgres/ckan_test
 solr_url = http://solr-test:8983/solr/ckan
-ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest hierarchy_display ytp_dataset
+ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest hierarchy_display ytp_dataset ytp_organizations
 ckan.locale_default = fi
 ckanext.sixodp_showcasesubmit.creating_user_username = ckan_admin
 ckanext.sixodp_showcasesubmit.recaptcha_sitekey = ""


### PR DESCRIPTION
- Added chained action for group_create to add all users as editors
- Added test for adding a dataset to a group when the group is created after the adding user
- CLI command opendata_group add must be ran on servers once after deploying this to make sure all current users are in all current groups