### PR TITLE
AV-2440: shield protection can only have one healthcheck

### DIFF
--- a/cdk/lib/shield-stack.ts
+++ b/cdk/lib/shield-stack.ts
@@ -56,9 +56,7 @@ export class ShieldStack extends Stack {
       name: 'Application Load Balancers',
       resourceArn: props.loadBalancer.loadBalancerArn,
       healthCheckArns: [
-        generateHealthCheckArn(nginxHealthCheck.healthCheckId, this),
-        generateHealthCheckArn(ckanHealthCheck.healthCheckId, this),
-        generateHealthCheckArn(drupalHealthCheck.healthCheckId, this)
+        generateHealthCheckArn(ckanHealthCheck.healthCheckId, this)
       ]
     })
     


### PR DESCRIPTION
Even though documentation says otherwise.