### PR TITLE
Add default project name to compose file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,6 +65,8 @@ x-env-ckan: &env-ckan
   FUSEKI_ADMIN_PASS: ${FUSEKI_ADMIN_PASS}
   FUSEKI_OPENDATA_DATASET: ${FUSEKI_OPENDATA_DATASET}
 
+name: opendata
+
 services:
   postgres:
     build:


### PR DESCRIPTION
Name can be still overridden with `-p` flag, but we shouldn't have reason to use default name of `docker-<somecontainer>`