### PR TITLE
AV-2187: Do not silently error and mark files as clean in case of errors

### DIFF
--- a/clamav/clamav-docker/src/app.py
+++ b/clamav/clamav-docker/src/app.py
@@ -36,7 +36,12 @@ def main():
 
     clamscanner = ClamScanner(processed_file.name)
     scan_output = clamscanner.scan_file()
+    errors = {error for status, error in scan_output.values() if status == 'ERROR'}
     infections = {virus for status, virus in scan_output.values() if status == 'FOUND'}
+
+    if errors:
+        error_str = ', '.join(errors)
+        raise RuntimeError(f'Error processing {object_key}: {error_str}')
 
     if infections:
         infection_name = ','.join(infections)


### PR DESCRIPTION
`scan_output` has `ERROR` status items if something goes wrong during the scan. Handle these as errors instead of just marking the files safe.