### PR TITLE
Reduce amount of messages on dying containers

### DIFF
--- a/cdk/lib/monitoring-stack.ts
+++ b/cdk/lib/monitoring-stack.ts
@@ -24,7 +24,6 @@ export class MonitoringStack extends Stack {
       eventPattern: {
         source: ['aws.ecs'],
         detail: {
-          desiredStatus: ['STOPPED'],
           lastStatus: ['STOPPED'],
           stoppedReason: [{wildcard: '*health*'}]
         }

--- a/cdk/lib/monitoring-stack.ts
+++ b/cdk/lib/monitoring-stack.ts
@@ -25,6 +25,7 @@ export class MonitoringStack extends Stack {
         source: ['aws.ecs'],
         detail: {
           desiredStatus: ['STOPPED'],
+          lastStatus: ['STOPPED'],
           stoppedReason: [{wildcard: '*health*'}]
         }
       },


### PR DESCRIPTION
There are multiple messages on dying containers, reduce them only to notify when status has been changed to stopped.