### PR TITLE
Upgrade python and alpine versions, and move base image out of arg variable

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -1,11 +1,10 @@
 # build args
 ARG SECRET_NPMRC
-ARG BASE_IMAGE=public.ecr.aws/docker/library/python:3.9.18-alpine3.18
 
 #
 # Add common configuration to base image
 #
-FROM ${BASE_IMAGE} AS configured_base
+FROM public.ecr.aws/docker/library/python:3.9.23-alpine3.22 AS configured_base
 
 ENV APP_DIR=/srv/app
 ENV SRC_DIR=${APP_DIR}/src


### PR DESCRIPTION
Used alpine version has lost its support, this upgrades alpine and python 3.9 to latest. 

Also remove base image arg as automatic updates does not pick up the version from that.