### PR TITLE
AV-2448: Add dataset type switch to batch_edit cli command

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/cli.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/cli.py
@@ -388,8 +388,9 @@ def package_generator(query, page_size, context={'ignore_auth': True}, dataset_t
 @click.option('--dryrun', is_flag=True)
 @click.option('--group', help="Make datasets members of a group")
 @click.option('--purge-extra', help="Remove an extras-field from datasets")
+@click.option('--dataset-type', help="Dataset type to process", default="dataset")
 @click.pass_context
-def batch_edit(ctx, search_string, dryrun, group, purge_extra):
+def batch_edit(ctx, search_string, dryrun, group, purge_extra, dataset_type):
     group_assigns = {}
 
     if group:
@@ -397,7 +398,7 @@ def batch_edit(ctx, search_string, dryrun, group, purge_extra):
 
     updated_packages = []
 
-    for package_dict in package_generator(search_string, 10):
+    for package_dict in package_generator(search_string, 10, dataset_type=dataset_type):
         if group:
             group_assigns[group].append(package_dict['name'])
         extras = package_dict.get('extras', [])

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/validators.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/validators.py
@@ -83,8 +83,8 @@ def tag_string_or_tags_required(key, data, errors, context):
 
 
 def set_private_if_not_admin_or_showcase_admin(private):
-    userobj = model.User.get(c.user)
-    if userobj and not (authz.is_sysadmin(c.user) or ShowcaseAdmin.is_user_showcase_admin(userobj)):
+    userobj = toolkit.current_user
+    if userobj and not (authz.is_sysadmin(userobj.name) or ShowcaseAdmin.is_user_showcase_admin(userobj)):
         return True
     else:
         return private


### PR DESCRIPTION
- `opendata-dataset batch_edit` cli command was missing a way to specify dataset_type, so it could not operate on showcases
- `set_private_if_not_admin_or_showcase_admin` validator used `c` globals which are not present in cli use. Replace with the new `toolkit.current_user` that handles missing user context with `None`