### PR TITLE
AV-2439: Block user agents in waf

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -174,7 +174,8 @@ const shieldStackBeta = new ShieldStack(app, 'ShieldStack-beta', {
   snsTopicArn: shieldParameterStackBeta.snsTopicArn,
   wafAutomationArn: shieldParameterStackBeta.wafAutomationArn,
   evaluationPeriod: shieldParameterStackBeta.evaluationPeriod,
-  loadBalancer: loadBalancerStackBeta.loadBalancer
+  loadBalancer: loadBalancerStackBeta.loadBalancer,
+  blockedUserAgentsParameterName: shieldParameterStackBeta.blockedUserAgentsParameterName
 })
 
 const cacheStackBeta = new CacheStack(app, 'CacheStack-beta', {
@@ -484,7 +485,8 @@ const shieldStackProd = new ShieldStack(app, 'ShieldStack-prod', {
   snsTopicArn: shieldParameterStackProd.snsTopicArn,
   wafAutomationArn: shieldParameterStackProd.wafAutomationArn,
   evaluationPeriod: shieldParameterStackProd.evaluationPeriod,
-  loadBalancer: loadBalancerStackProd.loadBalancer
+  loadBalancer: loadBalancerStackProd.loadBalancer,
+  blockedUserAgentsParameterName: shieldParameterStackProd.blockedUserAgentsParameterName
 })
 
 const cacheStackProd = new CacheStack(app, 'CacheStack-prod', {

--- a/cdk/lib/shield-parameter-stack.ts
+++ b/cdk/lib/shield-parameter-stack.ts
@@ -13,6 +13,7 @@ export class ShieldParameterStack extends Stack {
   readonly wafAutomationArn: aws_ssm.IStringParameter;
   readonly snsTopicArn: aws_ssm.IStringParameter;
   readonly evaluationPeriod: aws_ssm.IStringParameter;
+  readonly blockedUserAgentsParameterName: string;
 
   constructor(scope: Construct, id: string, props: EnvStackProps ) {
     super(scope, id, props);
@@ -73,6 +74,13 @@ export class ShieldParameterStack extends Stack {
       stringValue: '0',
       description: 'Evaluation period for rate limits',
       parameterName: `/${props.environment}/waf/evaluation_period`
+    })
+
+    this.blockedUserAgentsParameterName = `/${props.environment}/waf/blocked_user_agents`
+    new aws_ssm.StringParameter(this, 'blockedUserAgents', {
+      stringValue: "Some bogus user agent",
+      description: 'User Agents to be blocked in JSON',
+      parameterName: this.blockedUserAgentsParameterName
     })
   }
 }

--- a/cdk/lib/shield-stack-props.ts
+++ b/cdk/lib/shield-stack-props.ts
@@ -15,5 +15,6 @@ export interface ShieldStackProps extends EnvStackProps{
   wafAutomationArn: aws_ssm.IStringParameter,
   snsTopicArn: aws_ssm.IStringParameter,
   evaluationPeriod: aws_ssm.IStringParameter,
-  loadBalancer: aws_elasticloadbalancingv2.ApplicationLoadBalancer
+  loadBalancer: aws_elasticloadbalancingv2.ApplicationLoadBalancer,
+  blockedUserAgentsParameterName: string
 }


### PR DESCRIPTION
Adds rules to waf to block given list of user agents in parameter store.

For each string on the list, creates additional rule where it is checked if given string is contained withing User-Agent header.

If if its found, block the request.