### PR TITLE
AV-2440: Add route53 health checks to shield protection

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -175,7 +175,8 @@ const shieldStackBeta = new ShieldStack(app, 'ShieldStack-beta', {
   wafAutomationArn: shieldParameterStackBeta.wafAutomationArn,
   evaluationPeriod: shieldParameterStackBeta.evaluationPeriod,
   loadBalancer: loadBalancerStackBeta.loadBalancer,
-  blockedUserAgentsParameterName: shieldParameterStackBeta.blockedUserAgentsParameterName
+  blockedUserAgentsParameterName: shieldParameterStackBeta.blockedUserAgentsParameterName,
+  fqdn: betaProps.fqdn
 })
 
 const cacheStackBeta = new CacheStack(app, 'CacheStack-beta', {
@@ -486,7 +487,8 @@ const shieldStackProd = new ShieldStack(app, 'ShieldStack-prod', {
   wafAutomationArn: shieldParameterStackProd.wafAutomationArn,
   evaluationPeriod: shieldParameterStackProd.evaluationPeriod,
   loadBalancer: loadBalancerStackProd.loadBalancer,
-  blockedUserAgentsParameterName: shieldParameterStackProd.blockedUserAgentsParameterName
+  blockedUserAgentsParameterName: shieldParameterStackProd.blockedUserAgentsParameterName,
+  fqdn: prodProps.fqdn
 })
 
 const cacheStackProd = new CacheStack(app, 'CacheStack-prod', {

--- a/cdk/lib/shield-stack-props.ts
+++ b/cdk/lib/shield-stack-props.ts
@@ -1,5 +1,5 @@
 import {EnvStackProps} from "./env-stack-props";
-import {aws_ec2, aws_elasticloadbalancingv2, aws_ssm} from "aws-cdk-lib";
+import {aws_elasticloadbalancingv2, aws_ssm} from "aws-cdk-lib";
 
 export interface ShieldStackProps extends EnvStackProps{
   bannedIpsRequestSamplingEnabled: boolean,
@@ -16,5 +16,6 @@ export interface ShieldStackProps extends EnvStackProps{
   snsTopicArn: aws_ssm.IStringParameter,
   evaluationPeriod: aws_ssm.IStringParameter,
   loadBalancer: aws_elasticloadbalancingv2.ApplicationLoadBalancer,
-  blockedUserAgentsParameterName: string
+  blockedUserAgentsParameterName: string,
+  fqdn: string
 }

--- a/cdk/lib/shield-stack.ts
+++ b/cdk/lib/shield-stack.ts
@@ -4,21 +4,62 @@ import {
   aws_sns,
   aws_ssm,
   aws_wafv2,
-  Stack, Token, CfnParameter, aws_sns_subscriptions
+  Stack, Token, CfnParameter, aws_sns_subscriptions, aws_route53, Duration, Arn
 } from "aws-cdk-lib";
 import {Construct} from "constructs";
 
 import {ShieldStackProps} from "./shield-stack-props";
 
 import { z } from "zod";
+import { HealthCheckType } from "aws-cdk-lib/aws-route53";
 
 export class ShieldStack extends Stack {
   constructor(scope: Construct, id: string, props: ShieldStackProps) {
     super(scope, id, props);
 
+    const nginxHealthCheck = new aws_route53.HealthCheck(this, 'nginxHealthCheck', {
+      type: aws_route53.HealthCheckType.HTTPS,
+      fqdn: props.fqdn,
+      port: 443,
+      resourcePath: '/health',
+      failureThreshold: 3,
+      requestInterval: Duration.seconds(30)
+    })
+
+    const ckanHealthCheck = new aws_route53.HealthCheck(this, 'ckanHealthCheck', {
+      type: aws_route53.HealthCheckType.HTTPS,
+      fqdn: props.fqdn,
+      port: 443,
+      resourcePath: '/data/dataset',
+      failureThreshold: 3,
+      requestInterval: Duration.seconds(30)
+    })
+
+    const drupalHealthCheck = new aws_route53.HealthCheck(this, 'drupalHealthCheck', {
+      type: aws_route53.HealthCheckType.HTTPS,
+      fqdn: props.fqdn,
+      port: 443,
+      resourcePath: '/fi',
+      failureThreshold: 3,
+      requestInterval: Duration.seconds(30)
+    })
+
+    const generateHealthCheckArn = ((healthCheckId: string, stack: Stack) => {
+      return Arn.format({
+        resource: 'healthCheck',
+        service: 'route53',
+        resourceName: healthCheckId
+      }, stack)
+    })
+
     const cfnProtection = new aws_shield.CfnProtection(this, 'ShieldProtection', {
       name: 'Application Load Balancers',
-      resourceArn: props.loadBalancer.loadBalancerArn
+      resourceArn: props.loadBalancer.loadBalancerArn,
+      healthCheckArns: [
+        generateHealthCheckArn(nginxHealthCheck.healthCheckId, this),
+        generateHealthCheckArn(ckanHealthCheck.healthCheckId, this),
+        generateHealthCheckArn(drupalHealthCheck.healthCheckId, this)
+      ]
     })
     
 


### PR DESCRIPTION
This is somewhat guess work but this add 3 route53 based health checks to shield.

Routes to be checked:

- `/health` served from nginx container
- `/fi` served from drupal container
- `/data/dataset` served from ckan container.