### PR TITLE
AV-1536: Remove migration fs from stacks, allows deleting the old unencrypted efs

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -88,8 +88,7 @@ const fileSystemStackBeta = new FileSystemStack(app, 'FileSystemStack-beta', {
   environment: betaProps.environment,
   vpc: clusterStackBeta.vpc,
   backups: true,
-  backupPlan: backupStackBeta.backupPlan,
-  importMigrationFs: true,
+  backupPlan: backupStackBeta.backupPlan
 });
 
 const databaseStackBeta = new DatabaseStack(app, 'DatabaseStack-beta', {
@@ -209,10 +208,6 @@ const ckanStackBeta = new CkanStack(app, 'CkanStack-beta', {
     'solr': fileSystemStackBeta.solrFs,
     'fuseki': fileSystemStackBeta.fusekiFs,
   },
-  migrationFileSystemProps: {
-    securityGroup: fileSystemStackBeta.migrationFsSg!,
-    fileSystem: fileSystemStackBeta.migrationFs!,
-  },
   databaseSecurityGroup: databaseStackBeta.databaseSecurityGroup,
   databaseInstance: databaseStackBeta.databaseInstance,
   datastoreInstance: databaseStackBeta.datastoreInstance,
@@ -285,10 +280,6 @@ const drupalStackBeta = new DrupalStack(app, 'DrupalStack-beta', {
   namespace: clusterStackBeta.namespace,
   fileSystems: {
     'drupal': fileSystemStackBeta.drupalFs,
-  },
-  migrationFileSystemProps: {
-    securityGroup: fileSystemStackBeta.migrationFsSg!,
-    fileSystem: fileSystemStackBeta.migrationFs!,
   },
   databaseSecurityGroup: databaseStackBeta.databaseSecurityGroup,
   databaseInstance: databaseStackBeta.databaseInstance,
@@ -410,8 +401,7 @@ const fileSystemStackProd = new FileSystemStack(app, 'FileSystemStack-prod', {
   environment: prodProps.environment,
   vpc: clusterStackProd.vpc,
   backups: true,
-  backupPlan: backupStackProd.backupPlan,
-  importMigrationFs: true,
+  backupPlan: backupStackProd.backupPlan
 });
 
 const databaseStackProd = new DatabaseStack(app, 'DatabaseStack-prod', {
@@ -528,10 +518,6 @@ const ckanStackProd = new CkanStack(app, 'CkanStack-prod', {
     'solr': fileSystemStackProd.solrFs,
     'fuseki': fileSystemStackProd.fusekiFs,
   },
-  migrationFileSystemProps: {
-    securityGroup: fileSystemStackProd.migrationFsSg!,
-    fileSystem: fileSystemStackProd.migrationFs!,
-  },
   databaseSecurityGroup: databaseStackProd.databaseSecurityGroup,
   databaseInstance: databaseStackProd.databaseInstance,
   datastoreInstance: databaseStackProd.datastoreInstance,
@@ -604,10 +590,6 @@ const drupalStackProd = new DrupalStack(app, 'DrupalStack-prod', {
   namespace: clusterStackProd.namespace,
   fileSystems: {
     'drupal': fileSystemStackProd.drupalFs,
-  },
-  migrationFileSystemProps: {
-    securityGroup: fileSystemStackProd.migrationFsSg!,
-    fileSystem: fileSystemStackProd.migrationFs!,
   },
   databaseSecurityGroup: databaseStackProd.databaseSecurityGroup,
   databaseInstance: databaseStackProd.databaseInstance,

--- a/cdk/lib/efs-stack-props.ts
+++ b/cdk/lib/efs-stack-props.ts
@@ -7,5 +7,4 @@ export interface EfsStackProps extends EnvStackProps {
   backupPlan: aws_backup.BackupPlan;
   vpc: ec2.IVpc;
   backups: boolean;
-  importMigrationFs: boolean;
 }

--- a/cdk/lib/filesystem-stack.ts
+++ b/cdk/lib/filesystem-stack.ts
@@ -14,8 +14,6 @@ export class FileSystemStack extends Stack {
   readonly solrFs: efs.FileSystem;
   readonly fusekiFs: efs.FileSystem;
   readonly clamavFs: efs.FileSystem;
-  readonly migrationFsSg?: ec2.ISecurityGroup;
-  readonly migrationFs?: efs.IFileSystem;
 
   constructor(scope: Construct, id: string, props: EfsStackProps) {
     super(scope, id, props);
@@ -77,26 +75,6 @@ export class FileSystemStack extends Stack {
           bak.BackupResource.fromEfsFileSystem(this.ckanFs),
           // NOTE: we probably don't want to backup fusekiFs!
         ]
-      });
-    }
-
-    if (props.importMigrationFs) {
-      // get params
-      const pMigrationFsSgId = ssm.StringParameter.fromStringParameterAttributes(this, 'pMigrationFsSgId', {
-        parameterName: `/${props.environment}/opendata/cdk/migration_fs_sg_id`,
-      });
-      const pMigrationFsId = ssm.StringParameter.fromStringParameterAttributes(this, 'pMigrationFsId', {
-        parameterName: `/${props.environment}/opendata/cdk/migration_fs_id`,
-      });
-
-      this.migrationFsSg = ec2.SecurityGroup.fromSecurityGroupId(this, 'migrationFsSg', pMigrationFsSgId.stringValue, {
-        allowAllOutbound: true,
-        mutable: true,
-      });
-
-      this.migrationFs = efs.FileSystem.fromFileSystemAttributes(this, 'migrationFs', {
-        fileSystemId: pMigrationFsId.stringValue,
-        securityGroup: this.migrationFsSg,
       });
     }
   }

--- a/cdk/test/ckan-stack.test.ts
+++ b/cdk/test/ckan-stack.test.ts
@@ -31,8 +31,7 @@ test('verify ckan stack resources', () => {
     environment: 'mock-env',
     vpc: clusterStack.vpc,
     backups: true,
-    backupPlan: backupStack.backupPlan,
-    importMigrationFs: true,
+    backupPlan: backupStack.backupPlan
   });
 
   const databaseStack = new DatabaseStack(app, 'DatabaseStack-test', {
@@ -76,10 +75,6 @@ test('verify ckan stack resources', () => {
       'ckan': fileSystemStack.ckanFs,
       'solr': fileSystemStack.solrFs,
       'fuseki': fileSystemStack.fusekiFs,
-    },
-    migrationFileSystemProps: {
-      securityGroup: fileSystemStack.migrationFsSg!,
-      fileSystem: fileSystemStack.migrationFs!,
     },
     databaseSecurityGroup: databaseStack.databaseSecurityGroup,
     databaseInstance: databaseStack.databaseInstance,
@@ -173,8 +168,7 @@ test('create ckan stack without analytics', () => {
     environment: 'mock-env',
     vpc: clusterStack.vpc,
     backups: true,
-    backupPlan: backupStack.backupPlan,
-    importMigrationFs: true,
+    backupPlan: backupStack.backupPlan
   });
 
   const databaseStack = new DatabaseStack(app, 'DatabaseStack-test', {
@@ -218,10 +212,6 @@ test('create ckan stack without analytics', () => {
       'ckan': fileSystemStack.ckanFs,
       'solr': fileSystemStack.solrFs,
       'fuseki': fileSystemStack.fusekiFs,
-    },
-    migrationFileSystemProps: {
-      securityGroup: fileSystemStack.migrationFsSg!,
-      fileSystem: fileSystemStack.migrationFs!,
     },
     databaseSecurityGroup: databaseStack.databaseSecurityGroup,
     databaseInstance: databaseStack.databaseInstance,
@@ -314,8 +304,7 @@ test('create ckan stack without captcha', () => {
     environment: 'mock-env',
     vpc: clusterStack.vpc,
     backups: true,
-    backupPlan: backupStack.backupPlan,
-    importMigrationFs: true,
+    backupPlan: backupStack.backupPlan
   });
 
   const databaseStack = new DatabaseStack(app, 'DatabaseStack-test', {
@@ -359,10 +348,6 @@ test('create ckan stack without captcha', () => {
       'ckan': fileSystemStack.ckanFs,
       'solr': fileSystemStack.solrFs,
       'fuseki': fileSystemStack.fusekiFs,
-    },
-    migrationFileSystemProps: {
-      securityGroup: fileSystemStack.migrationFsSg!,
-      fileSystem: fileSystemStack.migrationFs!,
     },
     databaseSecurityGroup: databaseStack.databaseSecurityGroup,
     databaseInstance: databaseStack.databaseInstance,

--- a/cdk/test/drupal-stack.test.ts
+++ b/cdk/test/drupal-stack.test.ts
@@ -29,8 +29,7 @@ test('verify drupal stack resources', () => {
     environment: 'mock-env',
     vpc: clusterStack.vpc,
     backups: true,
-    backupPlan: backupStack.backupPlan,
-    importMigrationFs: true,
+    backupPlan: backupStack.backupPlan
   });
 
   const databaseStack = new DatabaseStack(app, 'DatabaseStack-test', {
@@ -63,10 +62,6 @@ test('verify drupal stack resources', () => {
     namespace: clusterStack.namespace,
     fileSystems: {
       'drupal': fileSystemStack.drupalFs,
-    },
-    migrationFileSystemProps: {
-      securityGroup: fileSystemStack.migrationFsSg!,
-      fileSystem: fileSystemStack.migrationFs!,
     },
     databaseSecurityGroup: databaseStack.databaseSecurityGroup,
     databaseInstance: databaseStack.databaseInstance,
@@ -121,8 +116,7 @@ test('create a drupal stack without analytics', () => {
     environment: 'mock-env',
     vpc: clusterStack.vpc,
     backups: true,
-    backupPlan: backupStack.backupPlan,
-    importMigrationFs: true,
+    backupPlan: backupStack.backupPlan
   });
 
   const databaseStack = new DatabaseStack(app, 'DatabaseStack-test', {
@@ -155,10 +149,6 @@ test('create a drupal stack without analytics', () => {
     namespace: clusterStack.namespace,
     fileSystems: {
       'drupal': fileSystemStack.drupalFs,
-    },
-    migrationFileSystemProps: {
-      securityGroup: fileSystemStack.migrationFsSg!,
-      fileSystem: fileSystemStack.migrationFs!,
     },
     databaseSecurityGroup: databaseStack.databaseSecurityGroup,
     databaseInstance: databaseStack.databaseInstance,
@@ -207,8 +197,7 @@ test('create a drupal stack without captcha', () => {
     environment: 'mock-env',
     vpc: clusterStack.vpc,
     backups: true,
-    backupPlan: backupStack.backupPlan,
-    importMigrationFs: true,
+    backupPlan: backupStack.backupPlan
   });
 
   const databaseStack = new DatabaseStack(app, 'DatabaseStack-test', {
@@ -241,10 +230,6 @@ test('create a drupal stack without captcha', () => {
     namespace: clusterStack.namespace,
     fileSystems: {
       'drupal': fileSystemStack.drupalFs,
-    },
-    migrationFileSystemProps: {
-      securityGroup: fileSystemStack.migrationFsSg!,
-      fileSystem: fileSystemStack.migrationFs!,
     },
     databaseSecurityGroup: databaseStack.databaseSecurityGroup,
     databaseInstance: databaseStack.databaseInstance,

--- a/cdk/test/filesystem-stack.test.ts
+++ b/cdk/test/filesystem-stack.test.ts
@@ -26,8 +26,7 @@ test('verify filesystem stack resources', () => {
     environment: 'mock-env',
     vpc: clusterStack.vpc,
     backups: true,
-    backupPlan: backupStack.backupPlan,
-    importMigrationFs: true,
+    backupPlan: backupStack.backupPlan
   });
   // THEN
   const template = Template.fromStack(stack);


### PR DESCRIPTION
CKAN and Drupal stack have migration efs mount which held the old data from ec2 era. The data has been migrated to the new efs volumes, so these can be removed from the stacks. Deploy probably fails due to dependecies between the stacks but i'll fix them if that happens.

Allows deleting the old efs completely.