### PR TITLE
AV-2440:  Configure docker healthchecks

### DIFF
--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -526,7 +526,7 @@ export class CkanStack extends Stack {
           streamPrefix: 'ckan_cron-service',
         }),
         healthCheck: {
-          command: ['CMD-SHELL', 'ps aux | grep -o "[s]upercronic" && ps aux | grep -o "[s]upervisord --configuration"'],
+          command: ['CMD-SHELL', 'ps | grep -o "[s]upercronic" && ps | grep -o "[s]upervisord --configuration"'],
           interval: Duration.seconds(15),
           timeout: Duration.seconds(5),
           retries: 5,

--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -637,13 +637,13 @@ export class CkanStack extends Stack {
         logGroup: datapusherLogGroup,
         streamPrefix: 'datapusher-service',
       }),
-      //healthCheck: {
-      //  command: ['CMD-SHELL', 'curl --fail http://localhost:8800/status || exit 1'],
-      //  interval: Duration.seconds(15),
-      //  timeout: Duration.seconds(5),
-      //  retries: 5,
-      //  startPeriod: Duration.seconds(15),
-      //},
+      healthCheck: {
+        command: ['CMD-SHELL', 'curl --fail http://localhost:8800/status || exit 1'],
+        interval: Duration.seconds(15),
+        timeout: Duration.seconds(5),
+        retries: 5,
+        startPeriod: Duration.seconds(15),
+      },
     });
 
 

--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -742,13 +742,6 @@ export class CkanStack extends Stack {
         logGroup: solrLogGroup,
         streamPrefix: 'solr-service',
       }),
-      healthCheck: {
-        command: ['CMD-SHELL', 'curl --fail -s http://localhost:8983/solr/ckan/admin/ping?wt=json | grep -o "OK"'],
-        interval: Duration.seconds(15),
-        timeout: Duration.seconds(5),
-        retries: 5,
-        startPeriod: Duration.seconds(15),
-      },
     });
 
     solrContainer.addPortMappings({

--- a/cdk/lib/ckan-stack.ts
+++ b/cdk/lib/ckan-stack.ts
@@ -838,7 +838,7 @@ export class CkanStack extends Stack {
         streamPrefix: 'fuseki-service',
       }),
       healthCheck: {
-        command: ['CMD-SHELL', 'curl --fail -s http://localhost:3030/$/ping'],
+        command: ['CMD-SHELL', 'curl --fail -s http://localhost:3030/$/ping || exit 1' ],
         interval: Duration.seconds(15),
         timeout: Duration.seconds(5),
         retries: 5,

--- a/docker/README.md
+++ b/docker/README.md
@@ -111,7 +111,6 @@ This file is automatically detected by docker-compose so you don't need to pass 
 # NOTE: This example assumes you have cloned opendata-ckan and opendata-drupal repos to ../../ path.
 # NOTE: We don't want node_modules in our bind-mount, thus we mask it with empty volume!
 # NOTE: Remember to build the `opendata-assets` frontend project on the host machine!
-version: "3.8"
 services:
   ckan:
     image: opendata/ckan:latest

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-env-ckan: &env-ckan
   CKAN_IMAGE_TAG: ${CKAN_IMAGE_TAG}
   CKAN_HOST: ${CKAN_HOST}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -170,7 +170,7 @@ services:
     volumes:
       - ckan_data:/srv/app/data
     healthcheck:
-      test: ["CMD-SHELL", "ps -aux | grep -o '[s]upercronic' && ps -aux | grep -o '[s]upervisord --configuration'"]
+      test: ["CMD-SHELL", "ps | grep -o '[s]upercronic' && ps | grep -o '[s]upervisord --configuration'"]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -296,6 +296,12 @@ services:
       FUSEKI_DATASET_1: "${FUSEKI_OPENDATA_DATASET}"
     volumes:
       - fuseki_data:/fuseki
+    healthcheck:
+      test: [ "CMD-SHELL", "curl --fail -s http://localhost:3030/$/ping || exit 1" ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     # Clear leftover database locks before starting server
     # command: ["sh", "-c", "rm /fuseki/system/tdb.lock /fuseki/databases/opendata/tdb.lock || /jena-fuseki/fuseki-server"]
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -122,12 +122,6 @@ services:
       - backend
     volumes:
       - solr_data:/var/solr/data/ckan/data
-    healthcheck:
-      test: ["CMD-SHELL", "curl --fail -s http://localhost:8983/solr/ckan/admin/ping?wt=json | grep -o 'OK'"]
-      interval: 15s
-      timeout: 5s
-      retries: 5
-      start_period: 15s
 
   ckan:
     image: ${REGISTRY}/${REPOSITORY}/ckan:${CKAN_IMAGE_TAG}

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -18,6 +18,9 @@ RUN chmod +x /docker-entrypoint.d/*.sh
 COPY www /var/www/
 
 
+HEALTHCHECK --interval=15s --timeout=5s \
+  CMD curl -f http://localhost/health || exit 1
+
 #
 # Production image
 #

--- a/docker/solr/Dockerfile
+++ b/docker/solr/Dockerfile
@@ -32,3 +32,6 @@ RUN chown -R "$SOLR_USER:$SOLR_USER" $SOLR_CORE_PATH/$SOLR_CORE
 
 # switch from root to solr user
 USER $SOLR_USER:$SOLR_USER
+
+HEALTHCHECK --interval=15s --timeout=5s \
+  CMD curl --fail -s http://localhost:8983/solr/ckan/admin/ping?wt=json | grep -o 'OK'


### PR DESCRIPTION
Configures various healthcheck for docker containers, both local and in ecs. CDK defaults to container health check if its not defined so some of those were moved around.

Now all containers (except local mailhog, should be replaced) report healthy status.