### PR TITLE
Add 'file' to ckan container, ckanext-qa requires it

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -71,7 +71,8 @@ RUN \
       pcre \
       libxslt \
       libxml2 \
-      tzdata
+      tzdata \
+      file
 
 # Get artifacts from build stages
 COPY --from=base_ckan_build /wheels /srv/app/wheels


### PR DESCRIPTION
Sentry had errors that `file` is missing, this adds it to container.