### PR TITLE
AV-2442: move robots.txt to subfolder for /var/www to be readonly

### DIFF
--- a/cdk/lib/web-stack.ts
+++ b/cdk/lib/web-stack.ts
@@ -42,7 +42,7 @@ export class WebStack extends Stack {
           name: 'nginx_var_run'
         },
         {
-          name: 'nginx_var_www'
+          name: 'nginx_var_www_static'
         }
       ]
     });
@@ -136,9 +136,9 @@ export class WebStack extends Stack {
       sourceVolume: 'nginx_var_run',
     },
     {
-      containerPath: '/var/www',
+      containerPath: '/var/www/static',
       readOnly: false,
-      sourceVolume: 'nginx_var_www'
+      sourceVolume: 'nginx_var_www_static'
     });
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -280,8 +280,7 @@ services:
         - /var/cache/nginx:uid=101,gid=101
         - /var/run:uid=101,gid=101
         - /etc/nginx/conf.d
-    volumes:
-      - /var/www
+        - /var/www/static
     environment:
       - NGINX_PORT=${NGINX_PORT}
       - DOMAIN_NAME=${DOMAIN_NAME}

--- a/docker/nginx/docker-entrypoint.d/100-install-jinja2-templates.sh
+++ b/docker/nginx/docker-entrypoint.d/100-install-jinja2-templates.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
 
-jinja2 /etc/nginx/jinja2-templates/robots.txt.j2 -o /var/www/robots.txt
+jinja2 /etc/nginx/jinja2-templates/robots.txt.j2 -o /var/www/static/robots.txt

--- a/docker/nginx/templates/server.conf.template
+++ b/docker/nginx/templates/server.conf.template
@@ -47,7 +47,7 @@ location = /favicon.ico {
 }
 
 location = /robots.txt {
-  root /var/www;
+  root /var/www/static;
   allow all;
   log_not_found off;
   access_log off;


### PR DESCRIPTION
Contents `/var/www` of is copied during docker build, `robots.txt` is created in entrypoint so move it to a subfolder.