### PR TITLE
Remove provenance from docker builds to reduce images in ecr

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -119,6 +119,7 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false
           tags: |
             ${{ steps.login.outputs.registry }}/opendata/${{ matrix.name }}:${{ github.sha }}
             ${{ steps.login.outputs.registry }}/opendata/${{ matrix.name }}:latest


### PR DESCRIPTION
Buildx generates provenance by default which in ECR shows up as 3 different images on every build.
We don't really need those, so disable them.

Ref: https://stackoverflow.com/a/77207574