### PR TITLE
AV-2000: ckanext-qa 2.10 & 2.11 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 	url = https://github.com/vrk-kpa/ckanext-fluent.git
 [submodule "modules/ckanext-qa"]
 	path = ckan/ckanext/ckanext-qa
-	url = https://github.com/vrk-kpa/ckanext-qa.git
+	url = https://github.com/ckan/ckanext-qa.git
 [submodule "modules/ckanext-archiver"]
 	path = ckan/ckanext/ckanext-archiver
 	url = https://github.com/vrk-kpa/ckanext-archiver.git

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -213,6 +213,20 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
  && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
 
 
+# Install qsv for ckanext-qa
+
+ENV QSV_URL=https://github.com/dathere/qsv/releases/download/3.3.0/qsv-3.3.0-x86_64-unknown-linux-musl.zip \
+    QSV_SHA1SUM=57f42781d57213416165bd6fcd366d0a20d4ec53 \
+    QSV_ZIP=qsv-3.3.0-x86_64-unknown-linux-musl.zip \
+    QSV=qsv
+
+RUN curl -fsSLO "$QSV_URL" \
+ && echo "${QSV_SHA1SUM}  ${QSV_ZIP}" | sha1sum -c - \
+ && unzip "$QSV_ZIP" -d /tmp/qsv \
+ && chmod +x "/tmp/qsv/$QSV" \
+ && mv "/tmp/qsv/$QSV" "/usr/local/bin/$QSV"
+
+
 #
 # Development image (for local development)
 #

--- a/ckan/templates/production.ini.j2
+++ b/ckan/templates/production.ini.j2
@@ -132,6 +132,9 @@ ckanext-archiver.send_notification_emails_to_maintainers = {{ environ('CKAN_ARCH
 ckanext-archiver.exempt_domains_from_broken_link_notifications = {{ environ('CKAN_ARCHIVER_EXEMPT_DOMAINS_FROM_BROKEN_LINK_NOTIFICATIONS') }}
 ckanext-archiver.resource_download_timeout = 15
 
+ckanext.qa.qsv_bin = /usr/local/bin/qsv
+
+
 ckanext.sixodp_showcasesubmit.creating_user_username = {{ environ('SYSADMIN_USER') }}
 ckanext.sixodp_showcasesubmit.recaptcha_sitekey = {{ environ('RECAPTCHA_PUBLIC_KEY') }}
 ckanext.sixodp_showcasesubmit.recaptcha_secret = {{ environ('RECAPTCHA_PRIVATE_KEY') }}


### PR DESCRIPTION
Replaces ckanext-qa fork with upstream repo, it hardly had any differences https://github.com/ckan/ckanext-qa/compare/master...vrk-kpa:ckanext-qa:master.

Otherwise update ckanext-qa to latest, adds qsv binary to container to handle sniffing of files.