### PR TITLE
AV-2453: Fix margins and paddings rendering into strings

### DIFF
--- a/opendata-assets/src/scss/utility.scss
+++ b/opendata-assets/src/scss/utility.scss
@@ -249,7 +249,7 @@ $display-properties: none,
   @if $size < 128 {
     @include make-margins-and-paddings($size * $increment, $index + 1);
 
-    $size-px: '#{$size}px';
+    $size-px: unquote('#{$size}px');
 
     @include make-margin-padding-css($index, $size-px);
   }


### PR DESCRIPTION
Sizes were rendered as string literals, ex. `"32px"` instead of literals like `32px`. Use unquote to fix.