### PR TITLE
AV-2418: Add validate packages feature to syke harvester

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/harvesters/syke_harvester.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/harvesters/syke_harvester.py
@@ -9,6 +9,7 @@ from ckan.logic import ValidationError, NotFound, get_action
 from ckan.lib.munge import munge_tag
 from ckanext.harvest.model import HarvestObject
 from ckanext.harvest.harvesters.ckanharvester import CKANHarvester
+import ckan.lib.plugins as lib_plugins
 
 import logging
 log = logging.getLogger(__name__)
@@ -435,6 +436,42 @@ class SYKEHarvester(CKANHarvester):
                 resource.pop('revision_id', None)
 
             package_dict = self.modify_package_dict(package_dict, harvest_object)
+
+            # validate packages if needed
+            validate_packages = self.config.get('validate_packages', {})
+            if validate_packages:
+                if 'type' not in package_dict:
+                    package_plugin = lib_plugins.lookup_package_plugin()
+                    try:
+                        # use first type as default if user didn't provide type
+                        package_type = package_plugin.package_types()[0]
+                    except (AttributeError, IndexError):
+                        package_type = 'dataset'
+                        # in case a 'dataset' plugin was registered w/o fallback
+                        package_plugin = lib_plugins.lookup_package_plugin(package_type)
+                    package_dict['type'] = package_type
+                else:
+                    package_plugin = lib_plugins.lookup_package_plugin(package_dict['type'])
+
+                errors = {}
+                # if package has been previously imported
+                try:
+                    existing_package_dict = self._find_existing_package(package_dict)
+
+                    if 'metadata_modified' not in package_dict or \
+                        package_dict['metadata_modified'] > existing_package_dict.get('metadata_modified'):
+                        schema = package_plugin.update_package_schema()
+                        data, errors = lib_plugins.plugin_validate(
+                            package_plugin, base_context, package_dict, schema, 'package_update')
+
+                except NotFound:
+
+                    schema = package_plugin.create_package_schema()
+                    data, errors = lib_plugins.plugin_validate(
+                        package_plugin, base_context, package_dict, schema, 'package_create')
+
+                if errors:
+                    raise ValidationError(errors)
 
             result = self._create_or_update_package(
                 package_dict, harvest_object, package_dict_form='package_show')


### PR DESCRIPTION
Syke harvester did not have validate packages feature which was implemented in ckan harverster in https://github.com/vrk-kpa/ckanext-harvest/commit/ec4c55c65d3e10b594984e275456b219d01c8959

without it, creating tags might fail on sql level and harvesting crashes or acts weirdly.