### PR TITLE
Define datastore db engine version

### DIFF
--- a/cdk/lib/database-stack.ts
+++ b/cdk/lib/database-stack.ts
@@ -64,7 +64,8 @@ export class DatabaseStack extends Stack {
 
 
     this.datastoreInstance = new rds.DatabaseInstance(this, 'datastoreInstance', {
-      engine: rds.DatabaseInstanceEngine.POSTGRES,
+      engine: rds.DatabaseInstanceEngine.postgres({version: rds.PostgresEngineVersion.VER_14}),
+      allowMajorVersionUpgrade: false,
       credentials: this.datastoreCredentials,
       vpc: props.vpc,
       port: 5432,


### PR DESCRIPTION
Doesn't change anything, it is version 14 but it has been default, easier to track changes when it's actually defined in code.