### PR TITLE
AV-2454: Fix header icon

### DIFF
--- a/drupal/modules/avoindata-header/templates/avoindata_search.html.twig
+++ b/drupal/modules/avoindata-header/templates/avoindata_search.html.twig
@@ -23,7 +23,7 @@
     <div class="header-search-group">
         <input class="header-search-input" type="search" class="form-control" name="search" placeholder="{{ placeholder }}">
         <button class="header-search-button" type="submit">
-            <span class="glyphicon glyphicon-search" aria-hidden="true">
+            <span class="fa fa-search" aria-hidden="true">
         </button>
         
     </div>

--- a/opendata-assets/gulpfile.js
+++ b/opendata-assets/gulpfile.js
@@ -32,7 +32,6 @@ var paths = {
     scripts: "src/scripts/**/*",
     bootstrap_styles: "./node_modules/bootstrap-sass/assets/stylesheets",
     bootstrap_scripts: "./node_modules/bootstrap-sass/assets/javascripts/*",
-    bootstrap_fonts: "./node_modules/bootstrap-sass/assets/fonts/*",
     moment_path: "./node_modules/moment",
     root: "src",
     fontawesome: "./node_modules/@fortawesome/fontawesome-pro"
@@ -336,13 +335,6 @@ gulp.task("bootstrap_styles", (done) => {
   ], done)
 });
 
-gulp.task("bootstrap_fonts", (done) => {
-  pump([
-    gulp.src(paths.src.bootstrap_fonts, {encoding: false}),
-    gulp.dest(paths.drupalTheme + '/fonts')
-  ], done)
-})
-
 gulp.task('copy:libs', (done) => {
   pump([
     gulp.src(npmDist({
@@ -369,8 +361,7 @@ gulp.task("vendor",
     "copy:moment",
     "copy:libs",
     "bootstrap_scripts",
-    "bootstrap_styles",
-    "bootstrap_fonts", (done) => {
+    "bootstrap_styles", (done) => {
       pump([
         gulp.src(paths.src.root + "/vendor/**/*", {encoding: false}),
         gulp.dest(paths.drupalTheme + "/vendor"),


### PR DESCRIPTION
For some weird reason, header uses bootstrap glyphicon icon which had faulty paths in assets. Instead of fixing the paths, since we will overhaul our assets soon with bootstrap upgrade, this replaces it with fontawesome icon and glyphicons are no longer needed.