### PR TITLE
AV-2557: Add perform_ckan_actions Cypress command

### DIFF
--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/plugin.py
@@ -1505,4 +1505,18 @@ def _reset(context, data_dict):
             toolkit.get_action('tag_create')(context, data)
 
     log.debug("Initial vocabularies and tags created")
-    return "Cleared"
+
+    log.debug("Creating admin token")
+    test_admin = get_action("user_create")(context, {"name": "test-admin",
+                                                     "email": "admin@test.internal",
+                                                     "password": "test-administrator",
+                                                     "with_apitoken": True})
+    test_admin_token = test_admin["token"]
+    test_admin_user = model.User.by_name("test-admin")
+    test_admin_user.sysadmin = True
+    model.Session.add(test_admin_user)
+    model.repo.commit()
+
+    return {
+        "token": test_admin_token
+    }

--- a/cypress/e2e/advancedsearch_spec.js
+++ b/cypress/e2e/advancedsearch_spec.js
@@ -1,9 +1,8 @@
 describe('Advanced search tests', () => {
     before(() => {
         cy.reset_db();
-        cy.perform_ckan_actions(ckanAction => {
-          ckanAction('group_create', {
-            "name": "siisti_kategoria",
+        cy.perform_ckan_actions(ckan => {
+          ckan.group("siisti_kategoria", {
             "title_translated-fi": "siisti kategoria",
             "title_translated-en": "siisti kategoria",
             "title_translated-sv": "siisti kategoria",
@@ -14,8 +13,7 @@ describe('Advanced search tests', () => {
                "capacity": "admin"}
             ]
           }, {failOnStatusCode: false}) // Admin making groups creates an unnecessary error
-          ckanAction('group_create', {
-            "name": "toinen_kategoria",
+          ckan.group("toinen_kategoria", {
             "title_translated-fi": "toinen kategoria",
             "title_translated-en": "toinen kategoria",
             "title_translated-sv": "toinen kategoria",
@@ -26,14 +24,10 @@ describe('Advanced search tests', () => {
                "capacity": "admin"}
             ]
           }, {failOnStatusCode: false}) // Admin making groups creates an unnecessary error
-          ckanAction('organization_create', {
-            "name": "testi_organisaatio",
-            "title_translated-fi": "testi_organisaatio",
-          })
-          ckanAction('package_create', {
-            "type": "dataset",
-            "owner_org": "testi_organisaatio",
-            "name": "first_dataset",
+
+          ckan.organization("testi_organisaatio")
+
+          ckan.dataset("testi_organisaatio", "first_dataset", {
             "title_translated-fi": "first dataset",
             "notes_translated-fi": "First dataset description",
             "maintainer": "test maintainer",
@@ -44,24 +38,20 @@ describe('Advanced search tests', () => {
             "keywords-fi": "test_keyword",
             "license_id": "cc-by-4.0",
           })
-          ckanAction('resource_create', {
-            "package_id": "first_dataset",
+          ckan.resource("first_dataset", {
             "name_translated-fi": "test data",
             "description_translated-fi": "test kuvaus",
             "url": "http://example.com",
             "format": "CSV"
           })
-          ckanAction('member_create', {
+          ckan.action('member_create', {
             "id": "siisti_kategoria",
             "object": "first_dataset",
             "object_type": "package",
             "capacity": "member"
           })
 
-          ckanAction('package_create', {
-            "type": "dataset",
-            "owner_org": "testi_organisaatio",
-            "name": "second_dataset",
+          ckan.dataset("testi_organisaatio", "second_dataset", {
             "title_translated-fi": "second dataset",
             "notes_translated-fi": "second dataset description with unicorns",
             "maintainer": "test maintainer",
@@ -72,8 +62,7 @@ describe('Advanced search tests', () => {
             "keywords-fi": "another_keyword test_keyword",
             "license_id": "notspecified"
           })
-          ckanAction('resource_create', {
-            "package_id": "second_dataset",
+          ckan.resource("second_dataset", {
             "name_translated-fi": "some test data",
             "description_translated-fi": "description for data",
             "url": "http://example.com",

--- a/cypress/e2e/advancedsearch_spec.js
+++ b/cypress/e2e/advancedsearch_spec.js
@@ -1,84 +1,87 @@
 describe('Advanced search tests', () => {
     before(() => {
         cy.reset_db();
+        cy.perform_ckan_actions(ckanAction => {
+          ckanAction('group_create', {
+            "name": "siisti_kategoria",
+            "title_translated-fi": "siisti kategoria",
+            "title_translated-en": "siisti kategoria",
+            "title_translated-sv": "siisti kategoria",
+            "users": [
+              {"name": "admin",
+               "capacity": "admin"},
+              {"name": "test-user",
+               "capacity": "admin"}
+            ]
+          }, {failOnStatusCode: false}) // Admin making groups creates an unnecessary error
+          ckanAction('group_create', {
+            "name": "toinen_kategoria",
+            "title_translated-fi": "toinen kategoria",
+            "title_translated-en": "toinen kategoria",
+            "title_translated-sv": "toinen kategoria",
+            "users": [
+              {"name": "admin",
+               "capacity": "admin"},
+              {"name": "test-user",
+               "capacity": "admin"}
+            ]
+          }, {failOnStatusCode: false}) // Admin making groups creates an unnecessary error
+          ckanAction('organization_create', {
+            "name": "testi_organisaatio",
+            "title_translated-fi": "testi_organisaatio",
+          })
+          ckanAction('package_create', {
+            "type": "dataset",
+            "owner_org": "testi_organisaatio",
+            "name": "first_dataset",
+            "title_translated-fi": "first dataset",
+            "notes_translated-fi": "First dataset description",
+            "maintainer": "test maintainer",
+            "maintainer_email": "test.maintainer@example.com",
+            'valid_from': '2019-02-04',
+            'valid_till': '2020-02-04',
+            "collection_type": "Open Data",
+            "keywords-fi": "test_keyword",
+            "license_id": "cc-by-4.0",
+          })
+          ckanAction('resource_create', {
+            "package_id": "first_dataset",
+            "name_translated-fi": "test data",
+            "description_translated-fi": "test kuvaus",
+            "url": "http://example.com",
+            "format": "CSV"
+          })
+          ckanAction('member_create', {
+            "id": "siisti_kategoria",
+            "object": "first_dataset",
+            "object_type": "package",
+            "capacity": "member"
+          })
 
-        // Admin things
-        cy.login_post_request('admin', 'administrator');
+          ckanAction('package_create', {
+            "type": "dataset",
+            "owner_org": "testi_organisaatio",
+            "name": "second_dataset",
+            "title_translated-fi": "second dataset",
+            "notes_translated-fi": "second dataset description with unicorns",
+            "maintainer": "test maintainer",
+            "maintainer_email": "test.maintainer@example.com",
+            'valid_from': '2019-02-04',
+            'valid_till': '2020-02-04',
+            "collection_type": "Open Data",
+            "keywords-fi": "another_keyword test_keyword",
+            "license_id": "notspecified"
+          })
+          ckanAction('resource_create', {
+            "package_id": "second_dataset",
+            "name_translated-fi": "some test data",
+            "description_translated-fi": "description for data",
+            "url": "http://example.com",
+            "format": "XML"
+          })
+        })
 
-        const category_name_1 = 'siisti kategoria';
-        const category_name_2 = 'toinen kategoria';
-
-        cy.create_category(category_name_1);
-        cy.create_category(category_name_2);
-
-        cy.logout();
-
-        // User things
-        cy.create_organization_for_user('testi_organisaatio', 'test-user');
         cy.login_post_request('test-user', 'test-user');
-
-        // Create datasets
-        const datasets = [
-            {
-                name: 'first dataset',
-                data: {
-                    "#field-title_translated-fi": 'first dataset',
-                    '#field-notes_translated-fi': 'First dataset description',
-                    // FIXME: This should just be 'test_keyword{enter}', see fill_form_fields in support/commands.js
-                    '#s2id_autogen1': {type: 'select2', values: ['test_keyword']},
-                    '#field-maintainer': 'test maintainer',
-                    '#field-maintainer_email': 'test.maintainer@example.com',
-                    '#field-valid_from': '2019-02-04',
-                    '#field-valid_till': '2020-02-04',
-                    '#field-license_id': {
-                        type: 'select',
-                        value: 'cc-by-4.0'
-                    }
-                },
-                resource_data: {
-                    '#field-name_translated-fi': 'test data',
-                    '#field-description_translated-fi': 'test kuvaus',
-                    '#field-image-url': 'http://example.com',
-                    '#field-format': {
-                        value: 'CSV',
-                        force: true
-                    },
-                }
-            },
-            {
-                name: 'second dataset',
-                data: {
-                    "#field-title_translated-fi": 'second dataset',
-                    '#field-notes_translated-fi': 'second dataset description with unicorns',
-                    // FIXME: This should just be 'another_keyword {enter} test_keyword {enter}',
-                    // see fill_form_fields in support/commands.js
-                    '#s2id_autogen1': {type: 'select2', values: ['another_keyword', 'test_keyword'] },
-                    '#field-maintainer': 'test maintainer',
-                    '#field-maintainer_email': 'test.maintainer@example.com',
-                    '#field-valid_from': '2019-02-04',
-                    '#field-valid_till': '2020-02-04'
-                },
-                resource_data: {
-                    '#field-name_translated-fi': 'some test data',
-                    '#field-description_translated-fi': 'description for data',
-                    '#field-image-url': 'http://example.com',
-                    '#field-format': {
-                        value: 'XML',
-                        force: true
-                    },
-                }
-            },
-        ];
-        for (let dataset of datasets) {
-            cy.create_new_dataset(dataset.name, dataset.data, dataset.resource_data);
-        }
-
-        // Add first dataset to group 'siisti kategoria'
-        cy.visit(`/data/fi/dataset/groups/${datasets[0].name.replace(' ', '-')}`)
-        cy.get('#field-siisti-kategoria').check({force: true})
-        cy.get('form > .btn').click();
-
-        // Navigate to advanced search
         cy.visit('/data/fi/advanced_search')
     });
 

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -23,9 +23,7 @@ describe('Apiset tests',
 
   before(function () {
     cy.reset_db();
-    // Creates test-user to CKAN
-    cy.login_post_request("test-user", "test-user")
-    cy.logout();
+    cy.ensure_user_is_in_ckan("test-user", "test-user")
     cy.perform_ckan_actions(ckan => {
       ckan.organization(test_organization, {
         users: [{
@@ -268,7 +266,15 @@ describe('Apiset tests',
   describe('Apiset creation', function () {
     beforeEach(function () {
       cy.reset_db();
-      cy.create_organization_for_user(test_organization, 'test-user', true);
+      cy.ensure_user_is_in_ckan("test-user", "test-user")
+      cy.perform_ckan_actions(ckan => {
+        ckan.organization(test_organization, {
+          users: [{
+            name: "test-user",
+            capacity: "admin"
+          }]
+        })
+      })
       cy.login_post_request('test-user', 'test-user')
       cy.visit('/');
     });
@@ -397,8 +403,10 @@ describe('Apiset tests',
       cy.login_post_request('test-user', 'test-user')
       cy.visit('/');
       // Create 2 datasets that will be used to test the addition of datasets to an apiset
-      cy.create_new_dataset(dataset_name_1);
-      cy.create_new_dataset(dataset_name_2);
+      cy.perform_ckan_actions(ckan => {
+        ckan.dataset(test_organization, dataset_name_1)
+        ckan.dataset(test_organization, dataset_name_2)
+      })
       // Create an apiset that will be used for all the tests
       cy.create_new_apiset(apiset_name);
     })

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -264,7 +264,7 @@ describe('Apiset tests',
   })
 
   describe('Apiset creation', function () {
-    beforeEach(function () {
+    before(function () {
       cy.reset_db();
       cy.ensure_user_is_in_ckan("test-user", "test-user")
       cy.perform_ckan_actions(ckan => {
@@ -275,6 +275,8 @@ describe('Apiset tests',
           }]
         })
       })
+    });
+    beforeEach(function () {
       cy.login_post_request('test-user', 'test-user')
       cy.visit('/');
     });

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -23,7 +23,17 @@ describe('Apiset tests',
 
   before(function () {
     cy.reset_db();
-    cy.create_organization_for_user(test_organization, 'test-user', true);
+    // Creates test-user to CKAN
+    cy.login_post_request("test-user", "test-user")
+    cy.logout();
+    cy.perform_ckan_actions(ckan => {
+      ckan.organization(test_organization, {
+        users: [{
+          name: "test-user",
+          capacity: "admin"
+        }]
+      })
+    })
   });
 
   describe('Apiset filtering', function () {

--- a/cypress/e2e/apiset_spec.js
+++ b/cypress/e2e/apiset_spec.js
@@ -400,13 +400,13 @@ describe('Apiset tests',
     });
 
     before(function () {
-      cy.login_post_request('test-user', 'test-user')
-      cy.visit('/');
       // Create 2 datasets that will be used to test the addition of datasets to an apiset
       cy.perform_ckan_actions(ckan => {
         ckan.dataset(test_organization, dataset_name_1)
         ckan.dataset(test_organization, dataset_name_2)
       })
+      cy.login_post_request('test-user', 'test-user')
+      cy.visit('/');
       // Create an apiset that will be used for all the tests
       cy.create_new_apiset(apiset_name);
     })

--- a/cypress/e2e/dataset_resource_spec.js
+++ b/cypress/e2e/dataset_resource_spec.js
@@ -3,11 +3,23 @@ describe('Dataset resource tests', function(){
 
     before(function(){
         cy.reset_db();
-        cy.create_organization_for_user('dataset_test_organization', 'test-user', true);
+        cy.ensure_user_is_in_ckan("test-user", "test-user")
+        cy.perform_ckan_actions(ckan => {
+          ckan.organization("dataset_test_organization", {
+            users: [{
+              name: "test-user",
+              capacity: "admin"
+            }]
+          })
+          ckan.dataset("dataset_test_organization", "test_dataset", {
+            "notes_translated-fi": "Dataset test description"
+          })
+          ckan.resource("test_dataset", {
+            "name_translated-fi": "test data",
+            "description_translated-fi": "",
+          })
+        })
         cy.login_post_request('test-user', 'test-user')
-        cy.visit('/data/fi/dataset');
-        const dataset_name = 'test_dataset';
-        cy.create_new_dataset(dataset_name); 
     })
 
     beforeEach(function () {

--- a/cypress/e2e/dataset_spec.js
+++ b/cypress/e2e/dataset_spec.js
@@ -26,7 +26,15 @@ describe('Dataset tests',
 
   before(function(){
     cy.reset_db();
-    cy.create_organization_for_user(test_organization, 'test-user', true);
+    cy.ensure_user_is_in_ckan("test-user", "test-user")
+    cy.perform_ckan_actions(ckan => {
+      ckan.organization(test_organization, {
+        users: [{
+          name: "test-user",
+          capacity: "admin"
+        }]
+      })
+    })
   });
 
   describe('Navigation', function(){
@@ -43,12 +51,12 @@ describe('Dataset tests',
     const dataset_name_2 = "second_dataset";
 
     before(function(){
-      // cy.reset_db();
-      // cy.create_organization_for_user(test_organization, 'test-user', true);
-      cy.login_post_request('test-user', 'test-user')
       cy.visit('/data/dataset');
-      cy.create_new_dataset(dataset_name_1);
-      cy.create_new_dataset(dataset_name_2);
+      cy.perform_ckan_actions(ckan => {
+        ckan.dataset(test_organization, dataset_name_1)
+        ckan.dataset(test_organization, dataset_name_2)
+      })
+      cy.login_post_request('test-user', 'test-user')
     });
 
     beforeEach(function(){
@@ -139,7 +147,16 @@ describe('Dataset tests',
   describe('Dataset creation and deletion tests', function() {
     beforeEach(function () {
       cy.reset_db();
-      cy.create_organization_for_user(test_organization, 'test-user', true);
+      cy.ensure_user_is_in_ckan("test-user", "test-user")
+      cy.perform_ckan_actions(ckan => {
+        ckan.organization(test_organization, {
+          users: [{
+            name: "test-user",
+            capacity: "admin"
+          }]
+        })
+      })
+      // cy.create_organization_for_user(test_organization, 'test-user', true);
       cy.login_post_request('test-user', 'test-user')
       cy.visit('/data/fi/dataset');
     })

--- a/cypress/e2e/showcase_spec.js
+++ b/cypress/e2e/showcase_spec.js
@@ -2,13 +2,23 @@ describe('Showcase tests', function() {
 
   before(function(){
     cy.reset_db();
-    cy.create_organization_for_user('showcase_test_organization', 'test-publisher', true);
+    cy.ensure_user_is_in_ckan("test-publisher", "test-publisher")
+    cy.perform_ckan_actions(ckan => {
+      ckan.organization('showcase_test_organization', {
+        users: [{
+          name: 'test-publisher',
+          capacity: "admin"
+        }]
+      })
+    })
+    cy.add_showcase_user();
   })
 
   describe('Showcase creation tests', function(){
 
     it('Create a new minimal showcase, edit it and delete it', function() {
-      cy.add_showcase_user();
+      cy.login_post_request('test-publisher', 'test-publisher')
+      cy.visit('/data/fi/dataset');
       const showcase_name = 'test_showcase';
       cy.create_new_showcase(showcase_name);
       cy.edit_showcase(showcase_name);
@@ -19,7 +29,6 @@ describe('Showcase tests', function() {
     });
   
     it('Create a showcase with all fields', function() {
-      cy.add_showcase_user();
       const showcase_name = 'test_showcase_with_all_fields';
       const showcase_form_data = {
         '#field-title_translated-fi': showcase_name,
@@ -36,6 +45,8 @@ describe('Showcase tests', function() {
         '#field-notes_translated-sv': 'test beskrivning'
       };
   
+      cy.login_post_request('test-publisher', 'test-publisher')
+      cy.visit('/data/fi/dataset');
       cy.create_new_showcase(showcase_name, showcase_form_data);
     });
   
@@ -61,10 +72,6 @@ describe('Showcase tests', function() {
     })
   
     it('Add dataset to showcase and edit showcase with dataset', function() {
-  
-      cy.add_showcase_user();
-      cy.logout();
-  
       // Organization
       cy.login_post_request('admin', 'administrator');
       const organization_name = 'testi_organisaatio_2';
@@ -161,7 +168,6 @@ describe('Showcase tests', function() {
   });
 
   it('Showcase should not render as dataset', function () {
-    cy.add_showcase_user();
     cy.create_new_showcase("test_showcase_render");
 
     cy.visit('/data/fi/dataset/test_showcase_render')

--- a/cypress/e2e/sparql_spec.js
+++ b/cypress/e2e/sparql_spec.js
@@ -2,72 +2,56 @@ describe('SPARQL tests', () => {
     before(() => {
         cy.reset_db();
 
-        // Admin things
-        cy.login_post_request('admin', 'administrator');
-
-        cy.logout();
-
         // User things
-        cy.create_organization_for_user('testi_organisaatio', 'test-user');
-        cy.login_post_request('test-user', 'test-user');
+        cy.ensure_user_is_in_ckan("admin", "administrator")
+        cy.ensure_user_is_in_ckan("test-user", "test-user")
+        cy.perform_ckan_actions(ckan => {
+          const test_organization = 'testi_organisaatio'
+          ckan.organization(test_organization, {
+            users: [{
+              name: 'test-user',
+              capacity: "admin"
+            }]
+          })
+          ckan.dataset(test_organization, "first_dataset", {
+            "title_translated-fi": "first dataset",
+            "notes_translated-fi": "First dataset description",
+            "maintainer": "test maintainer",
+            "maintainer_email": "test.maintainer@example.com",
+            'valid_from': '2019-02-04',
+            'valid_till': '2020-02-04',
+            "collection_type": "Open Data",
+            "keywords-fi": "test_keyword",
+            "license_id": "cc-by-4.0",
+          })
+          ckan.resource("first_dataset", {
+            "name_translated-fi": "test data",
+            "description_translated-fi": "test kuvaus",
+            "url": "http://example.com",
+            "format": "CSV"
+          })
 
-        // Create datasets
-        const datasets = [
-            {
-                name: 'first dataset',
-                data: {
-                    "#field-title_translated-fi": 'first dataset',
-                    '#field-notes_translated-fi': 'First dataset description',
-                    // FIXME: This should just be 'test_keyword{enter}', see fill_form_fields in support/commands.js
-                    '#s2id_autogen1': {type: 'select2', values: ['test_keyword']},
-                    '#field-maintainer': 'test maintainer',
-                    '#field-maintainer_email': 'test.maintainer@example.com',
-                    '#field-valid_from': '2019-02-04',
-                    '#field-valid_till': '2020-02-04',
-                    '#field-license_id': {
-                        type: 'select',
-                        value: 'cc-by-4.0'
-                    }
-                },
-                resource_data: {
-                    '#field-name_translated-fi': 'test data',
-                    '#field-description_translated-fi': 'test kuvaus',
-                    '#field-image-url': 'http://example.com',
-                    '#field-format': {
-                        value: 'CSV',
-                        force: true
-                    },
-                }
-            },
-            {
-                name: 'second dataset',
-                data: {
-                    "#field-title_translated-fi": 'second dataset',
-                    '#field-notes_translated-fi': 'second dataset description with unicorns',
-                    // FIXME: This should just be 'another_keyword {enter} test_keyword {enter}',
-                    // see fill_form_fields in support/commands.js
-                    '#s2id_autogen1': {type: 'select2', values: ['another_keyword', 'test_keyword'] },
-                    '#field-maintainer': 'test maintainer',
-                    '#field-maintainer_email': 'test.maintainer@example.com',
-                    '#field-valid_from': '2019-02-04',
-                    '#field-valid_till': '2020-02-04'
-                },
-                resource_data: {
-                    '#field-name_translated-fi': 'some test data',
-                    '#field-description_translated-fi': 'description for data',
-                    '#field-image-url': 'http://example.com',
-                    '#field-format': {
-                        value: 'XML',
-                        force: true
-                    },
-                }
-            },
-        ];
-        for (let dataset of datasets) {
-            cy.create_new_dataset(dataset.name, dataset.data, dataset.resource_data);
-        }
+          ckan.dataset(test_organization, "second_dataset", {
+            "title_translated-fi": "second dataset",
+            "notes_translated-fi": "second dataset description with unicorns",
+            "maintainer": "test maintainer",
+            "maintainer_email": "test.maintainer@example.com",
+            'valid_from': '2019-02-04',
+            'valid_till': '2020-02-04',
+            "collection_type": "Open Data",
+            "keywords-fi": "another_keyword test_keyword",
+            "license_id": "notspecified"
+          })
+          ckan.resource("second_dataset", {
+            "name_translated-fi": "some test data",
+            "description_translated-fi": "description for data",
+            "url": "http://example.com",
+            "format": "XML"
+          })
+        })
 
-
+        // Wait for fuseki to index the datasets
+        cy.wait(5000)
     });
 
     // The change sometimes takes a while to propagate to fuseki, so try three times 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -77,27 +77,6 @@ Cypress.Commands.add('login_post_request', (username, password) => {
   });
 });
 
-Cypress.Commands.add('perform_ckan_actions', (fn) => {
-  cy.login('admin', 'administrator')
-  cy.visit('/data/fi/user/admin/api-tokens')
-  cy.get('#name').type('cypress_apikey')
-  cy.get('button[value=create]').click()
-  cy.get('.alert-success code').then(apikeyEl => {
-    cy.clearCookies()
-    let apikey = apikeyEl.text()
-    function ckanAction(action, body, options={}) {
-      cy.request({
-          method: 'POST',
-          url: `/data/api/action/${action}`,
-          headers: {"Authorization": apikey},
-          ...options,
-          body
-      });
-    }
-    fn(ckanAction)
-  })
-})
-
 Cypress.Commands.add('login', (username, password) => {
   cy.visit('/user/login');
   cy.get('input[name=name]').type(username);
@@ -129,7 +108,10 @@ Cypress.Commands.add('logout', () => {
   })
 })
 
-
+Cypress.Commands.add('ensure_user_is_in_ckan', (username, password) => {
+  cy.login_post_request(username, password)
+  cy.logout()
+})
 /**
  * @description
  * This function only fills the fields according to given parameters.
@@ -407,24 +389,88 @@ Cypress.Commands.add('add_showcase_user', () => {
   cy.get('nav a[href="/data/fi/showcase"]').click({force: true});
 });
 
-Cypress.Commands.add('reset_db', () => {
-    if (Cypress.env('resetDB') === true){
-        cy.exec('npm run reset', {
-          env: {
-            DB_HOST: '127.0.0.1',
-            DB_CKAN: 'ckan',
-            DB_CKAN_USER: 'ckan',
-            DB_CKAN_PASS: 'ckan_pass'
-          }
-        });
+/* reset_db / perform_ckan_actions
 
-        //const containerName = Cypress.env('test_container_name') || 'opendata_ckan_1';
-        //cy.exec(`docker exec -i ${containerName} sh -c "ckan --config /srv/app/ckan.ini api action sparql_clear"`);
-        //cy.exec(`docker exec -i ${containerName} sh -c "ckan --config /srv/app/ckan.ini search-index clear"`);
-        // Init vocaularies
-        //cy.exec(`docker exec -i ${containerName} sh -c "ckan --config /srv/app/ckan.ini sixodp-showcase create_platform_vocabulary"`);
-      }
+   reset_db receives a sysadmin api token from CKAN reset action.
+   The token has to be distributed through a global variable,
+   because cypress clears any aliases or other methods between
+   tests, but database may not be reset at the start of every test.
+
+   perform_ckan_actions expects the CKAN_ADMIN_TOKEN to be set and
+   provides access to CKAN action API with some helpers
+*/
+let CKAN_ADMIN_TOKEN = null
+Cypress.Commands.add('reset_db', () => {
+    if (Cypress.env('resetDB') === true) {
+      cy.request({
+          method: 'POST',
+          url: '/data/api/action/reset',
+      }).then((result) => {
+        CKAN_ADMIN_TOKEN = result.body.result.token
+      })
+    }
 });
+
+Cypress.Commands.add('perform_ckan_actions', (fn) => {
+  if(CKAN_ADMIN_TOKEN === null) {
+    throw new Exception("CKAN_ADMIN_TOKEN not set, running perform_ckan_actions before reset")
+  }
+  let apikey = CKAN_ADMIN_TOKEN
+  let ckan = {
+    action(action, body, options={}) {
+      cy.request({
+          method: 'POST',
+          url: `/data/api/action/${action}`,
+          headers: {"Authorization": apikey},
+          ...options,
+          body
+      });
+    },
+    organization(name, fields={}, options={}) {
+      this.action('organization_create', {
+        name, 
+        "title_translated-fi": `${name} title`,
+        ...fields
+      }, options)
+    },
+    dataset(owner_org, name, fields={}, options={}) {
+      this.action('package_create', {
+        owner_org,
+        name,
+        "type": "dataset",
+        "title_translated-fi": name,
+        "notes_translated-fi": `${name} description`,
+        "maintainer": "test maintainer",
+        "maintainer_email": "test.maintainer@example.com",
+        "collection_type": "Open Data",
+        "keywords-fi": "test_keyword",
+        "license_id": "notspecified",
+        ...fields
+      }, options)
+    },
+    resource(package_id, fields={}, options={}) {
+      this.action('resource_create', {
+        package_id, 
+        "name_translated-fi": "test data",
+        "description_translated-fi": "test data description",
+        "url": "http://example.com",
+        "format": "HTML",
+        ...fields
+      }, options)
+    },
+    group(name, fields={}, options={}) {
+      this.action('group_create', {
+        name, 
+        "title_translated-fi": `${name} title fi`,
+        "title_translated-sv": `${name} title sv`,
+        "title_translated-en": `${name} title en`,
+        ...fields
+      }, options)
+    }
+  }
+
+  fn(ckan)
+})
 
 Cypress.Commands.add('create_category', function (category_name) {
   cy.visit('/data/group');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -77,6 +77,27 @@ Cypress.Commands.add('login_post_request', (username, password) => {
   });
 });
 
+Cypress.Commands.add('perform_ckan_actions', (fn) => {
+  cy.login('admin', 'administrator')
+  cy.visit('/data/fi/user/admin/api-tokens')
+  cy.get('#name').type('cypress_apikey')
+  cy.get('button[value=create]').click()
+  cy.get('.alert-success code').then(apikeyEl => {
+    cy.clearCookies()
+    let apikey = apikeyEl.text()
+    function ckanAction(action, body, options={}) {
+      cy.request({
+          method: 'POST',
+          url: `/data/api/action/${action}`,
+          headers: {"Authorization": apikey},
+          ...options,
+          body
+      });
+    }
+    fn(ckanAction)
+  })
+})
+
 Cypress.Commands.add('login', (username, password) => {
   cy.visit('/user/login');
   cy.get('input[name=name]').type(username);


### PR DESCRIPTION
Cypress tests are very slow, try to speed them up by using the API for setup

- Added `perform_ckan_actions` Cypress command for running API actions
- Modified `reset_db` to return a token for a sysadmin user to use with initialisation
- Modified tests to initialise test data with `perform_ckan_actions`
