### PR TITLE
Revert "Bump actions/download-artifact from 4 to 5"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -287,7 +287,7 @@ jobs:
 
 
       - name: download built images
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         with:
           path: /tmp
 


### PR DESCRIPTION
Reverts vrk-kpa/opendata#2881

Fails if there is only single artifact https://github.com/actions/download-artifact/pull/416#issuecomment-3158579619