### PR TITLE
AV-2187: Remove old SHA256 and malware status when resource is reuploaded

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resourcestatusplugin.py
@@ -19,7 +19,7 @@ class ResourceStatusPlugin(p.SingletonPlugin, DefaultTranslation):
         return {'resource_status': resource_status}
 
     def before_resource_update(self, context: dict, current: dict, resource: dict) -> None:
-        if not (resource.get('upload_in_progress') or context.get('set_resource_status')):
+        if not (context.get('upload_in_progress') or context.get('set_resource_status')):
             resource.pop('sha256', None)
             resource.pop('malware', None)
 

--- a/ckan/ckanext/ckanext-ytp_main/test.ini
+++ b/ckan/ckanext/ckanext-ytp_main/test.ini
@@ -2,7 +2,7 @@
 use = config:../../src/ckan/test-core.ini
 sqlalchemy.url = postgresql://ckan:ckan_pass@postgres/ckan_test
 solr_url = http://solr-test:8983/solr/ckan
-ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest hierarchy_display ytp_dataset ytp_organizations
+ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest hierarchy_display ytp_dataset ytp_organizations ytp_resourcestatus
 ckan.locale_default = fi
 ckanext.sixodp_showcasesubmit.creating_user_username = ckan_admin
 ckanext.sixodp_showcasesubmit.recaptcha_sitekey = ""

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,3 +12,6 @@ line-length = 127
 
 [lint]
 select = ["E", "F"]
+
+[lint.per-file-ignores]
+"**/tests/*.py" = ["S101"]


### PR DESCRIPTION
Malware status was not updated when resource files were reuploaded due to `sha256` and `malware` fields still being defined.

Modify updated resources to remove these fields when they are updated, but not during multipart upload nor when updating the fields from this process.

Also added better typing and fixed ruff.toml by moving `select` to `[lint]`