### PR TITLE
AV-2418: Remove harvested information about harvesting which broke solr queries

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/harvesters/syke_harvester.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/harvesters/syke_harvester.py
@@ -112,6 +112,14 @@ class SYKEHarvester(CKANHarvester):
                               if topic_category in iso_topic_categories]
                 package_dict['categories'] = categories
 
+        # Remove harvested information about harvesting, it'll interfere with solr query logic
+        extras_copy = extras.copy()
+        for extra in extras_copy:
+            if (extra['key'] == 'harvest_object_id' or
+                extra['key'] == 'harvest_source_id' or
+                extra['key'] == 'harvest_source_title'):
+                extras.remove(extra)
+
         return package_dict
 
     def gather_stage(self, harvest_job):


### PR DESCRIPTION
Datasets in syke have harvesting information in there https://ckan.ymparisto.fi/api/action/package_search which was harvested as is. But as solr queries assume to have our internal ids in them, harvest status page didn't list harvested datasets, this removes the information and as such replaces it with our own.