### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -96,4 +96,5 @@ updates:
 
 multi-ecosystem-groups:
   cypress:
-    interval: "weekly"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,16 +49,13 @@ updates:
   open-pull-requests-limit: 10
 - package-ecosystem: "docker"
   directory: "/cypress/"
-  schedule:
-    interval: daily
-    time: "03:00"
   open-pull-requests-limit: 10
+  multi-ecosystem-group: cypress
 - package-ecosystem: npm
   directory: "/"
-  schedule:
-    interval: daily
-    time: "03:00"
   open-pull-requests-limit: 10
+  patterns: ['cypress']
+  multi-ecosystem-group: cypress
 - package-ecosystem: npm
   directory: "/opendata-assets/"
   schedule:
@@ -88,3 +85,8 @@ updates:
   schedule:
     # Check for updates to GitHub Actions every week
     interval: "weekly"
+
+
+- multi-ecosystem-groups:
+    cypress:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,50 +12,58 @@ updates:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 10
+
 - package-ecosystem: "docker"
   directory: "/ckan/"
   schedule:
     interval: daily
     time: "03:00"
+
 - package-ecosystem: "docker"
   directory: "/drupal/"
   schedule:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 10
+
 - package-ecosystem: "docker"
   directory: "/docker/solr/"
   schedule:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 10
+
 - package-ecosystem: "docker"
   directory: "/docker/nginx/"
   schedule:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 10
+
 - package-ecosystem: "docker"
   directory: "/docker/postgres/"
   schedule:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 10
+
 - package-ecosystem: "docker"
   directory: "/docker/datapusher-plus/"
   schedule:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 10
+
 - package-ecosystem: "docker"
   directory: "/cypress/"
-  open-pull-requests-limit: 10
-  multi-ecosystem-group: cypress
+  patterns: ['*']
+  multi-ecosystem-group: "cypress"
+
 - package-ecosystem: npm
   directory: "/"
-  open-pull-requests-limit: 10
   patterns: ['cypress']
-  multi-ecosystem-group: cypress
+  multi-ecosystem-group: "cypress"
+
 - package-ecosystem: npm
   directory: "/opendata-assets/"
   schedule:
@@ -78,7 +86,6 @@ updates:
     interval: daily
     time: "03:00"
   open-pull-requests-limit: 10
-
 
 - package-ecosystem: "github-actions"
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -76,6 +76,9 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
+  groups:
+    drupal:
+      applies-to: security-updates
   open-pull-requests-limit: 10
 
 - package-ecosystem: npm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,16 +8,12 @@ registries:
 updates:
 - package-ecosystem: pip
   directory: "/ckan/"
-  schedule:
-    interval: daily
-    time: "03:00"
-  open-pull-requests-limit: 10
+  multi-ecosystem-group: "ckan"
 
 - package-ecosystem: "docker"
   directory: "/ckan/"
-  schedule:
-    interval: daily
-    time: "03:00"
+  multi-ecosystem-group: "ckan"
+
 
 - package-ecosystem: "docker"
   directory: "/drupal/"
@@ -102,3 +98,6 @@ multi-ecosystem-groups:
   cypress:
     schedule:
       interval: "weekly"
+  ckan:
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,12 @@ registries:
 updates:
 - package-ecosystem: pip
   directory: "/ckan/"
+  patterns: ['*']
   multi-ecosystem-group: "ckan"
 
 - package-ecosystem: "docker"
   directory: "/ckan/"
+  patterns: ['*']
   multi-ecosystem-group: "ckan"
 
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -94,6 +94,6 @@ updates:
     interval: "weekly"
 
 
-- multi-ecosystem-groups:
-    cypress:
-      interval: "weekly"
+multi-ecosystem-groups:
+  cypress:
+    interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,6 +92,10 @@ updates:
   schedule:
     # Check for updates to GitHub Actions every week
     interval: "weekly"
+  groups:
+    actions:
+      patterns:
+        - '*'
 
 
 multi-ecosystem-groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,8 @@ updates:
   groups:
     drupal:
       applies-to: security-updates
+      patterns: ['*']
+
   open-pull-requests-limit: 10
 
 - package-ecosystem: npm


### PR DESCRIPTION
This should reduce the amount of PRs created by dependabot.

Merges cypress updates to single PR, now there is two: one for container which is used in CI and one for package.json which is used locally.

Merges github action updates to one PR.

Merges ckan container and pip updates.

Merges drupal updates and only makes them from security updates.