### PR TITLE
AV-2100: Allow searching two-letter terms starting with a number like '3d'

### DIFF
--- a/docker/solr/schema.xml
+++ b/docker/solr/schema.xml
@@ -71,7 +71,6 @@ attribute with the form `ckan-X.Y` -->
         </analyzer>
     </fieldType>
 
-
     <!-- A general unstemmed text field - good if one does not know the language of the field -->
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">

--- a/docker/solr/schema.xml
+++ b/docker/solr/schema.xml
@@ -54,17 +54,17 @@ attribute with the form `ckan-X.Y` -->
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
             <!-- opendata: moved from query -->
             <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
             <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
             <filter class="solr.LowerCaseFilterFactory"/>
             <!--<filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>-->
             <filter class="solr.ASCIIFoldingFilterFactory"/>
-            <filter class="solr.EdgeNGramFilterFactory" minGramSize="3" maxGramSize="30"/>
+            <filter class="solr.EdgeNGramFilterFactory" minGramSize="2" maxGramSize="30"/>
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
             <!--<filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>-->
-            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1" preserveOriginal="1"/>
             <filter class="solr.LowerCaseFilterFactory"/>
             <!--<filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>-->
             <filter class="solr.ASCIIFoldingFilterFactory"/>
@@ -76,14 +76,14 @@ attribute with the form `ckan-X.Y` -->
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0" preserveOriginal="1"/>
             <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.WhitespaceTokenizerFactory"/>
             <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
-            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0" preserveOriginal="1"/>
             <filter class="solr.LowerCaseFilterFactory"/>
         </analyzer>
     </fieldType>

--- a/drupal/i18n/drupal.pot
+++ b/drupal/i18n/drupal.pot
@@ -30336,7 +30336,7 @@ msgid ""
 "-_"
 msgstr ""
 
-msgid "Query must be at least three characters long"
+msgid "Query must be at least two characters long"
 msgstr ""
 
 msgid ""

--- a/drupal/modules/avoindata-hero/src/Plugin/Form/HeroForm.php
+++ b/drupal/modules/avoindata-hero/src/Plugin/Form/HeroForm.php
@@ -54,8 +54,8 @@ class HeroForm extends FormBase {
    * {@inheritdoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    if (strlen($form_state->getValue('search')) <= 2) {
-      $form_state->setErrorByName('search', $this->t('Query must be at least three characters long'));
+    if (strlen($form_state->getValue('search')) < 2) {
+      $form_state->setErrorByName('search', $this->t('Query must be at least two characters long'));
     }
   }
 


### PR DESCRIPTION
- Decrease `minGramSize` to 2 to allow two-letter substring searches
- Add `preserveOriginal=1` because otherwise `3d` gets split into two and ignored
- Modify error message translation