### PR TITLE
AV-2544: Add container insights to cluster

### DIFF
--- a/cdk/lib/cluster-stack.ts
+++ b/cdk/lib/cluster-stack.ts
@@ -21,6 +21,7 @@ export class ClusterStack extends Stack {
     this.cluster = new ecs.Cluster(this, 'cluster', {
       vpc: this.vpc,
       enableFargateCapacityProviders: true,
+      containerInsightsV2: ecs.ContainerInsights.ENHANCED
     });
 
     this.namespace = new sd.PrivateDnsNamespace(this, 'namespace', {


### PR DESCRIPTION
Enables container insights in cluster https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html, for monitoring individual services and containers.