### PR TITLE
AV-2452: spatial query assumes form id to be present, add it from ckan core

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
@@ -63,7 +63,7 @@
             (_('Date Created Descending'), 'metadata_created desc'),
             (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
           %}
-          {% snippet 'snippets/search_form.html', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, query_params=c.fields_grouped, show_advanced_search=true %}
+          {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, show_empty=request.params, error=c.query_error, query_params=c.fields_grouped, show_advanced_search=true %}
         </div>
         {% endblock %}
         <div class="container-search-result">

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -5,12 +5,15 @@
     {% set placeholder = placeholder if placeholder else _('Search apis...') %}
 {% else %}
     {% set placeholder = placeholder if placeholder else _('Search datasets...') %}
-{% endif%}
+{% endif %}
 
+{% set placeholder = placeholder if placeholder else _('Search datasets...') %}
+{% set sorting = sorting if sorting else [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
 {% set search_class = search_class if search_class else 'search-giant' %}
 {% set no_bottom_border = no_bottom_border if no_bottom_border else false %}
+{% set form_id = form_id if form_id else false %}
 
-<form class="search-form{% if no_bottom_border %} no-bottom-border{% endif %}" method="get" data-module="select-switch">
+<form {% if form_id %}id="{{ form_id }}" {% endif %}class="search-form{% if no_bottom_border %} no-bottom-border{% endif %}" method="get" data-module="select-switch">
 
     {% block search_facets %}
         {% if facets %}


### PR DESCRIPTION
Thought about simplifying the form, but the required modifications for layout aren't possible with the current blocks the form has. So this just updates the form and variables from the ckan core.