### PR TITLE
AV-2558: Enable fetching matomo data and track events

### DIFF
--- a/ckan/cron/crontab
+++ b/ckan/cron/crontab
@@ -11,8 +11,7 @@
 #
 # NOTE: Please make sure this file is using LF line-endings, windows CRLF breaks it!
 #
-# Fetching matomo data disabled, due to api not available
-# 0   1   *       *   *   cd /srv/app && ./cron/scripts/matomo-fetch.sh
+0   1   *       *   *   cd /srv/app && ./cron/scripts/matomo-fetch.sh
 0   3   */3     *   *   cd /srv/app && ./cron/scripts/archiver-update.sh
 */5 *   *       *   *   cd /srv/app && ./cron/scripts/harvester-run.sh
 # tracking updates disabled, due to performance reasons

--- a/ckan/templates/ckan.ini.j2
+++ b/ckan/templates/ckan.ini.j2
@@ -236,7 +236,7 @@ ckanext.matomo.domain = https://{{ environ('MATOMO_DOMAIN') }}/
 ckanext.matomo.script_domain = {{ environ('MATOMO_SCRIPT_DOMAIN') }}
 ckanext.matomo.token_auth = {{ environ('MATOMO_TOKEN') }}
 ckanext.matomo.ignored_user_agents = docker-healthcheck
-ckanext.matomo.track_api = false
+ckanext.matomo.track_api = true
 {% endif %}
 
 


### PR DESCRIPTION
Dev and prod was given access to the API, this enables fetching data daily.