### PR TITLE
AV-2435: Handle ObjectNotFound exceptions in openness_score_avg

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/reports.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/reports.py
@@ -1,15 +1,20 @@
-from ckan.plugins.toolkit import get_action
-from ckanext.matomo.model import PackageStats
-from .cli import package_generator
-from datetime import timedelta, datetime
-import iso8601
 import logging
+from collections.abc import Callable, Generator, Iterable
+from datetime import datetime, timedelta
 from functools import reduce
+from typing import Any, Optional
+
+import iso8601
+from ckan.plugins.toolkit import ObjectNotFound, get_action
+
+from ckanext.matomo.model import PackageStats
+
+from .cli import package_generator
 
 log = logging.getLogger(__name__)
 
 
-def administrative_branch_summary_report():
+def administrative_branch_summary_report() -> dict:
     org_names = [
         'ulkoministerio',
         'sisaministerio',
@@ -33,7 +38,7 @@ def administrative_branch_summary_report():
     org_trees = [get_action('group_tree_section')(context, {'id': org['id'], 'type': 'organization'})
                  for org in orgs]
 
-    def children(dataset):
+    def children(dataset: dict) -> None:
         return dataset['children']
 
     org_levels = {
@@ -43,7 +48,7 @@ def administrative_branch_summary_report():
 
     flat_orgs = (org for t in org_trees for org in flatten(t, children))
 
-    def with_totals(orgs):
+    def with_totals(orgs: Iterable[dict]) -> Generator[dict, None, None]:
         for org in orgs:
             if org_levels[org['name']] == 0:
                 total_org = org.copy()
@@ -57,8 +62,8 @@ def administrative_branch_summary_report():
         for r in with_totals(flat_orgs))
 
     # Optimization opportunity: Prefetch datasets for all related orgs in one go
-    root_datasets_pairs = (
-        (k, list(package_generator('owner_org:(%s)' % ' OR '.join(v), 1000, context)))
+    root_datasets_pairs: Iterable[tuple[dict, list[dict]]] = (
+        (k, list(package_generator('owner_org:({})'.format(' OR '.join(v)), 1000, context)))
         for k, v in root_tree_ids_pairs)
 
     try:
@@ -102,14 +107,14 @@ administrative_branch_summary_report_info = {
 }
 
 
-def deprecated_datasets_report():
+def deprecated_datasets_report() -> dict:
     # Get packages that are deprecated
     all_deprecated = package_generator('deprecated:true AND private:false', 10, {})
 
     # Function to loop packages through
     # Get package visit and download data
     # Resolve package structure to match table structure
-    def handle_package(pkg):
+    def handle_package(pkg: dict) -> dict:
         resolved_dict = {
             'title': pkg["title"],
             'id': pkg["id"],
@@ -160,51 +165,56 @@ deprecated_datasets_report_info = {
 }
 
 
-def age(dataset):
+def age(dataset: dict) -> timedelta:
     return datetime.now() - iso8601.parse_date(dataset['metadata_created'], default_timezone=None)
 
 
-def glen(generator):
+def glen(generator: Iterable) -> int:
     '''
     Returns the number of items in a generator without interemediate lists
     '''
     return sum(1 for x in generator)
 
 
-def flatten(x, children):
+def flatten(x, children: Callable) -> Generator:
     '''
     Flatten a hierarchy into an element iterator
     '''
     yield x
     for child in children(x):
-        for cx in flatten(child, children):
-            yield cx
+        yield from flatten(child, children)
 
 
-def hierarchy_levels(x, children, level=0):
+def hierarchy_levels(x, children: Callable, level: int = 0) -> Generator[tuple[Any, int]]:
     '''
     Provide hierarchy levels for nodes in a hierarchy
     '''
-    yield(x, level)
+    yield (x, level)
     for child in children(x):
-        for cx, cl in hierarchy_levels(child, children, level + 1):
-            yield (cx, cl)
+        yield from hierarchy_levels(child, children, level + 1)
 
 
-def resource_formats(datasets):
+def resource_formats(datasets: Iterable[dict]) -> str:
     return ', '.join({r['format'] for d in datasets for r in d['resources'] if r['format']})
 
 
-def openness_score_avg(context, datasets):
+def openness_score_avg(context: dict, datasets: Iterable[dict]) -> Optional[float]:
     openness_score = get_action('qa_package_openness_show')
-    scores = (openness_score(context, {"id": d['id']}) for d in datasets)
+
+    def openness_score_or_none(context: dict, data_dict: dict) -> Optional[dict]:
+        try:
+            return openness_score(context, data_dict)
+        except ObjectNotFound:
+            return None
+
+    scores = (openness_score_or_none(context, {"id": d['id']}) for d in datasets)
     total, count = reduce(tuple_sum, (
         (s['openness_score'], 1)
         for s in scores
-        if s.get('openness_score') is not None),
+        if s is not None and s.get('openness_score') is not None),
         (0, 0))
     return total / count if count > 0 else None
 
 
-def tuple_sum(*xs):
+def tuple_sum(*xs: tuple) -> tuple:
     return tuple(sum(x) for x in zip(*xs))


### PR DESCRIPTION
- handle `ObjectNotFound` exceptions from `qa_package_openness_show` by disregarding such cases in openness score average calculations
- added type annotations and fixed various style issues