### PR TITLE
AV-2543: Use selfhosted matomo instance and disable api tracking due to api not being available

### DIFF
--- a/cdk/lib/web-stack.ts
+++ b/cdk/lib/web-stack.ts
@@ -60,11 +60,10 @@ export class WebStack extends Stack {
       'https://www.google.com/recaptcha/',
       'https://www.gstatic.com/',
       'https://www.google.com',
-      'cdn.matomo.cloud',
-      'suomi.matomo.cloud',
       'https://js-de.sentry-cdn.com',
       'https://browser.sentry-cdn.com',
-      'cdn.jsdelivr.net'
+      'cdn.jsdelivr.net',
+      'https://matomo.cloud.dvv.fi'
     ];
     const nginxCspStyleSrc: string[] = [
       'https://fonts.googleapis.com',
@@ -79,9 +78,9 @@ export class WebStack extends Stack {
     ];
 
     const nginxCspConnectSrc: string[] = [
-      "suomi.matomo.cloud",
       "*.sentry.io",
-      "browser.sentry-cdn.com"
+      "browser.sentry-cdn.com",
+      "matomo.cloud.dvv.fi"
     ]
 
     const nginxCspFontSrc: string[] = [

--- a/ckan/cron/crontab
+++ b/ckan/cron/crontab
@@ -11,7 +11,8 @@
 #
 # NOTE: Please make sure this file is using LF line-endings, windows CRLF breaks it!
 #
-0   1   *       *   *   cd /srv/app && ./cron/scripts/matomo-fetch.sh
+# Fetching matomo data disabled, due to api not available
+# 0   1   *       *   *   cd /srv/app && ./cron/scripts/matomo-fetch.sh
 0   3   */3     *   *   cd /srv/app && ./cron/scripts/archiver-update.sh
 */5 *   *       *   *   cd /srv/app && ./cron/scripts/harvester-run.sh
 # tracking updates disabled, due to performance reasons

--- a/ckan/templates/ckan.ini.j2
+++ b/ckan/templates/ckan.ini.j2
@@ -236,7 +236,7 @@ ckanext.matomo.domain = https://{{ environ('MATOMO_DOMAIN') }}/
 ckanext.matomo.script_domain = {{ environ('MATOMO_SCRIPT_DOMAIN') }}
 ckanext.matomo.token_auth = {{ environ('MATOMO_TOKEN') }}
 ckanext.matomo.ignored_user_agents = docker-healthcheck
-ckanext.matomo.track_api = true
+ckanext.matomo.track_api = false
 {% endif %}
 
 


### PR DESCRIPTION
Matomo urls itself are in parameter store, CSP headers need modification.

Tracking api events is disabled as we don't have new api keys and the api itself is blocked with firewall, so this also prevents fetching data to the service.