### PR TITLE
AV-2556: Update defaults to rules

### DIFF
--- a/cdk/lib/shield-stack.ts
+++ b/cdk/lib/shield-stack.ts
@@ -290,7 +290,7 @@ export class ShieldStack extends Stack {
           }
         },
         action: {
-          count: {}
+          block: {}
         },
         name: `rate-limited-paths-${rule.name}`,
         priority: rules.length + index,
@@ -422,16 +422,13 @@ export class ShieldStack extends Stack {
       name: 'ratelimit-nonbot-traffic',
       priority: rules.length,
       action: {
-        count: {}
+        block: {}
       },
       statement: {
         rateBasedStatement: {
           limit: 10,
           evaluationWindowSec: 60,
-          aggregateKeyType: "CUSTOM_KEYS",
-          customKeys: [{
-            asn: {}
-          }],
+          aggregateKeyType: "CONSTANT",
           scopeDownStatement: {
             andStatement: {
               statements: [

--- a/cdk/lib/shield-stack.ts
+++ b/cdk/lib/shield-stack.ts
@@ -311,6 +311,7 @@ export class ShieldStack extends Stack {
         {
           groupName: z.string(),
           vendorName: z.string(),
+          version: z.string().default(""),
           ruleActionOverrideCounts: z.array(z.string()).default([]),
           ruleActionOverrideAllows: z.array(z.string()).default([]),
           ruleActionOverrideBlocks: z.array(z.string()).default([]),
@@ -387,7 +388,10 @@ export class ShieldStack extends Stack {
           ruleActionOverrides.push(overrideChallengeRuleObj)
         }
 
-
+        let ruleVersion = undefined;
+        if ( rule.version !== "" ) {
+          ruleVersion = rule.version;
+        }
 
         let managedRuleGroup: aws_wafv2.CfnWebACL.RuleProperty = {
           name: "managed-rule-group-" + rule.groupName,
@@ -399,7 +403,8 @@ export class ShieldStack extends Stack {
             managedRuleGroupStatement: {
               name: rule.groupName,
               vendorName: rule.vendorName,
-              ruleActionOverrides: ruleActionOverrides
+              ruleActionOverrides: ruleActionOverrides,
+              version: ruleVersion
             }
           },
           visibilityConfig: {


### PR DESCRIPTION
Updates default to block on filter page rules and non-bot rule.

Updates non-bot rule to block everything above the rate limit, ASN aggregation did not have effect.

Adds optional version to parameter store configuration as many managed rules have 1.0 as the default.