### PR TITLE
Upgrade flask for minimum required by sentry

### DIFF
--- a/ckan/ckan-requirements.txt
+++ b/ckan/ckan-requirements.txt
@@ -38,7 +38,8 @@ fanstatic==1.1
     # via ckan
 feedgen==0.9.0
     # via ckan
-flask==1.1.1
+# sentry sdk requires flask 1.1.4, should not break anything
+flask==1.1.4
     # via
     #   ckan
     #   flask-babel


### PR DESCRIPTION
Changelogs https://flask.palletsprojects.com/en/stable/changes/#version-1-1-4 contain only couple bug fixes, sentry sdk requires 1.1.4