### PR TITLE
Fix hero search button vertical position

### DIFF
--- a/opendata-assets/src/scss/components/forms.scss
+++ b/opendata-assets/src/scss/components/forms.scss
@@ -514,10 +514,8 @@ fieldset.checkboxes {
     cursor: pointer;
     display: block;
     position: absolute;
-    top: 50%;
-    margin-top: -10px;
     right: 10px;
-    height: 20px;
+    height: 100%;
     padding: 0;
     border: none;
     background: 0 0;


### PR DESCRIPTION
Before:
<img width="758" height="83" alt="image" src="https://github.com/user-attachments/assets/f13e756d-af0f-4460-9850-a26423ca58ad" />

After:
<img width="751" height="75" alt="image" src="https://github.com/user-attachments/assets/27d9e977-12a7-4e08-aca4-0dfec36021db" />
