### PR TITLE
AV-2187: Allow clamav task to publish on the provided SNS topic

### DIFF
--- a/cdk/lib/clamav-scanner-stack.ts
+++ b/cdk/lib/clamav-scanner-stack.ts
@@ -53,6 +53,9 @@ export class ClamavScannerStack extends Stack {
     // Allow clamavScan lambda to run the ecs task
     clamavTaskDef.grantRun(clamavScan.lambda);
 
+    // Allow clamavScan to publish on the SNS topic
+    props.topic.grantPublish(clamavTaskDef.taskRole)
+
     // Allow clamavScan to manage S3 files
     const bucket = s3.Bucket.fromBucketName(this, 'DatasetBucket', props.datasetBucketName);
     bucket.grantReadWrite(clamavTaskDef.taskRole);


### PR DESCRIPTION
Logging shows the clamav task fails when it tries to publish a message on teh provided SNS topic, grant publish privileges.