### PR TITLE
AV-2187: Give clamav container more memory per documentation

### DIFF
--- a/cdk/lib/clamav-scanner-stack.ts
+++ b/cdk/lib/clamav-scanner-stack.ts
@@ -29,6 +29,7 @@ export class ClamavScannerStack extends Stack {
     const clamavContainer = clamavTaskDef.addContainer('clamav', {
       image: ecs.ContainerImage.fromEcrRepository(clamavRepo, props.envProps.CLAMAV_IMAGE_TAG),
       containerName: "clamav-scanner",
+      memoryLimitMiB: 3072,
     });
 
     const privateSubnetA = Fn.importValue('vpc-SubnetPrivateA')


### PR DESCRIPTION
> Recommended RAM for ClamAV (As of 2020/09/20):
>
>    Minimum: 3 GiB
>    Preferred: 4 GiB

https://docs.clamav.net/manual/Installing/Docker.html

