### PR TITLE
Delete versions of deleted log entries

### DIFF
--- a/cdk/lib/load-balancer-stack.ts
+++ b/cdk/lib/load-balancer-stack.ts
@@ -58,7 +58,13 @@ export class LoadBalancerStack extends Stack {
       lifecycleRules: [
         {
           enabled: true,
-          expiration: Duration.days(30)
+          expiration: Duration.days(30),
+          noncurrentVersionExpiration: Duration.days(30),
+          abortIncompleteMultipartUploadAfter: Duration.days(30)
+        },
+        {
+          enabled: true,
+          expiredObjectDeleteMarker: true
         }
       ]
     })


### PR DESCRIPTION
30 days of logs are retained, but versions of those have been never removed, this will delete all expired versions after 30 days.