### PR TITLE
AV-2187: Add EFS privileges and open ports for it for clamav containers

### DIFF
--- a/cdk/lib/clamav-scan-props.ts
+++ b/cdk/lib/clamav-scan-props.ts
@@ -1,3 +1,4 @@
+import { ISecurityGroup } from "aws-cdk-lib/aws-ec2";
 import {EnvStackProps} from "./env-stack-props";
 import {ICluster, ITaskDefinition} from 'aws-cdk-lib/aws-ecs';
 import { ITopic } from "aws-cdk-lib/aws-sns";
@@ -6,7 +7,8 @@ export interface ClamavScanProps extends EnvStackProps {
   cluster: ICluster;
   task: ITaskDefinition;
   snsTopic: ITopic;
-  subnetIds: String[]
+  subnetIds: String[];
+  securityGroup: ISecurityGroup;
 }
 
 

--- a/cdk/lib/clamav-scan.function.ts
+++ b/cdk/lib/clamav-scan.function.ts
@@ -1,10 +1,10 @@
 import {Handler, S3Event} from 'aws-lambda';
 import {ECSClient,RunTaskCommand} from '@aws-sdk/client-ecs';
 
-const { CLUSTER_ID, SNS_TOPIC_ARN, TASK_DEFINITION, SUBNET_IDS } = process.env;
+const { CLUSTER_ID, SNS_TOPIC_ARN, TASK_DEFINITION, SUBNET_IDS, SECURITY_GROUP_ID } = process.env;
 
 export const handler: Handler = async (event: S3Event) => {
-    if(!CLUSTER_ID || !SNS_TOPIC_ARN || !TASK_DEFINITION || !SUBNET_IDS) {
+    if(!CLUSTER_ID || !SNS_TOPIC_ARN || !TASK_DEFINITION || !SUBNET_IDS || !SECURITY_GROUP_ID) {
         return {
           statusCode: 500,
           body: 'Missing configuration values',
@@ -22,7 +22,8 @@ export const handler: Handler = async (event: S3Event) => {
         networkConfiguration: {
             'awsvpcConfiguration': {
                 'subnets': subnetIds,
-                'assignPublicIp': 'DISABLED'
+                'assignPublicIp': 'DISABLED',
+                'securityGroups': [SECURITY_GROUP_ID],
             }
         },
         platformVersion: 'LATEST',

--- a/cdk/lib/clamav-scan.ts
+++ b/cdk/lib/clamav-scan.ts
@@ -14,7 +14,8 @@ export class ClamavScan extends Construct {
         CLUSTER_ID: props.cluster.clusterArn,
         SNS_TOPIC_ARN: props.snsTopic.topicArn,
         TASK_DEFINITION: props.task.taskDefinitionArn,
-        SUBNET_IDS: props.subnetIds.join(",")
+        SUBNET_IDS: props.subnetIds.join(","),
+        SECURITY_GROUP_ID: props.securityGroup.securityGroupId,
       },
       runtime: lambda.Runtime.NODEJS_20_X,
     });

--- a/cdk/lib/clamav-scanner-stack.ts
+++ b/cdk/lib/clamav-scanner-stack.ts
@@ -56,7 +56,7 @@ export class ClamavScannerStack extends Stack {
 
     const clamavSecurityGroup = new SecurityGroup(this, 'clamav-security-group', {
       vpc: props.cluster.vpc,
-      description: "clamav container sercurity group"
+      description: "clamav container security group"
     });
     clamavSecurityGroup.connections.allowFrom(props.clamavFileSystem, Port.tcp(2049), 'EFS connection (clamav)')
     clamavSecurityGroup.connections.allowTo(props.clamavFileSystem, Port.tcp(2049), 'EFS connection (clamav)')

--- a/cdk/lib/clamav-scanner-stack.ts
+++ b/cdk/lib/clamav-scanner-stack.ts
@@ -68,7 +68,7 @@ export class ClamavScannerStack extends Stack {
       cluster: props.cluster,
       task: clamavTaskDef,
       snsTopic: props.topic,
-      subnetIds: [privateSubnetA, privateSubnetB]
+      subnetIds: [privateSubnetA, privateSubnetB],
       securityGroup: clamavSecurityGroup,
     })
 

--- a/cdk/lib/clamav-scanner-stack.ts
+++ b/cdk/lib/clamav-scanner-stack.ts
@@ -58,7 +58,6 @@ export class ClamavScannerStack extends Stack {
       vpc: props.cluster.vpc,
       description: "clamav container security group"
     });
-    clamavSecurityGroup.connections.allowFrom(props.clamavFileSystem, Port.tcp(2049), 'EFS connection (clamav)')
     clamavSecurityGroup.connections.allowTo(props.clamavFileSystem, Port.tcp(2049), 'EFS connection (clamav)')
     const privateSubnetA = Fn.importValue('vpc-SubnetPrivateA')
     const privateSubnetB = Fn.importValue('vpc-SubnetPrivateB')


### PR DESCRIPTION
- Create a security group for clamav containers that allows EFS traffic on port 2049
- Add root privileges for clamav containers to the clamav EFS volume