### PR TITLE
Fix server error on invalid searches with ckan patch

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -185,7 +185,8 @@ RUN cd ${SRC_DIR}/ckan && \
     patch --strip=1 --input=patches/remove_tracking.patch && \
     patch --strip=1 --input=patches/remove_tracking_summary_from_solr_index.patch && \
     patch --strip=1 --input=patches/iauthenticator_fix.patch && \
-    patch --strip=1 --input=patches/fix_templatehelpers_plugin_order.patch
+    patch --strip=1 --input=patches/fix_templatehelpers_plugin_order.patch && \
+    patch --strip=1 --input=patches/fix_server_error_on_group_pages.patch
 
 RUN \
   # Make scripts executable

--- a/ckan/src/ckan/patches/fix_server_error_on_group_pages.patch
+++ b/ckan/src/ckan/patches/fix_server_error_on_group_pages.patch
@@ -1,0 +1,123 @@
+From 7f040cbb37401ce830cb218254613ef983b90362 Mon Sep 17 00:00:00 2001
+From: cirun <cirun@live.com>
+Date: Mon, 10 Jun 2024 20:14:53 +0200
+Subject: [PATCH 1/3] remove override of group_dict['package_count'] to display
+ the correct dataset count
+
+---
+ ckan/views/group.py | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/ckan/views/group.py b/ckan/views/group.py
+index 471aaeb3506..4ff4f7f91f7 100644
+--- a/ckan/views/group.py
++++ b/ckan/views/group.py
+@@ -352,11 +352,6 @@ def pager_url(q: Any = None, page: Optional[int] = None):
+             item_count=query['count'],
+             items_per_page=limit)
+
+-        # TODO: Remove
+-        # ckan 2.9: Adding variables that were removed from c object for
+-        # compatibility with templates in existing extensions
+-        g.group_dict['package_count'] = query['count']
+-
+         extra_vars["search_facets"] = query['search_facets']
+         extra_vars["search_facets_limits"] = g.search_facets_limits = {}
+         default_limit: int = config.get(u'search.facets.default')
+@@ -429,7 +424,6 @@ def read(group_type: str,
+         # Do not query for the group datasets when dictizing, as they will
+         # be ignored and get requested on the controller anyway
+         data_dict['include_datasets'] = False
+-        data_dict['include_dataset_count'] = False
+
+         # Do not query group members as they aren't used in the view
+         data_dict['include_users'] = False
+
+From 413cf2b0c65365ca9f8d10026073eec97f4c5533 Mon Sep 17 00:00:00 2001
+From: cirun <cirun@live.com>
+Date: Mon, 10 Jun 2024 20:52:02 +0200
+Subject: [PATCH 2/3] add test
+
+---
+ ckan/tests/controllers/test_organization.py | 26 +++++++++++++++++++++
+ 1 file changed, 26 insertions(+)
+
+diff --git a/ckan/tests/controllers/test_organization.py b/ckan/tests/controllers/test_organization.py
+index d2e4737aef3..9eecf37288b 100644
+--- a/ckan/tests/controllers/test_organization.py
++++ b/ckan/tests/controllers/test_organization.py
+@@ -107,6 +107,32 @@ def test_no_redirect_loop_when_name_is_the_same_as_the_id(self, app):
+             url_for("organization.read", id=org["id"]), status=200
+         )  # ie no redirect
+
++    def test_group_read_displays_correct_dataset_count(self, app):
++        """
++        Tests that the organization read view displays the correct
++        dataset count with and without a search query.
++        """
++        org = factories.Organization()
++        dataset1 = factories.Dataset(title="test", owner_org=org["id"])
++        dataset2 = factories.Dataset(title="title", owner_org=org["id"])
++
++        # Test without search query
++        resp = app.get(url_for("organization.read", id=org["id"]))
++        soup = BeautifulSoup(resp.body, 'html.parser')
++
++        dataset_count = soup.find('dt', text='Datasets').find_next_sibling('dd').find('span')
++        assert dataset_count.text == "2"
++
++        # Test with search query
++        resp = app.get(url_for("organization.read", id=org["id"], q="test"))
++        soup = BeautifulSoup(resp.body, 'html.parser')
++
++        dataset_count = soup.find('dt', text='Datasets').find_next_sibling('dd').find('span')
++        assert dataset_count.text == "2"
++
++        h1_tag = soup.select_one('h1:contains("dataset")')
++        assert h1_tag.text.strip() == '1 dataset found for "test"'
++
+
+ @pytest.mark.usefixtures("non_clean_db")
+ class TestOrganizationEdit(object):
+
+From a3ebd55ed0e337e42770573585fc68a345441338 Mon Sep 17 00:00:00 2001
+From: cirun <cirun@live.com>
+Date: Mon, 10 Jun 2024 20:59:26 +0200
+Subject: [PATCH 3/3] fix linter
+
+---
+ ckan/tests/controllers/test_organization.py | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/ckan/tests/controllers/test_organization.py b/ckan/tests/controllers/test_organization.py
+index 9eecf37288b..9f9c302923d 100644
+--- a/ckan/tests/controllers/test_organization.py
++++ b/ckan/tests/controllers/test_organization.py
+@@ -113,8 +113,7 @@ def test_group_read_displays_correct_dataset_count(self, app):
+         dataset count with and without a search query.
+         """
+         org = factories.Organization()
+-        dataset1 = factories.Dataset(title="test", owner_org=org["id"])
+-        dataset2 = factories.Dataset(title="title", owner_org=org["id"])
++        _, dataset = factories.Dataset.create_batch(2, owner_org=org["id"])
+
+         # Test without search query
+         resp = app.get(url_for("organization.read", id=org["id"]))
+@@ -124,14 +123,15 @@ def test_group_read_displays_correct_dataset_count(self, app):
+         assert dataset_count.text == "2"
+
+         # Test with search query
+-        resp = app.get(url_for("organization.read", id=org["id"], q="test"))
++        title = dataset["title"]
++        resp = app.get(url_for("organization.read", id=org["id"], q=title))
+         soup = BeautifulSoup(resp.body, 'html.parser')
+
+         dataset_count = soup.find('dt', text='Datasets').find_next_sibling('dd').find('span')
+         assert dataset_count.text == "2"
+
+         h1_tag = soup.select_one('h1:contains("dataset")')
+-        assert h1_tag.text.strip() == '1 dataset found for "test"'
++        assert h1_tag.text.strip() == f'1 dataset found for "{title}"'
+
+
+ @pytest.mark.usefixtures("non_clean_db")


### PR DESCRIPTION
Group and organization pages produce errors on sentry when there are invalid searches, CKAN has a fix for this on 2.11 onwards, this PR adds that fix to our environment.