### PR TITLE
Fix server error on deleted organization, extra arguments to render were deprecated and removed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -509,6 +509,26 @@ jobs:
         pip install -e .
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
+        
+        # create placeholder files for webassets
+        mkfile() { 
+          mkdir -p -- "$1" && touch -- "$1"/"$2" 
+        }
+        
+        mkfile ckanext/ytp/resources/vendor/bootstrap/dist/css bootstrap.css
+        mkfile ckanext/ytp/resources/vendor/eonasdan-bootstrap-datetimepicker/build/css bootstrap-datetimepicker.css
+        mkfile ckanext/ytp/resources/vendor/jstree/dist/themes/default style.css
+        mkfile ckanext/ytp/resources/vendor/select2-bootstrap-css select2-bootstrap.css
+        mkfile ckanext/ytp/resources/styles ckan.css
+        mkfile ckanext/ytp/resources/templates head-styles-ckan.html
+        mkfile ckanext/ytp/resources/scripts offcanvas.js
+        mkfile ckanext/ytp/resources/scripts avoindata_header.js
+        mkfile ckanext/ytp/resources/scripts inject_responsive_tables.js
+        mkfile ckanext/ytp/resources/vendor/moment/dist/min/ moment-with-locales.js
+        mkfile ckanext/ytp/resources/vendor/eonasdan-bootstrap-datetimepicker/build/js bootstrap-datetimepicker.js
+        mkfile ckanext/ytp/resources/vendor/jstree/dist jstree.js
+    
+        
         cd ../ckanext-scheming
         pip install -e .
         cd ../ckanext-fluent

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/tests/test_plugin.py
@@ -5,6 +5,7 @@ from ckan.tests.factories import Dataset, Group, Sysadmin, User, Organization
 from ckan.tests.helpers import call_action
 from ckan.plugins import toolkit
 from ckan import model
+from ckan.lib.helpers import url_for
 
 from .utils import minimal_dataset_with_one_resource_fields
 
@@ -376,3 +377,16 @@ class TestOrganizationHierarchy:
 
         assert helper_result['children'][0]['id'] == first_child['id']
         assert len(helper_result['children']) == 1
+
+@pytest.mark.usefixtures('clean_db', 'clean_index')
+class TestOrganizationView:
+    def test_deleted_organization_showing_error_message(self, app):
+        org = Organization()
+
+        org_url = url_for("organization.read", id=org['id'], locale='en')
+
+        call_action('organization_delete', id=org['id'])
+
+        result = app.get(org_url)
+
+        assert "Organization does not exist" in result

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/views_organization.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/views_organization.py
@@ -177,7 +177,8 @@ def read(group_type, is_organization, id=None, limit=20):
     except NotAuthorized:
         group = model.Session.query(model.Group).filter(model.Group.name == id).first()
         if group is None or group.state != 'active':
-            return base.render(_replace_group_org('group/organization_not_found.html'), group_type=group_type)
+            extra_vars["group_type"] = group_type
+            return base.render(_replace_group_org('group/organization_not_found.html'), extra_vars)
 
     # if the user specified a group id, redirect to the group name
     if data_dict['id'] == group_dict['id'] and \
@@ -195,8 +196,7 @@ def read(group_type, is_organization, id=None, limit=20):
     g.group = group
 
     extra_vars = _read(id, limit, group_type)
-
-    extra_vars["group_type"] = group_type
+    
     extra_vars["group_dict"] = group_dict
 
     return base.render(

--- a/ckan/ckanext/ckanext-ytp_main/test.ini
+++ b/ckan/ckanext/ckanext-ytp_main/test.ini
@@ -1,8 +1,8 @@
 [app:main]
-use = config:../../src/ckan/test-core.ini
+use = config:../ckan/test-core.ini
 sqlalchemy.url = postgresql://ckan:ckan_pass@postgres/ckan_test
 solr_url = http://solr-test:8983/solr/ckan
-ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest ytp_dataset ytp_organizations ytp_resourcestatus hierarchy_display
+ckan.plugins = dcat scheming_datasets scheming_groups scheming_organizations fluent harvest ytp_dataset ytp_organizations ytp_theme ytp_resourcestatus hierarchy_display
 ckan.locale_default = fi
 ckanext.sixodp_showcasesubmit.creating_user_username = ckan_admin
 ckanext.sixodp_showcasesubmit.recaptcha_sitekey = ""


### PR DESCRIPTION
`render` only takes `extra_vars` parameter, deprecated args and kwargs arguments were removed.

Add various placeholder files for unit tests as these are created by asset build and unit tests don't really require functional front end, only that pages actually open.