### PR TITLE
Av 2455 fix styles on advanced search

### DIFF
--- a/opendata-assets/src/scss/components/forms.scss
+++ b/opendata-assets/src/scss/components/forms.scss
@@ -424,6 +424,7 @@ fieldset.checkboxes {
 
 // Frontpage search bar input.
 .ytp-input-element-frontpage {
+  /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
   @extend .ytp-input-element;
 
   &::placeholder {
@@ -529,6 +530,7 @@ fieldset.checkboxes {
 
 // Frontpage search bar.
 .ytp-input-with-icon-frontpage {
+  /* stylelint-disable-next-line scss/at-extend-no-missing-placeholder */
   @extend .ytp-input-with-icon;
 
   height: 40px;

--- a/opendata-assets/src/scss/components/forms.scss
+++ b/opendata-assets/src/scss/components/forms.scss
@@ -397,7 +397,7 @@ fieldset.checkboxes {
   }
 }
 
-%ytp-input-element {
+.ytp-input-element {
   width: 100%;
   border: solid $input-border-width $input-border-color;
   padding: 8px 10px;
@@ -424,7 +424,7 @@ fieldset.checkboxes {
 
 // Frontpage search bar input.
 .ytp-input-element-frontpage {
-  @extend %ytp-input-element;
+  @extend .ytp-input-element;
 
   &::placeholder {
     color: rgb(109 120 126);
@@ -498,7 +498,7 @@ fieldset.checkboxes {
   }
 }
 
-%ytp-input-with-icon {
+.ytp-input-with-icon {
   position: relative;
   display: flex;
   align-items: center;
@@ -529,7 +529,7 @@ fieldset.checkboxes {
 
 // Frontpage search bar.
 .ytp-input-with-icon-frontpage {
-  @extend %ytp-input-with-icon;
+  @extend .ytp-input-with-icon;
 
   height: 40px;
   margin-right: 10px;


### PR DESCRIPTION
Placeholder selectors were used to fix linting error. Disable linting on those lines instead, extending classes is done on purpose.