### PR TITLE
AV-2461: Add check of old api keys are used in api

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -186,7 +186,8 @@ RUN cd ${SRC_DIR}/ckan && \
     patch --strip=1 --input=patches/remove_tracking_summary_from_solr_index.patch && \
     patch --strip=1 --input=patches/iauthenticator_fix.patch && \
     patch --strip=1 --input=patches/fix_templatehelpers_plugin_order.patch && \
-    patch --strip=1 --input=patches/fix_server_error_on_group_pages.patch
+    patch --strip=1 --input=patches/fix_server_error_on_group_pages.patch && \
+    patch --strip=1 --input=patches/add_check_if_old_api_keys_are_used.patch
 
 RUN \
   # Make scripts executable

--- a/ckan/src/ckan/patches/add_check_if_old_api_keys_are_used.patch
+++ b/ckan/src/ckan/patches/add_check_if_old_api_keys_are_used.patch
@@ -1,0 +1,94 @@
+From 789adfc45379cbe94c46f8ed2c0b75ca95b87bf4 Mon Sep 17 00:00:00 2001
+From: Jari Voutilainen <jari-pekka.voutilainen@gofore.com>
+Date: Mon, 15 Sep 2025 14:47:42 +0300
+Subject: [PATCH 1/2] Notify API user that they are using old removed api keys
+
+---
+ ckan/tests/controllers/test_api.py | 13 +++++++++++++
+ ckan/views/api.py                  |  9 +++++++++
+ 2 files changed, 22 insertions(+)
+
+diff --git a/ckan/tests/controllers/test_api.py b/ckan/tests/controllers/test_api.py
+index ef743111bc4..40febb88de5 100644
+--- a/ckan/tests/controllers/test_api.py
++++ b/ckan/tests/controllers/test_api.py
+@@ -5,6 +5,7 @@
+ """
+ import json
+ import re
++import uuid
+
+ import pytest
+ from io import BytesIO
+@@ -383,3 +384,15 @@ def test_package_search_connection_errors(app):
+         url_for("api.action", logic_function="package_search", ver=3),
+     )
+     assert res.json["error"]["__type"] == "Search Connection Error"
++
++
++@pytest.mark.usefixtures("clean_db")
++def test_api_key_giving_an_error(app):
++
++    headers = {"Authorization": uuid.uuid4()}
++    url = url_for("api.action", ver=3, logic_function="package_search")
++
++    res = app.get(url, headers=headers)
++
++    assert res.status_code == 400
++    assert "Bad request - Request made with old style API key, please use API token instead." in res
+diff --git a/ckan/views/api.py b/ckan/views/api.py
+index cc455b15bdc..21a9af1d515 100644
+--- a/ckan/views/api.py
++++ b/ckan/views/api.py
+@@ -6,6 +6,7 @@
+ import html
+ import io
+ import datetime
++import re
+
+ from typing import Any, Callable, Optional, Union
+
+@@ -231,6 +232,14 @@ def action(logic_function: str, ver: int = API_DEFAULT_VERSION) -> Response:
+                 or deleted as a result of this action (for some actions)
+     '''
+
++    # Check if old format api key is used
++    authorization_header = request.headers.get("Authorization")
++
++    if authorization_header:
++        uuid4_regex = re.compile('[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')
++        if re.match(uuid4_regex, authorization_header):
++            return _finish_bad_request("Request made with old style API key, please use API token instead.")
++
+     # Check if action exists
+     try:
+         function = get_action(logic_function)
+
+From 909255a9c9f6445a46b10e24416704a40e797263 Mon Sep 17 00:00:00 2001
+From: Jari Voutilainen <jari-pekka.voutilainen@gofore.com>
+Date: Mon, 15 Sep 2025 15:39:13 +0300
+Subject: [PATCH 2/2] lint
+
+---
+ ckan/views/api.py | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/ckan/views/api.py b/ckan/views/api.py
+index 21a9af1d515..59cd8ec1297 100644
+--- a/ckan/views/api.py
++++ b/ckan/views/api.py
+@@ -236,9 +236,12 @@ def action(logic_function: str, ver: int = API_DEFAULT_VERSION) -> Response:
+     authorization_header = request.headers.get("Authorization")
+
+     if authorization_header:
+-        uuid4_regex = re.compile('[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$')
++        uuid4_regex = re.compile('[a-f0-9]{8}-[a-f0-9]{4}-'
++                                 '4[a-f0-9]{3}-[89ab][a-f0-9]{3}-'
++                                 '[a-f0-9]{12}$')
+         if re.match(uuid4_regex, authorization_header):
+-            return _finish_bad_request("Request made with old style API key, please use API token instead.")
++            return _finish_bad_request("Request made with old style API key, "
++                                       "please use API token instead.")
+
+     # Check if action exists
+     try:


### PR DESCRIPTION
The API will return bad request if Authorization header contains uuid4 key.