### PR TITLE
AV-2187: Add missing container name to task definition container

### DIFF
--- a/cdk/lib/clamav-scanner-stack.ts
+++ b/cdk/lib/clamav-scanner-stack.ts
@@ -28,6 +28,7 @@ export class ClamavScannerStack extends Stack {
 
     const clamavContainer = clamavTaskDef.addContainer('clamav', {
       image: ecs.ContainerImage.fromEcrRepository(clamavRepo, props.envProps.CLAMAV_IMAGE_TAG),
+      containerName: "clamav-scanner",
     });
 
     const privateSubnetA = Fn.importValue('vpc-SubnetPrivateA')


### PR DESCRIPTION
The clamav scanner lambda references the taskdef container by name, add it.