### PR TITLE
Allow cloudstorage to use test role in aws

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -732,5 +732,6 @@ const ciTestStackBeta = new CiTestStack(app, 'CiTestStack-beta', {
   },
   githubOrg: "vrk-kpa",
   githubRepo: "opendata",
+  githubRepo2: "ckanext-cloudstorage",
   testBucketName: "avoindata-ci-test-bucket"
 })

--- a/cdk/lib/ci-test-stack-props.ts
+++ b/cdk/lib/ci-test-stack-props.ts
@@ -3,5 +3,6 @@ import {StackProps} from "aws-cdk-lib";
 export interface CiTestStackProps extends StackProps {
   testBucketName: string,
   githubOrg: string,
-  githubRepo: string
+  githubRepo: string,
+  githubRepo2: string
 }

--- a/cdk/lib/ci-test-stack.ts
+++ b/cdk/lib/ci-test-stack.ts
@@ -27,7 +27,9 @@ export class CiTestStack extends Stack {
     const testRole = new aws_iam.Role(this, 'TestRole', {
       assumedBy: new aws_iam.WebIdentityPrincipal(oidcProviderArn, {
           StringLike: {
-            "token.actions.githubusercontent.com:sub": `repo:${props.githubOrg}/${props.githubRepo}:*`
+            "token.actions.githubusercontent.com:sub": [
+              `repo:${props.githubOrg}/${props.githubRepo}:*`,
+              `repo:${props.githubOrg}/${props.githubRepo2}:*`]
           }
       })
     })


### PR DESCRIPTION
Allow vrk-kpa/ckanext-cloudstorage to use the CI role.