### PR TITLE
AV-2429: Allow svgs in group images

### DIFF
--- a/ckan/templates/production.ini.j2
+++ b/ckan/templates/production.ini.j2
@@ -98,6 +98,9 @@ ckan.activity_streams_email_notifications = True
 ckan.cache_enabled = True
 ckan.cache_expires = 90
 
+ckan.upload.group.mimetypes = image/png image/gif image/jpeg image/svg+xml
+
+
 email_to = {{ environ('SMTP_TO') }}
 error_email_from = {{ environ('SMTP_FROM_ERROR') }}
 


### PR DESCRIPTION
SVGs were limited by default due to XSS possibilities, this allows them in groups as we don't allow normal users to create groups.