### PR TITLE
AV-2187: Skip scanning empty files for viruses

### DIFF
--- a/clamav/clamav-docker/src/app.py
+++ b/clamav/clamav-docker/src/app.py
@@ -34,6 +34,9 @@ def main():
     target_file_hash = get_sha256(processed_file.name)
     set_object_tags(s3, s3_bucket, object_key, updated=datetime.datetime.utcnow().isoformat(), sha256=target_file_hash)
 
+    if os.stat(processed_file.name).st_size == 0:
+        logger.info("Empty file, skipping scan...")
+
     clamscanner = ClamScanner(processed_file.name)
     scan_output = clamscanner.scan_file()
     errors = {error for status, error in scan_output.values() if status == 'ERROR'}


### PR DESCRIPTION
After finding a virus the clamav task marks the file as infected and empties the s3 file content. This causes the bucket to issue a notification that the file has changed, prompting a second scan that overwrites the status as clean, since the file no longer contains the virus.

Zero-length files cannot have viruses, so we can safely just skip scanning them to avoid this.