### PR TITLE
AV-2486: Remove margin below service messages and fix multiline layout

### DIFF
--- a/drupal/modules/avoindata-servicemessage/templates/avoindata_servicemessage_block.html.twig
+++ b/drupal/modules/avoindata-servicemessage/templates/avoindata_servicemessage_block.html.twig
@@ -24,7 +24,7 @@
   <li class="alert alert-{{ alert_type }} alert-dismissible">
     <div class="container">
       <i class="far {{ alert_icon }}"></i>
-      <span>{{ message.body|raw }}</span>
+      <div>{{ message.body|raw }}</div>
       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{% trans %}Close{% endtrans %}">{% trans %}Close{% endtrans %}<i class="fal fa-times"></i></button>
     </div>
   </li>

--- a/opendata-assets/src/scss/navbars.scss
+++ b/opendata-assets/src/scss/navbars.scss
@@ -831,7 +831,7 @@ End of dropdown CSS
 
 .service-messages {
   list-style: none;
-  margin-bottom: 10px;
+  margin-bottom: 0;
   padding: 0;
   font-size: $font-size-base;
 
@@ -841,8 +841,8 @@ End of dropdown CSS
     border-radius: 0 !important;
     min-height: 46px;
 
-    span {
-      margin-left: 20px;
+    div {
+      padding: 0 25px;
     }
 
     .btn-close,
@@ -912,11 +912,9 @@ End of dropdown CSS
     }
   }
 
-
-
-
   .container{
     position: relative;
+    display: flex;
   }
 
   // Treat all links inside alert as .alert-link


### PR DESCRIPTION
Removes extra whiteish margin below service messages and fixes layout issues with long messages, screenshot below:
<img width="1173" height="261" alt="image" src="https://github.com/user-attachments/assets/6399dea4-d742-462f-860c-c253f5467103" />
