### PR TITLE
Remove jstree, it produces errors on clients

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -517,7 +517,6 @@ jobs:
         
         mkfile ckanext/ytp/resources/vendor/bootstrap/dist/css bootstrap.css
         mkfile ckanext/ytp/resources/vendor/eonasdan-bootstrap-datetimepicker/build/css bootstrap-datetimepicker.css
-        mkfile ckanext/ytp/resources/vendor/jstree/dist/themes/default style.css
         mkfile ckanext/ytp/resources/vendor/select2-bootstrap-css select2-bootstrap.css
         mkfile ckanext/ytp/resources/styles ckan.css
         mkfile ckanext/ytp/resources/templates head-styles-ckan.html
@@ -526,7 +525,6 @@ jobs:
         mkfile ckanext/ytp/resources/scripts inject_responsive_tables.js
         mkfile ckanext/ytp/resources/vendor/moment/dist/min/ moment-with-locales.js
         mkfile ckanext/ytp/resources/vendor/eonasdan-bootstrap-datetimepicker/build/js bootstrap-datetimepicker.js
-        mkfile ckanext/ytp/resources/vendor/jstree/dist jstree.js
     
         
         cd ../ckanext-scheming

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resources/opendata/scripts/ytp_form.js
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resources/opendata/scripts/ytp_form.js
@@ -265,17 +265,6 @@ $(document).ready(function(){
         });
     });
 
-    $('[data-tree]').each(function(){
-        var TreeConfig = JSON.parse($(this).attr('attrs'));
-        if ($.isEmptyObject(TreeConfig)) {
-            $(this).jstree({
-                plugins: ['checkbox']
-            });
-        }
-        else{
-            $(this).jstree(TreeConfig);
-        }
-    });
 
     $('[data-organization-tree] .js-expand').bind('click', function(){
         $(this).siblings('.js-collapse, .js-collapsed').show();
@@ -326,35 +315,3 @@ $(document).ready(function(){
     $('.tooltip-element span').tooltip();
 });
 
-
-/**
- * 
- * @param tree A jsTree instance
- * @param nodesToSelect A string indicating which nodes to select ('all', 'top', 'bottom')
- * @param targetElementId The id of the target input field
- */
-function transferSelectedFromTreeToForm(tree, nodesToSelect, targetElementId) {
-    // Check whether we are selecting all the nodes, just the parents, or just the children
-    if (!nodesToSelect || nodesToSelect == "all") {
-        var selected = tree.get_selected('full');
-    } else if (nodesToSelect == "top") {
-        selected = tree.get_top_selected('full');
-    } else if (nodesToSelect == "bottom") {
-        selected = tree.get_bottom_selected('full');
-    }
-
-    // Get a reference to the input field we are updating
-    var input = $('#' + targetElementId);
-    // Get the array of values in the input field
-    var values = input.select2('data');
-    // Empty the array
-    values.length = 0;
-
-    selected.forEach(function(element) {
-        // Append each of the selected items to the array
-        values.push({id: tree.get_text(element), text: tree.get_text(element), locked: true});
-    });
-
-    // Update the input field's values
-    input.select2('data', values);
-}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resources/webassets.yml
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/resources/webassets.yml
@@ -3,7 +3,6 @@ main_css:
   contents:
     - vendor/bootstrap/dist/css/bootstrap.css
     - vendor/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css
-    - vendor/jstree/dist/themes/default/style.css
     - vendor/select2-bootstrap-css/select2-bootstrap.css
     - styles/ckan.css
     - opendata/styles/ab-datepicker.css
@@ -20,7 +19,6 @@ main_js:
     - scripts/inject_responsive_tables.js
     - vendor/moment/dist/min/moment-with-locales.js
     - vendor/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.js
-    - vendor/jstree/dist/jstree.js
     - opendata/scripts/drag-n-drop-uploader.js
 
 openapi_view_css:

--- a/opendata-assets/package-lock.json
+++ b/opendata-assets/package-lock.json
@@ -13,7 +13,6 @@
         "bootstrap-sass": "^3.4.1",
         "bootstrap-table": "^1.20.2",
         "eonasdan-bootstrap-datetimepicker": "^4.17.49",
-        "jstree": "^3.3.12",
         "moment": "^2.29.4",
         "select2-bootstrap-css": "^1.4.6"
       },
@@ -5939,14 +5938,6 @@
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jstree": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/jstree/-/jstree-3.3.12.tgz",
-      "integrity": "sha512-vHNLWkUr02ZYH7RcIckvhtLUtneWCVEtIKpIp2G9WtRh01ITv18EoNtNQcFG3ozM+oK6wp1Z300gSLXNQWCqGA==",
-      "dependencies": {
-        "jquery": ">=1.9.1"
       }
     },
     "node_modules/junk": {

--- a/opendata-assets/package.json
+++ b/opendata-assets/package.json
@@ -38,7 +38,6 @@
     "bootstrap-sass": "^3.4.1",
     "bootstrap-table": "^1.20.2",
     "eonasdan-bootstrap-datetimepicker": "^4.17.49",
-    "jstree": "^3.3.12",
     "moment": "^2.29.4",
     "select2-bootstrap-css": "^1.4.6"
   },


### PR DESCRIPTION
Sentry has constant errors from jstree, its not used in anywhere anymore as org hierarchy has been reimplemented years ago not to use jstree, so this removes it from our assets.