### PR TITLE
Hero sparse layout

### DIFF
--- a/drupal/modules/avoindata-hero/templates/avoindata_hero_form.html.twig
+++ b/drupal/modules/avoindata-hero/templates/avoindata_hero_form.html.twig
@@ -20,7 +20,7 @@
             </h1>
         </div>
         <!-- TODO: Change justify "evenly" to "between" -->
-        <div class="d-flex flex-wrap justify-content-evenly mt-2">
+        <div class="d-flex flex-wrap justify-content-evenly">
           {{ form.statistics }}
         </div>
         <div class="hero-search-form">

--- a/opendata-assets/src/scss/components/forms.scss
+++ b/opendata-assets/src/scss/components/forms.scss
@@ -514,10 +514,8 @@ fieldset.checkboxes {
     cursor: pointer;
     display: block;
     position: absolute;
-    top: 50%;
-    margin-top: -10px;
     right: 10px;
-    height: 20px;
+    height: 100%;
     padding: 0;
     border: none;
     background: 0 0;

--- a/opendata-assets/src/scss/drupal/style.scss
+++ b/opendata-assets/src/scss/drupal/style.scss
@@ -180,7 +180,6 @@ p:last-child,
     display: flex;
     flex-direction: column;
     gap: 25px;
-
     margin: 0 auto;
 
     // NOTE: Without this you can't click the content inside.

--- a/opendata-assets/src/scss/drupal/style.scss
+++ b/opendata-assets/src/scss/drupal/style.scss
@@ -177,6 +177,10 @@ p:last-child,
   }
 
   .avoindata-hero-search-container {
+    display: flex;
+    flex-direction: column;
+    gap: 25px;
+
     margin: 0 auto;
 
     // NOTE: Without this you can't click the content inside.
@@ -235,6 +239,7 @@ p:last-child,
   }
 
   .hero-search-form {
+    width: 100%;
     max-width: map-get($container-max-widths, md);
     margin: auto;
   }
@@ -1736,6 +1741,7 @@ p:last-child,
 .avoindata-frontpage-header-text-container {
   text-align: center;
   width: 100%;
+  margin-bottom: 4px;
 }
 
 .messages__wrapper {


### PR DESCRIPTION
- Builds on #3186 
- Make hero a flexbox
- Tune spacing to have equal visual gaps closer to kehittajille.suomi.fi hero

Before:
<img width="1369" height="396" alt="image" src="https://github.com/user-attachments/assets/ddfcc208-3c1a-4321-aad1-b8df7b178187" />

After:
<img width="1369" height="441" alt="image" src="https://github.com/user-attachments/assets/36508a82-2726-48b9-af40-0e8a7d078569" />


Reference:
<img width="1369" height="438" alt="image" src="https://github.com/user-attachments/assets/e8f96615-5f3a-4cdd-84d1-b37c18b8fd5d" />
