### PR TITLE
AV-2549: Increase dev ckan capacity

### DIFF
--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -241,7 +241,7 @@ const ckanStackBeta = new CkanStack(app, 'CkanStack-beta', {
     taskMaxCapacity: 1,
   },
   ckanUwsgiProps: {
-    processes: 2,
+    processes: 4,
     threads: 2
   },
   ckanCronEnabled: true,

--- a/cdk/bin/opendata.ts
+++ b/cdk/bin/opendata.ts
@@ -211,8 +211,8 @@ const ckanStackBeta = new CkanStack(app, 'CkanStack-beta', {
   captchaEnabled: true,
   analyticsEnabled: true,
   ckanTaskDef: {
-    taskCpu: 512,
-    taskMem: 1024,
+    taskCpu: 1024,
+    taskMem: 2048,
     taskMinCapacity: 1,
     taskMaxCapacity: 3,
   },


### PR DESCRIPTION
Increases vCPU to next level, and increases memory as well as configuration is not allowing to have 1GB memory on 1 vCPU.