### PR TITLE
AV-2343: Add expiry rules on ecr template

### DIFF
--- a/cloudformation/ecr-repository-stack.yml
+++ b/cloudformation/ecr-repository-stack.yml
@@ -32,3 +32,48 @@ Resources:
               - "ecr:GetDownloadUrlForLayer"
               - "ecr:BatchGetImage"
               - "ecr:BatchCheckLayerAvailability"
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Keep image tagged as latest",
+                "selection": {
+                    "tagStatus": "tagged",
+                    "tagPatternList": ["latest"],
+                    "countType": "imageCountMoreThan",
+                    "countNumber": 1
+                },
+                "action": {
+                  "type": "expire"
+                }
+              },
+              {
+                "rulePriority": 2,
+                "description": "Keep 3 latest prod images",
+                "selection": {
+                    "tagStatus": "tagged",
+                    "tagPatternList": ["prod-*"],
+                    "countType": "imageCountMoreThan",
+                    "countNumber": 3
+                },
+                "action": {
+                  "type": "expire"
+                }
+              },
+              {
+                "rulePriority": 2,
+                "description": "Keep images newer than a week",
+                "selection": {
+                    "tagStatus": "any",
+                    "countType": "sinceImagePushed",
+                    "countNumber": 7
+                },
+                "action": {
+                  "type": "expire"
+                }
+              }
+            ]
+          }
+

--- a/cloudformation/ecr-repository-stack.yml
+++ b/cloudformation/ecr-repository-stack.yml
@@ -63,11 +63,12 @@ Resources:
                 }
               },
               {
-                "rulePriority": 2,
+                "rulePriority": 3,
                 "description": "Keep images newer than a week",
                 "selection": {
                     "tagStatus": "any",
                     "countType": "sinceImagePushed",
+                    "countUnit": "days",
                     "countNumber": 7
                 },
                 "action": {


### PR DESCRIPTION
Adds the following rules to ecr template:

1. Keeps the image tagged as latest (the one used on dev)
2. Keeps 3 latest images tagged with prefix `prod-`, the current one in use in prod and 2 others
3. Keeps any other image for a week. 