### PR TITLE
AV-2187: Fix infection information by not overwriting tagging for empty files

### DIFF
--- a/clamav/clamav-docker/src/app.py
+++ b/clamav/clamav-docker/src/app.py
@@ -28,7 +28,6 @@ def main() -> None:
         return
 
     s3 = boto3.client('s3')
-    set_object_tags(s3, s3_bucket, object_key, updated=utcnow_isoformat())
     sns = boto3.client('sns')
     processed_file = tempfile.NamedTemporaryFile(delete=False)
 


### PR DESCRIPTION
- `put_object_tagging` overwrites all tags, so infection information was scrubbed on the second run triggered by replacing infected objects with empty ones
- If the file was earlier marked as clean in CKAN, the marking would stick because the `malware` tag would be missing afterwards
- Same for if it was earlier marked as infected. The first value would stick.
- Fix by not updating object tags unless proceeding to run a scan