### PR TITLE
Remove going back from test, does nothing to tests but might hang the next test

### DIFF
--- a/cypress/e2e/dataset_resource_spec.js
+++ b/cypress/e2e/dataset_resource_spec.js
@@ -66,7 +66,6 @@ describe('Dataset resource tests', function(){
     
         cy.get('.toolbar-resource-secondary').find('a').click();
         cy.location('pathname').should('contain', `/data/fi/dataset/${dataset_name}`);
-        cy.go('back');
     });
 
     describe('Test Translations', function(){


### PR DESCRIPTION
Apparently sometimes browser asks "are you sure want to leave the form" as going back returns to edit form. This results of not firing load event in the following tests and the whole thing just hangs. Going back as the last thing in the test actually does nothing for test anyway so it can be removed.