### PR TITLE
Use CDK policies for bucket permissions instead of writing our own

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -265,7 +265,8 @@ const ckanStackBeta = new CkanStack(app, 'CkanStack-beta', {
   archiverExemptDomainsFromBrokenLinkNotifications: [],
   cloudstorageEnabled: true,
   sentryTracesSampleRate: "1.0",
-  sentryProfilesSampleRate: "1.0"
+  sentryProfilesSampleRate: "1.0",
+  datasetBucketName: "avoindata-beta-datasets"
 });
 
 const drupalStackBeta = new DrupalStack(app, 'DrupalStack-beta', {
@@ -577,7 +578,8 @@ const ckanStackProd = new CkanStack(app, 'CkanStack-prod', {
   archiverExemptDomainsFromBrokenLinkNotifications: ['fmi.fi'],
   cloudstorageEnabled: true,
   sentryTracesSampleRate: "0.1",
-  sentryProfilesSampleRate: "0.1"
+  sentryProfilesSampleRate: "0.1",
+  datasetBucketName: "avoindata-prod-datasets"
 });
 
 const drupalStackProd = new DrupalStack(app, 'DrupalStack-prod', {

--- a/cdk/lib/ckan-stack-props.ts
+++ b/cdk/lib/ckan-stack-props.ts
@@ -22,5 +22,6 @@ export interface CkanStackProps extends EcsStackProps {
   datastoreUserCredentials: rds.Credentials,
   datastoreReadCredentials: rds.Credentials,
   sentryTracesSampleRate: string,
-  sentryProfilesSampleRate: string
+  sentryProfilesSampleRate: string,
+  datasetBucketName: string
 }

--- a/cdk/test/ckan-stack.test.ts
+++ b/cdk/test/ckan-stack.test.ts
@@ -128,7 +128,8 @@ test('verify ckan stack resources', () => {
     archiverExemptDomainsFromBrokenLinkNotifications: [],
     cloudstorageEnabled: true,
     sentryTracesSampleRate: "1.0",
-    sentryProfilesSampleRate: "1.0"
+    sentryProfilesSampleRate: "1.0",
+    datasetBucketName: "example",
   });
   // THEN
   const template = Template.fromStack(stack);
@@ -264,7 +265,8 @@ test('create ckan stack without analytics', () => {
     archiverExemptDomainsFromBrokenLinkNotifications: [],
     cloudstorageEnabled: true,
     sentryTracesSampleRate: "1.0",
-    sentryProfilesSampleRate: "1.0"
+    sentryProfilesSampleRate: "1.0",
+    datasetBucketName: "example"
   });
   // THEN
   const template = Template.fromStack(stack);
@@ -399,7 +401,8 @@ test('create ckan stack without captcha', () => {
     archiverExemptDomainsFromBrokenLinkNotifications: [],
     cloudstorageEnabled: true,
     sentryTracesSampleRate: "1.0",
-    sentryProfilesSampleRate: "1.0"
+    sentryProfilesSampleRate: "1.0",
+    datasetBucketName: "example"
   });
   // THEN
   const template = Template.fromStack(stack);


### PR DESCRIPTION
Weird permission errors were found on sentry, this might fix them. Instead of writing our own permission policy, uses grantRead and grantReadWrite from cdk.