### PR TITLE
AV-2518: kehittäjille.suomi.fi style for showcases

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/package/search.html
@@ -42,7 +42,7 @@
 {% endblock %}
 
 {% block primary_content %}
-  <div class="container-apiset">
+  <div class="container-{{ dataset_type }}">
     <section class="module">
       <div class="module-content">
         {% block form %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/sixodp_showcase/search.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/sixodp_showcase/search.html
@@ -1,0 +1,11 @@
+{% ckan_extends %}
+
+{% block secondary_content %}
+  <div class="secondary__header">
+    <h3 class="secondary__title">{{ _('Filter list') }}</h3>
+  </div>
+  {% for facet in facet_titles %}
+    <hr>
+    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet) }}
+  {% endfor %}
+{% endblock %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/facet_list.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/facet_list.html
@@ -110,4 +110,3 @@
       {% endif %}
     {% endwith %}
   {% endblock %}
-  

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/snippets/search_form.html
@@ -13,7 +13,7 @@
 {% set no_bottom_border = no_bottom_border if no_bottom_border else false %}
 {% set form_id = form_id if form_id else false %}
 
-<form {% if form_id %}id="{{ form_id }}" {% endif %}class="search-form{% if no_bottom_border %} no-bottom-border{% endif %}" method="get" data-module="select-switch">
+<form {% if form_id %}id="{{ form_id }}" {% endif %}class="search-form{% if no_bottom_border %} no-bottom-border{% endif %} search-form-{{ type }}" method="get" data-module="select-switch">
 
     {% block search_input %}        
         <div class="search-input control-group {{ search_class }}">

--- a/opendata-assets/src/scss/components/dataset.scss
+++ b/opendata-assets/src/scss/components/dataset.scss
@@ -147,7 +147,7 @@
   }
 }
 
-#content .container-apiset {
+#content .container-apiset, #content .container-dataset, .search-form-showcase {
   .filter-list {
     display: flex;
     align-items: center;
@@ -193,7 +193,7 @@
     margin-bottom: -1px;
   }
 
-  .search-form .search-dataset {
+  input.form-control.search-dataset {
     border-radius: 0;
     height: 40px;
   }

--- a/opendata-assets/src/scss/components/forms.scss
+++ b/opendata-assets/src/scss/components/forms.scss
@@ -202,6 +202,12 @@ label.group-label {
     line-height: $line-height-h3-alt;
     font-weight: $font-weight-normal;
   }
+
+  &.search-form-showcase.no-bottom-border {
+    /* showcase search form removes bottom border, but that doesn't work with
+       our theme. Add the bottom border back */
+    border-bottom: 1px solid tokens.$fi-color-depth-light1;
+  }
 }
 
 .search-form.list-head-search-form {

--- a/opendata-assets/src/scss/components/showcase.scss
+++ b/opendata-assets/src/scss/components/showcase.scss
@@ -80,6 +80,7 @@
     flex: 0 0 calc(100% / 3 - $margin-x__showcase-item);
     box-shadow: $box-shadow__showcase-item;
     border-radius: $border-radius__showcase-item;
+    overflow: hidden; /* Keep rounded corners for tall images */
 
     &:hover {
       box-shadow: $box-shadow__showcase-item--hover;
@@ -106,6 +107,8 @@
   }
 
   .showcase-item__image {
+    display: flex;
+    justify-content: center;
     position: relative;
     max-width: 100%;
     height: 0;
@@ -115,7 +118,7 @@
     img {
       position: absolute;
       top: 50%;
-      transform: translateY(-50%);
+      transform: translateY(-56.6%);
       object-fit: cover;
       max-width: 100%;
       height: auto;


### PR DESCRIPTION
- Added some utility classes because ckanext-showcase handles its search view a bit differently
- Tuned the showcase search view to match previously migrated styles

Before:
<img width="1450" height="1367" alt="image" src="https://github.com/user-attachments/assets/c533c503-d096-432e-a5f8-0817bd8270e8" />

After:
<img width="1450" height="1367" alt="image" src="https://github.com/user-attachments/assets/06f442cc-0320-40ad-9633-056990b9fac9" />
