### PR TITLE
AV-2554: Fix missing showcase filters, breadcrumb link showing no results

### DIFF
--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/read.html
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/read.html
@@ -27,7 +27,7 @@
 
 {% block breadcrumb_content %}
   {% set showcase = h.get_translated(pkg, 'title') or pkg.name %}
-  <li>{{ h.nav_link(_('Showcases'), named_route='sixodp_showcase.search', highlight_actions = 'new index') }}</li>
+  <li>{{ h.nav_link(_('Showcases'), named_route='sixodp_showcase.search') }}</li>
   <li{{ self.breadcrumb_content_selected() }}>{% link_for showcase|truncate(30), named_route='showcase_read', id=pkg.name %}</li>
 {% endblock %}
 

--- a/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
+++ b/ckan/ckanext/ckanext-sixodp_showcase/ckanext/sixodp_showcase/templates/sixodp_showcase/search.html
@@ -9,7 +9,7 @@
 {% block subtitle %}{{ _("Showcases") }}{% endblock %}
 
 {% block breadcrumb_content %}
-  <li class="active">{{ h.nav_link(_('Showcases'), named_route='sixodp_showcase.search', highlight_actions = 'new index') }}</li>
+  <li class="active">{{ h.nav_link(_('Showcases'), named_route='sixodp_showcase.search') }}</li>
 {% endblock %}
 
 
@@ -63,6 +63,6 @@
     <h3 class="secondary__title">{{ _('Filter list') }}</h3>
   </div>
   {% for facet in facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet) }}
+    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets) }}
   {% endfor %}
 {% endblock %}

--- a/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/sixodp_showcase/search.html
+++ b/ckan/ckanext/ckanext-ytp_main/ckanext/ytp/templates/sixodp_showcase/search.html
@@ -6,6 +6,6 @@
   </div>
   {% for facet in facet_titles %}
     <hr>
-    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet) }}
+    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, search_facets=search_facets) }}
   {% endfor %}
 {% endblock %}


### PR DESCRIPTION
- Showcase search facets were showing no items because the facet list was not properly forwarded to the snippet
- `highlight_actions = 'new index'` in showcase list breadcrumb link actually prevented showing any results