### PR TITLE
AV-2447: Fix Templatehelpers order

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -503,6 +503,10 @@ jobs:
     - uses: actions/checkout@v5
       with:
         submodules: true
+    - name: Install required patches
+      run: |
+        cd ${SRC_DIR}/ckan
+        patch --strip=1 --input=$GITHUB_WORKSPACE/ckan/src/ckan/patches/fix_templatehelpers_plugin_order.patch
     - name: Install requirements
       run: |
         cd ckan/ckanext/ckanext-ytp_main

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -184,7 +184,8 @@ RUN cd ${SRC_DIR}/ckan && \
     patch --strip=1 --input=patches/fix_use_default_schema_parameter.patch && \
     patch --strip=1 --input=patches/remove_tracking.patch && \
     patch --strip=1 --input=patches/remove_tracking_summary_from_solr_index.patch && \
-    patch --strip=1 --input=patches/iauthenticator_fix.patch
+    patch --strip=1 --input=patches/iauthenticator_fix.patch && \
+    patch --strip=1 --input=patches/fix_templatehelpers_plugin_order.patch
 
 RUN \
   # Make scripts executable

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
@@ -4,6 +4,8 @@ import pytest
 from ckan.tests.factories import Dataset, Group, Sysadmin, User, Organization
 from ckan.tests.helpers import call_action
 from ckan.plugins import toolkit
+from ckan import model
+
 from .utils import minimal_dataset_with_one_resource_fields
 
 def create_minimal_dataset():
@@ -330,3 +332,47 @@ class TestResourceStatusPlugin:
 
         assert modified_resource.get('malware') is None
         assert modified_resource.get('sha256') is None
+
+
+@pytest.mark.usefixtures('clean_db', 'clean_index')
+class TestOrganizationHierarchy:
+    def test_suborganization_is_under_parent(self):
+        parent = Organization()
+        child = Organization()
+
+        member = model.Member(
+            group=model.Group.get(child['id']),
+            table_id=parent['id'], table_name='group', capacity='parent')
+
+        model.Session.add(member)
+        model.Session.commit()
+
+        result = call_action('group_tree_section', id=parent['id'], type='organization')
+        assert result['children'][0]['id'] == child['id']
+
+    def test_tree_section_has_only_approved_organizations(self):
+
+        parent = Organization()
+        first_child = Organization(approval_status="approved")
+        second_child = Organization(approval_status="pending")
+
+        member = model.Member(
+            group=model.Group.get(first_child['id']),
+            table_id=parent['id'], table_name='group', capacity='parent')
+
+        model.Session.add(member)
+        member = model.Member(
+            group=model.Group.get(second_child['id']),
+            table_id=parent['id'], table_name='group', capacity='parent')
+        model.Session.add(member)
+        model.Session.commit()
+
+        result = call_action('group_tree_section', id=parent['id'], type='organization', only_approved=True)
+
+        assert result['children'][0]['id'] == first_child['id']
+        assert len(result['children']) == 1
+
+        helper_result = toolkit.h.group_tree_section(id_=parent['id'], type_='organization', only_approved=True)
+
+        assert helper_result['children'][0]['id'] == first_child['id']
+        assert len(helper_result['children']) == 1

--- a/ckan/ckanext/ckanext-ytp_main/test.ini
+++ b/ckan/ckanext/ckanext-ytp_main/test.ini
@@ -2,7 +2,7 @@
 use = config:../../src/ckan/test-core.ini
 sqlalchemy.url = postgresql://ckan:ckan_pass@postgres/ckan_test
 solr_url = http://solr-test:8983/solr/ckan
-ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest hierarchy_display ytp_dataset ytp_organizations ytp_resourcestatus
+ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest ytp_dataset ytp_organizations ytp_resourcestatus hierarchy_display
 ckan.locale_default = fi
 ckanext.sixodp_showcasesubmit.creating_user_username = ckan_admin
 ckanext.sixodp_showcasesubmit.recaptcha_sitekey = ""

--- a/ckan/src/ckan/patches/fix_templatehelpers_plugin_order.patch
+++ b/ckan/src/ckan/patches/fix_templatehelpers_plugin_order.patch
@@ -1,0 +1,13 @@
+diff --git a/ckan/lib/helpers.py b/ckan/lib/helpers.py
+index 4858d7063..d9b0e525b 100644
+--- a/ckan/lib/helpers.py
++++ b/ckan/lib/helpers.py
+@@ -2660,7 +2660,7 @@ def load_plugin_helpers() -> None:
+     helper_functions.update(_builtin_functions)
+     chained_helpers = defaultdict(list)
+
+-    for plugin in p.PluginImplementations(p.ITemplateHelpers):
++    for plugin in reversed(list(p.PluginImplementations(p.ITemplateHelpers))):
+         for name, func in plugin.get_helpers().items():
+             if _is_chained_helper(func):
+                 chained_helpers[name].append(func)


### PR DESCRIPTION
Fixes template helpers order with a patch to ckan core and adds tests.

Adds patch file to github actions test workflow as unit tests are run with ckan provided container, which requires said patch to fix bug in ckan core.